### PR TITLE
Hide incumbent from /elections/search

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1138,6 +1138,8 @@ ElectionsListSchema = make_schema(
         'exclude': (
             'idx',
             'sort_order',
+            'incumbent_id',
+            'incumbent_name',
         )
     }
 )


### PR DESCRIPTION
## Summary (required)

- Resolves #3247 

_Hide incumbent from /elections/search._

## How to test the changes locally

-http://localhost:5000/v1/elections/search/
Make sure `incumbent_id` and `incumbent_name` aren't there


## Impacted areas of the application
List general components of the application that this PR will affect:

-  This doesn't show up on the front end.



