### PR TITLE
Clean up unused slack notification task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -199,25 +199,6 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
             space=space
         ), echo=True)
 
-
-@task
-def notify(ctx):
-    try:
-        meta = json.load(open('.cfmeta'))
-    except OSError:
-        meta = {}
-    slack = Slacker(env.get_credential('FEC_SLACK_TOKEN'))
-    slack.chat.post_message(
-        env.get_credential('FEC_SLACK_CHANNEL', '#fec'),
-        'deploying branch {branch} of app {name} to space {space} by {user}'.format(
-            name=env.name,
-            space=env.space,
-            user=meta.get('user'),
-            branch=meta.get('branch'),
-        ),
-        username=env.get_credential('FEC_SLACK_BOT', 'fec-bot'),
-    )
-
 @task
 def create_sample_db(ctx):
     """

--- a/tasks.py
+++ b/tasks.py
@@ -1,11 +1,9 @@
 import json
 import os
 import subprocess
-
 import git
-from invoke import task
-# from slacker import Slacker
 
+from invoke import task
 from webservices.env import env
 from jdbc_utils import to_jdbc_url
 


### PR DESCRIPTION
We aren't using the `notify` task in `tasks.py`. Rather - we’re using `utils.post_to_slack`. 

- Remove the task `notify`
- Remove the commented import of `Slacker` at the top
- Clean up `import` statements