### PR TITLE
Upgrade boto3 to 1.7.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ marshmallow-sqlalchemy==0.8.0
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Data export
-boto3==1.4.4
+boto3==1.7.21
 smart_open==1.5.6
 
 # Task queue


### PR DESCRIPTION
## Summary (required)

Fixes #3087.

The minimum version required to fix the issue is 1.5.31. Upgrading to
1.7.21, which is the latest release at this time.

## Impacted areas of the application
- Downloads
- Caching of requests in S3