### PR TITLE
Feature/remove cache folder from s3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -45,7 +45,7 @@ manager.command(legal_docs.delete_docs_index)
 manager.command(legal_docs.move_archived_murs)
 manager.command(legal_docs.initialize_current_legal_docs)
 manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
-manager.command(cache_request.delete_cache_calls_from_s3)
+manager.command(cache_request.delete_cached_calls_from_s3)
 
 def get_projected_weekly_itemized_totals(schedules):
     """Calculates the weekly total of itemized records that should have been

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -24,7 +24,7 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
         },
         'delete_cached_call_folder': {
             'task': 'webservices.tasks.cache_request.delete_cached_calls_from_s3',
-            'schedule': crontab(minute=0, hour=10),
+            'schedule': crontab(minute=0, hour=17),
         },
     }
 

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -23,7 +23,7 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
             'schedule': crontab(minute='*/5'),
         },
         'delete_cached_call_folder': {
-            'task': 'webservices.tasks.cache_request.delete_cached_calls_folder',
+            'task': 'webservices.tasks.cache_request.delete_cached_calls_from_s3',
             'schedule': crontab(minute=0, hour=10),
         },
     }

--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -28,23 +28,13 @@ def cache_all_requests(json_data, formatted_url):
     except Exception as e:
         logger.error('Exception occured while uploading the cache request to S3.%s', e)
 
-def delete_cache_calls_from_s3():
+def delete_cached_calls_from_s3():
     """
     Deletes all files and folders under cached-calls from S3
     """
     bucket = utils.get_bucket()
     for obj in bucket.objects.filter(Prefix="cached-calls/"):
         obj.delete()
-    slack_message = 'Successfully deleted the cached-calls folder in {0} from S3'.format(env.get_credential('NEW_RELIC_APP_NAME'))
-    web_utils.post_to_slack(slack_message, '#bots')
-    logger.info(slack_message)
-
-@app.task
-def delete_cache_calls_folder():
-    permanent_dir = ('cached-calls')
-    for obj in utils.get_bucket().objects.all():
-        if obj.key.startswith(permanent_dir):
-            obj.delete()
     slack_message = 'Successfully deleted the cached-calls folder in {0} from S3'.format(env.get_credential('NEW_RELIC_APP_NAME'))
     web_utils.post_to_slack(slack_message, '#bots')
     logger.info(slack_message)

--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -28,6 +28,7 @@ def cache_all_requests(json_data, formatted_url):
     except Exception as e:
         logger.error('Exception occured while uploading the cache request to S3.%s', e)
 
+@app.task
 def delete_cached_calls_from_s3():
     """
     Deletes all files and folders under cached-calls from S3


### PR DESCRIPTION
## Summary (required)
Create a celery schedule task to delete the folders unders cached-calls from s3 bucket.
Schedule task run every day @1p (This is just for testing).

Addresses # [fecgov/openFEC#3009]

_Include a summary of proposed changes._

## How to test the changes locally

-redis-server, celery beat, celery worker should be UP and running in your local.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  folders/files under cached-calls on s3 bucket should be deleted.



## Related PRs
None
