### PR TITLE
add table entity_chart

### DIFF
--- a/data/migrations/V0084__add_table_entity_chart.sql
+++ b/data/migrations/V0084__add_table_entity_chart.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS disclosure.entity_chart
+(
+ idx	numeric	
+ ,month	numeric	NOT NULL
+ ,year	numeric	NOT NULL
+ ,cycle	numeric	NOT NULL
+ ,end_date	numeric	
+ ,total_candidate_receipts	numeric	
+ ,total_candidate_disbursements	numeric	
+ ,total_pac_receipts	numeric	
+ ,total_pac_disbursements	numeric	
+ ,total_party_receipts	numeric	
+ ,total_party_disbursements	numeric	
+ ,pg_date	timestamp without time zone DEFAULT now()
+,CONSTRAINT entity_chart_pkey PRIMARY KEY (month,year,cycle)
+)
+WITH (OIDS=FALSE);
+ALTER TABLE disclosure.entity_chart OWNER TO fec;
+GRANT ALL ON TABLE disclosure.entity_chart TO fec;
+GRANT SELECT ON TABLE disclosure.entity_chart TO fec_read;


### PR DESCRIPTION
## Summary (required)

- Resolves # 3204

Add new table disclosure.Entity_Chart to cloud databases

## How to test the changes locally

After migration is done, a new table disclosure.entity_chart should be created in disclosure schema.

## Impacted areas of the application
List general components of the application that this PR will affect:

Currently no API is pointing to this new table 



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
