### PR TITLE
update migration file for permission problem

### DIFF
--- a/data/migrations/V0096__drop_ofec_sched_a_objects.sql
+++ b/data/migrations/V0096__drop_ofec_sched_a_objects.sql
@@ -33,7 +33,9 @@ drop function IF EXISTS public.finalize_itemized_schedule_a_tables(numeric, nume
 -- Originally extension pg_trgm had been created with schema "public"
 -- Need to be with schema pg_catalog 
 -- otherwise the execution of disclosure.finalize_itemized_schedule_a_tables will have error
-alter extension pg_trgm set schema pg_catalog;
+
+-- migrator does not have permission to make the following change
+-- alter extension pg_trgm set schema pg_catalog;
 
 -- ------------------
 -- FUNCTION disclosure.finalize_itemized_schedule_a_tables
@@ -98,7 +100,7 @@ BEGIN
         EXECUTE format('CREATE INDEX IF NOT EXISTS %s_contrib_emp_text_dt_sub_id %s ON %I USING gin (contributor_employer_text, contb_receipt_dt, sub_id)', child_index_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX IF NOT EXISTS %s_contrib_name_text_dt_sub_id %s ON %I USING gin (contributor_name_text, contb_receipt_dt, sub_id)', child_index_root, index_name_suffix, child_table_name);
     --
-        EXECUTE format('CREATE INDEX IF NOT EXISTS %s_contbr_zip %s ON %I USING gin (contbr_zip COLLATE pg_catalog."default" gin_trgm_ops)', child_index_root, index_name_suffix, child_table_name);
+        --EXECUTE format('CREATE INDEX IF NOT EXISTS %s_contbr_zip %s ON %I USING gin (contbr_zip COLLATE pg_catalog."default" gin_trgm_ops)', child_index_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX IF NOT EXISTS %s_entity_tp %s ON %I USING btree (entity_tp COLLATE pg_catalog."default")', child_index_root, index_name_suffix, child_table_name);
         EXECUTE format('CREATE INDEX IF NOT EXISTS %s_rpt_yr %s ON %I USING btree (rpt_yr)', child_index_root, index_name_suffix, child_table_name);
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3099 
ofec_sched_a_master and its children tables are dropped. The queue table, database procedures/triggers and the scheduled tasksused to handle their updates are dropped too. SQL statements in the Sample_db.sql that populated these tables are removed too.

## How to test the changes locally
After Flyway migration completed, the ofec_sched_a related objects listed in the migration file V0096 should not exist in the local database anymore.


## Impacted areas of the application
List general components of the application that this PR will affect:

After successfully switching to use the fec_fitem_sched_a tables, these ofec_sched_a table are not in use anymore and will not have impact on API.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
