### PR TITLE
Allow more complex parsing of AO citations

### DIFF
--- a/tests/test_advisory_opinions.py
+++ b/tests/test_advisory_opinions.py
@@ -11,7 +11,9 @@ from webservices.legal_docs.advisory_opinions import (
     get_advisory_opinions,
     parse_ao_citations,
     parse_regulatory_citations,
-    parse_statutory_citations
+    parse_statutory_citations,
+    validate_statute_citation,
+    validate_regulation_citation,
 )
 
 EMPTY_SET = set()
@@ -33,29 +35,92 @@ def test_parse_ao_citations(text, ao_nos, expected):
     ao_component_to_name_map = {tuple(map(int, a.split('-'))): a for a in ao_nos}
     assert parse_ao_citations(text, ao_component_to_name_map) == expected
 
+@pytest.mark.parametrize("title,section,expected", [
+    ("52", "10-Day", False),
+    ("2", "431", True),
+    ("2", "590", False),
+    ("18", "590", True),
+    ("18", "100", True),
+    ("18", "620", False),
+    ("26", "9001", True),
+    ("26", "9050", False),
+    ("26", "501", True),
+    ("26", "525", False),
+    ("52", "30101", True),
+    ("26", "30201", False),
+    ("123", "123456", True),
+])
+def test_validate_statute_citation(title, section, expected):
+    assert validate_statute_citation(title, section) == expected
 
 @pytest.mark.parametrize("text,expected", [
     ("2 U.S.C. 432", set([(52, '30102')])),
     ("52 U.S.C. 30116(a", set([(52, '30116')])),
     ("52 USC § 30116a", set([(52, '30116a')])),
-    ("2 U.S.C. 441b, 441c, 441e", set([(52, '30118')])),
     ("2 U.S.C. 441a-1", set([(52, '30117')])),
     (" 2 U.S.C. §437f", set([(52, '30108')])),
+    ("52 U.S.C. §§ 30101-30146", set([(52, '30101')])),
     ("52 U.S.C. § 30101", set([(52, '30101')])),
     (" 2 USC §437f **test with no . in USC**", set([(52, '30108')])),
     ("52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words", set([(52, '30101')])),
+    ("18 U.S.C. 613 (1970)", set([(18, '613')])),
+    # Test multiples
+    ("52 U.S.C §§ 30106(c), 30107(a)(7) other words.", set([(52, '30106'), (52, '30107')])),
+    ("2 U.S.C. §§431(9) and 439a;", set([(52, '30101'), (52, '30114')])),
+    ("2 U.S.C. 441b, 441c, 441e.", set([(52, '30118'), (52, '30119'), (52, '30121')])),
+    ("52 U.S.C. 30101, 30108 and 10 days.", set([(52, '30101'), (52, '30108')])),
+    ("18 U.S.C. §§610, 611, 613, 614 and 615.", set([(18, '610'), (18, '611'), (18, '613'), (18, '613'), (18, '614'), (18, '615')])),
+    ("2 U.S.C. §§434(b)(2)(A) and (3)(A), and 431(13) *we need the sentence to end*.", set([(52, '30104'), (52, '30101')])),
+    ("2 U.S.C. 439a and 11 CFR Part 113.", set([(52, '30114')])),
+    ("52 U.S.C. §§ 30101(4) (defining political committee), 30104(a), (b) (reporting requirements of political committees).", set([(52, '30101'), (52, '30104')])),
+    ("2 U.S.C. 432(e)(1), 433, and 434(a).", set([(52, '30102'), (52, '30103'), (52, '30104')])),
 ])
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
 
 
+@pytest.mark.parametrize("title,part,expected", [
+    ("11", "123c", False),
+    ("11", "1", True),
+    ("11", "9", False),
+    ("11", "100", True),
+    ("11", "121", False),
+    ("11", "200", True),
+    ("11", "210", False),
+    ("11", "300", True),
+    ("11", "310", False),
+    ("11", "9001", True),
+    ("11", "9100", False),
+    ("12", "544", True),
+    ("11", "400", True),
+    # Check on 11 CFR 140.8-142
+])
+def test_validate_regulation_citation(title, part, expected):
+    assert validate_regulation_citation(title, part) == expected
+
+
 @pytest.mark.parametrize("text,expected", [
     ("11 CFR 113.2", set([(11, 113, 2)])),
     ("11 CFR §9034.4(b)(4)", set([(11, 9034, 4)])),
-    ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),  # TODO: Ranges
-    ("11 CFR 300.60 through 300.65", set([(11, 300, 60)])),
+    # Doubles
+    ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),
     ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
     ("11 C.F.R. § 100.15 **newline needed to ensure two entries**,\n 11 C.F.R. § 100.15", set([(11, 100, 15)])),
