### PR TITLE
[Migration 76] Refactor /candidates/totals to show candidates with $0 activity

### DIFF
--- a/data/migrations/V0076__add_ofec_candidate_totals_with_0s_mv.sql
+++ b/data/migrations/V0076__add_ofec_candidate_totals_with_0s_mv.sql
@@ -1,0 +1,67 @@
+/*
+Issue #3023
+
+-Based on `ofec_candidate_all_totals_mv`
+-Bring over the existing logic but use `ofec_candidate_history_mv`
+as base table in order to show $0 for candidates who haven't filed yet
+
+*/
+
+SET search_path = public, pg_catalog;
+
+CREATE MATERIALIZED VIEW ofec_candidate_totals_with_0s_mv AS
+  SELECT cand.candidate_id,
+    cand.candidate_election_year AS election_year,
+    cand.two_year_period AS cycle,
+    COALESCE (totals.is_election, false) AS is_election,
+    COALESCE (totals.receipts, 0) AS receipts,
+    COALESCE (totals.disbursements, 0) AS disbursements,
+    COALESCE (totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE (totals.cash_on_hand_end_period, 0) AS cash_on_hand_end_period,
+    COALESCE (totals.debts_owed_by_committee, 0) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE (totals.federal_funds_flag, false) AS federal_funds_flag
+  FROM ofec_candidate_history_mv cand
+  LEFT JOIN ofec_candidate_totals_mv totals
+  ON cand.candidate_id = totals.candidate_id
+    AND cand.candidate_election_year = totals.election_year
+    AND cand.two_year_period = totals.cycle;
+
+--Permissions-------------------
+
+ALTER TABLE ofec_candidate_totals_with_0s_mv OWNER TO fec;
+GRANT SELECT ON TABLE ofec_candidate_totals_with_0s_mv TO fec_read;
+GRANT ALL ON TABLE ofec_candidate_totals_with_0s_mv TO fec;
+
+--Indexes including unique idx--
+
+CREATE UNIQUE INDEX ofec_candidate_totals_with_0s_mv_candidate_id_cycle_is_election_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (candidate_id, cycle, is_election);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_candidate_id_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (candidate_id);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_cycle_candidate_id_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (cycle, candidate_id);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_cycle_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (cycle);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_disbursements_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (disbursements);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_election_year_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (election_year);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_federal_funds_flag_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (federal_funds_flag);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_has_raised_funds_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (has_raised_funds);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_is_election_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (is_election);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_receipts_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (receipts);

--- a/manage.py
+++ b/manage.py
@@ -303,7 +303,7 @@ def refresh_materialized(concurrent=True):
         'totals_ie': ['ofec_totals_ie_only_mv'],
         'totals_house_senate': ['ofec_totals_house_senate_mv'],
         'totals_presidential': ['ofec_totals_presidential_mv'],
-        'candidate_aggregates': ['ofec_candidate_totals_mv'],
+        'candidate_aggregates': ['ofec_candidate_totals_mv', 'ofec_candidate_totals_with_0s_mv'],
         'candidate_flags': ['ofec_candidate_flag_mv'],
         'sched_c': ['ofec_sched_c_mv'],
         'sched_a_by_state_recipient_totals': ['ofec_sched_a_aggregate_state_recipient_totals_mv'],

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -210,7 +210,7 @@ class TestCandidateAggregates(ApiBaseTest):
             receipts=75,
         )
         factories.CandidateFlagsFactory(
-            candidate_id = self.candidate.candidate_id
+            candidate_id=self.candidate.candidate_id
         )
         db.session.flush()
         # Create two-year totals for both the target period (2011-2012) and the
@@ -235,6 +235,22 @@ class TestCandidateAggregates(ApiBaseTest):
             committee_designation='A',
             committee_type='S',
             fec_election_year=2010,
+        )
+        # Create a candidate_zero without a committee and $0 in CandidateTotal
+        self.candidate_zero = factories.CandidateHistoryFactory(
+            candidate_id='H321',
+            two_year_period=2018,
+            candidate_election_year=2018,
+        )
+        factories.CandidateDetailFactory(
+            candidate_id=self.candidate_zero.candidate_id,
+            election_years=[2018],
+        )
+        factories.CandidateTotalFactory(
+            candidate_id=self.candidate_zero.candidate_id,
+            cycle=2018,
+            is_election=False,
+            receipts=0,
         )
 
     def test_by_size(self):
@@ -312,6 +328,17 @@ class TestCandidateAggregates(ApiBaseTest):
         )
         assert len(results) == 1
         assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 75})
+
+        # candidate_zero
+        results = self._results(
+            api.url_for(
+                TotalsCandidateView,
+                candidate_id=self.candidate_zero.candidate_id,
+                cycle=2018,
+            )
+        )
+        assert len(results) == 1
+        assert_dicts_subset(results[0], {'cycle': 2018, 'receipts': 0})
 
     def test_totals_full(self):
         results = self._results(

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -130,7 +130,7 @@ class CandidateHistoryLatest(BaseCandidate):
 
 
 class CandidateTotal(db.Model):
-    __tablename__ = 'ofec_candidate_totals_mv'
+    __tablename__ = 'ofec_candidate_totals_with_0s_mv'
     candidate_id = db.Column(db.String, index=True, primary_key=True)
     election_year = db.Column(db.Integer, index=True, primary_key=True)
     cycle = db.Column(db.Integer, index=True, primary_key=True)
@@ -141,6 +141,8 @@ class CandidateTotal(db.Model):
     debts_owed_by_committee = db.Column(db.Numeric(30, 2))
     coverage_start_date = db.Column(db.Date, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column(db.Date, doc=docs.COVERAGE_END_DATE)
+    federal_funds_flag = db.Column(db.Boolean, index=True, doc=docs.FEDERAL_FUNDS_FLAG)
+    has_raised_funds = db.Column(db.Boolean, index=True, doc=docs.HAS_RAISED_FUNDS)
 
 
 class CandidateElection(db.Model):


### PR DESCRIPTION
## Summary (required)

- Addresses #3023

_Refactor /candidates/totals to show candidates with $0 activity and simplify endpoint query logic_
    
- Use new MV/Model: change model `CandidateTotal(db.Model)` to use `ofec_candidate_totals_with_0s_mv`
- Move some filters into `filter_match` utility
- Simplify the SQLAlchemy join
- Add test  for candidates without filings and $0 activity

## How to test the changes locally

- Test the migration - `flyway migrate`
- Set `SQLA_CONN=postgresql://:@/cfdm_test` and test refreshing the MV's. You'll need to manually change this because we don't have data for all MV's - `refresh_materialized(concurrent=False)` - `./manage.py refresh_materialized`
- Set `SQLA_CONN` to the `dev` database and use the temporary view on `dev` - change model `CandidateTotal(db.Model)` to use `ofec_candidate_totals_with_0s_mv_tmp`
- Look at http://localhost:5000/v1/candidates/totals/?api_key=DEMO_KEY&per_page=20&page=1&candidate_id=H8ME02193 - this should now return results even though the candidate has no financial activity
- Compare https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&per_page=20&page=1&q=pelosi to http://localhost:5000/v1/candidates/totals/?api_key=DEMO_KEY&per_page=20&page=1&q=pelosi - they should have the same results

## Impacted areas of the application
List general components of the application that this PR will affect:

CMS
- https://www.fec.gov/data/candidates/house/
- https://www.fec.gov/data/candidates/senate/
- https://www.fec.gov/data/candidates/presidential/
API
- https://api.open.fec.gov/v1/candidates/totals
