### PR TITLE
Fixed the broken api link.

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -167,7 +167,7 @@ def add_caching_headers(response):
     if max_age is not None:
         response.headers.add('Cache-Control', 'public, max-age={}'.format(max_age))
 
-    if (cache_all_requests and status_code == 200):
+    if (cache_all_requests and status_code == 200 and '/v1/' in request.url):
         # convert the response content into a JSON object
         json_data = utils.get_json_data(response)
         # format the URL by removing the api_key and special characters


### PR DESCRIPTION

## Summary (required)
Check if the request.url has /v1/ then cache the endpoints.

- Addresses # [_Issue number_]
https://github.com/fecgov/openFEC/issues/2913
_Include a summary of proposed changes._

## How to test the changes locally
This link should be UP and running when you start the server on openfec repo.
- http://localhost:5000/developers/

## Impacted areas of the application
Swagger API
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
