### PR TITLE
feature/test-es-connection-timeouts

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -194,11 +194,17 @@ class Tasks(locust.TaskSet):
         self.client.get('legal/search', name='legal_search', params=params)
 
     @locust.task
-    def get_document(self, term=None):
+    def get_mur(self, term=None):
         params = {
             'api_key': API_KEY,
         }
-        self.client.get('legal/docs/murs/7074', name='legal_get', params=params)
+        self.client.get('legal/docs/murs/7074', name='legal_get_mur', params=params)
+    @locust.task
+    def get_ao(self, term=None):
+        params = {
+            'api_key': API_KEY,
+        }
+        self.client.get('legal/docs/advisory_opinions/2018-07', name='legal_get_ao', params=params)
 
     @locust.task
     def load_schedule_a_small(self):

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -405,7 +405,7 @@ def get_elasticsearch_connection():
         url = es_conn.get_url(url='uri')
     else:
         url = 'http://localhost:9200'
-    es = Elasticsearch(url)
+    es = Elasticsearch(url, timeout=5, max_retries=5, retry_on_timeout=True)
 
     return es
 


### PR DESCRIPTION
Deploying a hot fix to address: https://github.com/fecgov/openFEC/issues/3270

1. ElasticSearch connection is set to retry on timeout. timeouts are set as below:
    - Elasticsearch(url, timeout=5, max_retries=5, retry_on_timeout=True)

2. Added a new locust task for advisory_opinions. 
    - This task is specific to AO's. We can run locust tests on advisory_opinions from now on. 

3. Renamed existing locust MUR task.
    - Made this task specific to MUR.



