### PR TITLE
Fix AO statute mapping where section contains a letter

### DIFF
--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -35,13 +35,14 @@ def test_parse_ao_citations(text, ao_nos, expected):
 
 
 @pytest.mark.parametrize("text,expected", [
-    ("2 U.S.C. 432h", set([(52, 30102)])),
-    ("52 U.S.C. 30116a", set([(52, 30116)])),
-    ("2 U.S.C. 441b, 441c, 441e", set([(2, 441)])),
-    (" 2 U.S.C. §437f", set([(52, 30105)])),
-    ("52 U.S.C. § 30101", set([(52, 30101)])),
-    (" 2 USC §437f **test with no . in USC**", set([(52, 30105)])),
-    ("52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words", set([(52, 30101)])),
+    ("2 U.S.C. 432", set([(52, '30102')])),
+    ("52 U.S.C. 30116(a", set([(52, '30116')])),
+    ("2 U.S.C. 441b, 441c, 441e", set([(52, '30118')])),
+    ("2 U.S.C. 441a-1", set([(52, '30117')])),
+    (" 2 U.S.C. §437f", set([(52, '30108')])),
+    ("52 U.S.C. § 30101", set([(52, '30101')])),
+    (" 2 USC §437f **test with no . in USC**", set([(52, '30108')])),
+    ("52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words", set([(52, '30101')])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
@@ -254,7 +255,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
 
         actual_ao = next(get_advisory_opinions(None))
 
-        assert actual_ao["statutory_citations"] == [{'title': 52, 'section': 30101}]
+        assert actual_ao["statutory_citations"] == [{'title': 52, 'section': '30101'}]
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     @patch("webservices.legal_docs.advisory_opinions.get_elasticsearch_connection")

--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -37,6 +37,7 @@ def test_parse_ao_citations(text, ao_nos, expected):
 @pytest.mark.parametrize("text,expected", [
     ("2 U.S.C. 432", set([(52, '30102')])),
     ("52 U.S.C. 30116(a", set([(52, '30116')])),
+    ("52 USC § 30116a", set([(52, '30116a')])),
     ("2 U.S.C. 441b, 441c, 441e", set([(52, '30118')])),
     ("2 U.S.C. 441a-1", set([(52, '30117')])),
     (" 2 U.S.C. §437f", set([(52, '30108')])),

--- a/tests/test_map_citations_murs.py
+++ b/tests/test_map_citations_murs.py
@@ -7,19 +7,19 @@ from webservices.legal_docs import load_legal_docs, reclassify_statutory_citatio
 
 class TestGetCitations(unittest.TestCase):
 
-    def test_reclassify_archived_mur_statutory_citation(self):
+    def test_reclassify_statutory_citation(self):
         # spot check a few cases from the csv
-        assert reclassify_statutory_citation.reclassify_archived_mur_statutory_citation('2', '431') == ('52', '30101')
-        assert reclassify_statutory_citation.reclassify_archived_mur_statutory_citation('2', '437g') == ('52', '30109')
-        assert reclassify_statutory_citation.reclassify_archived_mur_statutory_citation('2', '441a-1') == ('52', '30117')
+        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '431') == ('52', '30101')
+        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '437g') == ('52', '30109')
+        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '441a-1') == ('52', '30117')
 
         # and a fallback
-        assert reclassify_statutory_citation.reclassify_archived_mur_statutory_citation('99', '12345') == ('99', '12345')
+        assert reclassify_statutory_citation.reclassify_statutory_citation('99', '12345') == ('99', '12345')
 
 
-    @mock.patch.object(reclassify_statutory_citation, 'reclassify_archived_mur_statutory_citation')
-    def test_get_citations_statute(self, reclassify_archived_mur_statutory_citation):
-        reclassify_archived_mur_statutory_citation.return_value = ('99', '31999')
+    @mock.patch.object(reclassify_statutory_citation, 'reclassify_statutory_citation')
+    def test_get_citations_statute(self, reclassify_statutory_citation):
+        reclassify_statutory_citation.return_value = ('99', '31999')
         citation_text = [
             '2 U.S.C. 23',
             '2 U.S.C. 23a',
@@ -40,7 +40,7 @@ class TestGetCitations(unittest.TestCase):
         us_code = citations['us_code']
 
         assert len(us_code) == len(expected_calls)
-        assert reclassify_archived_mur_statutory_citation.call_args_list == expected_calls
+        assert reclassify_statutory_citation.call_args_list == expected_calls
 
         assert us_code[0]['text'] == '99 U.S.C. 31999'
         assert us_code[1]['text'] == '99 U.S.C. 31999'

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -6,7 +6,7 @@ from webservices.env import env
 from webservices.rest import db
 from webservices.utils import get_elasticsearch_connection
 from webservices.tasks.utils import get_bucket
-from .reclassify_statutory_citation import reclassify_archived_mur_statutory_citation
+from .reclassify_statutory_citation import reclassify_statutory_citation
 
 
 logger = logging.getLogger(__name__)
@@ -290,7 +290,7 @@ def parse_statutory_citations(text):
     matches = set()
     if text:
         for citation in STATUTE_CITATION_REGEX.finditer(text):
-            new_title, new_section = reclassify_archived_mur_statutory_citation(
+            new_title, new_section = reclassify_statutory_citation(
                 citation.group('title'), citation.group('section'))
             matches.add((
                 int(new_title),

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -11,6 +11,13 @@ from .reclassify_statutory_citation import reclassify_archived_mur_statutory_cit
 
 logger = logging.getLogger(__name__)
 
+"""Uncomment this for additional local logging:
+We've kept some logs at DEBUG to avoid cluttering production logs.
+"""
+
+# logger.setLevel(logging.DEBUG)
+
+
 ALL_AOS = """
     SELECT
         ao_parsed.ao_id,

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -67,7 +67,7 @@ AO_DOCUMENTS = """
 """
 
 STATUTE_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+\d+[-0-9a-z]*).*\.?")
+    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+[a-z]?(-1)?).*\.?")
 
 REGULATION_CITATION_REGEX = re.compile(
     r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -67,7 +67,7 @@ AO_DOCUMENTS = """
 """
 
 STATUTE_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+).*\.?")
+    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+\d+[-0-9a-z]*).*\.?")
 
 REGULATION_CITATION_REGEX = re.compile(
     r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")
@@ -266,7 +266,7 @@ def get_citations(ao_names):
         es.index('docs_index', 'citations', entry, id=entry['citation_text'])
 
     for citation in all_statutory_citations:
-        entry = {'citation_text': '%d U.S.C. §%d'
+        entry = {'citation_text': '%d U.S.C. §%s'
                  % (citation[0], citation[1]), 'citation_type': 'statute'}
         es.index('docs_index', 'citations', entry, id=entry['citation_text'])
 
@@ -294,7 +294,7 @@ def parse_statutory_citations(text):
                 citation.group('title'), citation.group('section'))
             matches.add((
                 int(new_title),
-                int(new_section)
+                str(new_section)
             ))
     return matches
 

--- a/webservices/legal_docs/current_murs.py
+++ b/webservices/legal_docs/current_murs.py
@@ -8,7 +8,7 @@ from webservices.rest import db
 from webservices.utils import create_eregs_link, get_elasticsearch_connection
 from webservices.tasks.utils import get_bucket
 
-from .reclassify_statutory_citation import reclassify_current_mur_statutory_citation
+from .reclassify_statutory_citation import reclassify_statutory_citation_without_title
 
 logger = logging.getLogger(__name__)
 
@@ -278,7 +278,7 @@ def parse_statutory_citations(statutory_citation, case_id, entity_id):
         matches = list(STATUTE_REGEX.finditer(statutory_citation))
         for index, match in enumerate(matches):
             section = match.group('section')
-            orig_title, new_title, new_section = reclassify_current_mur_statutory_citation(section)
+            orig_title, new_title, new_section = reclassify_statutory_citation_without_title(section)
             url = 'https://api.fdsys.gov/link?' +\
                 urlencode([
                     ('collection', 'uscode'),

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -261,7 +261,7 @@ MAPPINGS = {
                 "type": "nested",
                 "properties": {
                     "section": {
-                        "type": "long"
+                        "type": "string"
                     },
                     "title": {
                         "type": "long"

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -323,7 +323,7 @@ def get_citations(citation_texts):
             "(?P<title>[0-9]+) C\.F\.R\. (?P<part>[0-9]+)(?:\.(?P<section>[0-9]+))?", citation_text)
 
         if us_code_match:
-            title, section = reclassify_statutory_citation.reclassify_archived_mur_statutory_citation(
+            title, section = reclassify_statutory_citation.reclassify_statutory_citation(
                 us_code_match.group('title'), us_code_match.group('section'))
             citation_text = '%s U.S.C. %s%s' % (title, section, us_code_match.group('paragraphs'))
             url = 'http://api.fdsys.gov/link?' +\

--- a/webservices/legal_docs/reclassify_statutory_citation.py
+++ b/webservices/legal_docs/reclassify_statutory_citation.py
@@ -47,23 +47,24 @@ CITATIONS_MAP = {
 # The new section numbers are 5 digit numbers starting with 30. e.g., 30106
 RECLASSIFIED_STATUTE_SECTION_REGEX = re.compile(r'30\d{3,}')
 
-def reclassify_archived_mur_statutory_citation(title, section):
+def reclassify_statutory_citation(title, section):
     """
-    Archived MURs indicate the titles explicitly. They also cite titles other than 2,
-    but not 52. If we can successfully reclassify title 2, we assume that they
+    Archived MURs and Advisory Opinions indicate the titles explicitly.
+    They also cite titles other than 2, but not 52.
+    If we can successfully reclassify title 2, we assume that they
     are title 52, otherwise we retain the original title.
     """
     MAPPED_TITLE = "52"
     if title == "2":
         mapped_section = CITATIONS_MAP.get(section)
         if mapped_section:
-            logger.debug('Mapping archived MUR statute citation %s -> %s',
+            logger.debug('Mapping 2 U.S.C statute citation %s -> %s',
                         (title, section), (MAPPED_TITLE, mapped_section))
             return MAPPED_TITLE, mapped_section
         logger.debug('Unmapped 2 U.S.C citation: %s', (title, section))
     return title, section
 
-def reclassify_current_mur_statutory_citation(section):
+def reclassify_statutory_citation_without_title(section):
     """
     Current MURs do not indicate the titles explicitly; they have to be deduced
     from the section. Sometimes the sections have already been reclassified.

--- a/webservices/legal_docs/reclassify_statutory_citation.py
+++ b/webservices/legal_docs/reclassify_statutory_citation.py
@@ -60,6 +60,7 @@ def reclassify_archived_mur_statutory_citation(title, section):
             logger.debug('Mapping archived MUR statute citation %s -> %s',
                         (title, section), (MAPPED_TITLE, mapped_section))
             return MAPPED_TITLE, mapped_section
+        logger.debug('Unmapped 2 U.S.C citation: %s', (title, section))
     return title, section
 
 def reclassify_current_mur_statutory_citation(section):


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/fecgov/openFEC/issues/2803

_Fix bug where REGEX isn't accounting for characters (IE "2 USC 441b" is being parsed as "2 USC 441") which is causing lookup mistakes. 1980-01 is an example. Add tests for handling these characters properly_

### Before
~2 U.S.C. §437f == 52 U.S.C. §30105~
~2 U.S.C. §441b == 2 U.S.C. §441~

### After
2 U.S.C. §437f == 52 U.S.C. §30108
2 U.S.C. §441b == 52 U.S.C. §30118
2 U.S.C. §441a-1 == 52 U.S.C. §30117

## How to test the changes locally

- Get Elasticsearch up and running
- get the latest S3 credentials from `dev`
- run `./manage.py initialize_current_legal_docs` which recreates the docs index and loads current AO's. Quit the process when it gets to MURs - not needed.
- Check http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_no=1980-01&ao_category=F and the statutory citations should be 52 30108 and 52 30118 (vs. [dev](https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&ao_no=1980-01&ao_category=F) which still shows 2 441)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/data/legal/advisory-opinions/
