### PR TITLE
Upgrade Celery to fix kombu issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,6 @@ boto3==1.4.4
 smart_open==1.5.6
 
 # Task queue
-celery==4.1.0
+celery==4.1.1
 celery-once==1.2.0
 redis==2.10.6


### PR DESCRIPTION
According to
https://stackoverflow.com/questions/50444988/celery-attributeerror-async-error,
Celery does not pin its requirements for kombu and billiard to specific
versions. kombu 4.2.0 was released with a breaking change and previous
versions of celery automatically install it.

