### PR TITLE
update fec_fitem_sched_b table to rename one column and update trigge…

### DIFF
--- a/data/migrations/V0070__alter_table_fec_fitem_sched_b.sql
+++ b/data/migrations/V0070__alter_table_fec_fitem_sched_b.sql
@@ -1,0 +1,39 @@
+
+/*
+column election_cycle and two_year_transaction_period in public.ofec_sched_b_master tables has exactly the same data
+So disclosure.fec_fitem_sched_b does not add the extra column two_year_transaction_period
+However, since existing API referencing column two_year_transaction_period a lot, rename election_cycle to two_year_transaction_period
+  to mitigate impact to API when switching from using public.ofec_sched_b_master tables to disclosure.fec_fitem_sched_b table
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.fec_fitem_sched_b rename column election_cycle to two_year_transaction_period');
+    EXCEPTION 
+             WHEN undefined_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+/*
+The calculation of value for recipient_name_text in both public.ofec_sched_b and disclosure.fec_fitem_sched_b are slightly incorrect.
+It should use clean_recipient_cmte_id instead of recipient_cmte_id.
+*/
+
+CREATE OR REPLACE FUNCTION disclosure.fec_fitem_sched_b_insert()
+  RETURNS trigger AS
+$BODY$
+begin
+	new.pdf_url := image_pdf_url(new.image_num);
+	new.disbursement_description_text := to_tsvector(new.disb_desc);
+	new.recipient_name_text := to_tsvector(concat(new.recipient_nm,' ', new.clean_recipient_cmte_id));
+	new.disbursement_purpose_category := disbursement_purpose(new.disb_tp, new.disb_desc);
+	new.line_number_label := expand_line_number(new.filing_form, new.line_num);
+  return new;
+end
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+ALTER FUNCTION disclosure.fec_fitem_sched_b_insert()
+  OWNER TO fec;


### PR DESCRIPTION
…r function

## Summary (required)

- Addresses # 2854

disclosure.fec_fitem_sched_b does not add the extra column two_year_transaction_period since column election_cycle and two_year_transaction_period in public.ofec_sched_b_master tables has exactly the same data.
However, existing API referencing column two_year_transaction_period a lot, it might be less impact to the API to just rename election_cycle to two_year_transaction_period without duplicated data when switching from using public.ofec_sched_b_master tables to disclosure.fec_fitem_sched_b table.
The calculation of value for recipient_name_text in both public.ofec_sched_b and disclosure.fec_fitem_sched_b are slightly incorrect.
It should use clean_recipient_cmte_id instead of recipient_cmte_id.

## How to test the changes locally
- After migration script run, login the database, 
table disclosure.fec_fitem_sched_b should have a column named two_year_transaction_period, and the column election_cycle should not exist
Trigger function disclosure.fec_fitem_sched_b_insert() should have the calculation for recipient_name_text should be as followed:
new.recipient_name_text := to_tsvector(concat(new.recipient_nm,' ', new.clean_recipient_cmte_id));

## Impacted areas of the application
List general components of the application that this PR will affect:
-  This table is not used by API yet, so there will be no impact to the application

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
