### PR TITLE
Feature/refactor cache calls

### DIFF
--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 
 from celery_once import QueueOnce
 from smart_open import smart_open
@@ -10,16 +11,19 @@ from webservices.env import env
 
 logger = logging.getLogger(__name__)
 
+def get_cache_expiration():
+    return datetime.datetime.now() + datetime.timedelta(days=3)
+
 @app.task(base=QueueOnce, once={'graceful': True})
-def cache_all_requests(json_data, formatted_url):
+def cache_all_requests(json_str, formatted_url):
 
     try:
         cached_url = 'cached-calls/{}'.format(formatted_url)
-        s3_key = utils.get_s3_key(cached_url)
 
+        bucket = utils.get_bucket()
         # upload the json_data to s3 bucket
-        with smart_open(s3_key, 'wb') as cached_file:
-            cached_file.write(json_data)
+        bucket.put_object(Key=cached_url, Body=json_str,
+                        ContentType="application/json", Expires=get_cache_expiration())
         logger.info(
             'The following request has been uploaded to S3 successfully: {}'.format(
                 cached_url

--- a/webservices/tasks/cache_request.py
+++ b/webservices/tasks/cache_request.py
@@ -12,7 +12,7 @@ from webservices.env import env
 logger = logging.getLogger(__name__)
 
 def get_cache_expiration():
-    return datetime.datetime.now() + datetime.timedelta(days=3)
+    return datetime.datetime.now() + datetime.timedelta(minutes=60)
 
 @app.task(base=QueueOnce, once={'graceful': True})
 def cache_all_requests(json_str, formatted_url):


### PR DESCRIPTION
## Summary (required)

Saved the cache requests using the put_object.
Set the expiration date of each cached request to one day.

- Addresses # https://github.com/fecgov/openFEC/issues/3009

_Include a summary of proposed changes._

## How to test the changes locally

- export the latest s3 keys in the openFEC, celery worker terminal
- start these servers : redis-server, celery worker

## Impacted areas of the application
List general components of the application that this PR will affect:

-  cached-calls folders on s3.



## Related PRs
List related PRs against other branches:

None
