### PR TITLE
[WIP]Fix schedule A zip search

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1,3 +1,4 @@
+
 import datetime
 
 import sqlalchemy as sa
@@ -106,15 +107,21 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_state'], 'CA')
 
-    def test_filter_zip(self):
+    def test_filter_sa_zip(self):
         [
             factories.ScheduleAFactory(contributor_zip=96789),
-            factories.ScheduleAFactory(contributor_zip=66111)
+            factories.ScheduleAFactory(contributor_zip=9678912),
+            factories.ScheduleAFactory(contributor_zip=967891234)
         ]
 
         results = self._results(api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs))
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['contributor_zip'], '96789')
+        self.assertEqual(len(results), 3)
+        
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=9678912, **self.kwargs))
+        self.assertEqual(len(results), 3)
+        
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=967891234, **self.kwargs))
+        self.assertEqual(len(results), 3)
 
     def test_filter_case_insensitive(self):
         [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -107,7 +107,7 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_state'], 'CA')
 
-    def test_filter_sa_zip(self):
+    def test_filter_sched_a_zip(self):
         [
             factories.ScheduleAFactory(contributor_zip=96789),
             factories.ScheduleAFactory(contributor_zip=9678912),
@@ -122,6 +122,14 @@ class TestItemized(ApiBaseTest):
         
         results = self._results(api.url_for(ScheduleAView, contributor_zip=967891234, **self.kwargs))
         self.assertEqual(len(results), 3)
+
+    def test_filter_multi_start_with(self):
+        [
+            factories.ScheduleAFactory(contributor_zip=1296789)
+        ]
+
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs))
+        self.assertEqual(len(results), 0)
 
     def test_filter_case_insensitive(self):
         [

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -970,7 +970,7 @@ CONTRIBUTOR_CITY = 'City of contributor'
 CONTRIBUTOR_STATE = 'State of contributor'
 CONTRIBUTOR_EMPLOYER = 'Employer of contributor, filers need to make an effort to gather this information'
 CONTRIBUTOR_OCCUPATION = 'Occupation of contributor, filers need to make an effort to gather this information'
-CONTRIBUTOR_ZIP = 'Zip code of contributor. All contributions match on first 5-digit will be retuned'
+CONTRIBUTOR_ZIP = 'Zip code of contributor. All contributions that have zipcode matchs on first 5-digit will be returned'
 IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo code is true. \
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -970,7 +970,7 @@ CONTRIBUTOR_CITY = 'City of contributor'
 CONTRIBUTOR_STATE = 'State of contributor'
 CONTRIBUTOR_EMPLOYER = 'Employer of contributor, filers need to make an effort to gather this information'
 CONTRIBUTOR_OCCUPATION = 'Occupation of contributor, filers need to make an effort to gather this information'
-CONTRIBUTOR_ZIP = 'Zip code of contributor'
+CONTRIBUTOR_ZIP = 'Zip code of contributor. All contributions match on first 5-digit will be retuned'
 IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo code is true. \
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -82,14 +82,12 @@ def filter_multi_start_with(query, kwargs, fields):
                     for value in exclude_list
                 ]
                 query = query.filter(sa.and_(*filters))
-                print(query)
             if include_list:
                 filters = [
                     column.like(value)
                     for value in include_list
                 ]
                 query = query.filter(sa.or_(*filters))
-                print(query)
     return query
 
 

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -73,18 +73,18 @@ def filter_fulltext(query, kwargs, fields):
 
 def filter_multi_start_with(query, kwargs, fields):
     for key, column in fields:
