### PR TITLE
Flask upgrade from 0.12 to 0.12.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apispec==0.19.0
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1
-Flask==0.12
+Flask==0.12.4
 Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-RESTful==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apispec==0.19.0
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1
-Flask==0.12.3
+Flask==0.12
 Flask-Cors==3.0.2
 Flask-Script==2.0.5
 Flask-RESTful==0.3.5


### PR DESCRIPTION
 This reverts fecgov/openFEC#3372, because the version targeted in that PR  (0.12.3 )failed certain tests. 
It was agreed to go to Flask==0.12.4, a stable version for our tests. Meaning it pasts all our tests. This  PR includes that change
