### PR TITLE
Update Flyway to v. 5.1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           command: |
             sudo apt-get update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.0.2/flyway-commandline-5.0.2-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-5.0.2:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.1.3/flyway-commandline-5.1.3-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-5.1.3:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -604,9 +604,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `Flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-5.0.2.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-5.0.2-macosx-x64.tar.gz`, `flyway-commandline-5.0.2-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-5.1.3.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-5.1.3-macosx-x64.tar.gz`, `flyway-commandline-5.1.3-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-5.0.2` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-5.1.3` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '5.0.2'
-    compile(group: 'org.flywaydb', name: 'flyway-commandline', version: '5.0.2') {
+    compile group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '5.1.3'
+    compile(group: 'org.flywaydb', name: 'flyway-commandline', version: '5.1.3') {
         exclude group: 'com.microsoft.sqlserver', module: 'msql-jdbc'
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -1,13 +1,13 @@
 ---
 applications:
-- name: flyway-independent-migration-kill-2018-03-15
+- name: flyway-independent-migration-kill-<date>
   buildpack: java_buildpack
   health-check-type: process
   no-route: true
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-5.0.2.jar:app/gradle/lib/flyway-core-5.0.2.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-5.1.3.jar:app/gradle/lib/flyway-core-5.1.3.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #3222 
_Update Flyway to v. 5.1.3._

## How to test the changes locally

- Test with a temporary deploy ([done](https://circleci.com/gh/fecgov/openFEC/408))
- Test with headless app (see instructions in [README](https://github.com/fecgov/openFEC/blob/develop/data/flyway/README.md)) (done)
- Locally: install new Flyway version (instructions [here](https://docs.google.com/document/d/1pMi59CQOj0dO9WyRS-tCGxHqd9CRTOU_4GaBD4VNbGk/edit)), drop/create `cfdm_test` and run `flyway migrate`

## Impacted areas of the application
List general components of the application that this PR will affect:

- Database Migrations upon merge 
- Database migrations using a headless app
