### PR TITLE
Add contributor committee type filter to sched_a end point.

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -125,6 +125,15 @@ class TestItemized(ApiBaseTest):
         response = self.app.get(api.url_for(ScheduleAView, contributor_zip='96%', cycle=2018))
         self.assertEqual(response.status_code, 400)
 
+    def test_sched_a_contributor_committee_type_filter(self):
+        [
+            factories.ScheduleAFactory(contributor_committee_type='S'),
+            factories.ScheduleAFactory(contributor_committee_type='S'),
+            factories.ScheduleAFactory(contributor_committee_type='P'),
+        ]
+        results = self._results(api.url_for(ScheduleAView, contributor_committee_type='S', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
     def test_filter_multi_start_with(self):
         [
             factories.ScheduleAFactory(contributor_zip=1296789)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -478,6 +478,12 @@ schedule_a = {
         required=True,
         missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
+    'contributor_committee_type': fields.List(
+        IStr(validate=validate.OneOf([
+            '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
+            'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
+        description=docs.COMMITTEE_TYPE,
+    ),
 }
 
 schedule_a_e_file = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -87,6 +87,7 @@ class ScheduleA(BaseItemized):
     )
 
     contributor_name = db.Column('contbr_nm', db.String, doc=docs.CONTRIBUTOR_NAME)
+    contributor_committee_type = db.Column('cmte_tp', db.String(1), index=True)
 
     contributor_name_text = db.Column(TSVECTOR)
     contributor_first_name = db.Column('contbr_nm_first', db.String)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -38,6 +38,7 @@ class ScheduleAView(ItemizedResource):
         ('contributor_id', models.ScheduleA.contributor_id),
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
+        ('contributor_committee_type', models.ScheduleA.contributor_committee_type),
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),


### PR DESCRIPTION
## Summary (required)
Contributor committee type add in this PR: [https://github.com/fecgov/openFEC/issues/3357](https://github.com/fecgov/openFEC/issues/3357)
added the contributor committee type column (cmte_tp) into discloure.fec_fitem_sched_a tables.

- Resolves # [https://github.com/fecgov/openFEC/issues/3248]

## How to test the changes locally 
1)checkout branch locally feature/sched_a_add_contributor_committee_type_filter 
2)set SQLA_CONN to dev-replica-1
3)test url:

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort_hide_null=false&sort=contribution_receipt_date&per_page=20&contributor_committee_type=d&contributor_committee_type=e&sort_null_only=false&two_year_transaction_period=2018&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort_hide_null=false&sort=contribution_receipt_date&per_page=20&contributor_committee_type=q&sort_null_only=false&two_year_transaction_period=2018&api_key=DEMO_KEY)

## Impacted areas of the application
Receipts

## Related PRs and Issues:

cms issue:
Relevant issue: fecgov/fec-cms#2129
Front-end WIP PR: fecgov/fec-cms#2150

closed PR for reference:
[https://github.com/fecgov/openFEC/pull/3291]