### PR TITLE
[MERGE WITH GIT FLOW] Hotfix: Revert elasticsearch connection settings to the defaults

### DIFF
--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -405,7 +405,7 @@ def get_elasticsearch_connection():
         url = es_conn.get_url(url='uri')
     else:
         url = 'http://localhost:9200'
-    es = Elasticsearch(url, timeout=5, max_retries=5, retry_on_timeout=True)
+    es = Elasticsearch(url)
 
     return es
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3270 
Now that cloud.gov has implemented an elasticsearch configuration fix on their end, I've tested and confirmed that we have [vastly improved performance](https://docs.google.com/spreadsheets/d/176GslTcBtvxMUBM6PK3XaH1ZRdDJ3RQOwtOTOzICji8/edit#gid=0) with our default settings. We should revert our elasticsearch connection settings to the defaults (`timeout=10, retry_on_timeout=False, max_retries=3`)  so that MUR 253 will load: https://fec-dev-api.app.cloud.gov/v1/legal/search/?mur_no=253

## How to test the changes locally

- I tested with a manual deploy to `dev` and ran locust tests `get_mur` and `get_ao`. This wasn't an issue locally - only on cloud.gov. 
- This bug archived MUR only loads with the default connection settings: https://fec-dev-api.app.cloud.gov/v1/legal/search/?mur_no=253. You can see the error on stage: https://api-stage.open.fec.gov/v1/legal/search/?mur_no=253&API_KEY=DEMO_KEY

## Impacted areas of the application
List general components of the application that this PR will affect:

-  AO/MUR canonical pages as well as AO search.
