### PR TITLE
[WIP]Enable zipcode search for foreign zipcodes, and remove input of 5-digits restricition

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -111,24 +111,27 @@ class TestItemized(ApiBaseTest):
         [
             factories.ScheduleAFactory(contributor_zip=96789),
             factories.ScheduleAFactory(contributor_zip=9678912),
-            factories.ScheduleAFactory(contributor_zip=967891234)
+            factories.ScheduleAFactory(contributor_zip=967891234),
+            factories.ScheduleAFactory(contributor_zip='M4C 1M7')
         ]
-
-        results = self._results(api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs))
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=967893405, **self.kwargs))
         self.assertEqual(len(results), 3)
     
-    def test_invalid_sched_a_zip(self): 
-        response = self.app.get(api.url_for(ScheduleAView,contributor_zip=9678912,cycle=2018))
-        self.assertEqual(response.status_code,400)
+        results = self._results(api.url_for(ScheduleAView, contributor_zip='M4C 1M55', **self.kwargs))
+        self.assertEqual(len(results), 1)
 
-        response = self.app.get(api.url_for(ScheduleAView,contributor_zip='9678-',cycle=2018))
+        contributor_zips = ['M4C 1M5555',96789]
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=contributor_zips,**self.kwargs))
+        self.assertEqual(len(results), 4)
+
+    def test_invalid_sched_a_zip(self): 
+        response = self.app.get(api.url_for(ScheduleAView,contributor_zip='96%',cycle=2018))
         self.assertEqual(response.status_code,400)
 
     def test_filter_multi_start_with(self):
         [
             factories.ScheduleAFactory(contributor_zip=1296789)
         ]
-
         results = self._results(api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs))
         self.assertEqual(len(results), 0)
 

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1,4 +1,3 @@
-
 import datetime
 
 import sqlalchemy as sa
@@ -116,17 +115,17 @@ class TestItemized(ApiBaseTest):
         ]
         results = self._results(api.url_for(ScheduleAView, contributor_zip=967893405, **self.kwargs))
         self.assertEqual(len(results), 3)
-    
+
         results = self._results(api.url_for(ScheduleAView, contributor_zip='M4C 1M55', **self.kwargs))
         self.assertEqual(len(results), 1)
 
-        contributor_zips = ['M4C 1M5555',96789]
-        results = self._results(api.url_for(ScheduleAView, contributor_zip=contributor_zips,**self.kwargs))
+        contributor_zips = ['M4C 1M5555', 96789]
+        results = self._results(api.url_for(ScheduleAView, contributor_zip=contributor_zips, **self.kwargs))
         self.assertEqual(len(results), 4)
 
-    def test_invalid_sched_a_zip(self): 
-        response = self.app.get(api.url_for(ScheduleAView,contributor_zip='96%',cycle=2018))
-        self.assertEqual(response.status_code,400)
+    def test_invalid_sched_a_zip(self):
+        response = self.app.get(api.url_for(ScheduleAView, contributor_zip='96%', cycle=2018))
+        self.assertEqual(response.status_code, 400)
 
     def test_filter_multi_start_with(self):
         [
@@ -145,10 +144,10 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(results[0]['contributor_city'], 'NEW YORK')
 
     def test_filter_fulltext(self):
-        '''
+        """
         Note: this is the only test for filter_fulltext.
         If this is removed, please add a test to test_filters.py
-        '''
+        """
         names = ['David Koch', 'George Soros']
         filings = [
             factories.ScheduleAFactory(contributor_name=name)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -859,7 +859,7 @@ CONTRIBUTOR_CITY = 'City of contributor'
 CONTRIBUTOR_STATE = 'State of contributor'
 CONTRIBUTOR_EMPLOYER = 'Employer of contributor, filers need to make an effort to gather this information'
 CONTRIBUTOR_OCCUPATION = 'Occupation of contributor, filers need to make an effort to gather this information'
-CONTRIBUTOR_ZIP = 'Zip code of contributor. Only 5-digit zip code is allowed'
+CONTRIBUTOR_ZIP = 'Zip code of contributor'
 IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo code is true. \
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -80,20 +80,20 @@ class ScheduleAView(ItemizedResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
-        zip_list=[]
+        zip_list = []
         if kwargs.get('contributor_zip'):
             for value in kwargs['contributor_zip']:
-                if re.search('[^a-zA-Z0-9-\s]+',value):
+                if re.search('[^a-zA-Z0-9-\s]', value):
                     raise exceptions.ApiError(
                         'Invalid zip code. It can not have special character',
                         status_code=400,
                     )
                 else:
                     zip_list.append(value[:5])
-            contributor_zip_list = {'contributor_zip':zip_list}
+            contributor_zip_list = {'contributor_zip': zip_list}
             query = filters.filter_multi_start_with(query, contributor_zip_list, self.filter_multi_start_with_fields)
         if kwargs.get('sub_id'):
-            query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
+            query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
@@ -145,4 +145,3 @@ class ScheduleAEfileView(views.ApiResource):
                 ]),
             ),
         )
-

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -80,16 +80,18 @@ class ScheduleAView(ItemizedResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
-
+        zip_list=[]
         if kwargs.get('contributor_zip'):
             for value in kwargs['contributor_zip']:
-                if re.search('^-?\d{5}$',value) is None:
+                if re.search('[^a-zA-Z0-9-\s]+',value):
                     raise exceptions.ApiError(
-                        'Invalid Zip code. It must be 5 digits',
+                        'Invalid zip code. It can not have special character',
                         status_code=400,
                     )
-            query = filters.filter_multi_start_with(query, kwargs, self.filter_multi_start_with_fields)
-        
+                else:
+                    zip_list.append(value[:5])
+            contributor_zip_list = {'contributor_zip':zip_list}
+            query = filters.filter_multi_start_with(query, contributor_zip_list, self.filter_multi_start_with_fields)
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):


### PR DESCRIPTION
## Summary (required)

- Resolves [#3054](https://github.com/fecgov/openFEC/issues/3054)
1) Enable zipcode search for zipcodes greater than 5 digits.
2) Enable search for foreign zipcode that has letters, space, and -,  and to exclude certain special character.  
3) The results still match on the first 5 characters.
 4) refactor test case accordingly.

## How to test the changes locally
1) run this branch locally, using DEV database
2) test this endpoint locally :  /schedules/schedule_a/
    
    two_year_transaction_period=2016
    contributor_zip: using the value in **zip code** column
    
    

zip code | counts before change | counts after change |  
---- | -- | -- | --
10050 | 26 | 26 |  
100502814 | error code = 400 | 26 |  
10050-2814|error_code = 400 | 26
L2A2W4 | error code = 400 | 3 |  L2A2W4 ( 3 )
L5K 2B3 | error code = 400 | 3 | L5K 2G1;   L5K 2G1;    L5K 2B3

The counts  concur with the results by running query against database directly.





