### PR TITLE
Add better error message for missing migrator environmental variable

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -183,8 +183,15 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, skip_migrations=
     if skip_migrations:
         print("\nSkipping migrations. Database not migrated.\n")
     else:
+        migration_env_var = 'FEC_MIGRATOR_SQLA_CONN_{0}'.format(space.upper())
+        migration_credential = os.getenv(migration_env_var)
+
+        if migration_credential is None:
+            print("\nUnable to retrieve {0}. Make sure the environmental variable is set.\n".format(migration_env_var))
+            return
+
         print("\nMigrating database...")
-        jdbc_url = to_jdbc_url(os.getenv('FEC_MIGRATOR_SQLA_CONN_{0}'.format(space.upper())))
+        jdbc_url = to_jdbc_url(migration_credential)
         run_migrations(ctx, jdbc_url)
         print("Database migrated\n")
 


### PR DESCRIPTION
## Summary (required)

- Resolves an issue that came up in testing `invoke deploy --space [SPACE: dev/stage/prod]`

Check for FEC_MIGRATOR_SQLA_CONN_[SPACE] before trying to run migrations

### Before:

>Traceback (most recent call last):
  File "/Users/lbeaufort/.pyenv/versions/api-env/bin/invoke", line 11, in <module>
    sys.exit(program.run())
  File "/Users/lbeaufort/.pyenv/versions/3.6.5/envs/api-env/lib/python3.6/site-packages/invoke/program.py", line 293, in run
    self.execute()
  File "/Users/lbeaufort/.pyenv/versions/3.6.5/envs/api-env/lib/python3.6/site-packages/invoke/program.py", line 408, in execute
    executor.execute(*self.tasks)
  File "/Users/lbeaufort/.pyenv/versions/3.6.5/envs/api-env/lib/python3.6/site-packages/invoke/executor.py", line 114, in execute
    result = call.task(*args, **call.kwargs)
  File "/Users/lbeaufort/.pyenv/versions/3.6.5/envs/api-env/lib/python3.6/site-packages/invoke/tasks.py", line 114, in __call__
    result = self.body(*args, **kwargs)
  File "/Users/lbeaufort/dev/API/openFEC/tasks.py", line 187, in deploy
    jdbc_url = to_jdbc_url(os.getenv('FEC_MIGRATOR_SQLA_CONN_{0}'.format(space.upper())))
  File "/Users/lbeaufort/dev/API/openFEC/jdbc_utils.py", line 4, in to_jdbc_url
    match = DB_URL_REGEX.match(dbi_url)
TypeError: expected string or bytes-like object 👎 

### After
> Unable to retrieve FEC_MIGRATOR_SQLA_CONN_DEV. Make sure the environmental variable is set. 👍 

## How to test the changes locally

- `unset $FEC_MIGRATOR_SQLA_CONN_DEV` and run `invoke deploy --space dev`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Manual and Circle deploys

## Related PRs
#3324 