### PR TITLE
fix ofec_sched_e reoccurring permission problem

### DIFF
--- a/data/refresh/rebuild_schedule_e.sql
+++ b/data/refresh/rebuild_schedule_e.sql
@@ -10,6 +10,10 @@ select
     now() as pg_date
 from fec_fitem_sched_e_vw;
 
+ALTER TABLE public.ofec_sched_e_tmp
+  OWNER TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_e_tmp TO fec_read;
+
 -- Add in records from the Schedule E notices view
 insert into ofec_sched_e_tmp
 select *,


### PR DESCRIPTION
## Summary (required)

- Addresses # 2927

_Include a summary of proposed changes._
Some database objects have incorrect permissions, PR #3001 had a migration file had already address these permission issues.  However, after the PR had been merged in DEV database and all permission are good, we noticed the permission to ofec_sched_e had been flipped back to the incorrect permission repeatedly while all the other fixed permission stays correct.  After research, I discovered that the cronjob to refresh this table everyday is actually recreate this table. And the script that recreate this table does not specify the owner; and the cronjob is run by fec_api, so every night this table recreated, the ownership flip back to fec_api.   Therefore, in addition to the migration file, data/refresh/rebuild_schedule_e.sql need to be updated to specify the ownership of this table.

## How to test the changes locally
When run locally, point the database to the local database, run ./manage.py rebuild_itemized_e.  Check the ownership and permission to make sure fec is the owner and fec_read has the select privilege.
-

## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
