### PR TITLE
Remove the joint fundraisers inflating money from totals

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -286,6 +286,7 @@ def join_candidate_totals(query, kwargs, totals_model):
         sa.and_(
             CandidateCommitteeLink.committee_id == totals_model.committee_id,
             CandidateCommitteeLink.fec_election_year == totals_model.cycle,
+            CandidateCommitteeLink.committee_designation.in_(['P', 'A']),
         )
     )
 

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -273,8 +273,16 @@ election_durations = {
     'house': 2,
 }
 
-
 def join_candidate_totals(query, kwargs, totals_model):
+    """
+    Joint Fundraising Committees raise money for multiple
+    candidate committees and transfer that money to those committees.
+    By limiting the committee designations to A and P
+    you eliminate J (joint) and thus do not inflate
+    the candidate's money by including it twice and
+    by including money that was raised and transferred
+    to the other committees in the joint fundraiser.
+    """
     return query.outerjoin(
         CandidateCommitteeLink,
         sa.and_(


### PR DESCRIPTION
## Summary 
remove joint fundraiser inflated figures from totals

- Resolves  The first Item of Issue [3221] 
[https://github.com/fecgov/openFEC/issues/3221](https://github.com/fecgov/openFEC/issues/3221)

## How to test the changes locally
1)checkout openFEC feature branch:  feature/joint_fundraisers_inflating_mone
2)run py.test and run server,
3)compare Total receipts, Total disbursements, Cash on hand 
from prod and local. will see difference as screenshot below.
[http://127.0.0.1:8000/data/elections/senate/VA/2018/](http://127.0.0.1:8000/data/elections/senate/VA/2018/)
[https://www.fec.gov/data/elections/senate/VA/2018/](https://www.fec.gov/data/elections/senate/VA/2018/)


on production:
<img width="726" alt="screen shot 2018-06-27 at 12 13 07 am" src="https://user-images.githubusercontent.com/24395751/42109780-d9df654c-7bac-11e8-8955-ec82e2c7c462.png">


on local:
<img width="622" alt="screen shot 2018-06-27 at 12 12 37 am" src="https://user-images.githubusercontent.com/24395751/42109792-e4f951e0-7bac-11e8-9882-16240a189f6c.png">







