### PR TITLE
Add ‘count’ col to ScheduleABySizeCandidateView and  ScheduleAByStateCandidateView

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -541,12 +541,14 @@ class TestCandidateAggregates(ApiBaseTest):
                 cycle=2012,
                 total=50,
                 size=200,
+                count=20,
             ),
             factories.ScheduleABySizeFactory(
                 committee_id=self.committees[1].committee_id,
                 cycle=2012,
                 total=150,
                 size=200,
+                count=20,
             ),
         ]
         results = self._results(
@@ -562,6 +564,7 @@ class TestCandidateAggregates(ApiBaseTest):
             'cycle': 2012,
             'total': 200,
             'size': 200,
+            'count': 20,
         }
         assert results[0] == expected
 
@@ -573,6 +576,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 total=50,
                 state='NY',
                 state_full='New York',
+                count=30,
             ),
             factories.ScheduleAByStateFactory(
                 committee_id=self.committees[1].committee_id,
@@ -580,6 +584,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 total=150,
                 state='NY',
                 state_full='New York',
+                count=30,
             ),
         ]
         results = self._results(
@@ -596,6 +601,7 @@ class TestCandidateAggregates(ApiBaseTest):
             'total': 200,
             'state': 'NY',
             'state_full': 'New York',
+            'count': 30,
         }
         assert results[0] == expected
 

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -11,7 +11,7 @@ class BaseAggregate(BaseModel):
     cycle = db.Column(db.Integer, primary_key=True, doc=docs.RECORD_CYCLE)
     #? not sure how to document this
     total = db.Column(db.Numeric(30, 2), index=True,)
