### PR TITLE
add memo agg to sched b agg tables

### DIFF
--- a/data/migrations/V0115__add_memo_agg_to_sched_b_agg_tables.sql
+++ b/data/migrations/V0115__add_memo_agg_to_sched_b_agg_tables.sql
@@ -1,0 +1,207 @@
+--==================================================================
+--	disclosure.dsc_sched_b_aggregate_purpose
+--==================================================================
+DO $$
+BEGIN
+    EXECUTE format('CREATE SEQUENCE public.ofec_sched_b_aggregate_purpose_new_idx_seq1 INCREMENT 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 CACHE 1;');
+
+    EXECUTE format('CREATE TABLE disclosure.dsc_sched_b_aggregate_purpose_new
+	(
+	  cmte_id character varying(9),
+	  cycle numeric,
+	  purpose character varying,
+	  non_memo_total numeric,
+	  non_memo_count bigint,
+	  memo_total numeric,
+	  memo_count bigint,
+	  idx integer NOT NULL DEFAULT nextval(''ofec_sched_b_aggregate_purpose_new_idx_seq1''::regclass),
+	  CONSTRAINT uq_dsc_sched_b_agg_purpose_new_cmte_id_cycle_purpose_new UNIQUE (cmte_id, cycle, purpose)
+	)
+	WITH (
+	  OIDS=FALSE
+	);');
+	
+	
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_cycle
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (cycle);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_cycle_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (cycle, cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_purpose_new
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (purpose COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_non_memo_count
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (non_memo_count);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_purpose_new_non_memo_total
+	  ON disclosure.dsc_sched_b_aggregate_purpose_new
+	  USING btree
+	  (non_memo_total);');
+  
+  
+    EXCEPTION 
+             WHEN duplicate_table THEN 
+		null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+ALTER TABLE IF EXISTS public.ofec_sched_b_aggregate_purpose_new_idx_seq1 OWNER TO fec;
+
+ALTER TABLE disclosure.dsc_sched_b_aggregate_purpose_new OWNER TO fec;
+GRANT ALL ON TABLE disclosure.dsc_sched_b_aggregate_purpose_new TO fec;
+GRANT SELECT ON TABLE disclosure.dsc_sched_b_aggregate_purpose_new TO fec_read;
+
+
+
+
+--==================================================================
+--	disclosure.dsc_sched_b_aggregate_recipient
+--==================================================================
+DO $$
+BEGIN
+    EXECUTE format('CREATE SEQUENCE public.ofec_sched_b_aggregate_recipient_new_idx_seq1 INCREMENT 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 CACHE 1;');
+    
+    EXECUTE format('CREATE TABLE disclosure.dsc_sched_b_aggregate_recipient_new
+	(
+	  cmte_id character varying(9),
+	  cycle numeric,
+	  recipient_nm character varying(200),
+	  non_memo_total numeric,
+	  non_memo_count bigint,
+	  memo_total numeric,
+	  memo_count bigint,
+	  idx integer NOT NULL DEFAULT nextval(''ofec_sched_b_aggregate_recipient_new_idx_seq1''::regclass),
+	  CONSTRAINT uq_dsc_sched_b_agg_recpnt_new_cmte_id_cycle_recpnt_new UNIQUE (cmte_id, cycle, recipient_nm)
+	)
+	WITH (
+	  OIDS=FALSE
+	);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_cycle
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (cycle);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_cycle_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (cycle, cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_recpnt_nm
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (recipient_nm COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_non_memo_count
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (non_memo_count);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_new_non_memo_total
+	  ON disclosure.dsc_sched_b_aggregate_recipient_new
+	  USING btree
+	  (non_memo_total);');
+
+    EXCEPTION 
+             WHEN duplicate_table THEN 
+		null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+
+ALTER TABLE IF EXISTS public.ofec_sched_b_aggregate_recipient_new_idx_seq1 OWNER TO fec;
+
+ALTER TABLE disclosure.dsc_sched_b_aggregate_recipient_new OWNER TO fec;
+GRANT ALL ON TABLE disclosure.dsc_sched_b_aggregate_recipient_new TO fec;
+GRANT SELECT ON TABLE disclosure.dsc_sched_b_aggregate_recipient_new TO fec_read;
+
+
+--==================================================================
+--	disclosure.dsc_sched_b_aggregate_recipient_id
+--==================================================================
+DO $$
+BEGIN
+    EXECUTE format('CREATE SEQUENCE public.ofec_sched_b_aggregate_recipient_id_new_idx_seq1 INCREMENT 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 CACHE 1;');
+
+    EXECUTE format('CREATE TABLE disclosure.dsc_sched_b_aggregate_recipient_id_new
+	(
+	  cmte_id character varying(9),
+	  cycle numeric,
+	  recipient_cmte_id character varying,
+	  recipient_nm text,
+	  non_memo_total numeric,
+	  non_memo_count bigint,
+	  memo_total numeric,
+	  memo_count bigint,
+	  idx integer NOT NULL DEFAULT nextval(''ofec_sched_b_aggregate_recipient_id_new_idx_seq1''::regclass),
+	  CONSTRAINT uq_sched_b_agg_recpnt_id_cmte_id_cycle_recpnt_cmte_id UNIQUE (cmte_id, cycle, recipient_cmte_id)
+	)
+	WITH (
+	  OIDS=FALSE
+	);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_cycle
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (cycle);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_cycle_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (cycle, cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_recpnt_cmte_id
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (recipient_cmte_id COLLATE pg_catalog."default");');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_non_memo_count
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (non_memo_count);');
+
+    EXECUTE format('CREATE INDEX dsc_sched_b_agg_recpnt_id_new_non_memo_total
+	  ON disclosure.dsc_sched_b_aggregate_recipient_id_new
+	  USING btree
+	  (non_memo_total);');
+
+    EXCEPTION 
+             WHEN duplicate_table THEN 
+		null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+ALTER TABLE IF EXISTS public.ofec_sched_b_aggregate_recipient_id_new_idx_seq1 OWNER TO fec;
+
+ALTER TABLE disclosure.dsc_sched_b_aggregate_recipient_id_new OWNER TO fec;
+GRANT ALL ON TABLE disclosure.dsc_sched_b_aggregate_recipient_id_new TO fec;
+GRANT SELECT ON TABLE disclosure.dsc_sched_b_aggregate_recipient_id_new TO fec_read;
+
+--==================================================================


### PR DESCRIPTION
## Summary (required)

- Resolves # [_Issue number_]
#3431 

The original logic for sched_b_aggregate tables is to only include the non-memo entries (i.e. memo_cd != ‘X’ or memo_cd is null).

Issue #3390 requires memo entries to be included for dsc_sched_b_aggregate_recipient as well.

The proposed business logic updates separated the entries into non-memo and memo items, with two additional columns of memo_total and memo_count.
Non-memo:
memo_cd !='X' or memo_cd is null
Memo:
memo_cd = 'X'

There are currently 3 sched_b aggregate tables that all use the same business logic. All these 3 tables will be changed to keep the consistency.
dsc_sched_b_aggregate_purpose
dsc_sched_b_aggregate_recipient
dsc_sched_b_aggregate_recipient_id


## How to test the changes locally
After migration had been executed into local database, the three new tables with both memo_total/count and non_memo_total/count columns will be created.

## Impacted areas of the application
List general components of the application that this PR will affect:

These three tables are not been used right now.  They will be used by API after #3390 been implemented.  

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
