### PR TITLE
Fix totals for off-year special candidates on /candidates/totals endpoint

### DIFF
--- a/data/migrations/V0085__fix_ofec_candidate_totals_mv.sql
+++ b/data/migrations/V0085__fix_ofec_candidate_totals_mv.sql
@@ -290,5 +290,7 @@ CREATE INDEX ofec_candidate_totals_with_0s_mv_is_election_idx
 CREATE INDEX ofec_candidate_totals_with_0s_mv_receipts_idx
     ON ofec_candidate_totals_with_0s_mv USING btree (receipts);
 
+--MV no longer needed
 
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_history_latest_mv
 

--- a/data/migrations/V0085__fix_ofec_candidate_totals_mv.sql
+++ b/data/migrations/V0085__fix_ofec_candidate_totals_mv.sql
@@ -1,0 +1,294 @@
+/*
+Addresses #3196 and #3200
+
+#3196: Fix doubled totals for off-year special election candidates
+#3200: Fixes missing off-year special candidates
+
+- Recreate ofec_candidate_totals_mv
+- Recreate two dependent views:
+    -ofec_candidate_flag_mv
+    -ofec_candidate_totals_with_0s_mv;
+
+*/
+
+SET search_path = public;
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_totals_mv_tmp;
+
+CREATE MATERIALIZED VIEW ofec_candidate_totals_mv_tmp AS
+ WITH totals AS (
+         SELECT ofec_totals_house_senate_mv.committee_id,
+            ofec_totals_house_senate_mv.cycle,
+            ofec_totals_house_senate_mv.receipts,
+            ofec_totals_house_senate_mv.disbursements,
+            ofec_totals_house_senate_mv.last_cash_on_hand_end_period,
+            ofec_totals_house_senate_mv.last_debts_owed_by_committee,
+            ofec_totals_house_senate_mv.coverage_start_date,
+            ofec_totals_house_senate_mv.coverage_end_date,
+            false AS federal_funds_flag
+           FROM ofec_totals_house_senate_mv
+        UNION ALL
+         SELECT ofec_totals_presidential_mv.committee_id,
+            ofec_totals_presidential_mv.cycle,
+            ofec_totals_presidential_mv.receipts,
+            ofec_totals_presidential_mv.disbursements,
+            ofec_totals_presidential_mv.last_cash_on_hand_end_period,
+            ofec_totals_presidential_mv.last_debts_owed_by_committee,
+            ofec_totals_presidential_mv.coverage_start_date,
+            ofec_totals_presidential_mv.coverage_end_date,
+            ofec_totals_presidential_mv.federal_funds_flag
+           FROM ofec_totals_presidential_mv
+ ), link AS ( --Off-year special election candidates have > 1 row/cycle
+         SELECT DISTINCT cand_id,
+            cand_election_yr + cand_election_yr % 2 as rounded_election_yr,
+            fec_election_yr,
+            cmte_id,
+            cmte_dsgn
+          FROM ofec_cand_cmte_linkage_mv
+          WHERE cmte_dsgn IN ('P', 'A')
+ ), cycle_totals AS (
+         SELECT DISTINCT ON (link.cand_id, totals.cycle) link.cand_id AS candidate_id,
+            max(link.rounded_election_yr) AS election_year,
+            totals.cycle,
+            false AS is_election,
+            sum(totals.receipts) AS receipts,
+            sum(totals.disbursements) AS disbursements,
+            (sum(totals.receipts) > (0)::numeric) AS has_raised_funds,
+            sum(totals.last_cash_on_hand_end_period) AS cash_on_hand_end_period,
+            sum(totals.last_debts_owed_by_committee) AS debts_owed_by_committee,
+            min(totals.coverage_start_date) AS coverage_start_date,
+            max(totals.coverage_end_date) AS coverage_end_date,
+            (array_agg(totals.federal_funds_flag) @> ARRAY[true]) AS federal_funds_flag
+           FROM link
+             INNER JOIN totals
+                ON link.cmte_id = totals.committee_id
+                AND link.fec_election_yr = totals.cycle
+             LEFT JOIN ofec_candidate_election_mv election
+                ON link.cand_id = election.candidate_id
+                AND totals.cycle <= election.cand_election_year
+                AND totals.cycle > election.prev_election_year
+          GROUP BY link.cand_id, election.cand_election_year, totals.cycle
+ ), election_aggregates AS (
+         SELECT cycle_totals.candidate_id,
+            cycle_totals.election_year,
+            sum(cycle_totals.receipts) AS receipts,
+            sum(cycle_totals.disbursements) AS disbursements,
+            (sum(cycle_totals.receipts) > (0)::numeric) AS has_raised_funds,
+            min(cycle_totals.coverage_start_date) AS coverage_start_date,
+            max(cycle_totals.coverage_end_date) AS coverage_end_date,
+            (array_agg(cycle_totals.federal_funds_flag) @> ARRAY[true]) AS federal_funds_flag
+           FROM cycle_totals
+          GROUP BY cycle_totals.candidate_id, cycle_totals.election_year
+ ), election_latest AS (
+         SELECT DISTINCT ON (totals.candidate_id, totals.election_year) totals.candidate_id,
+            totals.election_year,
+            totals.cash_on_hand_end_period,
+            totals.debts_owed_by_committee,
+            totals.federal_funds_flag
+           FROM cycle_totals totals
+          ORDER BY totals.candidate_id, totals.election_year, totals.cycle DESC
+ ), election_totals AS (
+         SELECT totals.candidate_id,
+            totals.election_year,
+            totals.election_year AS cycle,
+            true AS is_election,
+            totals.receipts,
+            totals.disbursements,
+            totals.has_raised_funds,
+            latest.cash_on_hand_end_period,
+            latest.debts_owed_by_committee,
+            totals.coverage_start_date,
+            totals.coverage_end_date,
+            totals.federal_funds_flag
+           FROM (election_aggregates totals
+             JOIN election_latest latest USING (candidate_id, election_year))
+ )
+ SELECT cycle_totals.candidate_id,
+    cycle_totals.election_year,
+    cycle_totals.cycle,
+    cycle_totals.is_election,
+    cycle_totals.receipts,
+    cycle_totals.disbursements,
+    cycle_totals.has_raised_funds,
+    cycle_totals.cash_on_hand_end_period,
+    cycle_totals.debts_owed_by_committee,
+    cycle_totals.coverage_start_date,
+    cycle_totals.coverage_end_date,
+    cycle_totals.federal_funds_flag
+   FROM cycle_totals
+UNION ALL
+ SELECT election_totals.candidate_id,
+    election_totals.election_year,
+    election_totals.cycle,
+    election_totals.is_election,
+    election_totals.receipts,
+    election_totals.disbursements,
+    election_totals.has_raised_funds,
+    election_totals.cash_on_hand_end_period,
+    election_totals.debts_owed_by_committee,
+    election_totals.coverage_start_date,
+    election_totals.coverage_end_date,
+    election_totals.federal_funds_flag
+   FROM election_totals;
+
+--Permissions
+
+ALTER TABLE ofec_candidate_totals_mv_tmp OWNER TO fec;
+GRANT SELECT ON TABLE ofec_candidate_totals_mv_tmp TO fec_read;
+
+--Indexes--------------
+
+/*
+Filters on this model for TotalsCandidateView:
+
+- filter_multi_fields = election_year, cycle
+- filter_range_fields = receipts, disbursements, cash_on_hand_end_period, debts_owed_by_committee
+- filter_match_fields = has_raised_funds, federal_funds_flag, is_election
+
+*/
+
+CREATE UNIQUE INDEX ofec_candidate_totals_mv_candidate_id_cycle_is_election_idx_tmp ON ofec_candidate_totals_mv_tmp USING btree (candidate_id, cycle, is_election);
+
+CREATE INDEX ofec_candidate_totals_mv_candidate_id_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (candidate_id);
+
+CREATE INDEX ofec_candidate_totals_mv_cycle_candidate_id_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (cycle, candidate_id);
+
+CREATE INDEX ofec_candidate_totals_mv_cycle_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (cycle);
+
+CREATE INDEX ofec_candidate_totals_mv_receipts_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (receipts);
+
+CREATE INDEX ofec_candidate_totals_mv_disbursements_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (disbursements);
+
+CREATE INDEX ofec_candidate_totals_mv_election_year_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (election_year);
+
+CREATE INDEX ofec_candidate_totals_mv_federal_funds_flag_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (federal_funds_flag);
+
+CREATE INDEX ofec_candidate_totals_mv_has_raised_funds_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (has_raised_funds);
+
+CREATE INDEX ofec_candidate_totals_mv_is_election_idx_tmp
+    ON ofec_candidate_totals_mv_tmp USING btree (is_election);
+
+
+/*
+Drop dependent MV's
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_flag_mv;
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_totals_with_0s_mv;
+
+/*
+Drop old ofec_candidate_totals_mv, rename _tmp MV and indexes
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_candidate_totals_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS ofec_candidate_totals_mv_tmp RENAME TO ofec_candidate_totals_mv;
+
+SELECT rename_indexes('ofec_candidate_totals_mv');
+
+/*
+Recreate ofec_candidate_flag_mv
+
+Supersedes migrations V0026, V0034, V0038, V0059.2, V0059, V0069
+*/
+
+CREATE MATERIALIZED VIEW ofec_candidate_flag_mv AS
+ SELECT row_number() OVER () AS idx,
+    ofec_candidate_history_mv.candidate_id,
+    (array_agg(oct.has_raised_funds) @> ARRAY[true]) AS has_raised_funds,
+    (array_agg(oct.federal_funds_flag) @> ARRAY[true]) AS federal_funds_flag
+   FROM ofec_candidate_history_mv
+     LEFT JOIN ofec_candidate_totals_mv oct USING (candidate_id)
+  GROUP BY ofec_candidate_history_mv.candidate_id;
+
+
+ALTER TABLE ofec_candidate_flag_mv OWNER TO fec;
+GRANT SELECT ON TABLE ofec_candidate_flag_mv TO fec_read;
+
+
+CREATE UNIQUE INDEX ofec_candidate_flag_mv_idx_idx
+    ON ofec_candidate_flag_mv USING btree (idx);
+
+CREATE INDEX ofec_candidate_flag_mv_candidate_id_idx
+    ON ofec_candidate_flag_mv USING btree (candidate_id);
+
+CREATE INDEX ofec_candidate_flag_mv_federal_funds_flag_idx
+    ON ofec_candidate_flag_mv USING btree (federal_funds_flag);
+
+CREATE INDEX ofec_candidate_flag_mv_has_raised_funds_idx
+    ON ofec_candidate_flag_mv USING btree (has_raised_funds);
+
+/*
+Recreate ofec_candidate_totals_with_0s_mv
+
+Supersedes migration V0076
+*/
+
+
+CREATE MATERIALIZED VIEW ofec_candidate_totals_with_0s_mv AS
+  SELECT cand.candidate_id,
+    cand.candidate_election_year AS election_year,
+    cand.two_year_period AS cycle,
+    COALESCE (totals.is_election, false) AS is_election,
+    COALESCE (totals.receipts, 0) AS receipts,
+    COALESCE (totals.disbursements, 0) AS disbursements,
+    COALESCE (totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE (totals.cash_on_hand_end_period, 0) AS cash_on_hand_end_period,
+    COALESCE (totals.debts_owed_by_committee, 0) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE (totals.federal_funds_flag, false) AS federal_funds_flag
+  FROM ofec_candidate_history_mv cand
+  LEFT JOIN ofec_candidate_totals_mv totals
+  ON cand.candidate_id = totals.candidate_id
+    AND cand.two_year_period = totals.cycle;
+    --Removed overly restrictive join that was preventing some candidates from appearing
+
+--Permissions-------------------
+
+ALTER TABLE ofec_candidate_totals_with_0s_mv OWNER TO fec;
+GRANT SELECT ON TABLE ofec_candidate_totals_with_0s_mv TO fec_read;
+
+--Indexes including unique idx--
+
+CREATE UNIQUE INDEX ofec_candidate_totals_with_0s_mv_candidate_id_cycle_is_election_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (candidate_id, cycle, is_election);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_candidate_id_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (candidate_id);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_cycle_candidate_id_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (cycle, candidate_id);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_cycle_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (cycle);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_disbursements_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (disbursements);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_election_year_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (election_year);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_federal_funds_flag_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (federal_funds_flag);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_has_raised_funds_idx1
+    ON ofec_candidate_totals_with_0s_mv USING btree (has_raised_funds);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_is_election_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (is_election);
+
+CREATE INDEX ofec_candidate_totals_with_0s_mv_receipts_idx
+    ON ofec_candidate_totals_with_0s_mv USING btree (receipts);
+
+
+

--- a/manage.py
+++ b/manage.py
@@ -290,7 +290,6 @@ def refresh_materialized(concurrent=True):
         'candidate_flags': ['ofec_candidate_flag_mv'],
         'candidate_fulltext': ['ofec_candidate_fulltext_mv'],
         'candidate_history': ['ofec_candidate_history_mv'],
-        'candidate_history_latest': ['ofec_candidate_history_latest_mv'],
         'committee_detail': ['ofec_committee_detail_mv'],
         'committee_fulltext': ['ofec_committee_fulltext_mv'],
         'committee_history': ['ofec_committee_history_mv'],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -58,11 +58,6 @@ class CandidateHistoryFactory(BaseCandidateFactory):
     candidate_inactive = False
 
 
-class CandidateHistoryLatestFactory(CandidateHistoryFactory):
-    class Meta:
-        model = models.CandidateHistoryLatest
-
-
 class CandidateElectionFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateElection

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -360,12 +360,11 @@ class TestCommitteeHistory(ApiBaseTest):
             api.url_for(
                 CommitteeHistoryView,
                 candidate_id=self.candidate.candidate_id,
-                cycle=2012,
-                election_full='true'
             )
         )
         assert len(results) == 2
