### PR TITLE
Prevent flask-restful from taking over all errors

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -101,6 +101,8 @@ app.config['SQLALCHEMY_FOLLOWERS'] = [
     for follower in env.get_credential('SQLA_FOLLOWERS', '').split(',')
     if follower.strip()
 ]
+app.config['PROPAGATE_EXCEPTIONS'] = True
+
 # app.config['SQLALCHEMY_ECHO'] = True
 
 # Modify app configuration and logging level for production


### PR DESCRIPTION
Fixes fecgov/openFEC#2962

Thanks to @lbeaufort for discovering flask-restful/flask-restful#578.

It was difficult to investigate this in local environments as they run
in debug mode where all exceptions are propagated. 

## Summary (required)

- Addresses #2962 


_Include a summary of proposed changes._

## How to test the changes locally
- Turn off debug mode by running
```
python manage.py runserver --no-debug
```
- Access the API endpoint with an invalid query, e.g., `curl -v http://localhost:5000/v1/elections/`

You should get a clean 422 response with a proper JSON message:
```
{
  "message": "Required parameter \"office\" not found.",
  "status": 422
}
```

## Impacted areas of the application
List general components of the application that this PR will affect:

-  This would primarily benefit public API users by providing better error responses



