### PR TITLE
drop original dsc_sched_b_aggregate tables

### DIFF
--- a/data/migrations/V0118__drop_original_sb_agg_tables.sql
+++ b/data/migrations/V0118__drop_original_sb_agg_tables.sql
@@ -1,0 +1,24 @@
+/*
+Issue #3431
+The following 3 tables had been replaced by
+dsc_sched_b_aggregate_purpose
+dsc_sched_b_aggregate_recipient
+dsc_sched_b_aggregate_recipient_id
+
+dsc_sched_b_aggregate_purpose_new
+dsc_sched_b_aggregate_recipient_new
+dsc_sched_b_aggregate_recipient_id_new
+
+with updated business logic and new and renamed columns
+
+The process had been completed with completion of issue #3390 in Sprint 7.5
+
+So these tables (and related process) are dropped by issue #3459
+*/
+
+-- ------------------
+-- 	drop tables
+-- ------------------
+drop table if exists disclosure.dsc_sched_b_aggregate_purpose;
+drop table if exists disclosure.dsc_sched_b_aggregate_recipient;
+drop table if exists disclosure.dsc_sched_b_aggregate_recipient_id;


### PR DESCRIPTION
## Summary (required)

- #3459 Drop old set of dsc_sched_b_aggregate tables after complete switch to new tables with update business logic

## How to test the changes locally
After run the migration file in local database, make sure the following 3 tables not exist anymore:
disclosure.dsc_sched_b_aggregate_purpose
disclosure.dsc_sched_b_aggregate_recipient
disclosure.dsc_sched_b_aggregate_recipient_id

## Impacted areas of the application
List general components of the application that this PR will affect:

These three tables are not being used anymore after issue #3390 had been deployed.



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
