### PR TITLE
Rename 'ofec_rad_analyst_vw.assignment_update' to 'assignment_update_date'

### DIFF
--- a/data/migrations/V0103__fix_ofec_rad_analyst_vw.sql
+++ b/data/migrations/V0103__fix_ofec_rad_analyst_vw.sql
@@ -1,0 +1,10 @@
+/*
+
+Rename assignment_update to assignment_update_date
+
+*/
+
+SET search_path = public;
+
+ALTER TABLE ofec_rad_analyst_vw
+RENAME COLUMN assignment_update to assignment_update_date


### PR DESCRIPTION
## Summary (required)

Resolves issue found in testing. Rename `ofec_rad_analyst_vw.assignment_update` to `assignment_update_date`

I ran this on `dev` with a manual deploy so our migrations will stay in order.

Test with http://localhost:5000/v1/rad-analyst/?per_page=20 or https://fec-dev-api.app.cloud.gov/v1/rad-analyst/