### PR TITLE
[WIP] Add /legal/ to Swagger API docs

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1228,7 +1228,7 @@ EFILE_REPORTS += WIP_TAG
 MIN_FILTER = 'Filter for all amounts greater than a value.'
 MAX_FILTER = 'Filter for all amounts less than a value.'
 
-ENTITY_RECEIPTS_TOTLAS = '''
+ENTITY_RECEIPTS_TOTALS = '''
 Provides cumulative receipt totals by entity type, over a two year cycle. Totals are adjusted to avoid double counting.
 
 This is [the sql](https://github.com/fecgov/openFEC/blob/develop/data/migrations/V41__large_aggregates.sql) that creates these calculations.

--- a/webservices/resources/large_aggregates.py
+++ b/webservices/resources/large_aggregates.py
@@ -10,7 +10,7 @@ from webservices.common.views import ApiResource
 
 @doc(
     tags=['financial'],
-    description=docs.ENTITY_RECEIPTS_TOTLAS,
+    description=docs.ENTITY_RECEIPTS_TOTALS,
 )
 class EntityReceiptDisbursementTotalsView(ApiResource):
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -1,19 +1,7 @@
 """
-A RESTful web service supporting fulltext and field-specific searches on FEC data. For
-full documentation visit: https://api.open.fec.gov/developers.
+A RESTful web service supporting fulltext and field-specific searches on FEC data.
+For full documentation visit: https://api.open.fec.gov/developers.
 """
-from webservices.env import env
-
-def initialize_newrelic():
-    license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
-    if license_key:
-        import newrelic.agent
-        settings = newrelic.agent.global_settings()
-        settings.license_key = license_key
-        newrelic.agent.initialize()
-
-initialize_newrelic()
-
 import http
 import json
 import logging
@@ -75,10 +63,22 @@ from webservices.tasks.response_exception import ResponseException
 from webservices.tasks.json_response import JsonResponse
 from webservices.tasks.error_code import ErrorCode
 from webservices.tasks import cache_request
+from webservices.env import env
 
+
+def initialize_newrelic():
+    license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
+    if license_key:
+        import newrelic.agent
+        settings = newrelic.agent.global_settings()
+        settings.license_key = license_key
+        newrelic.agent.initialize()
+
+initialize_newrelic()
 
 app = Flask(__name__)
 logger = logging.getLogger('rest.py')
+
 
 def sqla_conn_string():
     sqla_conn_string = env.get_credential('SQLA_CONN')
@@ -116,6 +116,7 @@ if not app.debug:
 
 db.init_app(app)
 cors.CORS(app)
+
 
 class FlaskRestParser(FlaskParser):
 
@@ -340,6 +341,7 @@ api.add_resource(audit.AuditCaseView, '/audit-case/')
 api.add_resource(audit.AuditCandidateNameSearch, '/names/audit_candidates/')
 api.add_resource(audit.AuditCommitteeNameSearch, '/names/audit_committees/')
 
+
 def add_aggregate_resource(api, view, schedule, label):
     api.add_resource(
         view,
@@ -476,6 +478,9 @@ apidoc.register(audit.AuditCategoryView, blueprint='v1')
 apidoc.register(audit.AuditCaseView, blueprint='v1')
 apidoc.register(audit.AuditCandidateNameSearch, blueprint='v1')
 apidoc.register(audit.AuditCommitteeNameSearch, blueprint='v1')
+apidoc.register(legal.UniversalSearch, blueprint='v1')
+apidoc.register(legal.GetLegalCitation, blueprint='v1')
+apidoc.register(legal.GetLegalDocument, blueprint='v1')
 
 # Adapted from https://github.com/noirbizarre/flask-restplus
 here, _ = os.path.split(__file__)

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -89,6 +89,10 @@ spec = APISpec(
         {
             'name': 'audit',
             'description': docs.AUDIT,
+        },
+        {
+            'name': 'legal',
+            'description': docs.LEGAL_SEARCH,
         }
     ]
 )


### PR DESCRIPTION
## Summary (required)

_Add /legal/ to Swagger API docs._

## How to test the changes locally

-Get Elasticsearch running locally
- Go to http://127.0.0.1:5000/developers and the /legal/ section and try out a query

## Impacted areas of the application
api.open.fec.gov/developers

