### PR TITLE
Upgrade smart-open==1.7.1 and remove request module from task/utils.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,7 @@ marshmallow-sqlalchemy==0.15.0
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Data export
-boto3==1.7.21
-smart_open==1.5.6
+smart_open==1.7.1
 
 # Task queue
 celery==4.1.1

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -10,8 +10,6 @@ from boto.s3.key import Key
 
 import boto3
 
-import requests
-
 from webservices.env import env
 
 


### PR DESCRIPTION


## Summary (required)

- Resolves # [https://github.com/fecgov/openFEC/issues/3398](https://github.com/fecgov/openFEC/issues/3398)
- Resolve # [https://github.com/fecgov/openFEC/issues/3527](https://github.com/fecgov/openFEC/issues/3527)

_Include a summary of proposed changes._
Upgrade smart-open to version 1.7.1
Remove request module from webservices/tasks/utils.py

## How to test the changes locally

1. Pull branch to local environment

2. Remove following packages from your local python environment using pip uninstall:
pip uninstall boto
pip uninstall boto3
pip uninstall botocore
pip uninstall smart-open

3. Run the following commands to install new packages:
pip install -r requirements.txt
pip install -r requirements-dev.txt

4. Run `pip freeze` to check the newer version of packages
smart-open==1.7.1
boto==2.49.0
boto3==1.9.62
botocore==1.12.62

5. Run
`python endpoints_walk.py`  
make sure all return status 'OK'

6. Run
`pytest `
Make sure all test cases are passed

## Impacted areas of the application
List general components of the application that this PR will affect:
Almost all of API endpoints

