### PR TITLE
Add handling for include/exclude AO citations

### DIFF
--- a/tests/test_ao_citations.py
+++ b/tests/test_ao_citations.py
@@ -117,3 +117,5 @@ def test_validate_regulation_citation(title, part, expected):
 ])
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected
+
+# Test exclude/include

--- a/tests/test_ao_citations.py
+++ b/tests/test_ao_citations.py
@@ -123,13 +123,12 @@ def test_parse_regulatory_citations(text, expected):
 class TestManualCitations(unittest.TestCase):
     def test_exclude_citations(self):
         original_ao_citations = set(['2011-12', '2017-03', '2014-18', '2010-11', '2004-41', '2007-13', '1996-26', '2005-17', '2017-01', '2016-02', '2012-21', '2012-23', '2014-11', '2002-15', '2006-12', '2015-16', '2014-21'])
-        expected_citations = set(['2017-03', '2014-18', '2004-41', '2007-13', '1996-26', '2005-17', '2017-01', '2016-02', '2012-21', '2012-23', '2014-11', '2002-15', '2006-12', '2014-21'])
-
         fixed_citations = fix_citations('2017-03', 'ao', original_ao_citations)
-        assert fixed_citations == expected_citations
+        assert '2010-11' not in fixed_citations
+        assert '2011-12' not in fixed_citations
+        assert '2015-16' not in fixed_citations
 
     def test_include_citations(self):
         original_reg_citations = set([(11, 110, 4), (11, 110, 1), (11, 102, 9), (11, 102, 6), (11, 114, 5), (11, 100, 8), (11, 114, 1), (11, 100, 5), (11, 103, 3), (11, 104, 14), (11, 100, 6), (11, 102, 8), (11, 114, 7)])
-        expected_citations = set([(11, 110, 4), (11, 110, 1), (11, 102, 9), (11, 102, 6), (11, 114, 5), (11, 100, 8), (11, 114, 1), (11, 100, 5), (11, 103, 3), (11, 104, 14), (11, 100, 6), (11, 102, 8), (11, 114, 7), (11, 110, 3)])
         fixed_citations = fix_citations('1999-40', 'regulation', original_reg_citations)
-        assert fixed_citations == expected_citations
+        assert (11, 110, 3) in fixed_citations

--- a/tests/test_ao_citations.py
+++ b/tests/test_ao_citations.py
@@ -1,5 +1,5 @@
 import pytest
-
+import unittest
 
 from webservices.legal_docs.advisory_opinions import (
     parse_ao_citations,
@@ -7,6 +7,7 @@ from webservices.legal_docs.advisory_opinions import (
     parse_statutory_citations,
     validate_statute_citation,
     validate_regulation_citation,
+    fix_citations,
 )
 
 EMPTY_SET = set()
@@ -118,4 +119,17 @@ def test_validate_regulation_citation(title, part, expected):
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected
 
-# Test exclude/include
+
+class TestManualCitations(unittest.TestCase):
+    def test_exclude_citations(self):
+        original_ao_citations = set(['2011-12', '2017-03', '2014-18', '2010-11', '2004-41', '2007-13', '1996-26', '2005-17', '2017-01', '2016-02', '2012-21', '2012-23', '2014-11', '2002-15', '2006-12', '2015-16', '2014-21'])
+        expected_citations = set(['2017-03', '2014-18', '2004-41', '2007-13', '1996-26', '2005-17', '2017-01', '2016-02', '2012-21', '2012-23', '2014-11', '2002-15', '2006-12', '2014-21'])
+
+        fixed_citations = fix_citations('2017-03', 'ao', original_ao_citations)
+        assert fixed_citations == expected_citations
+
+    def test_include_citations(self):
+        original_reg_citations = set([(11, 110, 4), (11, 110, 1), (11, 102, 9), (11, 102, 6), (11, 114, 5), (11, 100, 8), (11, 114, 1), (11, 100, 5), (11, 103, 3), (11, 104, 14), (11, 100, 6), (11, 102, 8), (11, 114, 7)])
+        expected_citations = set([(11, 110, 4), (11, 110, 1), (11, 102, 9), (11, 102, 6), (11, 114, 5), (11, 100, 8), (11, 114, 1), (11, 100, 5), (11, 103, 3), (11, 104, 14), (11, 100, 6), (11, 102, 8), (11, 114, 7), (11, 110, 3)])
+        fixed_citations = fix_citations('1999-40', 'regulation', original_reg_citations)
+        assert fixed_citations == expected_citations


### PR DESCRIPTION
## Summary (required)

- Resolves #3461

Add handling for manually including/excluding AO citations (AO, statute, regulation)

## How to test the changes locally

- Uncomment `logger.setLevel(logging.DEBUG)` in `advisory_opinions.py`, get local elasticsearch set up, and `./manage.py load_advisory_opinions -f '1999-40'` and `2017-03` (you can cancel after each one loads). 

- AO '2017-03' shouldn't cite: ['2010-11', '2011-12', '2015-16']
- AO '1999-40' should cite (11, 110, 3)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Advisory opinion AO, statute, regulatory citations
