### PR TITLE
Remove non-word characters from full-text queries.

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -41,10 +41,17 @@ class CommitteeFormatTest(ApiBaseTest):
             id=committee.committee_id,
             fulltxt=sa.func.to_tsvector(committee.name),
         )
-        results = self._results(api.url_for(CommitteeList, q='america'))
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['committee_id'], committee.committee_id)
-        self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)
+        queries = [
+            'america',
+            'tomorrow',
+            'america tomorrow',
+            'america & tomorrow',
+        ]
+        for query in queries:
+            results = self._results(api.url_for(CommitteeList, q=query))
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]['committee_id'], committee.committee_id)
+            self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)
 
     def test_filter_by_candidate_id(self):
         candidate_id = 'ID0'
@@ -218,7 +225,7 @@ class CommitteeFormatTest(ApiBaseTest):
             set((each.committee_id for each in committees)),
         )
 
-    def test_committees_by_candidatee_count(self):
+    def test_committees_by_candidate_count(self):
         candidate_id = 'id0'
         committee = factories.CommitteeFactory()
         db.session.flush()

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -85,8 +85,10 @@ def search_text(query, column, text, order=True):
     :param order: Order results by text similarity, descending; prohibitively
         slow for large collections
     """
-    vector = ' & '.join(text.split())
-    vector = sa.func.concat(vector, ':*')
+    vector = ' & '.join([
+        part + ':*'
+        for part in re.sub(r'\W', ' ', text).split()
+    ])
     query = query.filter(column.match(vector))
     if order:
         query = query.order_by(


### PR DESCRIPTION
This patch fixes an error that's been popping up in New Relic lately, such that auto-complete search values that include special characters (&, |, *, etc.) throw API errors: e.g., https://rpm.newrelic.com/accounts/958521/applications/5782977/traced_errors/9d4b62-23d61769-8180-11e5-a540-f8bc12425498.

The proposed fix sanitizes all non-word characters in the query, so that queries like "(hillary | hilary) & clinton" become "hillary hilary clinton". We _could_ expose some of the internals of postgres full-text search to the user and allow special characters, but I think that would lead to a lot of extra work and user confusion for minimal benefit.

This patch also uses prefix search for all tokens in the query, so that "hill clin" still matches "Hillary Clinton". Currently, only the last token uses prefix search, so "hill" would match "Hillary Clinton", but "hill clin" would not.

I'm submitting this as a hotfix because it's a production bug (albeit a minor one). @LindsayYoung, once this is ready for merge, either let me know, or run `git flow hotfix finish ...` on your side.
