### PR TITLE
Feature/removeofec candidate flag

### DIFF
--- a/data/migrations/V0069__remove_ofec_candidate_flag.sql
+++ b/data/migrations/V0069__remove_ofec_candidate_flag.sql
@@ -1,0 +1,12 @@
+
+/*
+public.ofec_candidate_flag was renamed to public.ofec_candidate_flag_mv in 
+migration script V0059 to fit our naming convention for MATERIALIZED VIEWs. 
+However, in order to run a time/resource consuming migration script V0060 
+the night before the code release to avoid time-out issues during high traffic hour, 
+public.ofec_candidate_flag was temporarily added back. 
+It should be dropped to finish the work.
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_flag;
+    

--- a/data/migrations/V0069__remove_ofec_candidate_flag.sql
+++ b/data/migrations/V0069__remove_ofec_candidate_flag.sql
@@ -8,5 +8,5 @@ public.ofec_candidate_flag was temporarily added back.
 It should be dropped to finish the work.
 */
 
-DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_flag;
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_flag;
     


### PR DESCRIPTION
## Summary (required)

- Addresses # #3017 
public.ofec_candidate_flag was renamed to public.ofec_candidate_flag_mv in 
migration script V0059 to fit our naming convention for MATERIALIZED VIEWs. 
However, in order to run a time/resource consuming migration script V0060 
the night before the code release to avoid time-out issues during high traffic hour, 
public.ofec_candidate_flag was temporarily added back. 
It should be dropped to finish the work.

## How to test the changes locally

-log into postgresql database and make sure public.ofec_candidate_flag had been dropped

## Impacted areas of the application
List general components of the application that this PR will affect:

-  This is a cleanup job, no impact to the application



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
