### PR TITLE
Update instructions on loading archived MURs

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ python manage.py load_current_murs [-m MUR_NO]
 
 #### Loading archived MURs (This takes a very long time)
 ```
-python manage.py load_archived_murs
+python manage.py load_archived_murs [-s MUR_NO] or [-f FROM_MUR_NO]
 ```
 
 

--- a/manage.py
+++ b/manage.py
@@ -28,7 +28,7 @@ logger = logging.getLogger('manager')
 manager.add_command('runserver', Server(use_debugger=True, use_reloader=True))
 
 manager.command(legal_docs.delete_advisory_opinions_from_es)
-manager.command(legal_docs.delete_murs_from_es)
+manager.command(legal_docs.delete_current_murs_from_es)
 manager.command(legal_docs.delete_murs_from_s3)
 manager.command(legal_docs.index_regulations)
 manager.command(legal_docs.index_statutes)
@@ -219,7 +219,7 @@ def refresh_materialized(concurrent=True):
                     'ofec_filings_all_mv'],
         'large_aggregates': ['ofec_entity_chart_mv'],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],
-        'ofec_sched_e_mv': ['ofec_sched_e_mv'],        
+        'ofec_sched_e_mv': ['ofec_sched_e_mv'],
         'rad_analyst': ['ofec_rad_mv'],
         'reports_house_senate': ['ofec_reports_house_senate_mv'],
         'reports_ie': ['ofec_reports_ie_only_mv'],

--- a/tests/test_load_legal_docs.py
+++ b/tests/test_load_legal_docs.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 from webservices.legal_docs import (
-    delete_murs_from_es,
+    delete_current_murs_from_es,
     delete_murs_from_s3,
     index_regulations,
     index_statutes,
@@ -271,5 +271,5 @@ class LoadArchivedMursTest(unittest.TestCase):
         delete_murs_from_s3()
 
     @patch('webservices.utils.get_elasticsearch_connection', get_es_with_doc({}))
-    def test_delete_murs_from_es(self):
-        delete_murs_from_es()
+    def test_delete_current_murs_from_es(self):
+        delete_current_murs_from_es()

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -14,7 +14,7 @@ logger.setLevel('WARN')
 
 from .load_legal_docs import (
     delete_advisory_opinions_from_es,
-    delete_murs_from_es,
+    delete_current_murs_from_es,
     delete_murs_from_s3,
     index_regulations,
     index_statutes,

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -347,9 +347,9 @@ def delete_murs_from_s3():
     for obj in bucket.objects.filter(Prefix="legal/murs"):
         obj.delete()
 
-def delete_murs_from_es():
+def delete_current_murs_from_es():
     """
-    Deletes all MURs from Elasticsearch
+    Deletes all current MURs from Elasticsearch
     """
     delete_from_es('docs_index', 'murs')
 
@@ -446,9 +446,9 @@ def process_murs(raw_mur_tr_element_list):
 
 def load_archived_murs(from_mur_no=None, specific_mur_no=None, num_processes=1, tasks_per_child=None):
     """
-    Reads data for archived MURs from http://classic.fec.gov/MUR, assembles a JSON
+    Reads data for archived MURs from http://classic.fec.gov/MUR/, assembles a JSON
     document corresponding to the MUR and indexes this document in Elasticsearch
-    in the index `docs_index` with a doc_type of `murs`. In addition, the MUR
+    in the index `archived_murs` with a doc_type of `murs`. In addition, the MUR
     document is uploaded to an S3 bucket under the _directory_ `legal/murs/`.
     """
     logger.info("Loading archived MURs")


### PR DESCRIPTION
## Summary (required)

- Resolves #3234 

_Update instructions on loading archived MURs._

## How to test the changes locally

- See if you understand how to load archived MURs

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Index management/legal docs

## Related PRs
List related PRs against other branches:

Modify `load_archived_murs` to properly handle MURs with multiple PDFs https://github.com/fecgov/openFEC/pull/3278
