### PR TITLE
Efile raw data query performance improvement

### DIFF
--- a/data/migrations/V0075__add_efile_raw_tabale_indexes.sql
+++ b/data/migrations/V0075__add_efile_raw_tabale_indexes.sql
@@ -1,0 +1,26 @@
+-- add these index to aid the efile raw data filters
+-- Since we change the API use real_efile.sa7 table instead of real_efile_sa7 view
+-- dropping the unused view public.real_efile_sa7 view
+
+CREATE INDEX real_efile_sa7_state_idx
+  ON real_efile.sa7
+  USING btree
+  (state);
+
+CREATE INDEX real_efile_sa7_comid_state_idx
+  ON real_efile.sa7
+  USING btree
+  (comid,state);
+  
+CREATE INDEX ofec_committee_history_mv_tmp_state_idx1
+  ON public.ofec_committee_history_mv
+  USING btree
+  (state);
+  
+CREATE INDEX ofec_committee_history_mv_tmp_comid_state_idx1
+  ON public.ofec_committee_history_mv
+  USING btree
+  (committee_id,state);  
+
+drop view if exists public.real_efile_sa7;
+

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -167,11 +167,12 @@ class ScheduleA(BaseItemized):
 
 
 class ScheduleAEfile(BaseRawItemized):
-    __tablename__ = 'real_efile_sa7'
+    __table_args__ = {'schema': 'real_efile'}
+    __tablename__ = 'sa7'
 
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
-    committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
+    committee_id = db.Column("comid", db.String, index=True, doc=docs.COMMITTEE_ID)
     contributor_prefix = db.Column('prefix', db.String)
     contributor_name_text = db.Column(TSVECTOR)
     contributor_first_name = db.Column('fname', db.String)
@@ -182,7 +183,7 @@ class ScheduleAEfile(BaseRawItemized):
     # contributor_street_1 = db.Column('contbr_st1', db.String)
     # contributor_street_2 = db.Column('contbr_st2', db.String)
     contributor_city = db.Column('city', db.String, doc=docs.CONTRIBUTOR_CITY)
-    contributor_state = db.Column('state', db.String, doc=docs.CONTRIBUTOR_STATE)
+    contributor_state = db.Column('state', db.String, index=True, doc=docs.CONTRIBUTOR_STATE)
     contributor_zip = db.Column('zip', db.String, doc=docs.CONTRIBUTOR_ZIP)
     contributor_employer = db.Column('indemp', db.String, doc=docs.CONTRIBUTOR_EMPLOYER)
     contributor_employer_text = db.Column(TSVECTOR)


### PR DESCRIPTION
## Summary (required)
When query advance data -> Receipts filters do not return results, time out, or displays the entire table data.

- Addresses # [_Issue number_]
https://github.com/fecgov/fec-cms/pull/1920

_Include a summary of proposed changes._
Modified public.efiling_amendment_chain_vw sql to increase query performance
Use of real_efile.sa7 table instead of public.real_efile_sa7 view
Create following index
CREATE INDEX real_efile_sa7_state_idx on real_efile.sa7
CREATE INDEX real_efile_sa7_comid_state_idx ON real_efile.sa7
CREATE INDEX ofec_committee_history_mv_tmp_state_idx1 ON public.ofec_committee_history_mv
CREATE INDEX ofec_committee_history_mv_tmp_comid_state_idx1 ON 

## How to test the changes locally
http://localhost:8000/data/receipts/
-

## Impacted areas of the application
List general components of the application that this PR will affect:
API
http://localhost:5000/v1/schedules/schedule_a/efile/?page=1&sort=-contribution_receipt_date&per_page=20

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
