### PR TITLE
drop ofec_entity_chart and its nightly refreshing

### DIFF
--- a/data/migrations/V0108__drop_ofec_entity_chart.sql
+++ b/data/migrations/V0108__drop_ofec_entity_chart.sql
@@ -1,0 +1,10 @@
+/*
+Addresses issue #3399
+public.ofec_entity_chart_mv, and ofec_entity_chart_vw are not used by by line chart anymore and can be dropped
+*/
+
+SET search_path = public, pg_catalog;
+
+DROP VIEW ofec_entity_chart_vw;
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_entity_chart_mv;

--- a/manage.py
+++ b/manage.py
@@ -219,7 +219,6 @@ def refresh_materialized(concurrent=True):
         'filings': ['ofec_filings_amendments_all_mv',
                     'ofec_filings_mv',
                     'ofec_filings_all_mv'],
-        'large_aggregates': ['ofec_entity_chart_mv'],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],
         'ofec_sched_e_mv': ['ofec_sched_e_mv'],
         'reports_house_senate': ['ofec_reports_house_senate_mv'],

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -30,7 +30,6 @@ def get_graph():
         'filing_amendments_pac_party',
         'filing_amendments_presidential',
         'filings',
-        'large_aggregates',
         'ofec_agg_coverage_date',
         'ofec_sched_e_mv',
         'reports_house_senate',
@@ -121,12 +120,6 @@ def get_graph():
     graph.add_edges_from([
         ('filings', 'totals_combined'),
         ('filings', 'report_pac_party_all'),
-    ])
-
-    graph.add_edges_from([
-        ('totals_pac_party', 'large_aggregates'),
-        ('totals_house_senate', 'large_aggregates'),
-        ('totals_combined', 'large_aggregates'),
     ])
 
     graph.add_edges_from([


### PR DESCRIPTION
## Summary (required)

- Resolves # [3399](https://github.com/fecgov/openFEC/issues/3399)

_Materialized view public.ofec_entity_chart_mv is not used by by line chart anymore,  and should be 
deleted_

## How to test the changes locally

- set up cfdm_test database locally
- run migration against cfdm_test and check to see this object has been dropped.



