### PR TITLE
Show non-US states(Other) in Committee Schedule A by state aggregates

### DIFF
--- a/data/migrations/V0098__add_ofec_sched_a_agg_state_vw.sql
+++ b/data/migrations/V0098__add_ofec_sched_a_agg_state_vw.sql
@@ -1,0 +1,32 @@
+DROP VIEW IF EXISTS public.ofec_sched_a_agg_state_vw;
+
+CREATE OR REPLACE VIEW public.ofec_sched_a_agg_state_vw AS
+select cmte_id,
+cycle as CYCLE,
+COALESCE (st.st, 'ot') AS STATE,
+COALESCE (STATE_FULL, 'Other') AS STATE_FULL,
+max(idx) as IDX,
+SUM(total) AS TOTAL,
+SUM(count) AS COUNT
+from disclosure.dsc_sched_a_aggregate_state sa
+LEFT OUTER JOIN staging.ref_st st
+ON sa.state = st.st
+GROUP BY CMTE_ID, CYCLE, st.st, STATE_FULL;
+
+-- grants
+ALTER TABLE public.ofec_sched_a_agg_state_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_a_agg_state_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_a_agg_state_vw TO fec_read;
+
+
+/*
+select cmte_id,
+STATE,
+STATE_FULL,
+total,
+count
+from public.ofec_sched_a_agg_state_vw
+WHERE CYCLE = 2018
+AND CMTE_ID = 'C00401224'
+ORDER BY STATE_FULL 
+*/

--- a/data/migrations/V0100__add_ofec_sched_a_agg_state_vw.sql
+++ b/data/migrations/V0100__add_ofec_sched_a_agg_state_vw.sql
@@ -1,19 +1,19 @@
 DROP VIEW IF EXISTS public.ofec_sched_a_agg_state_vw;
 
 CREATE OR REPLACE VIEW public.ofec_sched_a_agg_state_vw AS
-select cmte_id,
-cycle as CYCLE,
-COALESCE (st.st, 'OT') AS STATE,
-COALESCE (STATE_FULL, 'Other') AS STATE_FULL,
-max(idx) as IDX,
-SUM(total) AS TOTAL,
-SUM(count) AS COUNT
-from disclosure.dsc_sched_a_aggregate_state sa
+SELECT 
+	cmte_id,
+	cycle AS cycle,
+	COALESCE(st.st, 'OT') AS state,
+	COALESCE(state_full, 'Other') AS state_full,
+	MAX(idx) AS idx,
+	SUM(total) AS total,
+	SUM(count) AS count
+FROM disclosure.dsc_sched_a_aggregate_state sa
 LEFT OUTER JOIN staging.ref_st st
 ON sa.state = st.st
-GROUP BY CMTE_ID, CYCLE, st.st, STATE_FULL;
+GROUP BY cmte_id, cycle, st.st, state_full;
 
--- grants
 ALTER TABLE public.ofec_sched_a_agg_state_vw OWNER TO fec;
 GRANT ALL ON TABLE public.ofec_sched_a_agg_state_vw TO fec;
 GRANT SELECT ON TABLE public.ofec_sched_a_agg_state_vw TO fec_read;

--- a/data/migrations/V0100__add_ofec_sched_a_agg_state_vw.sql
+++ b/data/migrations/V0100__add_ofec_sched_a_agg_state_vw.sql
@@ -3,7 +3,7 @@ DROP VIEW IF EXISTS public.ofec_sched_a_agg_state_vw;
 CREATE OR REPLACE VIEW public.ofec_sched_a_agg_state_vw AS
 select cmte_id,
 cycle as CYCLE,
-COALESCE (st.st, 'ot') AS STATE,
+COALESCE (st.st, 'OT') AS STATE,
 COALESCE (STATE_FULL, 'Other') AS STATE_FULL,
 max(idx) as IDX,
 SUM(total) AS TOTAL,
@@ -17,16 +17,3 @@ GROUP BY CMTE_ID, CYCLE, st.st, STATE_FULL;
 ALTER TABLE public.ofec_sched_a_agg_state_vw OWNER TO fec;
 GRANT ALL ON TABLE public.ofec_sched_a_agg_state_vw TO fec;
 GRANT SELECT ON TABLE public.ofec_sched_a_agg_state_vw TO fec_read;
