### PR TITLE
Add filters to help ServiceNow query more efficiently

### DIFF
--- a/data/migrations/V0102__drop_ofec_rad_mv.sql
+++ b/data/migrations/V0102__drop_ofec_rad_mv.sql
@@ -1,0 +1,61 @@
+/*
+
+Addresses issue #3333: Add assignment_update_date to /rad-analyst/
+
+- Drop materialized view `ofec_rad_mv`
+--Drop function `fix_party_spelling`
+- Replace view `rad_cmte_analyst_search_vw` with `ofec_rad_analyst_vw`
+    - Move schema to `public`
+    - Need to drop it because we're adding columns (idx, assignment_update)
+    - Update column names to match `ofec_rad_mv`
+
+*/
+
+SET search_path = public;
+
+DROP MATERIALIZED VIEW ofec_rad_mv;
+
+DROP FUNCTION IF EXISTS fix_party_spelling(branch text);
+
+----
+
+SET search_path = disclosure, pg_catalog;
+
+DROP VIEW rad_cmte_analyst_search_vw;
+
+---
+
+SET search_path = public;
+
+CREATE VIEW ofec_rad_analyst_vw AS
+    SELECT row_number() OVER () AS idx,
+        ra.cmte_id AS committee_id,
+        cv.cmte_nm AS committee_name,
+        an.anlyst_id AS analyst_id,
+        (an.valid_id::numeric) AS analyst_short_id,
+        CASE
+            WHEN an.branch_id = 1 THEN 'Authorized'
+            WHEN an.branch_id = 2 THEN 'Party/Non Party'
+            ELSE NULL::text
+        END AS rad_branch,
+        an.firstname AS first_name,
+        an.lastname AS last_name,
+        to_tsvector((((an.firstname)::text || ' '::text) || (an.lastname)::text)) AS name_txt,
+        an.telephone_ext,
+        t.anlyst_title_desc AS analyst_title,
+        an.email AS analyst_email,
+        ra.last_rp_change_dt AS assignment_update
+    FROM rad_pri_user.rad_anlyst an
+    JOIN rad_pri_user.rad_assgn ra
+        ON an.anlyst_id = ra.anlyst_id
+    JOIN disclosure.cmte_valid_fec_yr cv
+        ON ra.cmte_id = cv.cmte_id
+    JOIN rad_pri_user.rad_lkp_anlyst_title t
+        ON an.anlyst_title_seq = t.anlyst_title_seq
+    WHERE an.status_id = 1
+        AND an.anlyst_id <> 999
+        AND cv.fec_election_yr = get_cycle(date_part('year', current_date)::integer);
+
+ALTER TABLE ofec_rad_analyst_vw OWNER TO fec;
+GRANT SELECT ON TABLE ofec_rad_analyst_vw TO fec_read;
+GRANT SELECT ON TABLE ofec_rad_analyst_vw TO openfec_read;

--- a/manage.py
+++ b/manage.py
@@ -220,7 +220,6 @@ def refresh_materialized(concurrent=True):
         'large_aggregates': ['ofec_entity_chart_mv'],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],
         'ofec_sched_e_mv': ['ofec_sched_e_mv'],
-        'rad_analyst': ['ofec_rad_mv'],
         'reports_house_senate': ['ofec_reports_house_senate_mv'],
         'reports_ie': ['ofec_reports_ie_only_mv'],
         'reports_pac_party': ['ofec_reports_pacs_parties_mv'],

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -14,12 +14,21 @@ from webservices.resources.committees import CommitteeHistoryView
 from webservices.resources.candidates import CandidateView
 
 
-## old, re-factored Committee tests ##
 class CommitteeFormatTest(ApiBaseTest):
