### PR TITLE
Feature/required api parameter

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -104,6 +104,7 @@ class TestAggregates(ApiBaseTest):
                     resource,
                     committee_id=self.committee.committee_id,
                     cycle=2012,
+                    office='president',
                 )
             )
             assert len(results) == 1
@@ -128,6 +129,7 @@ class TestAggregates(ApiBaseTest):
                     candidate_id=self.candidate.candidate_id,
                     committee_id=self.committee.committee_id,
                     cycle=2012,
+                    office='president',
                     election_full='true',
                 )
             )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -617,8 +617,9 @@ elections_list = {
 elections = {
     'state': IStr(description=docs.STATE),
     'district': District(description=docs.DISTRICT),
-    'cycle': fields.Int(description=docs.CANDIDATE_CYCLE),
+    'cycle': fields.Int(required=True, description=docs.CANDIDATE_CYCLE),
     'office': fields.Str(
+        required=True,
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
     ),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -554,6 +554,10 @@ schedule_c = {
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'office': fields.Str(
+        validate=validate.OneOf(['house', 'senate', 'president']),
+        description=docs.OFFICE,
+    ),
     'support_oppose': IStr(
         missing=None,
         validate=validate.OneOf(['S', 'O']),
@@ -602,6 +606,10 @@ electioneering = {
 electioneering_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'office': fields.Str(
+        validate=validate.OneOf(['house', 'senate', 'president']),
+        description=docs.OFFICE,
+    ),
 }
 
 elections_list = {
@@ -668,6 +676,10 @@ totals_committee_aggregate = {
 communication_cost_by_candidate = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'office': fields.Str(
+        validate=validate.OneOf(['house', 'senate', 'president']),
+        description=docs.OFFICE,
+    ),
     'support_oppose': IStr(
         missing=None,
         validate=validate.OneOf(['S', 'O']),


### PR DESCRIPTION
## Summary (required)

- Addresses #2963  and #2962
Required API parameters are not marked as required in rest.py #2963
Investigate why 422 (missing parameters) errors are coming through as 500 (Internal Server) errors #2962

_Make swagger UI input parameters required filed when they are required in underlying API._

## How to test the changes locally
- Install and run openFEC locally
- Run this end point: http://localhost:5000/developers/#!/financial/get_elections (with and without required fileds)
- Run this end point: http://localhost:5000/developers/#!/independent_expenditures/get_committee_committee_id_schedules_schedule_e_by_candidate (with and without required required fields)

## Impacted areas of the application
Filter changes effect the following endpoints:
/financial/elections/
/schedules/schedule_e/by_candidate/
/committee/{committee_id}/communication_costs/by_candidate/
/committee/{committee_id}/electioneering/by_candidate/
/communication_costs/by_candidate/
/electioneering/by_candidate/


## Related PRs
None

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
