### PR TITLE
Change typeahead search on home page to sort by total activity

### DIFF
--- a/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
+++ b/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
@@ -1,0 +1,131 @@
+/*
+From issue #3057 - Update sort order for search results
+
+-Add disbursement totals and IE totals to committees: ofec_committee_fulltext_mv
+-Add disbursement totals to candidates: ofec_candidate_fulltext_mv
+
+- Add indexes and permissions
+
+- Rename _tmp views and indexes
+*/
+
+SET search_path = public, pg_catalog;
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_committee_fulltext_mv_tmp;
+
+CREATE MATERIALIZED VIEW ofec_committee_fulltext_mv_tmp AS
+ WITH pacronyms AS (
+         SELECT ofec_pacronyms."ID NUMBER" AS committee_id,
+            string_agg(ofec_pacronyms."PACRONYM", ' '::text) AS pacronyms
+           FROM ofec_pacronyms
+          GROUP BY ofec_pacronyms."ID NUMBER"
+        ), totals AS (
+         SELECT ofec_totals_combined_mv.committee_id,
+            sum(ofec_totals_combined_mv.receipts) AS receipts,
+            sum(ofec_totals_combined_mv.disbursements) AS disbursements,
+            sum(ofec_totals_combined_mv.independent_expenditures) AS independent_expenditures
+           FROM ofec_totals_combined_mv
+          GROUP BY ofec_totals_combined_mv.committee_id
+        )
+ SELECT DISTINCT ON (committee_id) row_number() OVER () AS idx,
+    committee_id AS id,
+    cd.name,
+        CASE
+            WHEN (cd.name IS NOT NULL) THEN ((setweight(to_tsvector((cd.name)::text), 'A'::"char") || setweight(to_tsvector(COALESCE(pac.pacronyms, ''::text)), 'A'::"char")) || setweight(to_tsvector((committee_id)::text), 'B'::"char"))
+            ELSE NULL::tsvector
+        END AS fulltxt,
+    COALESCE(totals.receipts, (0)::numeric) AS receipts,
+    COALESCE(totals.disbursements, (0)::numeric) AS disbursements,
+    COALESCE(totals.independent_expenditures, (0)::numeric) AS independent_expenditures,
+    COALESCE(totals.receipts+totals.disbursements+totals.independent_expenditures, (0)::numeric) AS total_activity
+   FROM ((ofec_committee_detail_mv cd
+     LEFT JOIN pacronyms pac USING (committee_id))
+     LEFT JOIN totals USING (committee_id));
+
+--Permissions-------------------
+
+ALTER TABLE ofec_committee_fulltext_mv_tmp OWNER TO fec;
+GRANT SELECT ON TABLE ofec_committee_fulltext_mv_tmp TO fec_read;
+GRANT ALL ON TABLE ofec_committee_fulltext_mv_tmp TO fec;
+
+--Indexes including unique idx--
+
+CREATE UNIQUE INDEX ofec_committee_fulltext_mv_idx_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (idx);
+
+CREATE INDEX ofec_committee_fulltext_mv_fulltxt_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING gin (fulltxt);
+
+CREATE INDEX ofec_committee_fulltext_mv_receipts_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (receipts);
+
+CREATE INDEX ofec_committee_fulltext_mv_disbursements_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (disbursements);
+
+CREATE INDEX ofec_committee_fulltext_mv_independent_expenditures_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (independent_expenditures);
+
+----Rename view & indexes-------
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_committee_fulltext_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS ofec_committee_fulltext_mv_tmp RENAME TO ofec_committee_fulltext_mv;
+
+SELECT rename_indexes('ofec_committee_fulltext_mv');
+
+/*------------------------------
+
+Candidates - add disbursements only
+
+-------------------------------*/
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_fulltext_mv_tmp;
+
+CREATE MATERIALIZED VIEW ofec_candidate_fulltext_mv_tmp AS
+ WITH nicknames AS (
+         SELECT ofec_nicknames.candidate_id,
+            string_agg(ofec_nicknames.nickname, ' '::text) AS nicknames
+           FROM ofec_nicknames
+          GROUP BY ofec_nicknames.candidate_id
+        ), totals AS (
+         SELECT link.cand_id AS candidate_id,
+            sum(totals_1.receipts) AS receipts,
+            sum(totals_1.disbursements) AS disbursements
+           FROM (disclosure.cand_cmte_linkage link
+             JOIN ofec_totals_combined_mv totals_1 ON ((((link.cmte_id)::text = (totals_1.committee_id)::text) AND (link.fec_election_yr = (totals_1.cycle)::numeric))))
+          WHERE (((link.cmte_dsgn)::text = ANY ((ARRAY['P'::character varying, 'A'::character varying])::text[])) AND ((substr((link.cand_id)::text, 1, 1) = (link.cmte_tp)::text) OR ((link.cmte_tp)::text <> ALL ((ARRAY['P'::character varying, 'S'::character varying, 'H'::character varying])::text[]))))
+          GROUP BY link.cand_id
+        )
+ SELECT DISTINCT ON (candidate_id) row_number() OVER () AS idx,
+    candidate_id AS id,
+    ofec_candidate_detail_mv.name,
+    ofec_candidate_detail_mv.office AS office_sought,
+        CASE
+            WHEN (ofec_candidate_detail_mv.name IS NOT NULL) THEN ((setweight(to_tsvector((ofec_candidate_detail_mv.name)::text), 'A'::"char") || setweight(to_tsvector(COALESCE(nicknames.nicknames, ''::text)), 'A'::"char")) || setweight(to_tsvector((candidate_id)::text), 'B'::"char"))
+            ELSE NULL::tsvector
+        END AS fulltxt,
+    COALESCE(totals.receipts, (0)::numeric) AS receipts,
+    COALESCE(totals.disbursements, (0)::numeric) AS disbursements,
+    COALESCE(totals.receipts+totals.disbursements, (0)::numeric) AS total_activity
+   FROM ((ofec_candidate_detail_mv
+     LEFT JOIN nicknames USING (candidate_id))
+     LEFT JOIN totals USING (candidate_id));
+
+--Permissions-------------------
+
+ALTER TABLE ofec_candidate_fulltext_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE ofec_candidate_fulltext_mv_tmp TO fec;
+GRANT SELECT ON TABLE ofec_candidate_fulltext_mv_tmp TO fec_read;
+
+--Indexes uncluding unique idx---
+
+CREATE UNIQUE INDEX ofec_candidate_fulltext_mv_idx_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (idx);
+
+CREATE INDEX ofec_candidate_fulltext_mv_fulltxt_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING gin (fulltxt);
+
+CREATE INDEX ofec_candidate_fulltext_mv_receipts_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (receipts);
+
+CREATE INDEX ofec_candidate_fulltext_mv_disbursements_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (disbursements);
+
+----Rename view & indexes-------
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_fulltext_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS ofec_candidate_fulltext_mv_tmp RENAME TO ofec_candidate_fulltext_mv;
+
+SELECT rename_indexes('ofec_candidate_fulltext_mv');

