### PR TITLE
Show history for first-time, future-cycle house candidates

### DIFF
--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -229,7 +229,13 @@ class CandidateHistoryView(ApiResource):
             sa.and_(
                 models.CandidateHistory.candidate_id == models.CandidateElection.candidate_id,
                 models.CandidateHistory.two_year_period <= models.CandidateElection.cand_election_year,
-                models.CandidateHistory.two_year_period > models.CandidateElection.prev_election_year,
+                # For new house candidates that file for a future election,
+                #   the 2-year period will equal `prev_election_yr`
+                #   until we reach the 2-year period for that future election.
+                # This `>=` (rather than `>`)
+                #   guarantees results for candidate pages.
+                # A `SELECT DISTINCT` on `candidate_id` prevents duplicate rows.
+                models.CandidateHistory.two_year_period >= models.CandidateElection.prev_election_year,
             ),
         ).filter(
             cycle <= models.CandidateElection.cand_election_year,


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/2463

For new house candidates that file for a future election,
  the 2-year period will equal `prev_election_yr`
  until we reach the 2-year period for that future election.

This `>=` (rather than `>`) guarantees results for candidate pages.
~`models.CandidateHistory.two_year_period > models.CandidateElection.prev_election_year`~
`models.CandidateHistory.two_year_period >= models.CandidateElection.prev_election_year`

A `SELECT DISTINCT` on `candidate_id` prevents duplicate rows.

## How to test the changes locally

- Connect to `dev` replica

- This link should return results: http://127.0.0.1:5000/v1/candidate/H0FL18173/history/2020?per_page=1&election_full=true

whereas on production, there are no results: https://api.open.fec.gov/v1/candidate/H0FL18173/history/2020/?api_key=DEMO_KEY&election_full=true

If you run your local CMS and point to your local API, these pages should now load rather than 404:

http://localhost:8000/data/candidate/H0FL18173
http://localhost:8000/data/candidate/H0TX24134
http://localhost:8000/data/candidate/H0FL01112
http://localhost:8000/data/candidate/H0FL22050
http://localhost:8000/data/candidate/H0GA06150
http://localhost:8000/data/candidate/H0FL04124

Try these links for more test data (you'll need to click through to candidate pages) https://docs.google.com/spreadsheets/d/1xmDu2Ypr2tJnUjWZJcMIf_SOD7BOipCR4fGD3FmZLJ0/edit#gid=0

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages for new house candidates filing for future cycle
