### PR TITLE
Revert "fixing requirements.txt on develop branch."

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/fecgov/apispec.git@dev
+git+https://github.com/fecgov/apispec.git@dev#egg=apispec
 prance[osv]>=0.11 # use apispec[validation] once we no longer fork apispec
 cfenv==0.5.2
 invoke==0.15.0


### PR DESCRIPTION
This reverts commit 2e5686467745c7dc90dbedb874ea954084f77f38. Commits shouldn't be made directly to `develop`, `release`, or `master` branches.

I can't figure out what happened with commit 55349bb3d723f3b30104ff97c19b00cf39b1402a ("Merge branch 'develop' of https://github.com/fecgov/openFEC into develop") so I think I have to leave it there.

