### PR TITLE
Revert ES56 Services 

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -11,7 +11,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -10,7 +10,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -10,7 +10,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search56
+  - fec-api-search
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -16,7 +16,7 @@ applications:
   no-route: true
   services:
   - fec-s3-dev
-  - fec-api-search56
+  - fec-api-search
   - fec-creds-dev
   - fec-redis
   stack: cflinuxfs2

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -17,7 +17,7 @@ applications:
   no-route: true
   services:
   - fec-s3-prod
-  - fec-api-search56
+  - fec-api-search
   - fec-creds-prod
   - fec-redis
   stack: cflinuxfs2

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -16,7 +16,7 @@ applications:
   no-route: true
   services:
   - fec-s3-stage
-  - fec-api-search56
+  - fec-api-search
   - fec-creds-stage
   - fec-redis
   stack: cflinuxfs2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ gevent==1.2.2
 webargs==0.18.0
 ujson==1.33
 requests==2.18.4
-elasticsearch==5.5.1
-elasticsearch-dsl==5.4.0
+elasticsearch==2.4.0
+elasticsearch-dsl==2.1.0
 bandit==1.4.0
 git+https://github.com/18F/slate.git
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -395,7 +395,7 @@ def get_election_duration(column):
     )
 
 def get_elasticsearch_connection():
-    es_conn = env.get_service(name='fec-api-search56')
+    es_conn = env.get_service(name='fec-api-search')
     if es_conn:
         url = es_conn.get_url(url='uri')
     else:


### PR DESCRIPTION
Elastic Search Service was upgraded from 24 to 56 in this PR https://github.com/fecgov/openFEC/pull/3084

While testing this new ES56 service on **dev**, we encountered Gateway and ReadTime outs.
We are still following up with cloud.gov team to resolve the timeout issues.

Until then we are rolling back the ES56 services and will be using the existing ES24 service on cloud.