--- a/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
+++ b/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
@@ -60,6 +60,8 @@ CREATE INDEX ofec_committee_fulltext_mv_disbursements_idx1_tmp ON ofec_committee
 
 CREATE INDEX ofec_committee_fulltext_mv_independent_expenditures_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (independent_expenditures);
 
+CREATE INDEX ofec_committee_fulltext_mv_total_activity_idx1_tmp ON ofec_committee_fulltext_mv_tmp USING btree (total_activity);
+
 ----Rename view & indexes-------
 
 DROP MATERIALIZED VIEW IF EXISTS ofec_committee_fulltext_mv;
@@ -121,6 +123,8 @@ CREATE INDEX ofec_candidate_fulltext_mv_fulltxt_idx1_tmp ON ofec_candidate_fullt
 CREATE INDEX ofec_candidate_fulltext_mv_receipts_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (receipts);
 
 CREATE INDEX ofec_candidate_fulltext_mv_disbursements_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (disbursements);
+
+CREATE INDEX ofec_candidate_fulltext_mv_total_activity_idx1_tmp ON ofec_candidate_fulltext_mv_tmp USING btree (total_activity);
 
 ----Rename view & indexes-------
 

--- a/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
+++ b/data/migrations/V0073__update_ofec_committee_fulltext_and_candidate_fulltext_mvs.sql
@@ -37,7 +37,7 @@ CREATE MATERIALIZED VIEW ofec_committee_fulltext_mv_tmp AS
     COALESCE(totals.receipts, (0)::numeric) AS receipts,
     COALESCE(totals.disbursements, (0)::numeric) AS disbursements,
     COALESCE(totals.independent_expenditures, (0)::numeric) AS independent_expenditures,
-    COALESCE(totals.receipts+totals.disbursements+totals.independent_expenditures, (0)::numeric) AS total_activity
+    COALESCE(totals.receipts, (0)::numeric) + COALESCE(totals.disbursements, (0)::numeric) + COALESCE(totals.independent_expenditures, (0)::numeric) AS total_activity
    FROM ((ofec_committee_detail_mv cd
      LEFT JOIN pacronyms pac USING (committee_id))
      LEFT JOIN totals USING (committee_id));
@@ -103,7 +103,7 @@ CREATE MATERIALIZED VIEW ofec_candidate_fulltext_mv_tmp AS
         END AS fulltxt,
     COALESCE(totals.receipts, (0)::numeric) AS receipts,
     COALESCE(totals.disbursements, (0)::numeric) AS disbursements,
