### PR TITLE
Add endpoint-specific caching

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -152,14 +152,31 @@ def limit_remote_addr():
                 abort(403)
 
 
+def get_cache_duration(url):
+
+    EFILING_CACHE = 0
+    LEGAL_CACHE = 60 * 5
+    CALENDAR_CACHE = 60 * 5
+    DEFAULT_CACHE = 60 * 60
+
+    if '/efile/' in url:
+        return EFILING_CACHE
+    elif '/calendar-dates/' in url:
+        return CALENDAR_CACHE
+    elif '/legal/' in url:
+        return LEGAL_CACHE
+
+    return DEFAULT_CACHE
+
+
 @app.after_request
 def add_caching_headers(response):
-    if app.config['MAX_CACHE_AGE'] is not None:
-        response.headers.add(
-            'Cache-Control',
-            'public, max-age={}'.format(app.config['MAX_CACHE_AGE'])
-        )
 
+    cache_duration = get_cache_duration(request.path)
+    response.headers.add(
+        'Cache-Control',
+        'public, max-age={}'.format(cache_duration)
+    )
     return response
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3237 

_Add endpoint-specific caching: Default is 1 hour, legal and calendar are 5 minutes, efiling is none._

## How to test the changes locally

Run this branch locally and look at the response headers using `CURL`:
- default: `curl -I http://localhost:5000/` 1 hour = 3600s
- legal: `curl -I "http://localhost:5000/v1/legal/search/?description=excessive&ao_is_pending=True&type=advisory_opinions&api_key=DEMO_KEY"` 5 min = 300s
- calendar: `curl -I http://localhost:5000/v1/calendar-dates/` 5 min = 300s
- efile: `curl -I http://localhost:5000/v1/schedules/schedule_a/efile/?api_key=DEMO_KEY` = 0

## Impacted areas of the application
List general components of the application that this PR will affect:

-  API caching

## Related PRs
List related PRs against other branches:

Remove S3 caching #3235 