### PR TITLE
Disable sort_nulls_last for Sch A and B

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -637,6 +637,17 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleBView, min_amount=100, max_amount=150))
         self.assertTrue(all(100 <= each['disbursement_amount'] <= 150 for each in results))
 
+    def test_sort_sched_b_ignores_nulls_last_parameter(self):
+        disbursements = [
+            factories.ScheduleBFactory(disbursement_amount=50),
+            factories.ScheduleBFactory(disbursement_amount=200, disbursement_date=datetime.date(2016, 3, 1)),
+            factories.ScheduleBFactory(disbursement_amount=150, disbursement_date=datetime.date(2016, 2, 1)),
+            factories.ScheduleBFactory(disbursement_amount=100, disbursement_date=datetime.date(2016, 1, 1)),
+        ]
+        sub_ids = [str(each.sub_id) for each in disbursements]
+        results = self._results(api.url_for(ScheduleBView, sort='-disbursement_date', sort_nulls_last=True, **self.kwargs))
+        self.assertEqual([each['sub_id'] for each in results], sub_ids)
+
     def test_amount_sched_e(self):
         [
             factories.ScheduleEFactory(expenditure_amount=50),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -118,8 +118,8 @@ class IndicesValidator(IndexValidator):
                 )
 
 def make_sort_args(default=None, validator=None, default_hide_null=False,
-        default_nulls_only=False, default_sort_nulls_last=False):
-    return {
+        default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True):
+    args = {
         'sort': fields.Str(
             missing=default,
             validate=validator,
@@ -133,11 +133,14 @@ def make_sort_args(default=None, validator=None, default_hide_null=False,
             missing=default_nulls_only,
             description='Toggle that filters out all rows having sort column that is non-null'
         ),
-        'sort_nulls_last': fields.Bool(
+
+    }
+    if show_nulls_last_arg:
+        args['sort_nulls_last'] = fields.Bool(
             missing=default_sort_nulls_last,
             description='Toggle that sorts null values last'
         )
-    }
+    return args
 
 
 def make_multi_sort_args(default=None, validator=None, default_hide_null=False,

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -75,6 +75,7 @@ class ScheduleAView(ItemizedResource):
                     'contribution_receipt_amount',
                     'contributor_aggregate_ytd',
                 ]),
+                show_nulls_last_arg=False,
             )
         )
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -35,7 +35,7 @@ class ScheduleBView(ItemizedResource):
         ('recipient_committee_id', models.ScheduleB.recipient_committee_id),
         ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
         ('spender_committee_type', models.ScheduleB.spender_committee_type),
-        
+
     ]
     filter_match_fields = [
         ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
@@ -59,6 +59,7 @@ class ScheduleBView(ItemizedResource):
             args.make_sort_args(
                 default='-disbursement_date',
                 validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
+                show_nulls_last_arg=False,
             )
         )
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3495

## How to test the changes locally

- http://localhost:5000/v1/schedules/schedule_b/?sort=-disbursement_date&sort_nulls_last=true should still return nulls first
- http://localhost:5000 should not show `sort_nulls_last` parameter for schedules A and B

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Receipts, individual contributions, disbursements data tables

## Related PRs
List related PRs against other branches:

https://github.com/fecgov/openFEC/pull/3474 **Add optional parameter to sort nulls last** 

