### PR TITLE
[WIP] Add more robust itemized schedule nightly processing

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -207,12 +207,18 @@ def refresh_itemized_a():
     """Used to refresh the itemized Schedule A data."""
 
     logger.info('Updating Schedule A...')
-    message = partition.SchedAGroup.process_queues()
 
-    if message[0] == 0:
-        logger.info(message[1])
-    else:
-        logger.error(message[1])
+    while True:
+        message = partition.SchedAGroup.process_queues()
+
+        if message[0] == 0:
+            logger.info(message[1])
+            break
+        elif message[0] == 1:
+            logger.warning(message[1])
+        elif message[0] >= 2:
+            logger.error(message[1])
+            break
 
     logger.info('Finished updating Schedule A.')
 
@@ -220,12 +226,18 @@ def refresh_itemized_a():
 def refresh_itemized_b():
     """Used to refresh the itemized Schedule B data."""
     logger.info('Updating Schedule B...')
-    message = partition.SchedBGroup.process_queues()
 
-    if message[0] == 0:
-        logger.info(message[1])
-    else:
-        logger.error(message[1])
+    while True:
+        message = partition.SchedBGroup.process_queues()
+
+        if message[0] == 0:
+            logger.info(message[1])
+            break
+        elif message[0] == 1:
+            logger.warning(message[1])
+        elif message[0] >= 2:
+            logger.error(message[1])
+            break
 
     logger.info('Finished updating Schedule B.')
 

--- a/webservices/partition/base.py
+++ b/webservices/partition/base.py
@@ -155,6 +155,8 @@ class TableGroup:
                 )
                 logger.warning(output_message[1])
             except Exception as fatal_error:
+                transaction.rollback()
+
                 output_message = (
                     2,
                     'Aborting - Refreshing {name} failed: {error}'.format(


### PR DESCRIPTION
**WIP:  PLEASE DO NOT MERGE**

This changeset introduces more resilience to the nightly processing of the itemized schedule data by checking for a specific error condition and attempting to fix it before trying to process the data again.  We find that at times we run into a situation where an itemized record will be present in the new queue table as well as the master table, which indicates the need for an update, but the record is absent from the old queue table.  This change rectifies that by retrieving the values from the master table and creating a copy in the old queue, then retrying the processing again.  If the processing succeeds or fails in a fatal way (another type of error entirely or an error in trying to copy the record into the old queue), the loop is broken from the processing so the rest of the nightly refresh can continue.

TODO:
* [ ] Review the problem and proposed solution
* [ ] Update tests as necessary