### PR TITLE
Upgrade Elasticsearch to v. 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
-    * Elastic Search 2.4 (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/_installation.html))
+    * Elastic Search 5.6 (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/_installation.html))
     * Flyway 5.0.x ([download](https://flywaydb.org/getstarted/download))
 
 2. Set up your Node environment—  learn how to do this with our [Javascript Ecosystem Guide](https://github.com/18F/dev-environment-standardization/blob/18f-pages/pages/languages/javascript.md).
@@ -192,7 +192,7 @@ export SQLA_FOLLOWERS=<psql:address-to-replica-box-1>[,<psql:address-to-replica-
 Follow these steps every time you want to work on this project locally.
 
 1. If you are using the legal search portion of the site, you will need Elastic Search running.
-Navigate to the installation folder (eg., `elasticsearch-1.7.5`) and run:
+Navigate to the installation folder (eg., `elasticsearch-5.6.8`) and run:
 
 ```
 cd bin

--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -11,7 +11,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -10,7 +10,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -10,7 +10,7 @@ env:
   NEW_RELIC_LOG: stdout
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-dev
   - fec-s3-dev

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -13,7 +13,7 @@ env:
   PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-prod
   - fec-s3-prod

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -12,7 +12,7 @@ env:
   NEW_RELIC_ENV: stage
   WEB_CONCURRENCY: 4
 services:
-  - fec-api-search
+  - fec-api-search56
   - fec-redis
   - fec-creds-stage
   - fec-s3-stage

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -16,7 +16,7 @@ applications:
   no-route: true
   services:
   - fec-s3-dev
-  - fec-api-search
+  - fec-api-search56
   - fec-creds-dev
   - fec-redis
   stack: cflinuxfs2

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -17,7 +17,7 @@ applications:
   no-route: true
   services:
   - fec-s3-prod
-  - fec-api-search
+  - fec-api-search56
   - fec-creds-prod
   - fec-redis
   stack: cflinuxfs2

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -16,7 +16,7 @@ applications:
   no-route: true
   services:
   - fec-s3-stage
-  - fec-api-search
+  - fec-api-search56
   - fec-creds-stage
   - fec-redis
   stack: cflinuxfs2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ gevent==1.2.2
 webargs==0.18.0
 ujson==1.33
 requests==2.18.4
-elasticsearch==2.4.0
-elasticsearch-dsl==2.1.0
+elasticsearch==5.5.1
+elasticsearch-dsl==5.4.0
 bandit==1.4.0
 git+https://github.com/18F/slate.git
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -113,10 +113,10 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
             else:
                 comparator = self.max_column_map.get(self.sort_column[5])
 
-            
+
             if 'coalesce' not in str(left_index):
                 left_index = sa.func.coalesce(left_index, comparator)
-        
+
 
             lhs += (left_index,)
             rhs += (sort_index,)
@@ -395,7 +395,7 @@ def get_election_duration(column):
     )
 
 def get_elasticsearch_connection():
-    es_conn = env.get_service(name='fec-api-search')
+    es_conn = env.get_service(name='fec-api-search56')
     if es_conn:
         url = es_conn.get_url(url='uri')
     else:


### PR DESCRIPTION
## Summary (required)

- Addresses #2921 

_Upgrade Elasticsearch to v. 5.6. (Adding [asynchronous reindexing](https://github.com/fecgov/openFEC/issues/3118#issuecomment-389915229) later due to some wonkiness with the implementation.)_

## How to test the changes locally

- Install Elasticsearch 5.6 locally
- Update your requirements: `pip install -r requirements.txt`
- Try loading and reloading docs with the management commands


## Impacted areas of the application
List general components of the application that this PR will affect:

-  legal resources (AOs/MURs)

## Related PRs
List related PRs against other branches:

- Original upgrade: #3084 

- PR to back that out due to some cloud.gov issues: #3106 

