### PR TITLE
Upgrade Python to 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.5.3
+      - image: circleci/python:3.6.4-jessie-browsers
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:9.6.2
+      - image: circleci/postgres:9.6.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.5 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.6 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 9.6 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 2.4 (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/_installation.html))
-    * Flyway 4.2 ([download](https://flywaydb.org/getstarted/download))
+    * Flyway 5.0.x ([download](https://flywaydb.org/getstarted/download))
 
 2. Set up your Node environment—  learn how to do this with our [Javascript Ecosystem Guide](https://github.com/18F/dev-environment-standardization/blob/18f-pages/pages/languages/javascript.md).
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.4
+python-3.6.x


### PR DESCRIPTION
Upgrade the API to Python 3.6, update circle ci to use python 3.6, and cloud.gov deployment to use Python 3.6

