### PR TITLE
Add spender committee type filter into ScheduleBView

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -175,6 +175,7 @@ class TestItemized(ApiBaseTest):
         [
             factories.ScheduleBFactory(spender_committee_type='S'),
             factories.ScheduleBFactory(spender_committee_type='S'),
+            factories.ScheduleBFactory(spender_committee_type='P'),
         ]
         results = self._results(api.url_for(ScheduleBView, spender_committee_type='S', **self.kwargs))
         self.assertEqual(len(results), 2)

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1,14 +1,14 @@
 import datetime
 
-import sqlalchemy as sa
+# import sqlalchemy as sa
 
 from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices.rest import api
-from webservices.common.models import ScheduleA, ScheduleB, ScheduleE, ScheduleAEfile, ScheduleBEfile, ScheduleEEfile, EFilings
 from webservices.schemas import ScheduleASchema
 from webservices.schemas import ScheduleBSchema
+from webservices.common.models import ScheduleA, ScheduleB, ScheduleE, ScheduleAEfile, ScheduleBEfile, ScheduleEEfile, EFilings
 from webservices.resources.sched_a import ScheduleAView, ScheduleAEfileView
 from webservices.resources.sched_b import ScheduleBView, ScheduleBEfileView
 from webservices.resources.sched_e import ScheduleEView, ScheduleEEfileView
@@ -173,6 +173,14 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleBView, line_number='f3X-21', **self.kwargs))
         self.assertEqual(len(results), 1)
 
+    def test_sched_b_spender_committee_type_filter(self):
+        [
+            factories.ScheduleBFactory(spender_committee_type='S'),
+            factories.ScheduleBFactory(spender_committee_type='S'),
+        ]
+        results = self._results(api.url_for(ScheduleBView, spender_committee_type='S', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
     def test_filter_fulltext_employer(self):
         employers = ['Acme Corporation', 'Vandelay Industries']
         filings = [
@@ -234,7 +242,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page1],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in filings[5:25]]
+            [each.contribution_receipt_date.strftime('%Y-%m-%d')
+            if each.contribution_receipt_date else None for each in filings[5:25]]
         )
         page2 = self._results(
             api.url_for(
@@ -242,7 +251,8 @@ class TestItemized(ApiBaseTest):
                 last_index=page1[-1]['sub_id'],
                 sort='contribution_receipt_date',
                 **self.kwargs
-        ))
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -250,7 +260,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in filings[25:]]
+            [each.contribution_receipt_date.strftime('%Y-%m-%d')
+            if each.contribution_receipt_date else None for each in filings[25:]]
         )
 
     def test_null_pagination_with_null_sort_column_values_descending(self):
@@ -284,7 +295,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page1],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in top_reversed_from_middle]
+            [each.contribution_receipt_date.strftime('%Y-%m-%d')
+            if each.contribution_receipt_date else None for each in top_reversed_from_middle]
         )
         page2 = self._results(api.url_for(
             ScheduleAView,
@@ -300,7 +312,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in filings[14:9:-1]]
+            [each.contribution_receipt_date.strftime('%Y-%m-%d')
+            if each.contribution_receipt_date else None for each in filings[14:9:-1]]
         )
 
     def test_null_pagination_with_null_sort_column_values_ascending(self):
@@ -308,13 +321,13 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(contribution_receipt_date=None)
             # this range should ensure the page has a null transition
             for _ in range(10)
-            ]
+        ]
         filings = filings + [
             factories.ScheduleAFactory(
                 contribution_receipt_date=datetime.date(2016, 1, 1)
             )
             for _ in range(15)
-            ]
+        ]
 
         page1 = self._results(api.url_for(
             ScheduleAView,
@@ -422,7 +435,8 @@ class TestItemized(ApiBaseTest):
                 last_index=page1[-1]['sub_id'],
                 sort='disbursement_date',
                 **self.kwargs
-        ))
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -468,7 +482,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page1],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in top_reversed_from_middle]
+            [each.disbursement_date.strftime('%Y-%m-%d')
+            if each.disbursement_date else None for each in top_reversed_from_middle]
         )
         page2 = self._results(api.url_for(
             ScheduleBView,
@@ -484,7 +499,8 @@ class TestItemized(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page2],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[14:9:-1]]
+            [each.disbursement_date.strftime('%Y-%m-%d')
+            if each.disbursement_date else None for each in filings[14:9:-1]]
         )
 
     def test_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(self):
@@ -496,13 +512,13 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleBFactory(disbursement_date=None)
             # this range should ensure the page has a null transition
             for _ in range(10)
