### PR TITLE
Switch to new schedule B aggrgeate tables with memo totals

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -298,6 +298,9 @@ class ScheduleBByRecipientFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleBByRecipient
 
+class ScheduleBByRecipientIDFactory(BaseAggregateFactory):
+    class Meta:
+        model = models.ScheduleBByRecipientID
 
 class ScheduleEByCandidateFactory(BaseAggregateFactory):
     class Meta:

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -13,6 +13,7 @@ from webservices.resources.aggregates import (
     ScheduleBByPurposeView,
     ScheduleBByRecipientView,
     ScheduleEByCandidateView,
+    ScheduleBByRecipientIDView,
 )
 from webservices.resources.candidate_aggregates import (
     ScheduleABySizeCandidateView,
@@ -111,6 +112,8 @@ class TestCommitteeAggregates(ApiBaseTest):
             'cycle': 2012,
             'total': aggregate.total,
             'count': aggregate.count,
+            'memo_total': aggregate.memo_total,
+            'memo_count': aggregate.memo_count,
         }
         self.assertEqual(results[0], expected)
 
@@ -137,9 +140,42 @@ class TestCommitteeAggregates(ApiBaseTest):
             'cycle': 2012,
             'total': aggregate.total,
             'count': aggregate.count,
+            'memo_total': aggregate.memo_total,
+            'memo_count': aggregate.memo_count,
         }
         self.assertEqual(results[0], expected)
 