-    COALESCE(totals.receipts+totals.disbursements, (0)::numeric) AS total_activity
+    COALESCE(totals.receipts, (0)::numeric) + COALESCE(totals.disbursements, (0)::numeric) AS total_activity
    FROM ((ofec_candidate_detail_mv
      LEFT JOIN nicknames USING (candidate_id))
      LEFT JOIN totals USING (candidate_id));

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,7 +89,7 @@ class OverallTest(ApiBaseTest):
                 name='Bartlet {0}'.format(idx),
                 fulltxt=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
                 office_sought='P',
-                receipts=idx,
+                total_activity=idx,
             )
             for idx in range(30)
         ]
@@ -117,7 +117,7 @@ class OverallTest(ApiBaseTest):
             factories.CommitteeSearchFactory(
                 name='Bartlet {0}'.format(idx),
                 fulltxt=sa.func.to_tsvector('Bartlet for America {0}'.format(idx)),
-                receipts=idx,
+                total_activity=idx,
             )
             for idx in range(30)
         ]

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -15,6 +15,8 @@ class CandidateSearch(BaseModel):
     office_sought = db.Column(db.String, doc=docs.OFFICE)
     fulltxt = db.Column(TSVECTOR)
     receipts = db.Column(db.Numeric(30, 2))
+    disbursements = db.Column(db.Numeric(30, 2))
+    total_activity = db.Column(db.Numeric(30, 2))
 
 
 class CandidateFlags(db.Model):

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -12,6 +12,9 @@ class CommitteeSearch(BaseModel):
     name = db.Column(db.String, doc=docs.COMMITTEE_NAME)
     fulltxt = db.Column(TSVECTOR)
     receipts = db.Column(db.Numeric(30, 2))
+    disbursements = db.Column(db.Numeric(30, 2))
+    independent_expenditures = db.Column(db.Numeric(30, 2))
+    total_activity = db.Column(db.Numeric(30, 2))
 
 
 class BaseCommittee(BaseModel):

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -26,7 +26,7 @@ class CandidateNameSearch(utils.Resource):
     def get(self, **kwargs):
         query = filters.filter_fulltext(models.CandidateSearch.query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
-            sa.desc(models.CandidateSearch.receipts)
+            sa.desc(models.CandidateSearch.total_activity)
         ).limit(20)
         return {'results': query.all()}
 
@@ -46,6 +46,6 @@ class CommitteeNameSearch(utils.Resource):
     def get(self, **kwargs):
         query = filters.filter_fulltext(models.CommitteeSearch.query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
-            sa.desc(models.CommitteeSearch.receipts)
+            sa.desc(models.CommitteeSearch.total_activity)
         ).limit(20)
         return {'results': query.all()}


### PR DESCRIPTION
## Summary (required)

- Addresses #3057 

_Change the sort order for typeahead results. Previously, these results were being sorted by receipts, but that was making it very hard to find C7, C9 etc committees that tend to show more IE's. Update the `/names/committee` and `names/candidate` sort order to sort on receipts+disburs+IE's for committees and receipts+diburs for candidates. I used `EXPLAIN` and `EXPLAIN ANALYZE` to make sure there was no performance hit - oddly, these changes seemed to improve performance slightly._

## How to test the changes locally

- test the migration: `flyway migrate`
- Check out this branch and point to temporary MV's on `dev`:
- Change the `CandidateSearch` model to point to `'ofec_candidate_fulltext_mv_tmp'`
- Change the `CommitteeSearch` model to point to `'ofec_committee_fulltext_mv_tmp'`
- Run `develop` branch of CMS locally, point to local `FEC_API_URL` -
 `export FEC_API_URL=http://127.0.0.1:5000/`
- search in the upper-right hand corner of the home page for "America Inc"

## Impacted areas of the application
List general components of the application that this PR will affect:

Typeahead search on home page (results sorting)

- Update `ofec_committee_fulltext_mv` to output receipts + disburs + IE's total
- Update `ofec_candidate_fulltext_mv` to output receipts + disburs total
- Update resource file to change sort order
- Update tests

- [X] Test performance with new MV's - confirmed with @vrajmohan that putting the totals in the MV was best so we can add an index on that field.

### Before - harder to see C9 committees
<img width="293" alt="screen shot 2018-04-11 at 8 46 41 pm" src="https://user-images.githubusercontent.com/31420082/38650505-361c06ec-3dca-11e8-9316-fd68469e861d.png">

### After - a little easier to see C9 committees
<img width="298" alt="screen shot 2018-04-11 at 8 46 29 pm" src="https://user-images.githubusercontent.com/31420082/38650511-42547200-3dca-11e8-813e-ee3ea5770336.png">

Sorry, @PaulClark2 - it looks like there are so many "America" committees that "America Inc" still isn't a top result, even with IE's factored in.