-            ]
+        ]
         filings = filings + [
             factories.ScheduleBFactory(
                 disbursement_date=datetime.date(2016, 1, 1)
             )
             for _ in range(15)
-            ]
+        ]
 
         page1 = self._results(api.url_for(
             ScheduleBView,
@@ -584,7 +600,6 @@ class TestItemized(ApiBaseTest):
         self.assertTrue(all(each['image_number'] <= '3' for each in results))
         results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3'))
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
-
 
     def test_amount_sched_a(self):
         [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1,7 +1,5 @@
 import datetime
 
-# import sqlalchemy as sa
-
 from tests import factories
 from tests.common import ApiBaseTest
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -264,7 +264,9 @@ committee = {
         description=docs.ORGANIZATION_TYPE,
     ),
     'committee_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q', 'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
+        IStr(validate=validate.OneOf([
+            '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
+            'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
         description=docs.COMMITTEE_TYPE,
     ),
 }
@@ -352,7 +354,7 @@ reports = {
     'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
     'committee_id': fields.List(fields.Str, description=docs.COMMITTEE_ID),
     'amendment_indicator': fields.List(
-        IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C' , 'M', 'S'])),
+        IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
 }
 
@@ -546,7 +548,12 @@ schedule_b = {
         required=True,
         missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
-    'spender_committee_type': fields.List(IStr, description=docs.COMMITTEE_TYPE),
+    'spender_committee_type': fields.List(
+        IStr(validate=validate.OneOf([
+            '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
+            'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
+        description=docs.COMMITTEE_TYPE,
+    ),
 }
 
 schedule_b_efile = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -546,6 +546,7 @@ schedule_b = {
         required=True,
         missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
+    'spender_committee_type': fields.List(IStr, description=docs.COMMITTEE_TYPE),
 }
 
 schedule_b_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -68,7 +68,7 @@ class BaseRawItemized(db.Model):
 
 
 class ScheduleA(BaseItemized):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_a'
 
     committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_NAME)
@@ -85,7 +85,6 @@ class ScheduleA(BaseItemized):
             ScheduleA.report_year + ScheduleA.report_year % 2 == CommitteeHistory.cycle,
         )'''
     )
-
 
     contributor_name = db.Column('contbr_nm', db.String, doc=docs.CONTRIBUTOR_NAME)
 
@@ -145,7 +144,8 @@ class ScheduleA(BaseItemized):
     national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
 
     # Transaction meta info
-    election_type = db.Column('election_tp', db.String) # ? election_type looks like it's included in BaseItemized already
+    election_type = db.Column('election_tp', db.String)
+    # ? election_type looks like it's included in BaseItemized already
     election_type_full = db.Column('election_tp_desc', db.String)
     fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
     fec_election_year = db.Column('fec_election_yr', db.String)
@@ -240,7 +240,7 @@ class ScheduleAEfile(BaseRawItemized):
 
 
 class ScheduleB(BaseItemized):
-    __table_args__ = {'schema' : 'disclosure'}
+    __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'
 
     # Recipient info
@@ -292,7 +292,8 @@ class ScheduleB(BaseItemized):
     candidate_office_state_full = db.Column('cand_office_st_desc', db.String)
 
     # Transaction meta info
-    election_type = db.Column('election_tp', db.String) # ? election_type looks like it's included in BaseItemized already
+    election_type = db.Column('election_tp', db.String)
+    # ?election_type looks like it's included in BaseItemized already
     election_type_full = db.Column('election_tp_desc', db.String)
     fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
     fec_election_year = db.Column('fec_election_tp_year', db.String)
@@ -337,6 +338,8 @@ class ScheduleB(BaseItemized):
 
     ref_disp_excess_flg = db.Column('ref_disp_excess_flg', db.String)
     comm_dt = db.Column('comm_dt', db.Date)
+
+    spender_committee_type = db.Column('cmte_tp', db.String)
 
     @hybrid_property
     def sort_expressions(self):
@@ -404,8 +407,7 @@ class ScheduleBEfile(BaseRawItemized):
     )
 
 
-
-class ScheduleC(PdfMixin,BaseItemized):
+class ScheduleC(PdfMixin, BaseItemized):
     __tablename__ = 'ofec_sched_c_mv'
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
@@ -467,7 +469,7 @@ class ScheduleC(PdfMixin,BaseItemized):
         return None
 
 
-class ScheduleD(PdfMixin,BaseItemized):
+class ScheduleD(PdfMixin, BaseItemized):
     __tablename__ = 'fec_fitem_sched_d_vw'
 
     sub_id = db.Column(db.Integer, primary_key=True)
@@ -669,7 +671,6 @@ class ScheduleEEfile(BaseRawItemized):
         innerjoin='True',
     )
 
-
     committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -698,7 +699,7 @@ class ScheduleEEfile(BaseRawItemized):
         return name
 
 
-class ScheduleF(PdfMixin,BaseItemized):
+class ScheduleF(PdfMixin, BaseItemized):
     __tablename__ = 'ofec_sched_f_mv'
 
     sub_id = db.Column(db.Integer, primary_key=True)
@@ -774,7 +775,6 @@ class ScheduleF(PdfMixin,BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     load_date = db.Column('pg_date', db.DateTime)
     election_cycle = db.Column(db.Integer)
-
 
     @property
     def pdf_url(self):

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -145,7 +145,6 @@ class ScheduleA(BaseItemized):
 
     # Transaction meta info
     election_type = db.Column('election_tp', db.String)
-    # ? election_type looks like it's included in BaseItemized already
     election_type_full = db.Column('election_tp_desc', db.String)
     fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
     fec_election_year = db.Column('fec_election_yr', db.String)
@@ -293,7 +292,6 @@ class ScheduleB(BaseItemized):
 
     # Transaction meta info
     election_type = db.Column('election_tp', db.String)
-    # ?election_type looks like it's included in BaseItemized already
     election_type_full = db.Column('election_tp_desc', db.String)
     fec_election_type_desc = db.Column('fec_election_tp_desc', db.String)
     fec_election_year = db.Column('fec_election_tp_year', db.String)
@@ -339,7 +337,7 @@ class ScheduleB(BaseItemized):
     ref_disp_excess_flg = db.Column('ref_disp_excess_flg', db.String)
     comm_dt = db.Column('comm_dt', db.Date)
 
-    spender_committee_type = db.Column('cmte_tp', db.String)
+    spender_committee_type = db.Column('cmte_tp', db.String(1), index=True)
 
     @hybrid_property
     def sort_expressions(self):

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -34,6 +34,8 @@ class ScheduleBView(ItemizedResource):
         ('recipient_state', models.ScheduleB.recipient_state),
         ('recipient_committee_id', models.ScheduleB.recipient_committee_id),
         ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
+        ('spender_committee_type', models.ScheduleB.spender_committee_type),
+        
     ]
     filter_match_fields = [
         ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),


### PR DESCRIPTION
## Summary (required)
Thanks for this PR: [https://github.com/fecgov/openFEC/issues/3357](https://github.com/fecgov/openFEC/issues/3357)
added the spender committee type column (cmte_tp) into discloure.fec_fitem_sched_b tables.

unblock this ticket, we can add 'spender_committee_type' filter into ScheduleBView endpoint easily.

- Resolves # [https://github.com/fecgov/openFEC/issues/3274]
also clean some codes to fit flake8 format.

## How to test the changes locally 
1)checkout branch locally :feature/sched_b_add_spender_committee_type_filter
2)set SQLA_CONN to dev-replica-1
3)test url:
[http://127.0.0.1:5000/v1/schedules/schedule_b/?spender_committee_type=E&two_year_transaction_period=2018&sort=-disbursement_date&sort_hide_null=false&per_page=20&sort_null_only=false&api_key=DEMO_KEY](http://127.0.0.1:5000/v1/schedules/schedule_b/?spender_committee_type=E&two_year_transaction_period=2018&sort=-disbursement_date&sort_hide_null=false&per_page=20&sort_null_only=false&api_key=DEMO_KEY)


4)modify spender_committee_type and two_year_transaction_period to test performance.
ex: when two_year_transaction_period=2018, spender_committee_type= the below...
D   1.28s
E    1.43s
H    1.21s
I     1.5s
N   1.26s
O    13.8s
P     2.69s
Q     1.19s
S     43.8s
U    1.36s
V    3.35s
W   1.29s
X     2.15s
Y     6.91s
Z     1.30s (no result)


## Impacted areas of the application
Disbursements

## Related PRs and Issues:
[https://github.com/fecgov/openFEC/issues/3357](https://github.com/fecgov/openFEC/issues/3357)
[https://github.com/fecgov/openFEC/pull/3425](https://github.com/fecgov/openFEC/pull/3425)

cms issue:
[ https://github.com/fecgov/fec-cms/issues/2128]( https://github.com/fecgov/fec-cms/issues/2128)

closed PR for reference:
[https://github.com/fecgov/openFEC/pull/3349](https://github.com/fecgov/openFEC/pull/3349)