### PR TITLE
Show only authorized (P, A) committee_ids

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
+          - v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-fec-api-dependencies-
+          - v2-fec-api-dependencies-
 
       - run:
           name: Install node dependencies
@@ -73,7 +73,7 @@ jobs:
           paths:
             - ./venv
             - ./node_modules
-          key: v1-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
+          key: v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-ci.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -212,10 +212,13 @@ class TestElections(ApiBaseTest):
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
-        assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees)
+        assert set(results[0]['committee_ids']) == set(
+            each.committee_id for each in self.committees
+            if each.designation != 'J')
 
     def test_electionview_excludes_jfc(self):
         self.candidate_committee_links[0].committee_designation = 'J'
+        self.committees[0].designation = 'J'
 
         results = self._results(
             api.url_for(
@@ -223,13 +226,13 @@ class TestElections(ApiBaseTest):
                 office='senate', cycle=2012, state='NY', election_full='true',
             )
         )
-# Joint Fundraising Committees raise money for multiple
-# candidate committees and transfer that money to those committees.
-# By limiting the committee designations to A and P
-# you eliminate J (joint) and thus do not inflate
-# the candidate's money by including it twice and
-# by including money that was raised and transferred
-# to the other committees in the joint fundraiser.
+        # Joint Fundraising Committees raise money for multiple
+        # candidate committees and transfer that money to those committees.
+        # By limiting the committee designations to A and P
+        # you eliminate J (joint) and thus do not inflate
+        # the candidate's money by including it twice and
+        # by including money that was raised and transferred
+        # to the other committees in the joint fundraiser.
         totals_without_jfc = self.totals[1:]
         cash_on_hand_without_jfc = self.totals[1:2]
         expected = {
@@ -243,7 +246,7 @@ class TestElections(ApiBaseTest):
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
-        assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees)
+        assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees if each.designation != 'J')
 
     def test_election_summary(self):
         results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY'))

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -177,6 +177,8 @@ class ElectionView(ApiResource):
             sa.case(
                 [(CandidateCommitteeLink.committee_designation == 'P', CandidateCommitteeLink.committee_id)]  # noqa
             ).label('candidate_pcc_id')
+        ).filter(
+            CandidateCommitteeLink.committee_designation.in_(['P', 'A'])
         )
         pairs = join_candidate_totals(pairs, kwargs, totals_model)
         pairs = filter_candidate_totals(pairs, kwargs, totals_model)


### PR DESCRIPTION
## Summary (required)

Resolves #3442 and resolves https://github.com/fecgov/fec-cms/issues/1656

- Show only authorized (P, A) `committee_ids` in /elections/ endpoint
- Update Circle cache to v2 due to failing builds

## How to test the changes locally
- Point to `dev` db
- (optional) run local CMS and point to local API
- http://localhost:5000/v1/elections/?api_key=DEMO_KEY&cycle=2018&election_full=true&office=senate&state=MO&stateFull=Missouri&per_page=0&sort_hide_null=true - McCaskill should only have two authorized committees.
- Run CMS locally and test election profile page totals. Also, clicking through to "View all" under "Source Reports" should now only go to authorized campaign committees.
- Other candidates with multiple committees (Click "Compare to opposing candidates" button to see election profile pages): 

Feinstein (Senate)
http://localhost:8000/data/candidate/S0CA00199/

Coffman  (House)
http://localhost:8000/data/candidate/S0CA00199/

Luetkemeyer (House)
http://localhost:8000/data/candidate/S0CA00199/

Weaver (House)
http://localhost:8000/data/candidate/S0CA00199/

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Election profile pages
