### PR TITLE
Disables strict slashes in API, add 404 error handler

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -64,6 +64,7 @@ def initialize_newrelic():
 initialize_newrelic()
 
 app = Flask(__name__)
+app.url_map.strict_slashes = False
 
 
 def sqla_conn_string():

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -192,7 +192,12 @@ def handle_exception(exception):
         )
     )
     raise exceptions.ApiError('Could not process the request',
-            status_code=http.client.NOT_FOUND)
+        status_code=http.client.NOT_FOUND)
+
+@app.errorhandler(404)
+def page_not_found(exception):
+    wrapped = ResponseException(str(exception), exception.code, type(exception))
+    return wrapped.wrappedException, wrapped.status
 
 api.add_resource(candidates.CandidateList, '/candidates/')
 api.add_resource(candidates.CandidateSearch, '/candidates/search/')


### PR DESCRIPTION
## Summary

- Related #3403 

_The latest upgrade of flask was causing requests from the CMS to 500 in the API due to lack of a trailing slash from the CMS request call. To fix this, this PR disables `strict_slashes` so that both types of requests will work._

Solution from: https://stackoverflow.com/questions/33241050/trailing-slash-triggers-404-in-flask-path-rule

## How to test the changes locally

- Run local API and make sure that both of these endpoint sill render (notice one has a trailing slash after history and the other does not):
http://localhost:5000/v1/candidate/H8GA06195/history?api_key=DEMO_KEY
http://localhost:5000/v1/candidate/H8GA06195/history/?api_key=DEMO_KEY
- Run local CMS environment and try to render a candidate or committee page based on these changes:
http://localhost:8000/data/candidate/H8GA06195/
http://localhost:8000/data/committee/C00657353/

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Flask slash settings

## Related PRs
List related PRs against other branches:

qqss88:feat-3371 | #3403 