### PR TITLE
Fix Legal search endpoint 500 error for unexpected parameters

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -26,6 +26,7 @@ INNER_HITS = {
     }
 }
 
+ALL_DOCUMENT_TYPES = ['statutes', 'regulations', 'advisory_opinions', 'murs']
 
 class GetLegalCitation(utils.Resource):
     @property
@@ -81,14 +82,14 @@ class UniversalSearch(utils.Resource):
         }
 
         if kwargs.get('type', 'all') == 'all':
-            doc_types = ['statutes', 'regulations', 'advisory_opinions', 'murs']
+            doc_types = ALL_DOCUMENT_TYPES
         else:
             doc_types = [kwargs.get('type')]
 
-            # if doc_types is not in one of these 4 doc types :'statutes', 'regulations', 'advisory_opinions', 'murs'
-            # then reset type = all (= four default search types)
-            if doc_types[0] not in ('statutes', 'regulations', 'advisory_opinions', 'murs'):
-                doc_types = ['statutes', 'regulations', 'advisory_opinions', 'murs']
+            # if doc_types is not in one of ALL_DOCUMENT_TYPES
+            # then reset type = all (= ALL_DOCUMENT_TYPES)
+            if doc_types[0] not in ALL_DOCUMENT_TYPES:
+                doc_types = ALL_DOCUMENT_TYPES
 
         hits_returned = min([200, hits_returned])
 


### PR DESCRIPTION
## Summary (required)
For our API design, we can follow the “gracious" way to handle request parameters.

Scenario1) if miss mandatory parameter:
	a) if have default. set to default.
	b) if don’t have default, abort right away, don’t need execute query

Scenario2) if miss need parameter:
	set to default or None

Scenario3)For extra parameters or bad value parameters:
	ignore those parameters quietly


this ticket only fix /legal/search/ endpoint with nonsense parameters: type.
we will set default type=all

- Addresses # [_Issue number_]
[https://github.com/18F/openFEC/issues/2934](https://github.com/18F/openFEC/issues/2934)


_Include a summary of proposed changes._
in legal.py:
if doc_types is not in one of these 4 doc types :'statutes', 'regulations', 'advisory_opinions', 'murs'
then reset type = all (= four default search types)

and add more except handle.


## How to test the changes locally
—[1] Reproduce error and fix:
1)Check out “fix_500_error” branch on local.
set SQLA_CONN to dev db

2) ./manage.py runserver

3) on localhost, correct link: type=all, no error
http://127.0.0.1:5000/v1/legal/search/?type=all&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY

on dev api, correct link: type=all, no error
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=all&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY


4) on dev api, error link: type=error_type, 
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=error_type&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY
(because type is not in one of these('statutes', 'regulations', 'advisory_opinions', 'murs'), will get 500 error.

on localhost fixed, reset type=all, so no error, get some results.
http://127.0.0.1:5000/v1/legal/search/?type=error_type&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY



-[2]Test with extra parameters:
1)on dev api, as long as type value is correct and q is correct , will ignore extra parameters, get some results
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=all&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY&nonsenseword=nonoe%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0


type is not correct, will get 500 error:
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=error_type&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY&nonsenseword=nonoe%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0


2)on localhost. type is not correct, no error, get some results based on type=all
http://127.0.0.1:5000/v1/legal/search/?type=error_type&q=public&hits_returned=3&from_hit=0&api_key=DEMO_KEY&nonsenseword=nonoe%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0


-[3] if q with nonsenseword parameter, will get 500 error on dev 
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY


on localhost. will catch 400 “Elasticsearch failed to execute query”
http://127.0.0.1:5000/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/legal/search/?q=president%20AND%20OR&type=advisory_opinions



## Impacted areas of the application
Legal Doc Search


