### PR TITLE
Automate elasticsearch backups

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -46,6 +46,8 @@ manager.command(legal_docs.move_archived_murs)
 manager.command(legal_docs.initialize_current_legal_docs)
 manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
 manager.command(legal_docs.create_elasticsearch_backup)
+manager.command(legal_docs.restore_elasticsearch_backup)
+
 
 def execute_sql_file(path):
     """This helper is typically used within a multiprocessing pool; create a new database

--- a/manage.py
+++ b/manage.py
@@ -45,6 +45,7 @@ manager.command(legal_docs.delete_docs_index)
 manager.command(legal_docs.move_archived_murs)
 manager.command(legal_docs.initialize_current_legal_docs)
 manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+manager.command(legal_docs.create_elasticsearch_backup)
 
 def execute_sql_file(path):
     """This helper is typically used within a multiprocessing pool; create a new database

--- a/manage.py
+++ b/manage.py
@@ -45,6 +45,7 @@ manager.command(legal_docs.delete_docs_index)
 manager.command(legal_docs.move_archived_murs)
 manager.command(legal_docs.initialize_current_legal_docs)
 manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+manager.command(legal_docs.create_backup_repository)
 manager.command(legal_docs.create_elasticsearch_backup)
 manager.command(legal_docs.restore_elasticsearch_backup)
 

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -29,6 +29,7 @@ from .index_management import (
     restore_from_staging_index,
     move_archived_murs,
     create_elasticsearch_backup,
+    restore_elasticsearch_backup,
 )
 
 def load_current_legal_docs():

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -27,7 +27,8 @@ from .index_management import (
     delete_docs_index,
     create_staging_index,
     restore_from_staging_index,
-    move_archived_murs
+    move_archived_murs,
+    create_elasticsearch_backup,
 )
 
 def load_current_legal_docs():

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -28,6 +28,7 @@ from .index_management import (
     create_staging_index,
     restore_from_staging_index,
     move_archived_murs,
+    create_backup_repository,
     create_elasticsearch_backup,
     restore_elasticsearch_backup,
 )

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -616,19 +616,20 @@ def create_backup_repository(repository=BACKUP_REPOSITORY_NAME):
     es.snapshot.create_repository(repository=repository, body=body)
 
 
-def create_elasticsearch_backup(snapshot_name="auto_backup"):
+def create_elasticsearch_backup(repository_name=None, snapshot_name="auto_backup"):
     '''
     Create elasticsearch shapshot in the `legal_s3_repository`.
     '''
     es = utils.get_elasticsearch_connection()
 
+    repository_name = repository_name or BACKUP_REPOSITORY_NAME
     logger.info("Verifying repository setup")
     try:
-        es.snapshot.verify_repository(repository=BACKUP_REPOSITORY_NAME)
+        es.snapshot.verify_repository(repository=repository_name)
     except elasticsearch.exceptions.NotFoundError:
         logger.error(
             "Unable to verify repository {0}. Configure repository with create_backup_repository command.".format(
-                BACKUP_REPOSITORY_NAME
+                repository_name
             )
         )
         return
@@ -638,7 +639,7 @@ def create_elasticsearch_backup(snapshot_name="auto_backup"):
     )
     logger.info("Creating snapshot {0}".format(snapshot_name))
     result = es.snapshot.create(
-        repository=BACKUP_REPOSITORY_NAME, snapshot=snapshot_name
+        repository=repository_name, snapshot=snapshot_name
     )
     if result.get('accepted'):
         logger.info("Successfully created snapshot: {0}".format(snapshot_name))

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -599,9 +599,11 @@ def move_archived_murs():
 
 def create_backup_repository(repository=BACKUP_REPOSITORY_NAME):
     '''
-    Create repository `legal_s3_repository` if it doesn't exist
+    Create s3 backup repository using api credentials.
+    This should only need to get run once.
     '''
     es = utils.get_elasticsearch_connection()
+    logger.info("Creating backup repository: {0}".format(repository))
     body = {
         'type': 's3',
         'settings': {

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -655,8 +655,7 @@ def restore_elasticsearch_backup(snapshot_name=None):
     es = utils.get_elasticsearch_connection()
 
     most_recent_snapshot_name = get_most_recent_snapshot()
-    if not snapshot_name:
-        snapshot_name = most_recent_snapshot_name
+    snapshot_name = snapshot_name or most_recent_snapshot_name
 
     logger.info("Deleting docs index")
     delete_docs_index()

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -647,7 +647,7 @@ def create_elasticsearch_backup(repository_name=None, snapshot_name="auto_backup
         logger.error("Unable to create snapshot: {0}".format(snapshot_name))
 
 
-def restore_elasticsearch_backup(snapshot_name=None):
+def restore_elasticsearch_backup(repository_name=None, snapshot_name=None):
     '''
     Delete docs index
     Restore from elasticsearch snapshot
@@ -655,7 +655,8 @@ def restore_elasticsearch_backup(snapshot_name=None):
     '''
     es = utils.get_elasticsearch_connection()
 
-    most_recent_snapshot_name = get_most_recent_snapshot()
+    repository_name = repository_name or BACKUP_REPOSITORY_NAME
+    most_recent_snapshot_name = get_most_recent_snapshot(repository_name)
     snapshot_name = snapshot_name or most_recent_snapshot_name
 
     logger.info("Deleting docs index")
@@ -676,16 +677,17 @@ def restore_elasticsearch_backup(snapshot_name=None):
             )
         )
 
-def get_most_recent_snapshot():
+def get_most_recent_snapshot(repository_name=None):
     '''
     Get the list of snapshots (sorted by date, ascending) and
     return most recent snapshot name
     '''
     es = utils.get_elasticsearch_connection()
 
+    repository_name = repository_name or BACKUP_REPOSITORY_NAME
     logger.info("Retreiving most recent snapshot")
     snapshot_list = es.snapshot.get(
-        repository=BACKUP_REPOSITORY_NAME, snapshot="*"
+        repository=repository_name, snapshot="*"
     ).get('snapshots')
 
     return snapshot_list.pop().get('snapshot')

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -30,6 +30,11 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
             'schedule': crontab(minute='*/5', hour='10-23'),
         },
 
