### PR TITLE
Bump pytest to 3.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            py.test
+            pytest
 
       - run:
           name: Perform post-test checks

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The connection URL has to strictly adhere to the structure `postgresql://<userna
 Running the tests:
 
 ```
-py.test
+pytest
 ```
 
 #### The test data subset

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ git+https://github.com/18F/rdbms-subsetter
 ipython==6.4.0
 
 # Testing
-pytest==3.6.0
+pytest==3.7.4
 pytest-cov==2.5.1
 factory_boy==2.8.1
 faker==0.7.18


### PR DESCRIPTION
This makes it consistent with `fec-cms`.
Also, change the invocation command to `pytest` instead of `py.test`
as per https://github.com/pytest-dev/pytest/issues/1629 and to be
consistent with `fec-cms`.