### PR TITLE
Fix missing reports from API's /reports/ endpoint

### DIFF
--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -226,7 +226,7 @@ class CommitteeReportsHouseSenate(CommitteeReports):
 
 
 class CommitteeReportsPacParty(CommitteeReports):
-    __tablename__ = 'ofec_reports_pacs_parties_mv'
+    __tablename__ = 'ofec_report_pac_party_all_mv'
 
     all_loans_received_period = db.Column(db.Numeric(30, 2))#mapped
     all_loans_received_ytd = db.Column(db.Numeric(30, 2))#mapped

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -288,7 +288,7 @@ class CommitteeReportsPacParty(CommitteeReports):
     transfers_from_nonfed_levin_ytd = db.Column(db.Numeric(30, 2))#mapped
     transfers_to_affiliated_committee_period = db.Column(db.Numeric(30, 2))#mapped
     transfers_to_affilitated_committees_ytd = db.Column(db.Numeric(30, 2))#mapped
-    report_form = 'Form 3X'
+    report_form = db.Column('form_tp', db.String)#mapped
 
 
 class CommitteeReportsPresidential(CommitteeReports):

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -202,10 +202,9 @@ class CommitteeReportsView(utils.Resource):
         if committee_id is not None:
             query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
             
-            if  kwargs.get('cycle'):
+            if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
-            if kwargs.get('year') :
-                cycle_list = []
+            if kwargs.get('year'):
                 cycle_list = [(year + year % 2) for year in kwargs['year']]
                 query = query.filter(models.CommitteeHistory.cycle.in_(cycle_list))
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -201,8 +201,14 @@ class CommitteeReportsView(utils.Resource):
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
             query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
-            if kwargs.get('cycle'):
+            
+            if  kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
+            if kwargs.get('year') :
+                cycle_list = []
+                cycle_list = [(year + year % 2) for year in kwargs['year']]
+                query = query.filter(models.CommitteeHistory.cycle.in_(cycle_list))
+
             query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
             committee = query.first_or_404()
             return committee.committee_type


### PR DESCRIPTION
## Summary (required)

- Resolves [#3103](https://github.com/fecgov/openFEC/issues/3103)


ofec_report_pac_party_all_mv was created to include F3 forms that were filed by pac/party. This was implemented in PR [#3164](https://github.com/fecgov/openFEC/pull/3164)
logic for **year** was added to function that checks for committee_type

## How to test the changes locally

- setup openFEC locally and pull branch: **feature/fix-missing-reports**
- test endpoint:  /reports/{committee_type}/. 

   > committee_id = C00156554;
   > year = 2017;
  > committee_type = pac-party

The endpoint will return 2 : FEC-1206344 (form 3) and  FEC-1175151 ( form 3x) 
<img width="420" alt="screen shot 2018-06-07 at 11 52 36 am" src="https://user-images.githubusercontent.com/24396726/41111202-54cc8ebc-6a49-11e8-8311-a1d8903280a4.png">

 current production api only returns 1:  FEC-1175151 ( form 3x) .  

https://api.open.fec.gov/v1/reports/pac-party/?sort=-coverage_end_date&page=1&per_page=20&year=2017&api_key=DEMO_KEY&committee_id=C00156554


- test endpoint:  /committee/{committee_id}/reports/. 

   > committee_id = C00350785;
   > year = 2015;

The endpoint will returns 11 reports. 
<img width="500" alt="screen shot 2018-06-07 at 11 57 13 am" src="https://user-images.githubusercontent.com/24396726/41111443-fb6e31a8-6a49-11e8-8b63-72987191b9ac.png">

  current production api returns 0
https://api.open.fec.gov/v1/committee/C00350785/reports/?sort=-coverage_end_date&page=1&per_page=20&year=2015&api_key=DEMO_KEY


**More testing data can be found in this ticket:** [#3038](https://github.com/fecgov/openFEC/issues/3038)
  

## Related PRs
part of the work was implemented in this PR: [#3164](https://github.com/fecgov/openFEC/pull/3164) which has been merged already
