### PR TITLE
Modify exception handler to return response

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -192,6 +192,7 @@ def handle_exception(exception):
     )
     raise exceptions.ApiError('Could not process the request',
             status_code=http.client.NOT_FOUND)
+    return wrapped.wrappedException, wrapped.status
 
 api.add_resource(candidates.CandidateList, '/candidates/')
 api.add_resource(candidates.CandidateSearch, '/candidates/search/')


### PR DESCRIPTION
## Summary (required)

- Resolves issues in testing Flask upgrade

Modify exception handler to return response per http://flask.pocoo.org/docs/1.0/errorhandling/ and https://stackoverflow.com/questions/29332056/global-error-handler-for-any-exception

## How to test the changes locally

- localhost:5000/v1/candidates should only return 200 response
- test error handler by `drop materialized view ofec_candidate_detail_mv cascade` **on CFDM_TEST database** and you should get a 500 error when trying the call again

## Impacted areas of the application
List general components of the application that this PR will affect:

-  API error handling

## Related PRs
List related PRs against other branches:

#3403 