### PR TITLE
Add Snyk vulnerability tracker badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Master**
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/openFEC/master.svg)](https://codecov.io/github/fecgov/openFEC)
 [![Code Climate](https://img.shields.io/codeclimate/github/fecgov/openFEC.svg)](https://codeclimate.com/github/fecgov/openFEC)
-[![Dependencies](https://img.shields.io/gemnasium/fecgov/openFEC.svg)](https://gemnasium.com/fecgov/openFEC)
+[![Dependencies](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC/badge.svg)
 
 
 ## About this project

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 **Master**
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/openFEC/master.svg)](https://codecov.io/github/fecgov/openFEC)
 [![Code Climate](https://img.shields.io/codeclimate/github/fecgov/openFEC.svg)](https://codeclimate.com/github/fecgov/openFEC)
-[![Dependencies](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC/badge.svg)
+[![Dependencies](https://img.shields.io/gemnasium/fecgov/openFEC.svg)](https://gemnasium.com/fecgov/openFEC)
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC)
 
 
 ## About this project


### PR DESCRIPTION
Add vulnerability tracker badge to show Snyk: https://snyk.io/docs/badges
We'll remove Gemnasium once we're no longer using both