### PR TITLE
Update apispec package to use fecgov's forked repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apispec==0.19.0
+apispec==0.39.0
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1
@@ -25,6 +25,7 @@ git+https://github.com/18F/slate.git
 
 # Marshalling
 flask-apispec==0.6.0.post0
+prance==0.13.1
 marshmallow==2.6.0
 marshmallow-sqlalchemy==0.8.0
 git+https://github.com/jmcarp/marshmallow-pagination@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ elasticsearch-dsl==5.4.0
 git+https://github.com/18F/slate.git
 
 # Marshalling
-flask-apispec==0.6.0.post0
+flask-apispec==0.7.0
 prance==0.13.1
 marshmallow==2.6.0
 marshmallow-sqlalchemy==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-apispec==1.0.0b2
+git+https://github.com/fecgov/apispec.git@dev
+prance[osv]>=0.11 # use apispec[validation] once we no longer fork apispec
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1
@@ -25,7 +26,6 @@ git+https://github.com/18F/slate.git
 
 # Marshalling
 flask-apispec==0.7.0
-prance==0.13.1
 marshmallow==2.6.0
 marshmallow-sqlalchemy==0.8.0
 git+https://github.com/jmcarp/marshmallow-pagination@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apispec==0.39.0
+apispec==1.0.0b2
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/fecgov/apispec.git@dev
+git+https://github.com/fecgov/apispec.git@dev#egg=apispec
 prance[osv]>=0.11 # use apispec[validation] once we no longer fork apispec
 cfenv==0.5.2
 invoke==0.15.0

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,7 +1,10 @@
 import unittest
-
 from apispec import utils, exceptions
+
+import webservices.rest
+import webservices.schemas  # needed to generate full spec
 from webservices.spec import spec, format_docstring
+
 
 class TestSwagger(unittest.TestCase):
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -10,7 +10,7 @@ class TestSwagger(unittest.TestCase):
 
     def test_swagger_valid(self):
         try:
-            utils.validate_swagger(spec)
+            utils.validate_spec(spec)
         except exceptions.SwaggerError as error:
             self.fail(str(error))
 

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -11,8 +11,6 @@ def format_docstring(docstring):
 
     formatted = []
     lines = docstring.expandtabs().splitlines()
-    indent = min(len(line) - len(line.strip()) for line in lines if line.strip())
-    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
 
     for line in lines:
         if line == '':

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -1,4 +1,6 @@
 from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+
 
 from webservices import docs
 from webservices import __API_VERSION__
@@ -20,13 +22,14 @@ def format_docstring(docstring):
 
     return ' '.join(formatted).strip()
 
+
 spec = APISpec(
     title='OpenFEC',
     version=__API_VERSION__,
     info={'description': format_docstring(docs.API_DESCRIPTION)},
     basePath='/v1',
     produces=['application/json'],
-    plugins=['apispec.ext.marshmallow'],
+    plugins=[MarshmallowPlugin()],
     securityDefinitions={
         'apiKey': {
             'type': 'apiKey',


### PR DESCRIPTION
Resolves #3356 and Resolves #3280 

`apispec` accepted my PR to [fix the `PyYAML` vulnerability](https://github.com/marshmallow-code/apispec/issues/278) but we haven't heard back on another change that's [preventing us from being able to run the latest `validate_spec`](https://github.com/marshmallow-code/apispec/issues/282) so I [made the change on our end](https://github.com/fecgov/apispec/pull/1). 

This PR uses our forked version until we can (hopefully) get `apispec` to make a change.
 