### PR TITLE
Add committee_designation filter into audit-case endpoint

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -772,6 +772,7 @@ auditCase = {
     'cycle': fields.List(fields.Int(), description=docs.CYCLE),
     'committee_id': fields.List(fields.Str(), description=docs.COMMITTEE_ID),
     'committee_type': fields.List(fields.Str(), description=docs.COMMITTEE_TYPE),
+    'committee_designation': fields.Str(description=docs.COMMITTEE_DESCRIPTION),
     'audit_id': fields.List(fields.Int(), description=docs.AUDIT_ID),
     'candidate_id': fields.List(fields.Str(), description=docs.CANDIDATE_ID),
     'min_election_cycle': fields.Int(description=docs.CYCLE),


### PR DESCRIPTION
## Summary 
Add committee_designation filter into /audit-case/ endpoint.
to enable JFC search

- Resolves # Issue: [https://github.com/fecgov/fec-cms/issues/2093](https://github.com/fecgov/fec-cms/issues/2093)

## How to test the changes locally

- [x] checkout feature/add_cmte_desigation_filter branch to local
- [x] Set SQLA_CONN = dev
- [x] start server and run **/audit-case/** endpoint (don't need any parameter)
will return 1023 rows
- [x] Input 'P' to committee_designation filter, will return 409 rows


