### PR TITLE
[WIP] remove cached folder contents from s3

### DIFF
--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -34,8 +34,8 @@ def delete_cached_calls_from_s3():
     Deletes all files and folders under cached-calls from S3
     """
     bucket = utils.get_bucket()
-    for obj in bucket.objects.filter(Prefix="cached-calls/"):
-        obj.delete()
+    bucketListResultSet = bucket.list(prefix="cached-calls/")
+    bucket.delete_keys([key.name for key in bucketListResultSet])
     slack_message = 'Successfully deleted the cached-calls folder in {0} from S3'.format(env.get_credential('NEW_RELIC_APP_NAME'))
     web_utils.post_to_slack(slack_message, '#bots')
     logger.info(slack_message)


### PR DESCRIPTION

## Summary (required)
To delete the cached-calls folder contents from s3 
- Addresses # https://github.com/fecgov/openFEC/issues/3009


_Include a summary of proposed changes._

get a list of all the contents in cached-calls folder on s3
delete the files.

## How to test the changes locally
- export the latest s3  keys in the celery worker, celery beat terminal
-  start these servers : redis-server, celery worker, celery beat 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  cached-calls folders on s3.



## Related PRs
List related PRs against other branches:

- None
