### PR TITLE
exception handling for legal search endpoint, debug single test_legal.py

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -107,8 +107,8 @@ class UniversalSearch(utils.Resource):
                 logger.info(e.args)
                 raise ApiError("Elasticsearch failed to execute query", 400)
             except:
-                logger.info("Unexpected Error")
-                raise ApiError("Unexpected Error", 400)
+                logger.info("Unexpected Server Error")
+                raise ApiError("Unexpected Server Error", 500)
             results[type_] = formatted_hits
             results['total_%s' % type_] = count
             total_count += count


### PR DESCRIPTION
This PR is partially related with PR#3018: [https://github.com/fecgov/openFEC/pull/3018](https://github.com/fecgov/openFEC/pull/3018)
and related this issue: [https://github.com/fecgov/openFEC/issues/2934](https://github.com/fecgov/openFEC/issues/2934)
and this issue: [https://github.com/fecgov/openFEC/issues/2962](https://github.com/fecgov/openFEC/issues/2962)

There are two problems need to be fixed in this PR:
##Problem 1) how to handle exception?
on dev server: return 500 (Internal Server Error)
[https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY](https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY)

on local: return what we catch 400 error.
[http://127.0.0.1:5000/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY](http://127.0.0.1:5000/v1/legal/search/?type=regulations&q=+public+%26%26+type+%25SystemRoot%25%5C%5Cwin.ini+%26%26+&hits_returned=20&from_hit=0&api_key=DEMO_KEY)

From PR#3018, we know, after setup `./manage.py runserver --no-debug`, we get same 500 error on both local and dev. this is really great.  Thanks Vraj.

question: How to handle `PROPAGATE_EXCEPTIONS` ?

##Problem2:
when running py.test again all test cases, will pass all test cases.
but when running one test case `py.test tests/test_legal.py` , the `test_invalid_search` function failed.
<img width="747" alt="screen shot 2018-03-20 at 9 54 48 pm" src="https://user-images.githubusercontent.com/24395751/37691598-673693c0-2c89-11e8-8a90-0b664c49ffad.png">

In order to pass single test, I set response.status_code == 500
but run `py.test` for all test cases will be failed.

How to test locally:
1)start elasticsearch server
2)setup openFEC locally, and ./manage.py runserver --no-debug

