### PR TITLE
Remove 'won' from /elections/

### DIFF
--- a/data/migrations/V0092__drop_ofec_election_result_mv.sql
+++ b/data/migrations/V0092__drop_ofec_election_result_mv.sql
@@ -1,0 +1,10 @@
+/*
+Resolves #3706
+
+Drop ofec_election_result_mv - removing elections/won until we can determine a better data source
+
+*/
+
+SET search_path = public;
+
+DROP MATERIALIZED VIEW IF EXISTS ofec_election_result_mv

--- a/manage.py
+++ b/manage.py
@@ -275,7 +275,6 @@ def refresh_materialized(concurrent=True):
         'committee_history': ['ofec_committee_history_mv'],
         'communication_cost': ['ofec_communication_cost_mv'],
         'communication_cost_by_candidate': ['ofec_communication_cost_aggregate_candidate_mv'],
-        'election_outcome': ['ofec_election_result_mv'],
         'electioneering': ['ofec_electioneering_mv'],
         'electioneering_by_candidate': ['ofec_electioneering_aggregate_candidate_mv'],
         'elections_list': ['ofec_elections_list_mv'],

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -338,16 +338,6 @@ class ElectionDateFactory(BaseFactory):
         model = models.ElectionDate
 
 
-class ElectionResultFactory(BaseFactory):
-    class Meta:
-        model = models.ElectionResult
-    election_yr = 2016
-    cand_office_st = 'US'
-    cand_office_district = '00'
-    election_type = 'P'
-    fec_election_yr = 2016
-
-
 class ElectionsListFactory(BaseFactory):
     class Meta:
         model = models.ElectionsList

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -188,7 +188,6 @@ class TestElections(ApiBaseTest):
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
             'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in totals),
-            'won': False,
         }
         assert_dicts_subset(results[0], expected)
         assert set(each.committee_id for each in self.committees) == set(results[0]['committee_ids'])
@@ -210,7 +209,6 @@ class TestElections(ApiBaseTest):
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
             'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
-            'won': False,
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
@@ -242,30 +240,11 @@ class TestElections(ApiBaseTest):
             'total_receipts': sum(each.receipts for each in totals_without_jfc),
             'total_disbursements': sum(each.disbursements for each in totals_without_jfc),
             'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_without_jfc),
-            'won': False,
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
         assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees)
 
-    def test_elections_winner(self):
-        [
-            factories.ElectionResultFactory(
-                cand_office='S',
-                election_yr=2012,
-                cand_office_st='NY',
-                cand_id=self.candidate.candidate_id,
-                cand_name=self.candidate.name,
-            )
-        ]
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
-        self.assertEqual(len(results), 1)
-        expected = {
-            'candidate_id': self.candidate.candidate_id,
-            'candidate_name': self.candidate.name,
-            'won': True,
-        }
-        assert_dicts_subset(results[0], expected)
 
     def test_election_summary(self):
         results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,12 +131,6 @@ class TestSort(ApiBaseTest):
             factories.CommitteeTotalsHouseSenateFactory(committee_id='H5678', cycle=2016)
 
         ]
-        electionResults = [
-            factories.ElectionResultFactory(cand_id='C1234', election_yr=2016, cand_office='S', cand_office_st='MO', cand_office_district='01' ),
-            factories.ElectionResultFactory(cand_id='C5678', election_yr=2016, cand_office='S', cand_office_st='MO',
-                                            cand_office_district='02')
-
-        ]
         db.session.flush()
         arg_map = {}
         arg_map['office'] = 'senate'

--- a/webservices/common/models/elections.py
+++ b/webservices/common/models/elections.py
@@ -3,19 +3,6 @@ from .base import db
 from webservices import docs
 
 
-class ElectionResult(db.Model):
-    __tablename__ = 'ofec_election_result_mv'
-
-    election_yr = db.Column(db.Integer, primary_key=True, doc=docs.ELECTION_YEAR)
-    cand_office = db.Column(db.String, primary_key=True, doc=docs.OFFICE)
-    cand_office_st = db.Column(db.String, primary_key=True, doc=docs.STATE_GENERIC)
-    cand_office_district = db.Column(db.String, primary_key=True, doc=docs.DISTRICT)
-    election_type = db.Column(db.String)
-    fec_election_yr = db.Column(db.Integer)
-    cand_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
-    cand_name = db.Column(db.String, doc=docs.CANDIDATE_NAME)
-
-
 class ElectionsList(db.Model):
     __tablename__ = 'ofec_elections_list_mv'
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -930,7 +930,6 @@ class ElectionSchema(ma.Schema):
     total_receipts = ma.fields.Decimal(places=2)
     total_disbursements = ma.fields.Decimal(places=2)
     cash_on_hand_end_period = ma.fields.Decimal(places=2)
-    won = ma.fields.Boolean()
     candidate_election_year = ma.fields.Int()
     coverage_end_date = ma.fields.Date()
 augment_schemas(ElectionSchema)


### PR DESCRIPTION
## Summary

- Resolves #3076 

_Remove 'won' from /elections/ until we find a better data source for won/lost results._

## How to test the changes locally
 
- Run this branch locally and test an elections query and make sure `won` is showing up http://localhost:5000/v1/elections/?api_key=DEMO_KEY&cycle=2018&office=house&state=CO&stateFull=Colorado&district=07&per_page=0&sort_hide_null=true

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://api.open.fec.gov/v1/elections - The `won` field doesn't show up on the front end - this is an API-only change