-        assert results[0]['cycle'] == 2010
-        assert results[0]['committee_id'] == self.committees[0].committee_id
-        assert results[1]['cycle'] == 2012
-        assert results[1]['committee_id'] == self.committees[1].committee_id
+        # Default sort for /committee/[ID]/history is cycle desc
+        assert results[0]['cycle'] == 2012
+        assert results[0]['committee_id'] == self.committees[1].committee_id
+        assert results[1]['cycle'] == 2010
+        assert results[1]['committee_id'] == self.committees[0].committee_id

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -115,20 +115,6 @@ class CandidateHistory(BaseCandidate):
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
 
 
-class CandidateHistoryLatest(BaseCandidate):
-    __tablename__ = 'ofec_candidate_history_latest_mv'
-    #Is there any good reason to have this as a separate model?
-    candidate_id = db.Column(db.String, primary_key=True, index=True)
-    two_year_period = db.Column(db.Integer, primary_key=True, index=True)
-    candidate_election_year = db.Column(db.Integer, doc="The last year of the cycle for this election.")
-    address_city = db.Column(db.String(100))
-    address_state = db.Column(db.String(2))
-    address_street_1 = db.Column(db.String(200))
-    address_street_2 = db.Column(db.String(200))
-    address_zip = db.Column(db.String(10))
-    candidate_inactive = db.Column(db.Boolean)
-
-
 class CandidateTotal(db.Model):
     __tablename__ = 'ofec_candidate_totals_with_0s_mv'
     candidate_id = db.Column(db.String, index=True, primary_key=True)

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -16,7 +16,6 @@ def get_graph():
         'candidate_flags',
         'candidate_fulltext',
         'candidate_history',