-
-
-/*
-select cmte_id,
-STATE,
-STATE_FULL,
-total,
-count
-from public.ofec_sched_a_agg_state_vw
-WHERE CYCLE = 2018
-AND CMTE_ID = 'C00401224'
-ORDER BY STATE_FULL 
-*/

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -18,7 +18,6 @@ from webservices.resources.candidate_aggregates import (
     TotalsCandidateView,
 )
 
-
 class TestCommitteeAggregates(ApiBaseTest):
     def test_stable_sort(self):
         rows = [
@@ -34,6 +33,7 @@ class TestCommitteeAggregates(ApiBaseTest):
             results = self._results(api.url_for(ScheduleAByEmployerView, sort='-total', per_page=50, page=page + 1))
             employers.extend(result['employer'] for result in results)
         assert len(set(employers)) == len(rows)
+
     def test_by_state(self):
         [
             factories.ScheduleAByStateFactory(
@@ -87,7 +87,6 @@ class TestCommitteeAggregates(ApiBaseTest):
         assert len(results) == 1
 
 class TestAggregates(ApiBaseTest):
-
     cases = [
         (
             factories.ScheduleEByCandidateFactory,
@@ -216,8 +215,8 @@ class TestAggregates(ApiBaseTest):
             )
             assert len(results) == 1
             assert results[0]['candidate_id'] == self.candidate.candidate_id
-class TestCandidateAggregates(ApiBaseTest):
 
+class TestCandidateAggregates(ApiBaseTest):
     current_cycle = get_current_cycle()
     next_cycle = current_cycle + 2
 

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -6,10 +6,11 @@ from webservices.utils import get_current_cycle
 from webservices import schemas
 from webservices.rest import db, api
 from webservices.resources.aggregates import (
-    ScheduleAByEmployerView,
-    ScheduleEByCandidateView,
     CommunicationCostByCandidateView,
     ElectioneeringByCandidateView,
+    ScheduleAByEmployerView,
+    ScheduleAByStateView,
+    ScheduleEByCandidateView,
 )
 from webservices.resources.candidate_aggregates import (
     ScheduleABySizeCandidateView,
@@ -19,7 +20,6 @@ from webservices.resources.candidate_aggregates import (
 
 
 class TestCommitteeAggregates(ApiBaseTest):
-
     def test_stable_sort(self):
         rows = [
             factories.ScheduleAByEmployerFactory(
@@ -34,7 +34,57 @@ class TestCommitteeAggregates(ApiBaseTest):
             results = self._results(api.url_for(ScheduleAByEmployerView, sort='-total', per_page=50, page=page + 1))
             employers.extend(result['employer'] for result in results)
         assert len(set(employers)) == len(rows)
+    def test_by_state(self):
+        [
+            factories.ScheduleAByStateFactory(
+                committee_id='C0001',
+                cycle=2012,
+                total=50,
+                state='NY',
+                state_full='New York',
+                count=5,
+            ),
+            factories.ScheduleAByStateFactory(
+                committee_id='C0002',
+                cycle=2012,
+                total=150,
+                state='NY',
+                state_full='New York',
+                count=6,
+            ),
+            factories.ScheduleAByStateFactory(
+                committee_id='C0003',
+                cycle=2018,
+                total=100,
+                state='OT',
+                state_full='Other',
+            ),
+        ]
+        results = self._results(
+            api.url_for(
+                ScheduleAByStateView,
+                committee_id='C0001',
+                cycle=2012
+            )
+        )
+        assert len(results) == 1
 
+        results = self._results(
+            api.url_for(
+                ScheduleAByStateView,
+                state='NY',
+            )
+        )
+        assert len(results) == 2
+
+        results = self._results(
+            api.url_for(
+                ScheduleAByStateView,
+                cycle=2018,
+                state='OT',
+            )
+        )
+        assert len(results) == 1
 
 class TestAggregates(ApiBaseTest):
 
@@ -166,8 +216,6 @@ class TestAggregates(ApiBaseTest):
             )
             assert len(results) == 1
             assert results[0]['candidate_id'] == self.candidate.candidate_id
-
-
 class TestCandidateAggregates(ApiBaseTest):
 
     current_cycle = get_current_cycle()
@@ -454,14 +502,14 @@ class TestCandidateAggregates(ApiBaseTest):
                 cycle=2012,
             )
         )
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'cycle': 2012,
             'total': 200,
             'size': 200,
         }
-        self.assertEqual(results[0], expected)
+        assert results[0] == expected
 
     def test_by_state(self):
         [
@@ -487,7 +535,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 cycle=2012,
             )
         )
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'cycle': 2012,
@@ -495,7 +543,7 @@ class TestCandidateAggregates(ApiBaseTest):
             'state': 'NY',
             'state_full': 'New York',
         }
-        self.assertEqual(results[0], expected)
+        assert results[0] == expected
 
     def test_totals(self):
         results = self._results(

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -26,7 +26,7 @@ class ScheduleAByState(BaseAggregate):
 
 
 class ScheduleAByZip(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_a_aggregate_zip'
     zip = db.Column(db.String, primary_key=True)
     state = db.Column(db.String, doc=docs.STATE_GENERIC)
@@ -34,25 +34,25 @@ class ScheduleAByZip(BaseAggregate):
 
 
 class ScheduleAByEmployer(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_a_aggregate_employer'
     employer = db.Column(db.String, primary_key=True, doc=docs.EMPLOYER)
 
 
 class ScheduleAByOccupation(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_a_aggregate_occupation'
     occupation = db.Column(db.String, primary_key=True, doc=docs.OCCUPATION)
 
 
 class ScheduleBByRecipient(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_b_aggregate_recipient'
     recipient_name = db.Column('recipient_nm', db.String, primary_key=True, doc=docs.RECIPIENT_NAME)
 
 
 class ScheduleBByRecipientID(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_b_aggregate_recipient_id'
     recipient_id = db.Column('recipient_cmte_id', db.String, primary_key=True, doc=docs.RECIPIENT_ID)
     committee = utils.related_committee('committee_id')
@@ -68,7 +68,7 @@ class ScheduleBByRecipientID(BaseAggregate):
 
 
 class ScheduleBByPurpose(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'dsc_sched_b_aggregate_purpose'
     purpose = db.Column(db.String, primary_key=True, doc=docs.PURPOSE)
 

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -20,8 +20,7 @@ class ScheduleABySize(BaseAggregate):
 
 
 class ScheduleAByState(BaseAggregate):
-    __table_args__ = {'schema' : 'disclosure'}
-    __tablename__ = 'dsc_sched_a_aggregate_state'
+    __tablename__ = 'ofec_sched_a_agg_state_vw'
     state = db.Column(db.String, primary_key=True, doc=docs.STATE_GENERIC)
     state_full = db.Column(db.String, primary_key=True, doc=docs.STATE_GENERIC)
 

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -77,12 +77,21 @@ class ScheduleAByStateView(AggregateResource):
         ('state', models.ScheduleAByState.state),
     ]
 
+    @property
+    def args(self):
+        return utils.extend(
+            args.paging,
+            args.schedule_a_by_state,
+            args.make_sort_args(
+                default='-total',
+            ),
+        )
+   
     def build_query(self, committee_id=None, **kwargs):
         query = super().build_query(committee_id, **kwargs)
         if kwargs['hide_null']:
             query = query.filter(self.model.state_full != None)  # noqa
         return query
-
 
 @doc(
     tags=['receipts'],


### PR DESCRIPTION
## Summary
Example link:
[https://www.fec.gov/data/committee/C00370007/?tab=raising](https://www.fec.gov/data/committee/C00370007/?tab=raising)
on Individual contributions section in committee profile page, click Group by State, we will group by all non-US state values into one new row called: `Other`

- Resolves # [https://github.com/fecgov/openFEC/issues/3246](https://github.com/fecgov/openFEC/issues/3246)

related fec-cms Issue: [https://github.com/fecgov/fec-cms/issues/2237](https://github.com/fecgov/fec-cms/issues/2237)

_Include a summary of proposed changes._
tag: receipts
Path:/committee/{committee_id}/schedules/schedule_a/by_state/
endpoint: resources---aggregates.ScheduleAByStateView
model. aggregates.py—ScheduleAByState
new view: public.ofec_sched_a_agg_state_vw
table: disclosure.dsc_sched_a_aggregate_state



## How to test the changes locally
1)checkout branch: fix-sched_a-by-state-display to local openFEC
2) SQLA_CONN =dev db
3)start server
4)setup fec-cms point to your local api
5)test example: 
 [http://127.0.0.1:8000/data/committee/C00370007/?tab=raising](http://127.0.0.1:8000/data/committee/C00370007/?tab=raising)
6)also test sort by state and by total columns
<img width="836" alt="screen shot 2018-08-01 at 11 09 45 am" src="https://user-images.githubusercontent.com/24395751/43544831-25ca805e-95a2-11e8-8ceb-603b5f89c0ca.png">