+    ("11 CFR 300.60 through 300.65", set([(11, 300, 60), (11, 300, 65)])),
+    ("11 C.F.R. §§ 100.73,100.132; The next", set([(11, 100, 73), (11, 100, 132)])),
+    ("11 C.F.R. §§ 100.5(g)(4)(ii)(F) and 110.3(a)(3)(ii)(F)",
+        set([(11, 100, 5), (11, 110, 3)])),
+    ("11 CFR 300.60 and 300.61.", set([(11, 300, 60), (11, 300, 61)])),
+    # Three or more
+    ("2 U.S.C. 432(e)(1), 433, and 434(a); 11 CFR 101.1, 102.1, and 104.1; Then the 10-day rule applies.", set([(11, 101, 1), (11, 102, 1), (11, 104, 1)])),
+    ("11 CFR 100.7(a)(1), 110.1(b)(3), 110.2(b)(3), and 110.3(g)",
+            set([(11, 100, 7), (11, 110, 1), (11, 110, 2), (11, 110, 3)])),
+    ("11 CFR 101.1, 102.1, 103.1, 104.1 and 105.1; Then the 10-day rule applies.",
+        set([(11, 101, 1), (11, 102, 1), (11, 103, 1), (11, 104, 1), (11, 105, 1)])),
+    # Sets
+    ("11 CFR 100.4(b)(15) and 100.7(b)(17) as 11 CFR 100.6(b)(20) and 100.8(b)(20)", set([(11, 100, 4), (11, 100, 7), (11, 100, 6), (11, 100, 8)])),
+
+
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -228,6 +228,9 @@ def get_citations(ao_names):
     for row in rs:
         logger.debug("Getting citations for AO %s" % row["ao_no"])
 
+        if not row["ocrtext"]:
+            logger.error("Missing OCR text for AO no {0}: unable to get citations".format(row['ao_no']))
+
         ao_citations_in_doc = parse_ao_citations(row["ocrtext"], ao_component_to_name_map)
         ao_citations_in_doc.discard(row["ao_no"])  # Remove self
 

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import logging
 import re
 
-from webservices.env import env
 from webservices.rest import db
 from webservices.utils import get_elasticsearch_connection
 from webservices.tasks.utils import get_bucket
@@ -66,11 +65,37 @@ AO_DOCUMENTS = """
     WHERE doc.ao_id = %s
 """
 
-STATUTE_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*(?P<section>\d+[a-z]?(-1)?).*\.?")
+TO_END_OF_SENTENCE = r"(?P<possible_sections>\d+[a-z]?(-1)?[^.;]*)[.;]"
 
