### PR TITLE
Feature/update ofec agg coverage date mv logic

### DIFF
--- a/data/migrations/V0098__update_ofec_agg_coverage_date_mv_logic.sql
+++ b/data/migrations/V0098__update_ofec_agg_coverage_date_mv_logic.sql
@@ -1,24 +1,44 @@
 -- update ofec_agg_coverage_date_mv logic to take amendment situation into consideration
+-- don’t look at operations log before 2003 (no consistent data)  
 DROP MATERIALIZED VIEW IF EXISTS public.ofec_agg_coverage_date_mv_tmp;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS public.ofec_agg_coverage_date_mv_tmp AS
 WITH OPERATIONS_LOG AS
 (
-SELECT sub_id, max(pass_3_entry_done_dt) over (partition by cand_cmte_id, rpt_yr, rpt_tp) max_pass_3_dt
-FROM staging.operations_log
-)
-SELECT row_number() OVER () AS idx,
-f.cmte_id AS cand_cmte_id,
-f.rpt_yr + f.rpt_yr % 2::numeric AS fec_election_yr,
-max(f.cvg_end_dt)::text::date AS coverage_end_date
-FROM disclosure.v_sum_and_det_sum_report f
-WHERE f.orig_sub_id IN
+   SELECT sub_id, max(pass_3_entry_done_dt) over (partition by cand_cmte_id, rpt_yr, rpt_tp) max_pass_3_dt
+   FROM staging.operations_log
+),
+AGG_CVG_DT AS
 (
-SELECT SUB_ID FROM OPERATIONS_LOG 
-WHERE max_pass_3_dt IS NOT NULL
+SELECT 
+f.cmte_id AS committee_id,
+f.rpt_yr + f.rpt_yr % 2::numeric AS fec_election_yr,
+max(f.cvg_end_dt)::text::timestamp without time zone AS transaction_coverage_date
+FROM disclosure.v_sum_and_det_sum_report f
+WHERE 
+( f.orig_sub_id IN
+  (
+    SELECT SUB_ID FROM OPERATIONS_LOG 
+    WHERE max_pass_3_dt IS NOT NULL
+  ) 
 )
 AND f.form_tp_cd::text ~~ 'F3%'::text
 GROUP BY f.cmte_id, (f.rpt_yr + f.rpt_yr % 2::numeric)
+UNION
+SELECT 
+f.cmte_id AS committee_id,
+f.rpt_yr + f.rpt_yr % 2::numeric AS fec_election_yr,
+max(f.cvg_end_dt)::text::timestamp without time zone AS transaction_coverage_date
+FROM disclosure.v_sum_and_det_sum_report f
+WHERE f.cvg_end_dt < '20030101'
+AND f.form_tp_cd::text ~~ 'F3%'::text
+GROUP BY f.cmte_id, (f.rpt_yr + f.rpt_yr % 2::numeric)
+)
+SELECT row_number() OVER () AS idx,
+AGG_CVG_DT.COMMITTEE_ID,
+AGG_CVG_DT.FEC_ELECTION_YR,
+AGG_CVG_DT.transaction_coverage_date
+FROM AGG_CVG_DT
 WITH DATA;
 
  
@@ -31,7 +51,7 @@ GRANT SELECT ON TABLE public.ofec_agg_coverage_date_mv_tmp TO fec_read;
 CREATE INDEX IF NOT EXISTS idx_ofec_agg_cvg_dt_mv_cmte_id_fec_elec_yr_tmp 
 ON public.ofec_agg_coverage_date_mv_tmp
   USING btree
-  (cand_cmte_id COLLATE pg_catalog."default", fec_election_yr);
+  (committee_id COLLATE pg_catalog."default", fec_election_yr);
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_ofec_agg_cvg_dt_mv_idx_tmp 
 ON public.ofec_agg_coverage_date_mv_tmp

--- a/data/migrations/V0098__update_ofec_agg_coverage_date_mv_logic.sql
+++ b/data/migrations/V0098__update_ofec_agg_coverage_date_mv_logic.sql
@@ -1,0 +1,41 @@
+-- update ofec_agg_coverage_date_mv logic to take amendment situation into consideration
+
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_agg_coverage_date_mv;
+
+CREATE MATERIALIZED VIEW public.ofec_agg_coverage_date_mv AS
+WITH OPERATIONS_LOG AS
+(
+SELECT sub_id, max(pass_3_entry_done_dt) over (partition by cand_cmte_id, rpt_yr, rpt_tp) max_pass_3_dt
+FROM staging.operations_log
+)
+SELECT row_number() OVER () AS idx,
+f.cmte_id AS cand_cmte_id,
+f.rpt_yr + f.rpt_yr % 2::numeric AS fec_election_yr,
+max(f.cvg_end_dt)::text::date AS coverage_end_date
+FROM disclosure.v_sum_and_det_sum_report f
+WHERE f.orig_sub_id IN
+(
+SELECT SUB_ID FROM OPERATIONS_LOG 
+WHERE max_pass_3_dt IS NOT NULL
+)
+AND f.form_tp_cd::text ~~ 'F3%'::text
+GROUP BY f.cmte_id, (f.rpt_yr + f.rpt_yr % 2::numeric)
+WITH DATA;
+
+ 
+-- grants
+ALTER TABLE public.ofec_agg_coverage_date_mv OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_agg_coverage_date_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_agg_coverage_date_mv TO fec_read;
+ 
+
+CREATE INDEX IF NOT EXISTS idx_ofec_agg_cvg_dt_mv_cmte_id_fec_elec_yr 
+ON public.ofec_agg_coverage_date_mv
+  USING btree
+  (cand_cmte_id COLLATE pg_catalog."default", fec_election_yr);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ofec_agg_cvg_dt_mv_idx 
+ON public.ofec_agg_coverage_date_mv
+  USING btree
+  (idx);


### PR DESCRIPTION
## Summary (required)

- Resolves # 3313
Update ofec_agg_coverage_date_mv logic to handle amendment.
The aggregate data is from f_item table.  FEC logic temporarily update f_item table to link the most recent filing (pass 1 form data) to the previous sched data (pass 3) before the pass3 data for the most recent filing data being processed.  So logic must include while checking operations_log that if there is pass3 data processed for the cmte_id/rpt_yr/rpt_tp, take the sub_id.
Also, don’t check on operations log for data prior to 2003 (no consistent data) 

## How to test the changes locally
The new version of ofec_agg_coverage_date_mv had been built in develop database as ofec_agg_coverage_date_mv_tmp (the migration script will take care of the deletion of this tmp version).
Execute the following two queries will reveal the difference:
select * from public.ofec_agg_coverage_date_mv_tmp where committee_id = 'C00000935' order by fec_election_yr;
(rows from 1976 through 2018 should show up.  And 2018 transaction_coverage_date should be 2018-05-31)
"C00000935";2018;"2018-05-31"

select * from public.ofec_agg_coverage_date_mv where cand_cmte_id = 'C00000935' order by fec_election_yr;
(only rows from 1998 through 2018 should show up.  And 2018 transaction_coverage_date should be 2018-03-31)
"C00000935";2018;"2018-03-31"

## Impacted areas of the application
List general components of the application that this PR will affect:
This materialized view is not being used in application yet.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
