### PR TITLE
Add ADR and AF to celery reload task

### DIFF
--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -277,7 +277,7 @@ def get_af_specific_fields(case_id):
             case["treasury_referral_amount"] = row["treasury_amount"]
             case["petition_court_filing_date"] = row["petition_court_filing_date"]
             case["petition_court_decision_date"] = row["petition_court_decision_date"]
-            return case
+    return case
 
 
 def get_election_cycles(case_id):

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -1,4 +1,3 @@
-
 import celery
 from celery import signals
 from celery.schedules import crontab


### PR DESCRIPTION
## Summary (required)

Follow-up issue for #3359 

- Add test data for sample db for ADR/AF
- Modify `reload_mur` celery task to reload all modified cases (MUR/ADR/AF)
- Add better error handling for when no AF-specific fields are found (may only apply to test data but we should account for the possibility)

## How to test the changes locally

- Recreate sample db (drop/create/ `invoke create_sample_db`)
- unset  SQLA_CONN to point to local
- run redis/celery beat/celery worker (https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads)
- run elasticsearch locally, make sure you have the required parameters
- fake a modified ADR/AF on local cfdm_test db: `update fecmur."case" set name=concat(name,' test'), pg_date=now()`
- see if it reloads properly