-        'candidate_history_latest',
         'committee_detail',
         'committee_fulltext',
         'committee_history',
@@ -53,11 +52,6 @@ def get_graph():
 
     graph.add_edge('candidate_history', 'candidate_detail')
     graph.add_edge('candidate_detail', 'candidate_election')
-
-    graph.add_edges_from([
-        ('candidate_history', 'candidate_history_latest'),
-        ('candidate_election', 'candidate_history_latest')
-    ])
 
     graph.add_edge('committee_history', 'committee_detail')
 

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -162,12 +162,7 @@ class TotalsCandidateView(ApiResource):
     ]
 
     def build_query(self, **kwargs):
-        if kwargs['election_full']:
-            history = models.CandidateHistoryLatest
-            year_column = history.candidate_election_year
-        else:
-            history = models.CandidateHistory
-            year_column = history.two_year_period
+        history = models.CandidateHistory
         query = db.session.query(
             history.__table__,
             models.CandidateTotal.__table__
@@ -175,8 +170,7 @@ class TotalsCandidateView(ApiResource):
             models.CandidateTotal,
             sa.and_(
                 history.candidate_id == models.CandidateTotal.candidate_id,
-                year_column == models.CandidateTotal.cycle,
-                history.candidate_election_year == models.CandidateTotal.cycle,
+                history.two_year_period == models.CandidateTotal.cycle,
             )
         ).join(
             models.Candidate,


### PR DESCRIPTION
## Summary (required)

- Resolves #3196 and Resolves #3200. The /candidates/totals endpoint was doubling totals for odd-year special election candidates, and missing at least one odd-year special election candidate

### 1) #3196: Fixes incorrect totals for /candidates/totals/ for off-year special election candidates

Change to `ofec_candidate_totals_mv`:
Add a `SELECT DISTINCT`:
```
 ), link AS ( --Off-year special election candidates have > 1 row/cycle
         SELECT DISTINCT cand_id,
            cand_election_yr + cand_election_yr % 2 as rounded_election_yr,
            fec_election_yr,
            cmte_id,
            cmte_dsgn
          FROM ofec_cand_cmte_linkage_mv
          WHERE cmte_dsgn IN ('P', 'A')
```
| cand_id   | cand_election_yr   | fec_election_yr   | cmte_id   | cmte_tp   | cmte_dsgn   
|-------|--------------|-----------|--------------------|-------------------|-----------|
| S0AL00156 | 2018               | 2018              | C00640623 | S         | P           | P  |
| S0AL00156 | 2017               | 2018              | C00640623 | S         | P           | P  |

### Performance
Before: 87037 rows, cost=(22821.52..22840.34)
After: 87037 rows, cost=(17454.39..17462.67)

Example: Doug Jones, Raised

| Total raised   | Total Receipts (from candidate page)|
|----------------|--------------------------------------|
| $46,956,378.00 | $23,478,189.00                       |

Incorrect totals in API call:
https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&per_page=20&page=1&candidate_id=S0AL00156&cycle=2018

### 2) #3200 : Fixes missing off-year special candidates

 Change to `ofec_candidate_totals_with_0s_mv`: Remove restrictive join on totals (`ofec_candidate_totals_mv`) that was preventing odd-year special candidates who didn't run again (H8GA06195 is an example) from showing up:
~`AND cand.candidate_election_year = totals.election_year`~

Missing candidate in API call (top raising candidate in 2018)
https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&sort_hide_null=true&q=H8GA06195&cycle=2018&sort=-receipts&per_page=30&page=1&office=H

Data tracking: https://docs.google.com/spreadsheets/d/1NUlhWZ6aHvNNSugPk3BWemDQSZn3pimjbqW_4IC_cnw/edit#gid=1784243483

### Background

- Resource is `TotalsCandidateView` 
- MV is `ofec_candidate_totals_with_0s_mv` which relies on `ofec_candidate_totals_mv`
- `ofec_candidate_totals_mv` has incorrect totals for Doug Jones (S0AL00156)
- The problem is with the join on `ofec_cand_cmte_linkage_mv` - off-year special election candidates will have two entries for 2018 in there.




## Impacted areas:
- https://www.fec.gov/data/candidates/senate/
- https://www.fec.gov/data/candidates/house/
- https://www.fec.gov/data/raising/
- https://www.fec.gov/data/spending
- Top raising candidates here: https://www.fec.gov/data/

## How to test locally
- Testing migration: Drop and recreate your local `cfdm_test` db, then `invoke create_sample_db`
## Testing real data: 
- Connect your `SQLA_CONN` to the `dev` database. 
 (There is an `ofec_candidate_totals_mv_tmp` and `ofec_candidate_totals_with_0s_mv_tmp` based off it for data testing.)
- To use these MV's, change `CandidateTotal(db.Model)` in `webservices/common/models/candidates.py` to point to `ofec_candidate_totals_with_0s_mv_tmp` 
-  Test totals for off-year special election candidates. S0AL00156 and H8GA06195 are a start, but extra eyes on other candidates are helpful. Compare totals to https://www.fec.gov/data/candidate/<ID>/ page. Can use "Impacted areas" to see where these appear on the front end https://docs.google.com/spreadsheets/d/1r9QtqGwWrK5ZZVz3tTBB8TpmDzPBgjzOvCmuHrbQ6tg/edit#gid=0

## Outstanding items
- [x] Figure out how to change this MV when other MV's depend on it <- You need to drop and re-create MV's that depend on it.
- [X] Ask DB team about performance - this is slower than before <- Moved the SELECT DISTINCT for link into a subquery and performance beat the old query - thanks @ChingKuan!
- [X] Once we can rename the MV/Indexes, check to make sure `rename_indexes` works <- I think this might be case sensitive? Will test if I can
- [x] Jon Ossoff, the top raising candidate for 2017-2018, is missing from this endpoint: https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&sort_hide_null=true&q=H8GA06195&cycle=2018&sort=-receipts&per_page=30&page=1&office=H
- [x] Update comments with new changes
- [X] Create `_tmp` for testing data
- [x] Add tests for odd-year house/senate special candidates