### PR TITLE
add-payee-columns-to-ec-endpoint

### DIFF
--- a/webservices/common/models/costs.py
+++ b/webservices/common/models/costs.py
@@ -1,7 +1,7 @@
 from sqlalchemy.dialects.postgresql import TSVECTOR
 
 from .base import db
-
+from webservices import docs
 
 class CommunicationCost(db.Model):
     __tablename__ = 'ofec_communication_cost_mv'
@@ -60,14 +60,17 @@ class Electioneering(db.Model):
     candidate_state = db.Column('cand_office_st', db.String, index=True)
     beginning_image_number = db.Column('f9_begin_image_num', db.String, index=True)
     sb_image_num = db.Column(db.String, index=True)
-    sub_id = db.Column(db.Integer, doc="The identifier for each electioneering record")
+    sub_id = db.Column(db.Integer, doc=docs.EC_SUB_ID)
     link_id = db.Column(db.Integer)
     sb_link_id = db.Column(db.String)
     number_of_candidates = db.Column(db.Numeric)
-    calculated_candidate_share = db.Column('calculated_cand_share', db.Numeric(30, 2), doc="If an electioneering cost targets several candidates, the total cost is divided by the number of candidates. If it only mentions one candidate the full cost of the communication is listed.")
-    communication_date = db.Column('comm_dt', db.Date, doc='It is the airing, broadcast, cablecast or other dissemination of the communication')
-    public_distribution_date = db.Column('pub_distrib_dt', db.Date, doc='The pubic distribution date is the date that triggers disclosure of the electioneering communication (date reported on page 1 of Form 9)')
-    disbursement_date = db.Column('disb_dt', db.Date, index=True, doc='Disbursement date includes actual disbursements and execution of contracts creating an obligation to make disbursements (SB date of disbursement)')
+    calculated_candidate_share = db.Column('calculated_cand_share', db.Numeric(30, 2),
+        doc=docs.CALCULATED_CANDIDATE_SHARE)
+    communication_date = db.Column('comm_dt', db.Date, doc=docs.COMMUNICATION_DT)
+    public_distribution_date = db.Column('pub_distrib_dt', db.Date,
+        doc=docs.PUBLIC_DISTRIBUTION_DT)
+    disbursement_date = db.Column('disb_dt', db.Date, index=True,
+        doc=docs.DISBURSEMENT_DT)
     disbursement_amount = db.Column('reported_disb_amt', db.Numeric(30, 2), index=True)
     purpose_description = db.Column('disb_desc', db.String)
     report_year = db.Column('rpt_yr', db.Integer, index=True)
@@ -78,7 +81,8 @@ class Electioneering(db.Model):
     pdf_url = db.Column(db.String)
 
     purpose_description_text = db.Column(TSVECTOR)
-
+    payee_name = db.Column('payee_nm', db.String, doc=docs.PAYEE_NAME)
+    payee_state = db.Column('payee_st', db.String)
     @property
     def election_type(self):
         return self.election_type_raw[:1]

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1530,3 +1530,22 @@ Record filed as 24- or 48-hour notice.
 filing_form = '''
 The form type filed by the canidate of committee
 '''
+CALCULATED_CANDIDATE_SHARE = '''
+"If an electioneering cost targets several candidates, the total cost is
+divided by the number of candidates. If it only mentions one candidate
+the full cost of the communication is listed."
+'''
+COMMUNICATION_DT = '''
+It is the airing, broadcast, cablecast or other dissemination of the communication.
+'''
+PUBLIC_DISTRIBUTION_DT = '''
+The pubic distribution date is the date that triggers disclosure of the
+electioneering communication (date reported on page 1 of Form 9).
+'''
+DISBURSEMENT_DT = '''
+Disbursement date includes actual disbursements and execution of contracts creating
+an obligation to make disbursements (SB date of disbursement).
+'''
+EC_SUB_ID = '''
+The identifier for each electioneering record.
+'''


### PR DESCRIPTION
## Summary (required)

- Resolves [https://github.com/fecgov/openFEC/issues/3535](https://github.com/fecgov/openFEC/issues/3535)

_Include a summary of proposed changes

1. Map the two DB columns  payee_nm and payee_st in EC model file.
2. Moved the column descriptions that are long to the docs.py.

## How to test the changes locally

- checkout the feature/add-payee-columns-to-ec-endpoint
- export SQLA_CONN to point to DEV DB
- test the /electioneering/ endpoint. the results section should display these two additional columns.
- test URL :
 http://127.0.0.1:5000/v1/electioneering/?page=1&sort_nulls_last=false&sort_null_only=false&per_page=20&sort_hide_null=false

Screenshot : 
![screen shot 2018-12-11 at 11 01 43 pm](https://user-images.githubusercontent.com/11650355/49846406-12152780-fd99-11e8-95c8-e91e67fa20ce.png)

Prod URL without the additional columns:
https://api.open.fec.gov/v1/electioneering/?sort_nulls_last=false&page=1&per_page=20&sort_null_only=false&sort_hide_null=false&api_key=DEMO_KEY

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Spending/Disbursement section.