+    def test_disbursement_recipient_id_total(self):
+        committee = factories.CommitteeHistoryFactory(cycle=2012)
+
+        aggregate = factories.ScheduleBByRecipientIDFactory(
+            committee_id=committee.committee_id,
+            cycle=committee.cycle,
+            recipient_id='C00507368',
+            total=4000,
+            count=2,
+            memo_total=0,
+            memo_count=0
+        )
+        results = self._results(
+            api.url_for(
+                ScheduleBByRecipientIDView,
+                committee_id=committee.committee_id,
+                cycle=2012,
+                recipient_id='C00507368'
+            )
+        )
+        self.assertEqual(len(results), 1)
+        expected = {
+            'committee_id': committee.committee_id,
+            'recipient_id': 'C00507368',
+            'cycle': 2012,
+            'total': aggregate.total,
+            'count': aggregate.count,
+            'memo_total': aggregate.memo_total,
+            'memo_count': aggregate.memo_count,
+        }
+        self.assertEqual(results[0], expected)
 
 class TestAggregates(ApiBaseTest):
     cases = [

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -154,8 +154,8 @@ class TestCommitteeAggregates(ApiBaseTest):
             recipient_id='C00507368',
             total=4000,
             count=2,
-            memo_total=0,
-            memo_count=0
+            memo_total=10,
+            memo_count=1
         )
         results = self._results(
             api.url_for(

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -45,15 +45,24 @@ class ScheduleAByOccupation(BaseAggregate):
     occupation = db.Column(db.String, primary_key=True, doc=docs.OCCUPATION)
 
 
-class ScheduleBByRecipient(BaseAggregate):
+class BaseDisbursementAggregate(BaseAggregate):
+    __abstract__ = True
+
+    total = db.Column('non_memo_total', db.Numeric(30, 2), index=True, doc=docs.NON_MEMO_TOTAL)
+    count = db.Column('non_memo_count', db.Integer, index=True, doc=docs.COUNT)
+    memo_total = db.Column('memo_total', db.Numeric(30, 2), index=True, doc=docs.MEMO_TOTAL)
+    memo_count = db.Column('memo_count', db.Integer, index=True, doc=docs.COUNT)
+
+
+class ScheduleBByRecipient(BaseDisbursementAggregate):
     __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_b_aggregate_recipient'
+    __tablename__ = 'dsc_sched_b_aggregate_recipient_new'
     recipient_name = db.Column('recipient_nm', db.String, primary_key=True, doc=docs.RECIPIENT_NAME)
 
 
-class ScheduleBByRecipientID(BaseAggregate):
+class ScheduleBByRecipientID(BaseDisbursementAggregate):
     __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_b_aggregate_recipient_id'
+    __tablename__ = 'dsc_sched_b_aggregate_recipient_id_new'
     recipient_id = db.Column('recipient_cmte_id', db.String, primary_key=True, doc=docs.RECIPIENT_ID)
     committee = utils.related_committee('committee_id')
     recipient = utils.related('CommitteeHistory', 'recipient_id', 'committee_id', cycle_label='cycle')
@@ -67,9 +76,9 @@ class ScheduleBByRecipientID(BaseAggregate):
         return self.recipient.name
 
 
-class ScheduleBByPurpose(BaseAggregate):
+class ScheduleBByPurpose(BaseDisbursementAggregate):
     __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_b_aggregate_purpose'
+    __tablename__ = 'dsc_sched_b_aggregate_purpose_new'
     purpose = db.Column(db.String, primary_key=True, doc=docs.PURPOSE)
 
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -420,9 +420,29 @@ Note: because the Schedule B data includes many records, counts for
 large result sets are approximate; you will want to page through the records until no records are returned.
 '''
 
+MEMO_TOTAL = '''
+Schedule B disbursements aggregated by memoed items only
+'''
+
+NON_MEMO_TOTAL = '''
+Schedule B disbursements aggregated by non-memoed items only
+'''
+
 SCHEDULE_B_BY_PURPOSE = '''
-Schedule B disbursements aggregated by disbursement purpose category. To avoid double counting, memoed items are not included.
-Purpose is a combination of transaction codes, category codes and disbursement description. See the `disbursement_purpose` sql function within the migrations for more details.
+Schedule B disbursements aggregated by disbursement purpose category. To avoid double counting,
+memoed items are not included.
+Purpose is a combination of transaction codes, category codes and disbursement description.
+See the `disbursement_purpose` sql function within the migrations for more details.
+'''
+
+SCHEDULE_B_BY_RECIPIENT_TAG = '''
+Schedule B disbursements aggregated by recipient name. To avoid double counting,
+memoed items are not included.
+'''
+
+SCHEDULE_B_BY_RECIPIENT_ID_TAG = '''
+Schedule B disbursements aggregated by recipient committee ID, if applicable.
+To avoid double counting, memoed items are not included.
 '''
 
 SCHEDULE_C_TAG = '''

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -163,10 +163,7 @@ class ScheduleAByOccupationView(AggregateResource):
 
 @doc(
     tags=['disbursements'],
-    description=(
-        'Schedule B receipts aggregated by recipient name. To avoid '
-        'double counting, memoed items are not included.'
-    )
+    description=(docs.SCHEDULE_B_BY_RECIPIENT_TAG)
 )
 class ScheduleBByRecipientView(AggregateResource):
 
@@ -184,10 +181,7 @@ class ScheduleBByRecipientView(AggregateResource):
 
 @doc(
     tags=['disbursements'],
-    description=(
-        'Schedule B receipts aggregated by recipient committee ID, if applicable. To avoid '
-        'double counting, memoed items are not included.'
-    )
+    description=(docs.SCHEDULE_B_BY_RECIPIENT_ID_TAG)
 )
 class ScheduleBByRecipientIDView(AggregateResource):
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -584,7 +584,7 @@ ScheduleBByRecipientIDSchema = make_schema(
         'recipient_name': ma.fields.Str(),
     },
     options={
-        'exclude': ('committee', 'recipient')
+        'exclude': ('idx', 'committee', 'recipient')
     },
 )
 


### PR DESCRIPTION
## Summary (required)

- Resolves # [_3390_](https://github.com/fecgov/openFEC/issues/3390)

_Currently some disbursements are missing from schedule B aggregate endpoints.  Most of those disbursements are memoed items.  To fix this, totals and counts of memoed items are added to three aggregate tables_

## How to test the changes locally

-Test this link and API will return 1 result ( using DEV database ): 
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2016&per_page=20&sort_null_only=false&sort_hide_null=false&page=1&recipient_name=DRL%20Publications

current API returns 0:
https://api.open.fec.gov/v1/schedules/schedule_b/by_recipient/?api_key=DEMO_KEY&per_page=20&page=1&sort_null_only=false&cycle=2016&recipient_name=DRL%20Publications&sort_hide_null=false

## Impacted areas of the application
Current disbursement aggregate pages only display non-memo total.  With endpoint returns memo-total now, we may need to think whether want to display memo total or not?
https://www.fec.gov/data/committee/C00575795/?tab=spending&cycle=2016
