### PR TITLE
Remove mur-specific query fields - use 'case'

### DIFF
--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -211,14 +211,14 @@ class SearchTest(unittest.TestCase):
                                      doc_type=mock.ANY)
 
     @patch.object(es, 'search')
-    def test_query_dsl_with_mur_filters(self, es_search):
+    def test_query_dsl_with_case_filters(self, es_search):
         response = self.app.get('/v1/legal/search/', query_string={
                                 'q': 'embezzle',
                                 'type': 'murs',
-                                'mur_min_open_date': '2012-01-01',
-                                'mur_max_open_date': '2013-12-31',
-                                'mur_min_close_date': '2014-01-01',
-                                'mur_max_close_date': '2015-12-31'})
+                                'case_min_open_date': '2012-01-01',
+                                'case_max_open_date': '2013-12-31',
+                                'case_min_close_date': '2014-01-01',
+                                'case_max_close_date': '2015-12-31'})
         assert response.status_code == 200
 
         expected_query = {

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -245,9 +245,9 @@ def apply_af_specific_query_params(query, **kwargs):
 
     date_range = {}
     if kwargs.get('af_min_fd_date'):
-        date_range['gte'] = kwargs.get('mur_min_fd_date')
+        date_range['gte'] = kwargs.get('af_min_fd_date')
     if kwargs.get('af_max_fd_date'):
-        date_range['lte'] = kwargs.get('mur_max_fd_date')
+        date_range['lte'] = kwargs.get('af_max_fd_date')
     if date_range:
         must_clauses.append(Q("range", final_determination_date=date_range))
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -195,42 +195,6 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
 def apply_mur_adr_specific_query_params(query, **kwargs):
     must_clauses = []
-    if kwargs.get('mur_no'):
-        must_clauses.append(Q('terms', no=kwargs.get('mur_no')))
-    if kwargs.get('mur_respondents'):
-        must_clauses.append(Q('match', respondents=kwargs.get('mur_respondents')))
-    if kwargs.get('mur_dispositions'):
-        must_clauses.append(Q('term', disposition__data__disposition=kwargs.get('mur_dispositions')))
-    if kwargs.get('mur_election_cycles'):
-        must_clauses.append(Q('term', election_cycles=kwargs.get('mur_election_cycles')))
-
-    if kwargs.get('mur_document_category'):
-        must_clauses = [Q('terms', documents__category=kwargs.get('mur_document_category'))]
-
-    #if the query contains min or max open date, add as a range clause ("Q(range)")
-    #to the set of must_clauses
-
-    #gte = greater than or equal to and lte = less than or equal to (see elasticsearch docs)
-    date_range = {}
-    if kwargs.get('mur_min_open_date'):
-        date_range['gte'] = kwargs.get('mur_min_open_date')
-    if kwargs.get('mur_max_open_date'):
-        date_range['lte'] = kwargs.get('mur_max_open_date')
-    if date_range:
-        must_clauses.append(Q("range", open_date=date_range))
-
-    date_range = {}
-    if kwargs.get('mur_min_close_date'):
-        date_range['gte'] = kwargs.get('mur_min_close_date')
-    if kwargs.get('mur_max_close_date'):
-        date_range['lte'] = kwargs.get('mur_max_close_date')
-    if date_range:
-        must_clauses.append(Q("range", close_date=date_range))
-
-    # Generic fields
-
-    # Refactor MURs to use `case_` filters
-    # once we change the front end to use generic params (fec-cms issue #2351)
 
     if kwargs.get('case_respondents'):
         must_clauses.append(Q('match', respondents=kwargs.get('case_respondents')))


### PR DESCRIPTION
## Summary (required)

- Resolves #3504 
- Remove mur-specific query fields - use `case_`
- Fix admin fine filter typo

## How to test the changes locally

- Run ES locally, do a mur query: http://localhost:5000/v1/legal/search/?case_no=7400

## Impacted areas of the application
List general components of the application that this PR will affect:

-  MUR search