-    count = db.Column(db.Integer, index=True, doc='Number of records making up the total')
+    count = db.Column(db.Integer, index=True, doc=docs.COUNT)
 
 
 class ScheduleABySize(BaseAggregate):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -500,13 +500,13 @@ these limits are detailed in Chapter 7 of the FEC Campaign Guide for Political P
 
 SIZE_DESCRIPTION = '''
 This endpoint aggregates Schedule A donations based on size:
-
+```
  - $200 and under\n\
  - $200.01 - $499.99\n\
  - $500 - $999.99\n\
  - $1000 - $1999.99\n\
  - $2000 +\n\
-
+```
 In cases where the donations are $200 or less, the results include small donations
 that are reported on Schedule A, but filers are not required to itemize those small
 donations, so we also add unitemized contributions. Unitemized contributions come
@@ -524,6 +524,22 @@ The total all contributions in the following ranges:
   -2000 $2000 +\n\
 ```
 Unitemized contributions are included in the `0` category.
+'''
+
+COUNT = '''
+Number of records making up the total.
+'''
+
+SCHEDULE_A_SIZE_CANDIDATE_TAG = '''
+Schedule A receipts aggregated by contribution size for a candidate.
+'''
+
+SCHEDULE_A_STATE_CANDIDATE_TAG = '''
+Schedule A receipts aggregated by contribution state for a candidate.
+'''
+
+TOTAL_CANDIDATE_TAG = '''
+Aggregated candidate receipts and disbursements grouped by cycle.
 '''
 
 STATE_AGGREGATE = '''

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -4,14 +4,17 @@ from flask_apispec import doc, marshal_with
 
 from webservices import args
 from webservices import utils
+from webservices import docs
 from webservices import filters
 from webservices import schemas
 from webservices.utils import use_kwargs
 from webservices.common.views import ApiResource
 from webservices.common import models
 from webservices.common.models import (
-    CandidateElection, CandidateCommitteeLink,
-    ScheduleABySize, ScheduleAByState,
+    CandidateCommitteeLink,
+    CandidateElection,
+    ScheduleABySize,
+    ScheduleAByState,
     db
 )
 
@@ -76,7 +79,7 @@ def join_elections(query, kwargs):
 
 @doc(
     tags=['receipts'],
-    description='Schedule A receipts aggregated by contribution size.',
+    description=docs.SCHEDULE_A_SIZE_CANDIDATE_TAG,
 )
 class ScheduleABySizeCandidateView(utils.Resource):
 
@@ -88,15 +91,16 @@ class ScheduleABySizeCandidateView(utils.Resource):
         label_columns = [
             ScheduleABySize.size,
             sa.func.sum(ScheduleABySize.total).label('total'),
+            ScheduleABySize.count,
         ]
-        group_columns = [ScheduleABySize.size]
+        group_columns = [ScheduleABySize.size, ScheduleABySize.count]
         _, query = candidate_aggregate(ScheduleABySize, label_columns, group_columns, kwargs)
         return utils.fetch_page(query, kwargs, cap=None)
 
 
 @doc(
     tags=['receipts'],
-    description='Schedule A receipts aggregated by contributor state.',
+    description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
 )
 class ScheduleAByStateCandidateView(utils.Resource):
 
@@ -111,15 +115,17 @@ class ScheduleAByStateCandidateView(utils.Resource):
                 ScheduleAByState.state,
                 sa.func.sum(ScheduleAByState.total).label('total'),
                 sa.func.max(ScheduleAByState.state_full).label('state_full'),
+                ScheduleAByState.count,
             ],
-            [ScheduleAByState.state],
+            [ScheduleAByState.state, ScheduleAByState.count],
             kwargs,
         )
         return utils.fetch_page(query, kwargs, cap=0)
 
+
 @doc(
     tags=['candidate'],
-    description='Aggregated candidate receipts and disbursements grouped by cycle.',
+    description=docs.TOTAL_CANDIDATE_TAG,
 )
 class TotalsCandidateView(ApiResource):
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -943,7 +943,7 @@ class ScheduleABySizeCandidateSchema(ma.Schema):
     cycle = ma.fields.Int()
     total = ma.fields.Decimal(places=2)
     size = ma.fields.Int()
-
+    count = ma.fields.Int()
 
 class ScheduleAByStateCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -951,6 +951,7 @@ class ScheduleAByStateCandidateSchema(ma.Schema):
     total = ma.fields.Decimal(places=2)
     state = ma.fields.Str()
     state_full = ma.fields.Str()
+    count = ma.fields.Int()
 
 
 class ScheduleAByContributorTypeCandidateSchema(ma.Schema):


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/3456

Add 'count' column into two endpoints:
ScheduleABySizeCandidateView 
ScheduleAByStateCandidateView

## How to test the changes locally
1)checkout branch feature/fix_no_count_sched_a
2)run api to check `count` column in result set.
3)test url:
**a) test /schedule_a/by_size/by_candidate**
[http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?per_page=20&page=1&api_key=DEMO_KEY&election_full=false&sort_null_only=false&cycle=2018&sort_hide_null=false&candidate_id=S8FL00166](http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?per_page=20&page=1&api_key=DEMO_KEY&election_full=false&sort_null_only=false&cycle=2018&sort_hide_null=false&candidate_id=S8FL00166)
<img width="337" alt="with_count_screen shot 2018-11-05 at 10 04 47 am" src="https://user-images.githubusercontent.com/24395751/48022632-ab517e00-e109-11e8-8522-aabcd52695f9.png">


**b) test /schedule_a/by_state/by_candidate**
[http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?per_page=20&page=1&api_key=DEMO_KEY&election_full=false&sort_null_only=false&cycle=2018&sort_hide_null=false&candidate_id=S8FL00166](http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?per_page=20&page=1&api_key=DEMO_KEY&election_full=false&sort_null_only=false&cycle=2018&sort_hide_null=false&candidate_id=S8FL00166)
<img width="506" alt="state_with_count_screen shot 2018-11-05 at 10 15 24 am" src="https://user-images.githubusercontent.com/24395751/48022692-d20fb480-e109-11e8-80e1-bd43910d8e92.png">


-

## Impacted areas of the application
no impact for front end.
-  

Notes:
for /schedule_a/by_size/by_candidate, when size=0, the count return "null".
because count for Unitemized individual contributions is not recorded.