### PR TITLE
[WIP]refactor elections endpoint to enable candidate financial totals export

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -171,7 +171,7 @@ class TestElections(ApiBaseTest):
         self.assertEquals(response.status_code, 200)
 
     def test_empty_query(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ', per_page=0))
+        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ', per_page=1))
         self.assertEqual(len(results), 0)
 
     def test_elections(self):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -935,6 +935,9 @@ class ElectionSchema(ma.Schema):
     coverage_end_date = ma.fields.Date()
 augment_schemas(ElectionSchema)
 
+ElectionPageSchema = make_page_schema(ElectionSchema)
+register_schema(ElectionPageSchema)
+
 
 class ScheduleABySizeCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()


### PR DESCRIPTION
## Summary (required)
in order to enable “candidate financial totals” data in election summery page, we need refactor election endpoint to extend ApiResource and overwrite 'build_query()' 

- Resolves # [_Issue number_]
[https://github.com/fecgov/fec-cms/issues/2010](https://github.com/fecgov/fec-cms/issues/2010)
enable the export link for “candidate financial totals” section in election summary page:
example link on prod which is disable now: 
[https://www.fec.gov/data/elections/senate/VA/2018/](https://www.fec.gov/data/elections/senate/VA/2018/)

openFEC Issue: Refactor elections (ElectionView) endpoint to extend ApiResource
[https://github.com/fecgov/openFEC/issues/3254](https://github.com/fecgov/openFEC/issues/3254)

## How to test the changes locally
This PR involves changes on both fec-cms and openFEC side.
1) checkout fec-cms feature branch:  feature/enable_export_link_candidate_info
export FEC_WEB_API_KEY_PUBLIC=xxxxxxx
export FEC_WEB_API_KEY=xxxxxxx
export FEC_CMS_ENVIRONMENT=LOCAL
export FEC_API_URL=http://localhost:5000
export DATABASE_URL=postgresql://:@/cfdm_cms_test

2)check out openFEC feature branch: feature/fix_elections_download
setup openFEC local (env api variables)
export SQLA_CONN=xxxxxxx
export access_key_id=
export secret_access_key=
export bucket=
export region=

3)start redis-server

4)Setup Celery Worker and start
export SQLA_CONN=xxxxxxx
export access_key_id=
export secret_access_key=
export bucket=
export region=

5)example url: [http://127.0.0.1:8000/data/elections/senate/VA/2018/](http://127.0.0.1:8000/data/elections/senate/VA/2018/)
Click "Export" on Candidate financial totals section, download the file.
