### PR TITLE
[WIP]Refactor elections endpoint to handle candidate finance totals export function

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -143,8 +143,8 @@ class TestDownloadResource(ApiBaseTest):
         assert not export.delay.called
 
     def test_download_forbidden(self):
-        with pytest.raises(ApiError):
-            self.client.post_json(api.url_for(resource.DownloadView, path='elections', office='house', cycle=2018))
+        response = self.app.get(api.url_for(resource.DownloadView, path='elections', office='house', cycle=2018))
+        self.assertEqual(response.status_code, 405)
 
     @mock.patch('webservices.resources.download.MAX_RECORDS', 2)
     @mock.patch('webservices.resources.download.get_cached_file')

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -143,8 +143,8 @@ class TestDownloadResource(ApiBaseTest):
         assert not export.delay.called
 
     def test_download_forbidden(self):
-        response = self.app.get(api.url_for(resource.DownloadView, path='elections', office='house', cycle=2018))
-        self.assertEqual(response.status_code, 405)
+        with pytest.raises(ApiError):
+            self.client.post_json(api.url_for(resource.DownloadView, path='elections/search', office='house', state='VA', cycle=2018))
 
     @mock.patch('webservices.resources.download.MAX_RECORDS', 2)
     @mock.patch('webservices.resources.download.get_cached_file')

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -173,8 +173,8 @@ class TestElections(ApiBaseTest):
         self.assertEquals(response.status_code, 200)
 
     def test_empty_query(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ', per_page=0))
-        self.assertEqual(len(results), 0)
+        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
+        assert len(results) == 0
 
     def test_elections(self):
         results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
@@ -244,7 +244,6 @@ class TestElections(ApiBaseTest):
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
         assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees)
-
 
     def test_election_summary(self):
         results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,18 +132,13 @@ class TestSort(ApiBaseTest):
 
         ]
         db.session.flush()
-        arg_map = {}
-        arg_map['office'] = 'senate'
-        arg_map['cycle'] = 2016
-        arg_map['state'] = 'MO'
-        #arg_map['district'] = '00'
 
         electionView = elections.ElectionView()
-        query, columns = sorting.sort(electionView._get_records(arg_map), 'total_disbursements', model=None)
+        query, columns = sorting.sort(electionView.build_query(office='senate', cycle=2016, state='MO'), 'total_disbursements', model=None)
 
         #print(str(query.statement.compile(dialect=postgresql.dialect())))
         self.assertEqual(len(query.all()), len(candidates))
-        query, columns = sorting.sort(electionView._get_records(arg_map), 'total_disbursements', model=None, hide_null=True)
+        query, columns = sorting.sort(electionView.build_query(office='senate', cycle=2016, state='MO'), 'total_disbursements', model=None, hide_null=True)
         #Taking this assert statement out because I believe, at least how the FEC interprets null (i.e. none) primary
         #committees for a candidate is that they have in fact raised/spent 0.0 dollars, this can be shown as true
         #using the Alabama special election as an example

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -128,11 +128,7 @@ class ElectionView(ApiResource):
             ),
         )
 
-    def build_query(self, *args, **kwargs):
-        query = self._get_records(kwargs)
-        return query
-
-    def _get_records(self, kwargs):
+    def build_query(self, **kwargs):
         utils.check_election_arguments(kwargs)
         totals_model = office_totals_map[kwargs['office']]
         pairs = self._get_pairs(totals_model, kwargs).subquery()
