### PR TITLE
Fix test_download function test_download_forbidden

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -144,7 +144,7 @@ class TestDownloadResource(ApiBaseTest):
 
     def test_download_forbidden(self):
         with pytest.raises(ApiError):
-            self.client.post_json(api.url_for(resource.DownloadView, path='elections'))
+            self.client.post_json(api.url_for(resource.DownloadView, path='elections', office='house', cycle=2018))
 
     @mock.patch('webservices.resources.download.MAX_RECORDS', 2)
     @mock.patch('webservices.resources.download.get_cached_file')


### PR DESCRIPTION
##Summary:
when run py.test on local based on develop branch, got the function **test_download_forbidden** in test_downloads.py failed

- Resolves
endpoint: **elections** has two required  parameters : cycle and office.
should add these two parameters in url.

## How to test the changes locally
checkout branch:feature/fix_test_download_miss_parameter locally, and run **py.test**, make sure pass all tests

