### PR TITLE
Remove stale code

### DIFF
--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -145,7 +145,7 @@ def export_query(path, qs):
 
 @app.task
 def clear_bucket():
-    permanent_dir = ('legal', 'bulk-downloads', 'cached-calls')
+    permanent_dir = ('legal', 'bulk-downloads')
     for obj in task_utils.get_bucket().objects.all():
         if not obj.key.startswith(permanent_dir):
             obj.delete()


### PR DESCRIPTION
This call is no longer needed as we no longer store anything under the
name cached-calls.