### PR TITLE
Feature/add swagger test cache calls

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,11 +4,8 @@ import unittest
 import sqlalchemy as sa
 import factory
 import manage
-
-from webservices.env import env
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm.session import make_transient
-from faker import Faker
 from factory.alchemy import SQLAlchemyModelFactory
 from apispec import utils, exceptions
 from tests import common, factories
@@ -75,7 +72,7 @@ class TestSwagger(unittest.TestCase):
     def test_swagger_without_cache(self):
         # Test if Swagger API documentation loads
         # when cache all requests is disabled
-        os.environ['CACHE_ALL_REQUESTS'] = 'False'
+        os.environ['CACHE_ALL_REQUESTS'] is False
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:
@@ -84,7 +81,7 @@ class TestSwagger(unittest.TestCase):
     def test_swagger_with_cache(self):
         # Test if Swagger API documentation loads
         # when cache all request is enabled
-        os.environ['CACHE_ALL_REQUESTS'] = 'True'
+        os.environ['CACHE_ALL_REQUESTS'] is True
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,19 +69,16 @@ TOTALS_MODELS = [
 
 class TestSwagger(unittest.TestCase):
 
-    def test_swagger_without_cache(self):
-        # Test if Swagger API documentation loads
-        # when cache all requests is disabled
-        os.environ['CACHE_ALL_REQUESTS'] is False
+    def test_swagger(self):
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:
             self.fail(str(error))
 
     def test_swagger_with_cache(self):
-        # Test if Swagger API documentation loads
-        # when cache all request is enabled
-        os.environ['CACHE_ALL_REQUESTS'] is True
+        # Test if Swagger API documentation loads OK
+        # when cache all requests is enabled
+        os.environ['CACHE_ALL_REQUESTS'] = 'True'
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,23 +1,21 @@
+import os
 import datetime
 import unittest
-
 import sqlalchemy as sa
+import factory
+import manage
+
+from webservices.env import env
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm.session import make_transient
-
 from faker import Faker
-import factory
 from factory.alchemy import SQLAlchemyModelFactory
-
 from apispec import utils, exceptions
-
-import manage
 from tests import common, factories
 from webservices.rest import db
 from webservices.spec import spec
 from webservices.common import models
 from webservices.common.models import ScheduleA
-
 
 def make_factory():
     # NOTE: Due to the changes made in the production database and the switch
@@ -74,12 +72,23 @@ TOTALS_MODELS = [
 
 class TestSwagger(unittest.TestCase):
 
-    def test_swagger_valid(self):
+    def test_swagger_without_cache(self):
+        # Test if Swagger API documentation loads
+        # when cache all requests is disabled
+        os.environ['CACHE_ALL_REQUESTS'] = False
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:
             self.fail(str(error))
 
+    def test_swagger_with_cache(self):
+        # Test if Swagger API documentation loads
+        # when cache all request is enabled
+        os.environ['CACHE_ALL_REQUESTS'] = True
+        try:
+            utils.validate_swagger(spec)
+        except exceptions.SwaggerError as error:
+            self.fail(str(error))
 
 class TestViews(common.IntegrationTestCase):
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,7 +75,7 @@ class TestSwagger(unittest.TestCase):
     def test_swagger_without_cache(self):
         # Test if Swagger API documentation loads
         # when cache all requests is disabled
-        os.environ['CACHE_ALL_REQUESTS'] = False
+        os.environ['CACHE_ALL_REQUESTS'] = 'False'
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:
@@ -84,7 +84,7 @@ class TestSwagger(unittest.TestCase):
     def test_swagger_with_cache(self):
         # Test if Swagger API documentation loads
         # when cache all request is enabled
-        os.environ['CACHE_ALL_REQUESTS'] = True
+        os.environ['CACHE_ALL_REQUESTS'] = 'True'
         try:
             utils.validate_swagger(spec)
         except exceptions.SwaggerError as error:


### PR DESCRIPTION
## Summary (required)
Added two swagger tests to verify that the openfec api swagger documentation loads fine when cache_all_requests environment variable is set to either True Or false
- Addresses # [_Issue number_]
https://github.com/fecgov/openFEC/issues/3014

_Include a summary of proposed changes._

## How to test the changes locally

- 1. set the cache_all_requests env variable to true.
- 2. run the server
- 3. launch the api (http://localhost:5000))
- 4. set the cache_all_requests env varibale to false.
- 4. repeat steps (ii) and (iii) 

## Impacted areas of the application
OpenFEC Swagger API Documentation
http://localhost:5000/ should load the api documentation without any errors.