### PR TITLE
Add candidate_pcc to /elections/ endpoint

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -925,6 +925,7 @@ class ElectionSchema(ma.Schema):
     incumbent_challenge_full = ma.fields.Str()
     party_full = ma.fields.Str()
     committee_ids = ma.fields.List(ma.fields.Str)
+    candidate_pcc = ma.fields.Str(doc="The candidate's primary campaign committee")
     total_receipts = ma.fields.Decimal(places=2)
     total_disbursements = ma.fields.Decimal(places=2)
     cash_on_hand_end_period = ma.fields.Decimal(places=2)


### PR DESCRIPTION
## Summary

Addresses https://github.com/fecgov/fec-cms/issues/1910

This modifies the /elections/ endpoint to show `candidate_pcc` where a candidate has a linked committee has designation 'P' (Primary Campaign Committee.) Where two committees are marked 'P' in an election cycle (this really shouldn't happen) it takes the highest (aka most recent) committee ID. 

The plan is to refactor the /elections/ endpoint this sprint, but this *unblocks* the election profile redesign (cc: @patphongs @JonellaCulmer) 

**Note**: not all candidates have committees yet. Where there is no linked committee, the elections endpoint returns `null`.

This works across time where the data is there. Example, Graham:
http://127.0.0.1:5000/v1/elections/?office=senate&cycle=2014&state=sc&per_page=100
PCC is C00458828 in 2014
http://127.0.0.1:5000/v1/elections/?office=senate&cycle=2008&state=sc&per_page=100
PCC is C00364505 in 2008