### PR TITLE
Use full text filter for aggregate resources

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -290,7 +290,10 @@ class ScheduleAByEmployerFactory(BaseAggregateFactory):
 class ScheduleBByPurposeFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleBByPurpose
-    purpose = 'ADMINISTRATIVE'
+
+class ScheduleBByRecipientFactory(BaseAggregateFactory):
+    class Meta:
+        model = models.ScheduleBByRecipient
 
 
 class ScheduleEByCandidateFactory(BaseAggregateFactory):

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -10,6 +10,8 @@ from webservices.resources.aggregates import (
     ElectioneeringByCandidateView,
     ScheduleAByEmployerView,
     ScheduleAByStateView,
+    ScheduleBByPurposeView,
+    ScheduleBByRecipientView,
     ScheduleEByCandidateView,
 )
 from webservices.resources.candidate_aggregates import (
@@ -85,6 +87,59 @@ class TestCommitteeAggregates(ApiBaseTest):
             )
         )
         assert len(results) == 1
+
+    def test_disbursement_purpose(self):
+        committee = factories.CommitteeHistoryFactory(cycle=2012)
+
+        aggregate = factories.ScheduleBByPurposeFactory(
+            committee_id=committee.committee_id,
+            cycle=committee.cycle,
+            purpose='ADMINISTRATIVE EXPENSES'
+        )
+        results = self._results(
+            api.url_for(
+                ScheduleBByPurposeView,
+                committee_id=committee.committee_id,
+                cycle=2012,
+                purpose='Administrative'
+            )
+        )
+        self.assertEqual(len(results), 1)
+        expected = {
+            'committee_id': committee.committee_id,
+            'purpose': 'ADMINISTRATIVE EXPENSES',
+            'cycle': 2012,
+            'total': aggregate.total,
+            'count': aggregate.count,
+        }
+        self.assertEqual(results[0], expected)
+
+    def test_disbursement_recipient(self):
+        committee = factories.CommitteeHistoryFactory(cycle=2012)
+
+        aggregate = factories.ScheduleBByRecipientFactory(
+            committee_id=committee.committee_id,
+            cycle=committee.cycle,
+            recipient_name='STARBOARD STRATEGIES, INC.'
+        )
+        results = self._results(
+            api.url_for(
+                ScheduleBByRecipientView,
+                committee_id=committee.committee_id,
+                cycle=2012,
+                recipient_name='Starboard Strategies'
+            )
+        )
+        self.assertEqual(len(results), 1)
+        expected = {
+            'committee_id': committee.committee_id,
+            'recipient_name': 'STARBOARD STRATEGIES, INC.',
+            'cycle': 2012,
+            'total': aggregate.total,
+            'count': aggregate.count,
+        }
+        self.assertEqual(results[0], expected)
+
 
 class TestAggregates(ApiBaseTest):
     cases = [

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -124,6 +124,8 @@ class ScheduleAByEmployerView(AggregateResource):
     query_args = args.schedule_a_by_employer
     filter_multi_fields = [
         ('cycle', models.ScheduleAByEmployer.cycle),
+    ]
+    filter_fulltext_fields = [
         ('employer', models.ScheduleAByEmployer.employer),
     ]
 
@@ -148,6 +150,8 @@ class ScheduleAByOccupationView(AggregateResource):
     query_args = args.schedule_a_by_occupation
     filter_multi_fields = [
         ('cycle', models.ScheduleAByOccupation.cycle),
+    ]
+    filter_fulltext_fields = [
         ('occupation', models.ScheduleAByOccupation.occupation),
     ]
 
@@ -172,6 +176,8 @@ class ScheduleBByRecipientView(AggregateResource):
     query_args = args.schedule_b_by_recipient
     filter_multi_fields = [
         ('cycle', models.ScheduleBByRecipient.cycle),
+    ]
+    filter_fulltext_fields = [
         ('recipient_name', models.ScheduleBByRecipient.recipient_name),
     ]
 
@@ -213,6 +219,8 @@ class ScheduleBByPurposeView(AggregateResource):
     query_args = args.schedule_b_by_purpose
     filter_multi_fields = [
         ('cycle', models.ScheduleBByPurpose.cycle),
+    ]
+    filter_fulltext_fields = [
         ('purpose', models.ScheduleBByPurpose.purpose),
     ]
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -266,7 +266,7 @@ def augment_itemized_aggregate_models(factory, committee_model, *models, namespa
         schema = factory(
             model,
             options={
-                'exclude': ('committee',),
+                'exclude': ('idx', 'committee',),
                 'relationships': [
                     Relationship(
                         model.committee,


### PR DESCRIPTION
Use fulltext filter for:
Schedule A: employer, occupation
Schedule B: purpose, and recipient name

## Summary (required)

- Resolves #3429 : "Disbursements missing from /schedule_b/by_recipient/"

    Use full text filter for aggregate resources
    
    Use fulltext filter for:
    **Schedule A:** employer, occupation
    **Schedule B:** purpose, and recipient name
    
    This allows partial matches on these text fields.

## How to test the changes locally

- http://localhost:5000/v1/schedules/schedule_b/by_recipient/?api_key=DEMO_KEY&cycle=2016&per_page=20&recipient_name=Starboard%20strategic&page=1 should return results for "STARBOARD STRATEGIC, INC."

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /schedule_a/by_employer/ -> Can use partial text search for employer
- /schedule_a/by_occupation/ -> "" occupation
- /schedule_b/by_purpose/ -> "" purpose
- /schedule_b/by_recipient/ -> "" recipient


