### PR TITLE
Set 500k threshold estimate for all endpoints

### DIFF
--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -15,10 +15,10 @@ count_pattern = re.compile(r'rows=(\d+)')
 
 def count_estimate(query, session, threshold=500000):
     rows = session.execute(explain(query)).fetchall()
-    count = extract_analyze_count(rows)
-    if count < threshold:
+    estimated_count = extract_analyze_count(rows)
+    if estimated_count < threshold:
         return query.count()
-    return count
+    return estimated_count
 
 
 def extract_analyze_count(rows):

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -13,10 +13,10 @@ from sqlalchemy.sql.expression import Executable, ClauseElement, _literal_as_tex
 count_pattern = re.compile(r'rows=(\d+)')
 
 
-def count_estimate(query, session, threshold=None):
+def count_estimate(query, session, threshold=500000):
     rows = session.execute(explain(query)).fetchall()
     count = extract_analyze_count(rows)
-    if threshold is not None and count < threshold:
+    if count < threshold:
         return query.count()
     return count
 

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -73,7 +73,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -100,5 +100,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return page_query, count

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -30,7 +30,7 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
@@ -73,7 +73,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -100,5 +100,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return page_query, count

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -129,7 +129,7 @@ class ScheduleAByEmployerView(AggregateResource):
 
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 
@@ -153,7 +153,7 @@ class ScheduleAByOccupationView(AggregateResource):
 
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -129,7 +129,7 @@ class ScheduleAByEmployerView(AggregateResource):
 
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 
@@ -153,7 +153,7 @@ class ScheduleAByOccupationView(AggregateResource):
 
     def get(self, committee_id=None, **kwargs):
         query = self.build_query(committee_id=committee_id, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return utils.fetch_page(query, kwargs, model=self.model, count=count, index_column=self.index_column)
 
 

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -131,7 +131,7 @@ class ElectionView(ApiResource):
 
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -69,7 +69,7 @@ class BaseFilings(views.ApiResource):
             #Adds FRQ types if RFAI was requested
             kwargs.get('form_type').append('FRQ')
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return utils.fetch_page(query, kwargs, model=models.Filings, count=count, multi=True)
 
 
@@ -127,7 +127,7 @@ class EFilingsView(views.ApiResource):
 
     def get(self, **kwargs):
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=500000)
+        count = counts.count_estimate(query, models.db.session)
         return utils.fetch_page(query, kwargs, model=models.EFilings, count=count)
 
     @property

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -69,7 +69,7 @@ class BaseFilings(views.ApiResource):
             #Adds FRQ types if RFAI was requested
             kwargs.get('form_type').append('FRQ')
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return utils.fetch_page(query, kwargs, model=models.Filings, count=count, multi=True)
 
 
@@ -127,7 +127,7 @@ class EFilingsView(views.ApiResource):
 
     def get(self, **kwargs):
         query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session, threshold=5000)
+        count = counts.count_estimate(query, models.db.session, threshold=500000)
         return utils.fetch_page(query, kwargs, model=models.EFilings, count=count)
 
     @property

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -31,7 +31,7 @@ def call_resource(path, qs):
     for field in IGNORE_FIELDS:
         kwargs.pop(field, None)
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
-    count = counts.count_estimate(query, db.session, threshold=500000)
+    count = counts.count_estimate(query, db.session)
     return {
         'path': path,
         'qs': qs,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -31,7 +31,7 @@ def call_resource(path, qs):
     for field in IGNORE_FIELDS:
         kwargs.pop(field, None)
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
-    count = counts.count_estimate(query, db.session, threshold=5000)
+    count = counts.count_estimate(query, db.session, threshold=500000)
     return {
         'path': path,
         'qs': qs,


### PR DESCRIPTION
## Summary (required)

- Resolves #3104: **Count estimate for receipts search approximately doubles the amount returned**

Set 500k default threshold estimate for all endpoints

Tested performance and results aren't wildly different, but we'll want to keep testing. Locust test results: https://docs.google.com/spreadsheets/d/11y9OcjiK5ZHYkyPXeN-Toerrtvh-J0mJNAEccRQDHTE/edit#gid=1816955716

## How to test the changes locally

- run this branch of the api, go to http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=XE9ZYUzWKKe8SRLfEftx9vUndkWYnIXIQw3cOQOS&sort_hide_null=true&data_type=processed&committee_id=C00000935&two_year_transaction_period=2018&min_date=01%2F01%2F2017&max_date=05%2F01%2F2018&contributor_state=IL&sort=-contribution_receipt_date&per_page=30 - counts are no longer doubled
- you can also test `feature/add-datatable-counts` branch of cms, point to your local API and go to  http://localhost:8000/data/receipts/?two_year_transaction_period=2018&data_type=processed&committee_id=C00000935&min_date=01%2F01%2F2017&max_date=05%2F01%2F2018&contributor_state=IL

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Endpoint counts


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
'feature/add-datatable-counts' | https://github.com/fecgov/fec-cms/pull/2430
