### PR TITLE
Make ScheE endpoint sortable by support_oppose_indicator

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -741,3 +741,23 @@ class TestItemized(ApiBaseTest):
             results = self._results(api.url_for(ScheduleEEfileView, **{label: values[0]}))
             assert len(results) == 1
             assert results[0][column.key] == values[0]
+
+    def test_schedule_e_sort_args_descending(self):
+        [
+            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
+                    committee_id='101', support_oppose_indicator='s'),
+            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
+                    committee_id='101', support_oppose_indicator='o'),
+        ]
+        results = self._results(api.url_for(ScheduleEView, sort='-support_oppose_indicator'))
+        self.assertEqual(results[0]['support_oppose_indicator'], 's')
+
+    def test_schedule_e_sort_args_ascending(self):
+        [
+            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
+                    committee_id='101', support_oppose_indicator='s'),
+            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
+                    committee_id='101', support_oppose_indicator='o'),
+        ]
+        results = self._results(api.url_for(ScheduleEView, sort='support_oppose_indicator'))
+        self.assertEqual(results[0]['support_oppose_indicator'], 'o')

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -742,36 +742,28 @@ entities = {
 }
 
 schedule_e = {
-    'candidate_office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
+    'candidate_office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])),
+        description=docs.OFFICE),
     'candidate_party': fields.List(IStr, description=docs.PARTY),
     'candidate_office_state': fields.List(IStr, description=docs.STATE_GENERIC),
     'candidate_office_district': fields.List(District, description=docs.DISTRICT),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'filing_form': fields.List(IStr, description='Filing form'),
+    'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
     'last_expenditure_date': fields.Date(missing=None,
-        description='When sorting by `expenditure_date`,'
-        'this is populated with the `expenditure_date` of the last result.'
-        'However, you will need to pass the index of that last result to `last_index` to get the next page.'),
+        description=docs.LAST_EXPENDITURE_DATE),
     'last_expenditure_amount': fields.Float(missing=None,
-        description='When sorting by `expenditure_amount`,'
-        'this is populated with the `expenditure_amount` of the last result.'
-        'However, you will need to pass the index of that last result to `last_index` to get the next page.'),
+        description=docs.LAST_EXPENDITURE_AMOUNT),
     'last_office_total_ytd': fields.Float(missing=None,
-        description='When sorting by `office_total_ytd`,'
-        'this is populated with the `office_total_ytd` of the last result.'
-        'However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'payee_name': fields.List(fields.Str, description='Name of the entity that received the payment'),
+        description=docs.LAST_OFFICE_TOTAL_YTD),
+    'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
-        description='Support or opposition',
-    ),
+        description=docs.SUPPORT_OPPOSE_INDICATOR),
     'last_support_oppose_indicator': fields.Str(missing=None,
-        description='When sorting by `support_oppose_indicator`,'
-        'this is populated with the `support_oppose_indicator` of the last result.'
-        'However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'is_notice': fields.List(fields.Bool, description='Record filed as 24- or 48-hour notice'),
+        description=docs.LAST_SUPPOSE_OPPOSE_INDICATOR),
+    'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
 }
 
 schedule_e_efile = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -767,6 +767,10 @@ schedule_e = {
         IStr(validate=validate.OneOf(['S', 'O'])),
         description='Support or opposition',
     ),
+    'last_support_oppose_indicator': fields.Str(missing=None,
+        description='When sorting by `support_oppose_indicator`,'
+        'this is populated with the `support_oppose_indicator` of the last result.'
+        'However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'is_notice': fields.List(fields.Bool, description='Record filed as 24- or 48-hour notice'),
 }
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1286,3 +1286,40 @@ Select all filings processed completely after this date
 MAX_TRANSACTION_DATA_COMPLETE_DATE = '''
 Select all filings processed completely before this date
 '''
+
+LAST_EXPENDITURE_DATE = '''
+When sorting by `expenditure_date`,
+this is populated with the `expenditure_date` of the last result.
+However, you will need to pass the index of that last result to
+`last_index` to get the next page.
+'''
+
+LAST_EXPENDITURE_AMOUNT = '''
+When sorting by `expenditure_amount`,
+this is populated with the `expenditure_amount` of the last result.
+However, you will need to pass the index of that last result to
+`last_index` to get the next page.
+'''
+LAST_OFFICE_TOTAL_YTD = '''
+When sorting by `office_total_ytd`,
+this is populated with the `office_total_ytd` of the last result.
+However, you will need to pass the index of that last result to
+`last_index` to get the next page.'
+'''
+
+LAST_SUPPOSE_OPPOSE_INDICATOR = '''
+When sorting by `support_oppose_indicator`,
+this is populated with the `support_oppose_indicator` of the last result.
+However, you will need to pass the index of that last result to `last_index`
+to get the next page.'
+'''
+
+PAYEE_NAME = '''
+Name of the entity that received the payment.
+'''
+IS_NOTICE = '''
+Record filed as 24- or 48-hour notice.
+'''
+filing_form = '''
+The form type filed by the canidate of committee
+'''

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -76,6 +76,7 @@ class ScheduleEView(ItemizedResource):
                     'expenditure_date',
                     'expenditure_amount',
                     'office_total_ytd',
+                    'support_oppose_indicator'
                 ]),
             ),
         )


### PR DESCRIPTION
## Summary 
From API, make support_oppose_indicator sortable on ScheE endpoint.

 API endpoint that is modified under **Independent Expenditures**:
/**schedules/schedule_e/**

- Resolves https://github.com/fecgov/openFEC/issues/3518

_Include a summary of proposed changes._

1. Make support_oppose_indicator sortable
2. Add tests to sort(asc,desc order) by support_oppose_indicator column

## How to test the changes locally

1. checkout feature/make-support-oppose-indicator-column-sortable-scheduleE
2. Sort by support_oppose_indicator in descending order :::

    - http://localhost:5000/v1/schedules/schedule_e/?sort=support_oppose_indicator&sort_hide_null=false&sort_nulls_last=false&committee_id=C90010661&per_page=100&sort_null_only=false

3. ascending order:::

    -  http://localhost:5000/v1/schedules/schedule_e/?sort=- support_oppose_indicator&sort_hide_null=false&sort_nulls_last=false&committee_id=C90010661&per_page=100&sort_null_only=false

## Impacted areas of the application
Independent Expenditures datatables. This will give the ability to sort by support/oppose column on the website