-        if kwargs.get('contributor_zip'):
-            exclude_list = [parse_exclude_arg(value)[:5]+'%' for value in kwargs[key] if is_exclude_arg(value)]
-            include_list = [value[:5]+'%' for value in kwargs[key] if not is_exclude_arg(value)]
+        if kwargs.get(key):
+            exclude_list = [parse_exclude_arg(value) for value in kwargs[key] if is_exclude_arg(value)]
+            include_list = [value for value in kwargs[key] if not is_exclude_arg(value)]
             if exclude_list:
                 filters = [
-                    sa.not_(column.like(value))
+                    sa.not_(column.startswith(value))
                     for value in exclude_list
                 ]
                 query = query.filter(sa.and_(*filters))
             if include_list:
                 filters = [
-                    column.like(value)
+                    column.startswith(value)
                     for value in include_list
                 ]
                 query = query.filter(sa.or_(*filters))

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -71,6 +71,27 @@ def filter_fulltext(query, kwargs, fields):
                 query = query.filter(sa.or_(*filters))
     return query
 
+def filter_multi_start_with(query, kwargs, fields):
+    for key, column in fields:
+        if kwargs.get('contributor_zip'):
+            exclude_list = [parse_exclude_arg(value)[:5]+'%' for value in kwargs[key] if is_exclude_arg(value)]
+            include_list = [value[:5]+'%' for value in kwargs[key] if not is_exclude_arg(value)]
+            if exclude_list:
+                filters = [
+                    sa.not_(column.like(value))
+                    for value in exclude_list
+                ]
+                query = query.filter(sa.and_(*filters))
+                print(query)
+            if include_list:
+                filters = [
+                    column.like(value)
+                    for value in include_list
+                ]
+                query = query.filter(sa.or_(*filters))
+                print(query)
+    return query
+
 
 def filter_contributor_type(query, column, kwargs):
     if kwargs.get('contributor_type') == ['individual']:

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -36,7 +36,6 @@ class ScheduleAView(ItemizedResource):
         ('contributor_id', models.ScheduleA.contributor_id),
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
-        # ('contributor_zip', models.ScheduleA.contributor_zip)
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
@@ -53,7 +52,7 @@ class ScheduleAView(ItemizedResource):
         ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
     ]
     filter_multi_start_with_fields = [
-        ('contributor_zip', models.ScheduleA.contributor_zip)
+        ('contributor_zip', models.ScheduleA.contributor_zip),
     ]
     query_options = [
         sa.orm.joinedload(models.ScheduleA.committee),
@@ -79,7 +78,10 @@ class ScheduleAView(ItemizedResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
-        query = filters.filter_multi_start_with(query, kwargs, self.filter_multi_start_with_fields)
+
+        if kwargs.get('contributor_zip'):
+            kwargs['contributor_zip'] = [value[:5] for value in kwargs['contributor_zip']]
+            query = filters.filter_multi_start_with(query, kwargs, self.filter_multi_start_with_fields)
         
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id= int(kwargs.get('sub_id')))

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -36,7 +36,7 @@ class ScheduleAView(ItemizedResource):
         ('contributor_id', models.ScheduleA.contributor_id),
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
-        ('contributor_zip', models.ScheduleA.contributor_zip)
+        # ('contributor_zip', models.ScheduleA.contributor_zip)
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
@@ -51,6 +51,9 @@ class ScheduleAView(ItemizedResource):
         ('contributor_name', models.ScheduleA.contributor_name_text),
         ('contributor_employer', models.ScheduleA.contributor_employer_text),
         ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
+    ]
+    filter_multi_start_with_fields = [
+        ('contributor_zip', models.ScheduleA.contributor_zip)
     ]
     query_options = [
         sa.orm.joinedload(models.ScheduleA.committee),
@@ -76,6 +79,8 @@ class ScheduleAView(ItemizedResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
+        query = filters.filter_multi_start_with(query, kwargs, self.filter_multi_start_with_fields)
+        
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):


### PR DESCRIPTION
This PR will refactor the zip code search for SA. No matter what zip code a user enters, it will always find returns transactions  that match the first 5-digit of the zip code

[#2980](https://github.com/fecgov/openFEC/issues/2980#issuecomment-371876195)

- new type of filter was added : filter_multi_start_with
- this new filter is used by SA
- test case was modofied: test_filter_sa_zip

## How to test the changes locally
-run API locally and test the searching feature






