### PR TITLE
Modify the list of report types in report endpoints

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -334,7 +334,7 @@ reports = {
     'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE_W_EXCLUDE),
+    'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
     'is_amended': fields.Bool(description=docs.IS_AMENDED),
     'most_recent': fields.Bool(description=docs.MOST_RECENT),
     'filer_type': fields.Str(
@@ -369,7 +369,7 @@ committee_reports = {
     'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE_W_EXCLUDE),
+    'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
     'is_amended': fields.Bool(description=docs.IS_AMENDED),
     'min_disbursements_amount': Currency(description=docs.MIN_FILTER),
     'max_disbursements_amount': Currency(description=docs.MAX_FILTER),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -839,7 +839,7 @@ FORM_TYPE = 'The form where the underlying data comes from, for example, Form 1 
     - F99  Miscellaneous Text\n\
     - FRQ  Request for Additional Information\n\
 '
-REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
+BASE_REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
     - 10D Pre-Election\n\
     - 10G Pre-General\n\
     - 10P Pre-Primary\n\
@@ -874,6 +874,11 @@ REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
     - Q3  October Quarterly\n\
     - TER Termination Report\n\
     - YE  Year-End\n\
+    - ADJ COMP ADJUST AMEND\n\
+    - CA  COMPREHENSIVE AMEND\n\
+'
+
+REPORT_TYPE = BASE_REPORT_TYPE + '\
     - 90S Post Inaugural Supplement\n\
     - 90D Post Inaugural\n\
     - 48  48 Hour Notification\n\
@@ -902,6 +907,8 @@ REQUEST_TYPE = 'Requests for additional information (RFAIs) sent to filers. The 
 '
 
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. ' + REPORT_TYPE
+
+BASE_REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. ' + BASE_REPORT_TYPE
 
 RECEIPT_DATE = 'Date the FEC received the electronic or paper record'
 


### PR DESCRIPTION
## Summary (required)

- Resolves # [3507](https://github.com/fecgov/openFEC/issues/3507)
_The list of report types in report endpoints has more than what it has in materialized views. A new list was created based on the data in materialized views._

## How to test the changes locally
-http://127.0.0.1:5000/developers/#/financial/get_committee__committee_id__reports_
-http://127.0.0.1:5000/developers/#/financial/get_reports__committee_type__


New list of base report type:
10D Pre-Election
10G Pre-General
10P Pre-Primary
10R Pre-Run-Off
10S Pre-Special
12C Pre-Convention
12G Pre-General
12P Pre-Primary
12R Pre-Run-Off
12S Pre-Special
30D Post-Election
30G Post-General
30P Post-Primary
30R Post-Run-Off
30S Post-Special
60D Post-Convention
M1 January Monthly
M10 October Monthly
M11 November Monthly
M12 December Monthly
M2 February Monthly
M3 March Monthly
M4 April Monthly
M5 May Monthly
M6 June Monthly
M7 July Monthly
M8 August Monthly
M9 September Monthly
MY Mid-Year Report
Q1 April Quarterly
Q2 July Quarterly
Q3 October Quarterly
TER Termination Report
YE Year-End
ADJ COMP ADJUST AMEND
CA COMPREHENSIVE AMEND