### PR TITLE
Remove Gemnasium badge - now using Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 **Master**
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/openFEC/master.svg)](https://codecov.io/github/fecgov/openFEC)
 [![Code Climate](https://img.shields.io/codeclimate/github/fecgov/openFEC.svg)](https://codeclimate.com/github/fecgov/openFEC)
-[![Dependencies](https://img.shields.io/gemnasium/fecgov/openFEC.svg)](https://gemnasium.com/fecgov/openFEC)
 [![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC)
 
 


### PR DESCRIPTION
Remove Gemnasium badge on README.md - now using Snyk to track vulnerabilities