+        'backup_elasticsearch_every_sunday': {
+            'task': 'webservices.tasks.legal_docs.create_es_backup',
+            'schedule': crontab(minute=0, hour=4, day_of_week='sun'),
+        },
+
     }
 
 def redis_url():

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -145,7 +145,7 @@ def export_query(path, qs):
 
 @app.task
 def clear_bucket():
-    permanent_dir = ('legal', 'bulk-downloads')
+    permanent_dir = ('legal', 'bulk-downloads', 'indices')
     for obj in task_utils.get_bucket().objects.all():
         if not obj.key.startswith(permanent_dir):
             obj.delete()

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -7,6 +7,7 @@ from celery_once import QueueOnce
 from webservices import utils
 from webservices.legal_docs.advisory_opinions import load_advisory_opinions
 from webservices.legal_docs.current_cases import load_cases
+from webservices.legal_docs.index_management import create_elasticsearch_backup
 from webservices.rest import db
 from webservices.tasks import app
 from webservices.tasks.utils import get_app_name
@@ -69,6 +70,14 @@ def reload_all_aos():
     load_advisory_opinions()
     logger.info("Weekly (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
     slack_message = 'Weekly reload of all AOs completed in {0} space'.format(get_app_name())
+    utils.post_to_slack(slack_message, '#bots')
+
+@app.task(once={'graceful': True}, base=QueueOnce)
+def create_es_backup():
+    logger.info("Weekly (%s) elasticsearch backup starting", datetime.date.today().strftime("%A"))
+    create_elasticsearch_backup()
+    logger.info("Weekly (%s) elasticsearch backup completed", datetime.date.today().strftime("%A"))
+    slack_message = 'Weekly elasticsearch backup completed in {0} space'.format(get_app_name())
     utils.post_to_slack(slack_message, '#bots')
 
 def refresh_aos(conn):


### PR DESCRIPTION
## Summary (required)

Resolves #3143: **Automate elasticsearch backups**

- Add a management task to configure elasticsearch backup repository
- Add a management command to create an elasticsearch backup (optional name parameter)
- Add a management command to restore from backup (optional name parameter)
- Add celery task for weekly backups

## How to test the changes locally

- I needed to do a test deploy to `dev` to test this one - `invoke deploy --space dev --skip-migrations`
- `cf target --space dev`

### Configure backup repository 
- This should only have to be run once, but it's nice to automate this too. I've had to do this before if I can't authenticate - I think sometimes it gets wonky.
- `cf run-task api "python manage.py create_backup_repository -r test_repo_setup" -m 4G --name es-backup-1`
- Set up port forwarding (see elasticsearch [backup instructions]( https://github.com/fecgov/openFEC/wiki/Elasticsearch-backup-instructions))
- `curl -X GET -u "${es_username}:${es_password}" "localhost:9200/_snapshot/test_repo_setup/_all" | python -m json.tool | less`

### **Create a backup**
- Create a backup: `cf run-task api "python manage.py create_elasticsearch_backup" -m 4G --name es-backup-1`
- Create a backup with a special name: `cf run-task api "python manage.py create_elasticsearch_backup -s my_test_backup" -m 4G --name es-backup-1`
- `cf logs api --recent | grep es-backup-1`

### **Restore from backup**
- Confirm this AO has a final opinion: https://fec-dev-proxy.app.cloud.gov/data/legal/advisory-opinions/2018-10/
- Confirm the latest AO is 2018-11: https://fec-dev-proxy.app.cloud.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_category=F
- Go to an old backup: `cf run-task api "python manage.py restore_elasticsearch_backup -s 20180725_archived_mur_reload_in_progress" -m 4G --name es-backup-1`
- Wait a couple minutes
- Test links (may need a hard refresh):
- Confirm that the AO is an older version and no longer has a final opinion: https://fec-dev-proxy.app.cloud.gov/data/legal/advisory-opinions/2018-10/
- Confirm the latest AO is 2018-09: https://fec-dev-proxy.app.cloud.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_category=F
- Go to the latest backup: `cf run-task api "python manage.py restore_elasticsearch_backup" -m 4G --name es-backup-2`
- Wait a couple minutes
- Test links (may need a hard refresh):
- Confirm the AO now shows the final opinion: https://fec-dev-proxy.app.cloud.gov/data/legal/advisory-opinions/2018-10/
- Confirm the latest AO is 2018-11: https://fec-dev-proxy.app.cloud.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&ao_category=F

### Celery backup
- Follow instructions for local redis/celery setup: https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads
- Change `'backup_elasticsearch_every_sunday'` `'schedule':` to ` 'schedule': crontab(minute='*/10', hour='10-23'),`
- Confirm backup appears (see elasticsearch [backup instructions]( https://github.com/fecgov/openFEC/wiki/Elasticsearch-backup-instructions))

## Impacted areas of the application
List general components of the application that this PR will affect: 

-  Legal search: AO/MUR/ADR/AF/Regs

## Related Info
Manual backup instructions: https://github.com/fecgov/openFEC/wiki/Elasticsearch-backup-instructions
Elasticsearch snapshot API: https://elasticsearch-py.readthedocs.io/en/master/api.html#snapshot