### PR TITLE
Add redis to manifest task files

### DIFF
--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -18,5 +18,6 @@ applications:
   - fec-s3-dev
   - fec-api-search56
   - fec-creds-dev
+  - fec-redis
   stack: cflinuxfs2
   health-check-type: process

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -19,4 +19,5 @@ applications:
   - fec-s3-prod
   - fec-api-search56
   - fec-creds-prod
+  - fec-redis
   stack: cflinuxfs2

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -18,5 +18,6 @@ applications:
   - fec-s3-stage
   - fec-api-search56
   - fec-creds-stage
+  - fec-redis
   stack: cflinuxfs2
   health-check-type: process


### PR DESCRIPTION
Addresses an issue found in testing - add redis to manifest task files

Test with a headless app: https://cloud.gov/docs/getting-started/one-off-tasks/#deploy-an-app-that-performs-a-task
