### PR TITLE
Fixed audit committee and candidate name sub-string search.

### DIFF
--- a/data/migrations/V0080__audit_committee_fulltext.sql
+++ b/data/migrations/V0080__audit_committee_fulltext.sql
@@ -1,0 +1,37 @@
+DROP MATERIALIZED VIEW ofec_committee_fulltext_audit_mv;
+CREATE MATERIALIZED VIEW ofec_committee_fulltext_audit_mv AS
+WITH
+cmte_info AS (
+    SELECT DISTINCT dc.cmte_id,
+        dc.cmte_nm,
+        dc.fec_election_yr,
+        dc.cmte_dsgn,
+        dc.cmte_tp,
+        b.FILED_CMTE_TP_DESC::text AS cmte_desc
+    FROM auditsearch.audit_case aa, disclosure.cmte_valid_fec_yr dc, staging.ref_filed_cmte_tp b
+    WHERE btrim(aa.cmte_id) = dc.cmte_id 
+      AND aa.election_cycle = dc.fec_election_yr
+      AND dc.cmte_tp IN ('H', 'S', 'P', 'X', 'Y', 'Z', 'N', 'Q', 'I', 'O', 'U', 'V', 'W')
+      AND dc.cmte_tp = b.filed_cmte_tp_cd
+)
+SELECT DISTINCT ON (cmte_id, cmte_nm)
+    row_number() over () AS idx,
+    cmte_id AS id,
+    cmte_nm AS name,
+CASE
+    WHEN cmte_nm IS NOT NULL THEN
+        setweight(to_tsvector(cmte_nm), 'A') ||
+        setweight(to_tsvector(cmte_id), 'B')
+    ELSE NULL::tsvector
+END AS fulltxt
+FROM cmte_info 
+ORDER BY cmte_id
+WITH DATA;
+
+ALTER TABLE ofec_committee_fulltext_audit_mv OWNER TO fec;
+
+CREATE UNIQUE INDEX ON ofec_committee_fulltext_audit_mv(idx);
+CREATE INDEX ON ofec_committee_fulltext_audit_mv using gin(fulltxt);
+
+GRANT ALL ON TABLE public.ofec_committee_fulltext_audit_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_committee_fulltext_audit_mv TO fec_read;

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -747,16 +747,16 @@ auditCategory = {
 
 # endpoint audit-case
 auditCase = {
+    'q': fields.List(fields.Str, description=docs.COMMITTEE_NAME),
+    'qq': fields.List(fields.Str, description=docs.CANDIDATE_NAME),
     'primary_category_id': fields.List(fields.Str(), missing='all', description=docs.PRIMARY_CATEGORY_ID),
     'sub_category_id': fields.List(fields.Str(), missing='all', description=docs.SUB_CATEGORY_ID),
     'audit_case_id': fields.List(fields.Str(), description=docs.AUDIT_CASE_ID),
     'cycle': fields.List(fields.Int(), description=docs.CYCLE),
     'committee_id': fields.List(fields.Str(), description=docs.COMMITTEE_ID),
-    'committee_name': fields.List(fields.Str(), description=docs.COMMITTEE_NAME),
     'committee_type': fields.List(fields.Str(), description=docs.COMMITTEE_TYPE),
     'audit_id': fields.List(fields.Int(), description=docs.AUDIT_ID),
     'candidate_id': fields.List(fields.Str(), description=docs.CANDIDATE_ID),
-    'candidate_name': fields.List(fields.Str(), description=docs.CANDIDATE_NAME),
     'min_election_cycle': fields.Int(description=docs.CYCLE),
     'max_election_cycle': fields.Int(description=docs.CYCLE),
 }

--- a/webservices/resources/audit.py
+++ b/webservices/resources/audit.py
@@ -102,6 +102,8 @@ class AuditCaseView(ApiResource):
         ('far_release_date', model.far_release_date),
         ('link_to_report', model.link_to_report),
         ('audit_id', model.audit_id),
+        ('committee_id', model.committee_id),
+        ('candidate_id', model.candidate_id),
     ]
 
     filter_range_fields = [
@@ -109,10 +111,8 @@ class AuditCaseView(ApiResource):
     ]
 
     filter_fulltext_fields = [
-        ('committee_name', model.committee_name),
-        ('committee_id', model.committee_id),
-        ('candidate_name', model.candidate_name),
-        ('candidate_id', model.candidate_id),
+        ('q', models.AuditCommitteeSearch.fulltxt),
+        ('qq', models.AuditCandidateSearch.fulltxt),
     ]
 
     @property
@@ -124,6 +124,22 @@ class AuditCaseView(ApiResource):
                 default=['-cycle', 'committee_name', ]
             ),
         )
+
+    def build_query(self, **kwargs):
+        query = super().build_query(**kwargs)
+        if kwargs.get('q'):
+            query = query.join(
+                models.AuditCommitteeSearch,
+                models.AuditCase.committee_id == models.AuditCommitteeSearch.id,
+            ).distinct()
+
+        if kwargs.get('qq'):
+            query = query.join(
+                models.AuditCandidateSearch,
+                models.AuditCase.candidate_id == models.AuditCandidateSearch.id,
+            ).distinct()
+
+        return query
 
     @property
     def index_column(self):


### PR DESCRIPTION
## Summary (required)
Partial name and keyword committee/candidate searches in audit search should return comprehensive results

- Addresses # [_fec-cms#1965 and #1966_]
[https://github.com/fecgov/fec-cms/issues/1965](https://github.com/fecgov/fec-cms/issues/1965)
[https://github.com/fecgov/fec-cms/issues/1966](https://github.com/fecgov/fec-cms/issues/1966)

_Include a summary of proposed changes._
This needs both openFEC and fec-cms repos changes
add 'q'--committee name/id search
'qq'--candidate name/id search
`    filter_fulltext_fields = [
        ('q', models.AuditCommitteeSearch.fulltxt),
        ('qq', models.AuditCandidateSearch.fulltxt),
    ]
`

## How to test the changes locally
test api locally
1)setup branch feature/fix_cand_cmte_name on local
2)test filters on auditcase endpoint:
a)candidate_id= P20002671 (should return 1 record)
b)committee_id= C00495622(should return 1 record)
c)q = john (return 19 records)
d)qq=ted(return 3 records)
e)q=john and qq= JOHNSON (return 4 records)


## Impacted areas of the application
Auditsearch

## Related PRs
[https://github.com/fecgov/fec-cms/pull/1963](https://github.com/fecgov/fec-cms/pull/1963)


