### PR TITLE
Connect to Redis using URI parameter

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -1,14 +1,10 @@
-from datetime import timedelta
-
 import celery
 from celery import signals
 from celery.schedules import crontab
-import logging
 
 from webservices.env import env
 from webservices.tasks import utils
 
-logger = logging.getLogger(__name__)
 
 # Feature and dev are sharing the same RDS box so we only want dev to update
 schedule = {}
@@ -31,42 +27,18 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
 
 def redis_url():
     """
-    Retrieves the URL needed to connect to a Redis instance.
+    Retrieve the URL needed to connect to a Redis instance, depending on environment.
+
+    When running in a cloud.gov environment, retrieve the uri credential for the 'redis32' service.
     """
 
-    # Attempt to retrieve the space name the application is running in; this
-    # will return the space if the app is running in a cloud.gov environment or
-    # None if it is running locally.
+    # Is the app running in a cloud.gov environment
     if env.space is not None:
-        logger.info(
-            'Running in the {0} space in cloud.gov.'.format(env.space)
-        )
+        redis_env = env.get_service(label='redis32')
+        redis_url = redis_env.credentials.get('uri')
 
-        # While we are not able to connect to Redis, retry as many times as
-        # necessary.  This is usually due to a brief 1 - 3 second downtime as
-        # a service instance is rebooted in the cloud.gov environment.
-        # TODO:  Make this more robust in the case of extended outages.
-        while True:
-            logger.info('Attempting to connect to Redis...')
-            redis = env.get_service(label='redis32')
+        return redis_url
 
-            if redis is not None:
-                logger.info('Successfully connected to Redis.')
-                break
-            else:
-                logger.error('Could not connect to Redis, retrying...')
-
-        # Construct the Redis instance URL based on the service information
-        # returned.
-        url = redis.get_url(host='hostname', password='password', port='port')
-        return 'redis:{}'.format(url)
-    else:
-        logger.debug(
-            'Not running in a cloud.gov space, attempting to connect locally.'
-        )
-
-    # Fall back to attempting to read whatever is set in the FEC_REDIS_URL
-    # environment variable, otherwise a localhost connection.
     return env.get_credential('FEC_REDIS_URL', 'redis://localhost:6379/0')
 
 app = celery.Celery('openfec')
@@ -79,8 +51,8 @@ app.conf.update(
         'webservices.tasks.cache_request',
     ),
     beat_schedule=schedule,
-    broker_connection_timeout=30, # in seconds 
-    broker_connection_max_retries=0, # for unlimited retries
+    broker_connection_timeout=30,  # in seconds
+    broker_connection_max_retries=0,  # for unlimited retries
     task_acks_late=False
 )
 


### PR DESCRIPTION
### Outstanding items:
- [X] Rename `redis` var
- [x] Remove logging statements: they're not showing up, and after spending lots of time we can't get celery to output the logs
- [x] Remove `while` loop - the app.config retries will take care of checking again.

## Summary (required)

- Addresses #3174 

As a corrective action to the outage on 5/29/18 (post-mortem [here](https://docs.google.com/document/d/1GLFkkWetHiCOz2LCiAHpQm0SA8AHrZ028wZjbzHTC7g/edit#heading=h.dmpjekprmy7z)) this PR changes how we connect to Redis.

We relied on [cfenv](https://github.com/fecgov/openFEC/blob/develop/webservices/tasks/__init__.py#L61) to grab our username, password, and port. `cfenv` [used FURL](https://github.com/jmcarp/py-cfenv/blob/master/cfenv/__init__.py#L85-L86) to assemble the URL, which had a backwards incompatible change. Instead, we can just use the URI parameter to connect to redis:
`url = redis.credentials.get('uri')`

Here, `redis` is a `Service` object. Here are the available properties and methods for a `Service` object in `cfenv`: https://github.com/jmcarp/py-cfenv/blob/master/cfenv/__init__.py#L75-L92. `credentials` should return a dictionary of the `redis` credentials.

## How to test the changes locally

- Must be tested in cloud.gov with a temporary deploy to the `dev` space. Test downloads and ensure celery-beat is running scheduled tasks.

## Impacted areas of the application
- Celery worker and celery beat - downloads, scheduled tasks  