+
+    # TODO: When we move to python 3.7, use datetime.date.fromisoformat('1982-12-31')
+
+    date_1982_12_31 = datetime.date(1982, 12, 31)
+    date_2012_01_01 = datetime.date(2012, 1, 1)
+    date_2015_01_01 = datetime.date(2015, 1, 1)
+    date_2015_02_01 = datetime.date(2015, 2, 1)
+    date_2015_02_03 = datetime.date(2015, 2, 3)
+    date_2015_03_01 = datetime.date(2015, 3, 1)
+    date_2015_04_01 = datetime.date(2015, 4, 1)
 
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
-            first_file_date=datetime.date(1982, 12, 31),
+            first_file_date=self.date_1982_12_31,
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -28,7 +37,7 @@ class CommitteeFormatTest(ApiBaseTest):
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['first_file_date'], committee.first_file_date.isoformat())
+        self.assertEqual(result['first_file_date'], self.date_1982_12_31.isoformat())
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -75,7 +84,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_detail_fields(self):
         committee = factories.CommitteeDetailFactory(
-            first_file_date=datetime.date(1982, 12, 31),
+            first_file_date=self.date_1982_12_31,
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -111,9 +120,6 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEquals(response[0]['party'], 'REP')
         self.assertEquals(response[0]['party_full'], 'Republican Party')
 
-    # TODO(jmcarp) Refactor as parameterized tests
-    # TODO(jmcarp) Generalize to /committees endpoint
-    # TODO(jmcarp) Generalize to candidate models
     def test_filters_generic(self):
         self._check_filter('designation', ['B', 'P'])
         self._check_filter('organization_type', ['M', 'T'])
@@ -179,10 +185,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_year_filter_skips_null_first_file_date(self):
         # Build fixtures
-        dates = [
-            datetime.date(2012, 1, 1),
-            datetime.date(2015, 1, 1),
-        ]
+        dates = [self.date_2012_01_01, self.date_2015_01_01]
         [
             factories.CommitteeFactory(first_file_date=None, last_file_date=None),
             factories.CommitteeFactory(first_file_date=dates[0], last_file_date=None),
@@ -245,7 +248,7 @@ class CommitteeFormatTest(ApiBaseTest):
         )
         self.assertEqual(1, len(results))
 
-    def test_candidates_by_com(self):
+    def test_candidates_by_committee(self):
         committee = factories.CommitteeFactory()
         candidate = factories.CandidateFactory()
         db.session.flush()
@@ -287,27 +290,29 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_date_filters(self):
         [
-            factories.CommitteeFactory(first_file_date=datetime.date(2015, 1, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.date(2015, 2, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.date(2015, 3, 1)),
-            factories.CommitteeFactory(first_file_date=datetime.date(2015, 4, 1)),
+            factories.CommitteeFactory(first_file_date=self.date_2015_01_01),
+            factories.CommitteeFactory(first_file_date=self.date_2015_02_01),
+            factories.CommitteeFactory(first_file_date=self.date_2015_03_01),
+            factories.CommitteeFactory(first_file_date=self.date_2015_04_01),
         ]
-        results = self._results(api.url_for(CommitteeList, min_first_file_date='02/01/2015'))
-        self.assertTrue(all(each['first_file_date'] >= datetime.date(2015, 2, 1).isoformat() for each in results))
-        results = self._results(api.url_for(CommitteeList, max_first_file_date='02/03/2015'))
-        self.assertTrue(all(each['first_file_date'] <= datetime.date(2015, 3, 1).isoformat() for each in results))
+        results = self._results(
+            api.url_for(CommitteeList, min_first_file_date=self.date_2015_02_01))
+        self.assertTrue(
+            all(each['first_file_date'] >= self.date_2015_02_01.isoformat() for each in results))
+        results = self._results(
+            api.url_for(CommitteeList, max_first_file_date=self.date_2015_02_03))
+        self.assertTrue(
+            all(each['first_file_date'] <= self.date_2015_02_03.isoformat() for each in results))
         results = self._results(
             api.url_for(
                 CommitteeList,
-                min_first_file_date='02/01/2015',
-                max_first_file_date='02/03/2015',
+                min_first_file_date=self.date_2015_02_01,
+                max_first_file_date=self.date_2015_03_01,
             )
         )
         self.assertTrue(
             all(
-                datetime.date(2015, 2, 1).isoformat()
-                <= each['first_file_date']
-                <= datetime.date(2015, 3, 1).isoformat()
+                self.date_2015_02_01.isoformat() <= each['first_file_date'] <= self.date_2015_03_01.isoformat()
                 for each in results
             )
         )

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -55,13 +55,10 @@ class TestFilerResources(ApiBaseTest):
         [
             factories.RadAnalystFactory(last_name='Young', committee_id='C0005'),
             factories.RadAnalystFactory(last_name='Old', committee_id='C0006'),
+            factories.RadAnalystFactory(last_name='Someone-Else', committee_id='C0007'),
         ]
         results = self._results(api.url_for(RadAnalystView, sort='last_name'))
-        self.assertTrue(
+        self.assertEqual(
             [each['last_name'] for each in results],
-            ['Old', 'Young']
+            ['Old', 'Someone-Else', 'Young']
         )
-
-    def test_sort_bad_column(self):
-        response = self.app.get(api.url_for(RadAnalystView, sort='request_type'))
-        self.assertEqual(response.status_code, 422)

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -62,3 +62,32 @@ class TestFilerResources(ApiBaseTest):
             [each['last_name'] for each in results],
             ['Old', 'Someone-Else', 'Young']
         )
+
+    def test_assignment_date_filters(self):
+        [
+            factories.RadAnalystFactory(assignment_update_date='2015-01-01', committee_id='C0007'),
+            factories.RadAnalystFactory(assignment_update_date='2015-02-01', committee_id='C0008'),
+            factories.RadAnalystFactory(assignment_update_date='2015-03-01', committee_id='C0009'),
+            factories.RadAnalystFactory(assignment_update_date='2015-04-01', committee_id='C0010'),
+        ]
+        results = self._results(
+            api.url_for(RadAnalystView, min_assignment_update_date='2015-02-01'))
+        self.assertTrue(
+            all(each['assignment_update_date'] >= '2015-02-01' for each in results))
+        results = self._results(
+            api.url_for(RadAnalystView, max_assignment_update_date='2015-02-03'))
+        self.assertTrue(
+            all(each['assignment_update_date'] <= '2015-02-03' for each in results))
+        results = self._results(
+            api.url_for(
+                RadAnalystView,
+                min_assignment_update_date='2015-02-01',
+                max_assignment_update_date='2015-03-01',
+            )
+        )
+        self.assertTrue(
+            all(
+                '2015-02-01' <= each['assignment_update_date'] <= '2015-03-01'
+                for each in results
+            )
+        )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -737,6 +737,8 @@ rad_analyst = {
     'name': fields.List(fields.Str, description='Name of RAD analyst'),
     'email': fields.List(fields.Str, description='Email of RAD analyst'),
     'title': fields.List(fields.Str, description='Title of RAD analyst'),
+    'min_assignment_update_date': fields.Date(description='Filter results for assignment updates made after this date'),
+    'max_assignment_update_date': fields.Date(description='Filter results for assignment updates made before this date')
 }
 
 large_aggregates = {'cycle': fields.Int(required=True, description=docs.RECORD_CYCLE)}

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -80,12 +80,12 @@ class IndexValidator(OptionValidator):
 
     :param Base model: SQLALchemy model.
     :param list exclude: Optional list of columns to exclude.
+    :param list extra: Optional list of extra columns to include.
     """
-    def __init__(self, model, extra=None, exclude=None, schema=None):
+    def __init__(self, model, extra=None, exclude=None):
         self.model = model
         self.extra = extra or []
         self.exclude = exclude or []
-        self.database_schema = schema
 
     @property
     def values(self):
@@ -96,7 +96,10 @@ class IndexValidator(OptionValidator):
         }
         return [
             column_map[column['column_names'][0]]
-            for column in inspector.get_indexes(self.model.__tablename__, self.database_schema)
+            for column in inspector.get_indexes(
+                self.model.__tablename__,
+                self.model.__table__.schema,
+            )
             if not self._is_excluded(column_map.get(column['column_names'][0]))
         ] + self.extra
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -249,8 +249,10 @@ committee_list = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'state': fields.List(IStr, description=docs.STATE_GENERIC),
     'party': fields.List(IStr, description=docs.PARTY),
-    'min_first_file_date': fields.Date(description='Selects all committees whose first filing was received by the FEC after this date'),
-    'max_first_file_date': fields.Date(description='Selects all committees whose first filing was received by the FEC before this date'),
+    'min_first_file_date': fields.Date(description='Filter for committees whose first filing was received on or after this date'),
+    'max_first_file_date': fields.Date(description='Filter for committees whose first filing was received on or before this date'),
+    'min_last_f1_date': fields.Date(description='Filter for committees whose latest Form 1 was received on or after this date'),
+    'max_last_f1_date': fields.Date(description='Filter for committees whose latest Form 1 was received on or before this date'),
     'treasurer_name': fields.List(fields.Str, description=docs.TREASURER_NAME),
 }
 
@@ -282,7 +284,7 @@ filings = {
     'file_number': fields.List(fields.Int, description=docs.FILE_NUMBER),
     'primary_general_indicator': fields.List(IStr, description='Primary, general or special election indicator'),
     'amendment_indicator': fields.List(
-        IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C' , 'M', 'S'])),
+        IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
 }
 

--- a/webservices/common/models/rad_analyst.py
+++ b/webservices/common/models/rad_analyst.py
@@ -20,4 +20,4 @@ class RadAnalyst(db.Model):
     telephone_ext = db.Column(db.Numeric(4, 0), index=True, doc='Telephone extension of RAD analyst')
     rad_branch = db.Column(db.String(100), index=True, doc='Branch of RAD analyst')
     name_txt = db.Column(TSVECTOR)
-    assignment_update = db.Column(db.DateTime, doc="WIP")
+    assignment_update_date = db.Column(db.Date, doc="Date of most recent RAD analyst assignment change")

--- a/webservices/common/models/rad_analyst.py
+++ b/webservices/common/models/rad_analyst.py
@@ -5,7 +5,8 @@ from webservices import docs
 
 
 class RadAnalyst(db.Model):
-    __tablename__ = 'ofec_rad_mv'
+    __table_args__ = {'schema': 'public'}
+    __tablename__ = 'ofec_rad_analyst_vw'
 
     idx = db.Column(db.Integer, primary_key=True)
     committee_id = db.Column(db.String, primary_key=True, index=True, doc=docs.COMMITTEE_ID)
@@ -19,3 +20,4 @@ class RadAnalyst(db.Model):
     telephone_ext = db.Column(db.Numeric(4, 0), index=True, doc='Telephone extension of RAD analyst')
     rad_branch = db.Column(db.String(100), index=True, doc='Branch of RAD analyst')
     name_txt = db.Column(TSVECTOR)
+    assignment_update = db.Column(db.DateTime, doc="WIP")

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -33,7 +33,6 @@ def get_graph():
         'large_aggregates',
         'ofec_agg_coverage_date',
         'ofec_sched_e_mv',
-        'rad_analyst',
         'reports_house_senate',
         'reports_ie',
         'reports_pac_party',

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -28,12 +28,9 @@ class AggregateResource(ApiResource):
 
     @property
     def sort_args(self):
-        schema = None
-        if self.model and hasattr(self.model,'__table_args__') and 'schema' in self.model.__table_args__.keys():
-            schema = self.model.__table_args__.get('schema')
-        return args.make_sort_args(validator=args.IndexValidator(self.model, schema=schema))
-
-        
+        return args.make_sort_args(
+            validator=args.IndexValidator(self.model)
+        )
 
     @property
     def index_column(self):
@@ -86,7 +83,7 @@ class ScheduleAByStateView(AggregateResource):
                 default='-total',
             ),
         )
-   
+
     def build_query(self, committee_id=None, **kwargs):
         query = super().build_query(committee_id, **kwargs)
         if kwargs['hide_null']:
@@ -130,8 +127,6 @@ class ScheduleAByEmployerView(AggregateResource):
         ('employer', models.ScheduleAByEmployer.employer),
     ]
 
-    
-
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
         count = counts.count_estimate(query, models.db.session, threshold=5000)
@@ -155,8 +150,6 @@ class ScheduleAByOccupationView(AggregateResource):
         ('cycle', models.ScheduleAByOccupation.cycle),
         ('occupation', models.ScheduleAByOccupation.occupation),
     ]
-
-
 
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -49,6 +49,7 @@ class CommitteeList(ApiResource):
     ]
     filter_range_fields = [
         (('min_first_file_date', 'max_first_file_date'), models.Committee.first_file_date),
+        (('min_last_f1_date', 'max_last_f1_date'), models.Committee.last_f1_date),
     ]
     filter_fulltext_fields = [
         ('q', models.CommitteeSearch.fulltxt),

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -31,7 +31,7 @@ class ReportingDatesView(ApiResource):
             args.reporting_dates,
             args.make_sort_args(
                 default='-due_date',
-                validator=args.IndexValidator(self.model, schema=models.ReportDate.__table_args__.get('schema')),
+                validator=args.IndexValidator(self.model),
             ),
         )
 
@@ -62,7 +62,7 @@ class ElectionDatesView(ApiResource):
             args.election_dates,
             args.make_sort_args(
                 default='-election_date',
-                validator=args.IndexValidator(self.model, schema=models.ElectionDate.__table_args__.get('schema')),
+                validator=args.IndexValidator(self.model),
             ),
         )
 

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -121,7 +121,7 @@ class EFilingsView(views.ApiResource):
             args.efilings,
             args.make_sort_args(
                 default='-receipt_date',
-                # validator=args.IndexValidator(self.model)
+                validator=args.IndexValidator(self.model)
             ),
         )
 

--- a/webservices/resources/rad_analyst.py
+++ b/webservices/resources/rad_analyst.py
@@ -36,9 +36,7 @@ class RadAnalystView(ApiResource):
         return utils.extend(
             args.paging,
             args.rad_analyst,
-            args.make_sort_args(
-                validator=args.IndexValidator(models.RadAnalyst),
-            ),
+            args.make_sort_args(),
         )
 
     @property

--- a/webservices/resources/rad_analyst.py
+++ b/webservices/resources/rad_analyst.py
@@ -31,6 +31,10 @@ class RadAnalystView(ApiResource):
         ('committee_id', model.committee_id),
     ]
 
+    filter_range_fields = [
+        (('min_assignment_update_date', 'max_assignment_update_date'), model.assignment_update_date),
+    ]
+
     @property
     def args(self):
         return utils.extend(

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -201,7 +201,7 @@ class CommitteeReportsView(utils.Resource):
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
             query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
-            
+
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
             if kwargs.get('year'):
@@ -240,7 +240,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
             args.efilings,
             args.make_sort_args(
                 default='-receipt_date',
-                # validator=args.IndexValidator(self.model),
+                validator=args.IndexValidator(self.model),
             ),
         )
 
@@ -274,7 +274,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
             args.efilings,
             args.make_sort_args(
                 default='-receipt_date',
-                # validator=args.IndexValidator(self.model),
+                validator=args.IndexValidator(self.model),
             ),
         )
 
@@ -308,7 +308,7 @@ class EFilingPacPartySummaryView(views.ApiResource):
             args.efilings,
             args.make_sort_args(
                 default='-receipt_date',
-                # validator=args.IndexValidator(self.model),
+                validator=args.IndexValidator(self.model),
             ),
         )
 


### PR DESCRIPTION
## Summary (required)

Resolves #3333 "Making "updated" fields available & searchable in API endpoints"

**`/committees/`:**
- make `last_filed_f1` filterable

**`/rad-analyst/`:**
- add `assignment_update` to output, make it filterable
- replace `ofec_rad_mv` with `ofec_rad_analyst_vw`

**technical debt**
- Modify `args.IndexValidator` to look up the model's schema

## How to test the changes locally

- Test migrations by `drop/create cfdm_test` and `invoke create_sample_db`
- point `SQLA_CONN` to `cfdm_test` (or just `unset SQLA_CONN`)
- http://localhost:5000/v1/committees/?sort=name&max_last_f1_date=7%2F31%2F18&min_last_f1_date=7%2F25%2F18&per_page=20&page=1
- http://localhost:5000/v1/rad-analyst/?per_page=20&page=1&max_assignment_update_date=2018-09-10
- Test endpoints with modified `IndexValidator`: https://docs.google.com/spreadsheets/d/1-VGrjxr8CYl_2UTSrOsporFX0IZUEz9ZXLJBPdZ1s5g/edit#gid=0

## Impacted areas of the application
List general components of the application that this PR will affect:

-  ServiceNow committee lookup