-REGULATION_CITATION_REGEX = re.compile(
-    r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*(?P<part>\d+)\.(?P<section>\d+)")
+# Statute REGEX
+
+STATUTE_TITLE = r"(?P<title>\d+)\s+U\.?S\.?C\.?\s+§*\s*"
+STATUTE_SECTION = r"(?P<section>\d+[a-z]?(-1)?)(?:\S*)"
+
+SINGLE_STATUTE_CITATION_REGEX = re.compile(
+    STATUTE_TITLE + STATUTE_SECTION + r".*\.?")
+
+MULTIPLE_STATUTE_CITATION_REGEX = re.compile(
+    STATUTE_TITLE + TO_END_OF_SENTENCE)
+
+STATUTE_SECTION_ONLY_REGEX = re.compile(STATUTE_SECTION)
+
+# Regulation REGEX
+
+MAX_MULTIPLE_REGULATION_CITATION_LENGTH = r"(?P<possible_parts_and_sections>.{,70})"
+
+REGULATION_TITLE = r"(?P<title>\d+)\s+C\.?F\.?R\.?\s+§*\s*"
+REGULATION_SECTION = r"(?P<part>\d+)\.(?P<section>\d+)+"
+
+SINGLE_REGULATION_CITATION_REGEX = re.compile(
+    REGULATION_TITLE + REGULATION_SECTION)
+
+MULTIPLE_REGULATION_CITATION_REGEX = re.compile(
+    REGULATION_TITLE + MAX_MULTIPLE_REGULATION_CITATION_LENGTH)
+
+REGULATION_SECTION_ONLY_REGEX = re.compile(REGULATION_SECTION)
+
+# AO REGEX
 
 AO_CITATION_REGEX = re.compile(
     r"\b(?P<year>\d{4,4})-(?P<serial_no>\d+)\b")
@@ -241,6 +266,7 @@ def get_citations(ao_names):
 
         statutory_citations = parse_statutory_citations(row["ocrtext"])
         regulatory_citations = parse_regulatory_citations(row["ocrtext"])
+
         all_statutory_citations.update(statutory_citations)
         all_regulatory_citations.update(regulatory_citations)
         raw_citations[row["ao_no"]]["statutes"].update(statutory_citations)
@@ -265,7 +291,7 @@ def get_citations(ao_names):
 
     for citation in all_regulatory_citations:
         entry = {'citation_text': '%d CFR §%d.%d'
-                 % (citation[0], citation[1], citation[2]),'citation_type': 'regulation'}
+                 % (citation[0], citation[1], citation[2]), 'citation_type': 'regulation'}
         es.index('docs_index', 'citations', entry, id=entry['citation_text'])
 
     for citation in all_statutory_citations:
@@ -289,26 +315,118 @@ def parse_ao_citations(text, ao_component_to_name_map):
     return matches
 
 
+def validate_statute_citation(title, section):
+    """
+    Check to see if the statute (USC) citation is in the expected range.
+
+    Convert the first 3 digits to an integer - the smallest number is 3 digits.
+    - Title 2 between 431a and 457b
+    - Title 18 between 590 and 619, and  1001
+    - Title 26 between 9001 and 9042, 501 (IRS)
+    - Title 52 between 30101 and 30146
+
+    If title isn't in this list, fall back to True and add unknown citations
+    """
+    try:
+        section_lookup = int(section[:3])
+    except:
+        return False
+
+    if title == '2':
+        return 431 <= section_lookup <= 457
+    elif title == '18':
+        return (590 <= section_lookup <= 619 or
+               section_lookup == 100)
+    elif title == '26':
+        return (900 <= section_lookup <= 904 or
+               section_lookup in (501, 527))
+    elif title == '52':
+        return section_lookup == 301
+
+    return True
+
+
 def parse_statutory_citations(text):
     matches = set()
     if text:
-        for citation in STATUTE_CITATION_REGEX.finditer(text):
+        for citation in SINGLE_STATUTE_CITATION_REGEX.finditer(text):
             new_title, new_section = reclassify_statutory_citation(
                 citation.group('title'), citation.group('section'))
             matches.add((
                 int(new_title),
                 str(new_section)
             ))
