### PR TITLE
Feature/remove cache folder from s3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -19,6 +19,7 @@ from webservices.config import SQL_CONFIG, check_config
 from webservices.common.util import get_full_path
 import webservices.legal_docs as legal_docs
 from webservices.utils import post_to_slack
+from webservices.tasks import cache_request
 
 manager = Manager(app)
 logger = logging.getLogger('manager')
@@ -44,6 +45,7 @@ manager.command(legal_docs.delete_docs_index)
 manager.command(legal_docs.move_archived_murs)
 manager.command(legal_docs.initialize_current_legal_docs)
 manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+manager.command(cache_request.delete_cache_calls_from_s3)
 
 def get_projected_weekly_itemized_totals(schedules):
     """Calculates the weekly total of itemized records that should have been

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -185,6 +185,7 @@ def handle_exception(exception):
     wrapped = ResponseException(str(exception), ErrorCode.INTERNAL_ERROR, type(exception))
 
     logger.info("In handle_exception(), received status code %s", wrapped.status)
+    logger.info("Retrieving the cached request from S3... %s")
 
     if wrapped.status in [500, 502, 503, 504]:
         formatted_url = utils.format_url(request.url)
@@ -199,6 +200,7 @@ def handle_exception(exception):
         cached_data = utils.get_cached_request(cached_url)
 
         if cached_data is not None:
+            logger.info("Successfully retrieved cached request from S3 %s")
             return cached_data
         else:
             logger.error("Exception occured while retrieving the cached file from S3")

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -22,6 +22,12 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
             'task': 'webservices.tasks.legal_docs.refresh',
             'schedule': crontab(minute='*/5'),
         },
+        # This task runs every 3 days and deletes all the folders 
+        # under cached-calls from S3
+        'delete_cached_call_folder': {
+            'task': 'webservices.tasks.cache_request.delete_cached_calls_folder',
+            'schedule': crontab(minute=0, hour=10, day_of_month=3),
+        },
     }
 
 

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -22,11 +22,9 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
             'task': 'webservices.tasks.legal_docs.refresh',
             'schedule': crontab(minute='*/5'),
         },
-        # This task runs every 3 days and deletes all the folders 
-        # under cached-calls from S3
         'delete_cached_call_folder': {
             'task': 'webservices.tasks.cache_request.delete_cached_calls_folder',
-            'schedule': crontab(minute=0, hour=10, day_of_month=3),
+            'schedule': crontab(minute=0, hour=10),
         },
     }
 

--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -4,6 +4,9 @@ from celery_once import QueueOnce
 from smart_open import smart_open
 from webservices.tasks import app
 from webservices.tasks import utils
+from webservices import utils as web_utils
+from webservices.env import env
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,3 +27,24 @@ def cache_all_requests(json_data, formatted_url):
         )
     except Exception as e:
         logger.error('Exception occured while uploading the cache request to S3.%s', e)
+
+def delete_cache_calls_from_s3():
+    """
+    Deletes all files and folders under cached-calls from S3
+    """
+    bucket = utils.get_bucket()
+    for obj in bucket.objects.filter(Prefix="cached-calls/"):
+        obj.delete()
+    slack_message = 'Successfully deleted the cached-calls folder in {0} from S3'.format(env.get_credential('NEW_RELIC_APP_NAME'))
+    web_utils.post_to_slack(slack_message, '#bots')
+    logger.info(slack_message)
+
+@app.task
+def delete_cache_calls_folder():
+    permanent_dir = ('cached-calls')
+    for obj in utils.get_bucket().objects.all():
+        if obj.key.startswith(permanent_dir):
+            obj.delete()
+    slack_message = 'Successfully deleted the cached-calls folder in {0} from S3'.format(env.get_credential('NEW_RELIC_APP_NAME'))
+    web_utils.post_to_slack(slack_message, '#bots')
+    logger.info(slack_message)

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -147,5 +147,5 @@ def export_query(path, qs):
 def clear_bucket():
     permanent_dir = ('legal', 'bulk-downloads', 'cached-calls')
     for obj in task_utils.get_bucket().objects.all():
-        if obj.key.startswith(permanent_dir):
+        if not obj.key.startswith(permanent_dir):
             obj.delete()

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -147,5 +147,5 @@ def export_query(path, qs):
 def clear_bucket():
     permanent_dir = ('legal', 'bulk-downloads', 'cached-calls')
     for obj in task_utils.get_bucket().objects.all():
-        if not obj.key.startswith(permanent_dir):
+        if obj.key.startswith(permanent_dir):
             obj.delete()

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -37,6 +37,7 @@ def get_s3_key(name):
     return key
 
 def get_json_data(response):
+    # convert the response bytes data to a string 
     python_str = json.dumps(response.data.decode('utf-8'))
     return python_str
 


### PR DESCRIPTION
## Summary (required)

Create a celery schedule task to delete the folders unders cached-calls from s3 bucket.
Schedule task run every day @6a.

- Addresses # [_Issue number_]

fecgov/openFEC#3009


_Include a summary of proposed changes._

## How to test the changes locally

- redis-server, celery beat, celery worker should be UP and running in your local.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  folders under cached-calls  on s3 bucket should be deleted.



## Related PRs
None
