### PR TITLE
Create Bastion Host Tunnel in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,15 @@ jobs:
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
+      - add_ssh_keys # add Bastion host private keys configured in the UI
+      - run: echo $FEC_BASTION_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts # copy Bastion host public key
+
+      - run: $FEC_BASTION_DEV_TUNNEL # establsh tunnel/port mapping to 'dev' RDS from CircleCI container through Bastion host.
+ 
+      - run: $FEC_BASTION_STAGE_TUNNEL # establsh tunnel/port mapping to 'stage' RDS from CircleCI container through Bastion host.
+ 
+      - run: $FEC_BASTION_PROD_TUNNEL # establsh tunnel/port mapping to 'prod' RDS from CircleCI container through Bastion host.
+
       - deploy:
           name: Deploy API
           command: |

--- a/tasks.py
+++ b/tasks.py
@@ -144,6 +144,7 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
+    # ('dev', lambda _, branch: branch == 'feature/create_bastion_host'),
 )
 
 


### PR DESCRIPTION
Related Issue: Add Circle Ci IP address to AWS DEV PG Security Group,
[https://github.com/18F/fec-accounts/issues/151](https://github.com/18F/fec-accounts/issues/151)

## Summary
- Enable IP whitelist for database connections
- Create Bastion Host 
- Establish Bastion Host tunnel through port mapping
- Modify FEC_MIGRATOR_SQLA_CONN_DEV to point to Bastion Host tunnel through port mapping.


**Notes for cut branch and release**
1)before cut release branch, update FEC_MIGRATOR_SQLA_CONN_STAGE
2)before release, update FEC_MIGRATOR_SQLA_CONN_PROD
