### PR TITLE
Use envvars instead of explicit connection params

### DIFF
--- a/webservices/env.py
+++ b/webservices/env.py
@@ -1,5 +1,16 @@
+import os
+
 import cfenv
 
+
 env = cfenv.AppEnv()
+
+
+if env.get_credential('access_key_id'):
+    os.environ['AWS_ACCESS_KEY_ID'] = env.get_credential('access_key_id')
+if env.get_credential('secret_access_key'):
+    os.environ['AWS_SECRET_ACCESS_KEY'] = env.get_credential('secret_access_key')
+if env.get_credential('region'):
+    os.environ['AWS_DEFAULT_REGION'] = env.get_credential('region')
 
 __all__ = ['env']

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -15,11 +15,7 @@ def get_app():
     return app
 
 def get_bucket():
-    session = boto3.Session(
-        aws_access_key_id=env.get_credential('access_key_id'),
-        aws_secret_access_key=env.get_credential('secret_access_key'),
-        region_name=env.get_credential('region')
-    )
+    session = boto3.Session()
     s3 = session.resource('s3')
     return s3.Bucket(env.get_credential('bucket'))
 
@@ -29,8 +25,6 @@ def get_object(key):
 def get_s3_key(name):
     connection = boto.s3.connect_to_region(
         env.get_credential('region'),
-        aws_access_key_id=env.get_credential('access_key_id'),
-        aws_secret_access_key=env.get_credential('secret_access_key'),
     )
     bucket = connection.get_bucket(env.get_credential('bucket'))
     key = Key(bucket=bucket, name=name)


### PR DESCRIPTION
`smart_open` uses `boto` and not `boto3`. The explicit connection
parameters seem to not work anymore and the current code requires that `~/.aws` is configured correctly. A workaround is to have them as
environment variables, which appears to work for both `boto` and `boto3`
connections.

This can be tested by renaming `~/.aws` or not configuring it correctly. 