### PR TITLE
Fix elections endpoint to handle per_page=0

### DIFF
--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -7,6 +7,7 @@ from webservices import docs
 from webservices import utils
 from webservices import filters
 from webservices import schemas
+from webservices.common import counts
 from webservices.utils import use_kwargs
 from webservices.common import models
 from webservices.common.views import ApiResource
@@ -126,6 +127,19 @@ class ElectionView(ApiResource):
             args.make_sort_args(
                 default='-total_receipts',
             ),
+        )
+
+    def get(self, *args, **kwargs):
+        query = self.build_query(*args, **kwargs)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        multi = False
+        if isinstance(kwargs['sort'], (list, tuple)):
+            multi = True
+
+        return utils.fetch_page(
+            query, kwargs,
+            count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
+            index_column=self.index_column, cap=0, multi=multi,
         )
 
     def build_query(self, **kwargs):


### PR DESCRIPTION
Summary:
when fec-cms pass per_page=0 (means: get all results, don't do pagination),  
the elections endpoint not handle this case, 
so set cap=0 to avoid doing pagination.

related PR: [https://github.com/fecgov/openFEC/pull/3292](https://github.com/fecgov/openFEC/pull/3292)

How to test locally:
1) checkout branch : feature/fix_elections_per_page
2)DB--dev
3)loach cms point to local api
4)test elections summary pages to make sure all data sets result correctly.
