### PR TITLE
Add ability to deploy without running migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,13 @@ invoke deploy --space dev
 
 This command will explicitly target the `dev` space.
 
+To skip migrations with a manual deploy, run:
+
+```
+invoke deploy --space dev --skip-migrations
+```
+
+
 #### Setting up a service
 On Cloud Foundry, we use the redis32
 service. The Redis service can be created as follows:


### PR DESCRIPTION
## Summary (required)

- Resolves #3324 

Add ability to deploy without running migrations. `Invoke` task can only take a `True` flag or a value flag (per the [docs](http://docs.pyinvoke.org/en/0.11.1/api/tasks.html#invoke.tasks.task)):
>"arguments may be given as value-taking options (e.g. `--my-arg=myvalue`, wherein the task is given `"myvalue"`) or as Boolean flags (`--my-arg`, resulting in `True`)."

so I made the flag `skip-migrations`, defaulted to `False`

This is a follow-up item from our post-mortem [here](https://docs.google.com/document/d/1t_up-38Kvofg8ILzVJq_RYgFXUxSF-xsxgSocjXT8vs/edit)

## How to test the changes locally

- With migrations: `invoke deploy --space dev`
- Without migrations `invoke deploy --space dev --skip-migrations`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Circle deploys and manual deploys of the API