@@ -186,7 +182,7 @@ class ElectionView(ApiResource):
         ).subquery()
         return db.session.query(
             latest.c.candidate_id,
-            sa.func.sum(sa.func.coalesce(latest.c.cash_on_hand_end_period,0.0)).label('cash_on_hand_end_period'),
+            sa.func.sum(sa.func.coalesce(latest.c.cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
         ).group_by(
             latest.c.candidate_id,
         )

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -115,15 +115,22 @@ class ElectionsListView(utils.Resource):
     description=docs.ELECTIONS,
     tags=['financial']
 )
-class ElectionView(utils.Resource):
+class ElectionView(ApiResource):
+    schema = schemas.ElectionSchema
+    page_schema = schemas.ElectionPageSchema
+    @property
+    def args(self):
+        return utils.extend(
+            args.paging,
+            args.elections,
+            args.make_sort_args(
+                default='-total_receipts',
+            ),
+        )
 
-    @use_kwargs(args.paging)
-    @use_kwargs(args.elections)
-    @use_kwargs(args.make_sort_args(default='-total_receipts'))
-    @marshal_with(schemas.ElectionPageSchema())
-    def get(self, **kwargs):
+    def build_query(self, *args, **kwargs):
         query = self._get_records(kwargs)
-        return utils.fetch_page(query, kwargs, cap=0)
+        return query
 
     def _get_records(self, kwargs):
         utils.check_election_arguments(kwargs)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -934,6 +934,8 @@ class ElectionSchema(ma.Schema):
     coverage_end_date = ma.fields.Date()
 augment_schemas(ElectionSchema)
 
+ElectionPageSchema = make_page_schema(ElectionSchema)
+register_schema(ElectionPageSchema)
 
 class ScheduleABySizeCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()


### PR DESCRIPTION
## Summary
1)In order to enable 'export' button on these two sections in election summery page, we need refactor elections endpoint to extend ApiResouce and handle download function.
These two sections use same endpoint: `resource.ElectionView`
a)Candidate financial totals section:
[https://www.fec.gov/data/elections/senate/VA/2018/?tab=election-data](https://www.fec.gov/data/elections/senate/VA/2018/?tab=election-data)

b)Candidate information section:
[https://www.fec.gov/data/elections/senate/VA/2018/?tab=about-election](https://www.fec.gov/data/elections/senate/VA/2018/?tab=about-election)


- Resolves Issue# [https://github.com/fecgov/openFEC/issues/3254](https://github.com/fecgov/openFEC/issues/3254)


## Include a summary of proposed changes
fec-cms need to be changed to enable the button and make event trigger work.


## How to test the changes locally
1)setup openFEC locally
check out openFEC feature branch: feature/refactor_elections_endpoint

set some variables:
export SQLA_CONN=dev
export access_key_id=
export secret_access_key=
export bucket=
export region=


2) setup fec-cms locally
checkout fec-cms feature branch:  feature/enable_cft_export_button
and point to your local api:
export FEC_WEB_API_KEY_PUBLIC=xxxxxxx
export FEC_WEB_API_KEY=xxxxxxx
export FEC_CMS_ENVIRONMENT=LOCAL
export FEC_API_URL=http://localhost:5000
export DATABASE_URL=postgresql://:@/cfdm_cms_test


3)start redis-server
redis-server


4)Setup Celery Worker and start
export SQLA_CONN=xxxxxxx
export access_key_id=
export secret_access_key=
export bucket=
export region=
celery worker --app webservices.tasks --loglevel INFO


5)test:
example1 url: [http://127.0.0.1:8000/data/elections/senate/VA/2018/?tab=election-data](http://127.0.0.1:8000/data/elections/senate/VA/2018/?tab=election-data)
Click "Export" on Candidate financial totals section, download the file.
<img width="814" alt="screen shot 2018-07-19 at 10 36 00 am" src="https://user-images.githubusercontent.com/24395751/42957311-44406c62-8b50-11e8-9010-d9455d64d7cd.png">



example2 url  [http://127.0.0.1:8000/data/elections/senate/VA/2018/?tab=about-election](http://127.0.0.1:8000/data/elections/senate/VA/2018/?tab=about-election)
Click "Export" on Candidate information section, download the file.
<img width="798" alt="screen shot 2018-07-19 at 10 36 20 am" src="https://user-images.githubusercontent.com/24395751/42957393-8e183cde-8b50-11e8-8a30-37168e0df9f1.png">