+        for possible_multiple_citation in MULTIPLE_STATUTE_CITATION_REGEX.finditer(text):
+            citations_title = possible_multiple_citation.group('title')
+            possible_sections = possible_multiple_citation.group('possible_sections')
+
+            for section in STATUTE_SECTION_ONLY_REGEX.finditer(possible_sections):
+                new_title, new_section = reclassify_statutory_citation(
+                    citations_title, section.group('section'))
+
+                if validate_statute_citation(new_title, new_section):
+                    matches.add((
+                        int(new_title),
+                        str(new_section)
+                    ))
+                else:
+                    logger.debug("Citation out of range - excluding {} USC {} from multiples.".format(new_title, new_section))
     return matches
+
+
+def validate_regulation_citation(title, part):
+    """
+    Check to see if the regulation (CFR) is in the expected range. Add padding for future regs.
+
+    Source: https://www.gpo.gov/fdsys/pkg/CFR-2018-title11-vol1/pdf/CFR-2018-title11-vol1-chapI.pdf
+
+    11 CFR: 1-8, 100-120, 200-205, 300-305, 400 (historical), 9001-9099
+
+    Other CFR's can appear, so fall back to True
+    12 CFR 544 (1984-55)
+
+    """
+    try:
+        part = int(part)
+    except:
+        return False
+
+    if title == '11':
+        return (1 <= part <= 8 or
+        100 <= part <= 120 or
+        200 <= part <= 205 or
+        300 <= part <= 305 or
+        part == 400 or
+        9001 <= part <= 9099)
+
+    return True
 
 
 def parse_regulatory_citations(text):
     matches = set()
     if text:
-        for citation in REGULATION_CITATION_REGEX.finditer(text):
+        for citation in SINGLE_REGULATION_CITATION_REGEX.finditer(text):
             matches.add((
                 int(citation.group('title')),
                 int(citation.group('part')),
                 int(citation.group('section'))
             ))
+
+        for possible_multiple_citation in MULTIPLE_REGULATION_CITATION_REGEX.finditer(text):
+            citations_title = possible_multiple_citation.group('title')
+            possible_parts_and_sections = possible_multiple_citation.group('possible_parts_and_sections')
+
+            for part_and_section in REGULATION_SECTION_ONLY_REGEX.finditer(possible_parts_and_sections):
+
+                if validate_regulation_citation(citations_title, part_and_section.group('part')):
+                    matches.add((
+                        int(citations_title),
+                        int(part_and_section.group('part')),
+                        int(part_and_section.group('section'))
+                    ))
+                else:
+                    logger.debug("Citation out of range - excluding {} CFR {}.{} from multiples.".
+                        format(citations_title,
+                            part_and_section.group('part'),
+                            int(part_and_section.group('section'))))
     return matches


### PR DESCRIPTION
Testing:
- [ ] Consider cross-referencing with existing citations to make sure we didn't lose any
- [x] Examine false positives further - I saved the output here: https://docs.google.com/spreadsheets/d/1-nf-oAPtw3LisZInuDHcQ7JdpyEQXRISZ4kY1ONrFcE/edit#gid=1216052006

## Summary (required)

- Resolves #2276 

Allow more complex parsing of AO citations: capture multiple statutes and regulations. Examples: 52 USC 30101 and 30106, 11 CFR 101, 102, 103, and 104.

**Statutes (ex. 52 USC 30101, 30133):**
Keep the first pass looking for citations REGEX and logic the same. When looking for multiples, grab all the text until a . or a ; Then loop through that group of text with the original citation REGEX to find matches.
    
**Regulations (ex. 11 CFR 110.1 and 112.4):**
Keep the first pass looking for citations REGEX and logic the same. When looking for multiples, grab the next 70 characters. Then loop through that group of text with the original citation REGEX to find matches.
    
Because the "multiples" logic is more forgiving, add functions that confirms the matches are within the expected range.
    
Add automated tests for new test cases and citation range lookups

## How to test the changes locally

- Reload advisory opinions. Helpful to set  logger.setLevel(logging.DEBUG) in `advisory_opinions.py`. reload by connecting to ES, getting s3 credentials, and running `./manage.py load_advisory_opinions -f 2012-01`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Legal citations in advisory opinions - canonical pages, searching
