### PR TITLE
Fix COH on election profile pages

### DIFF
--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -9,66 +9,66 @@ from webservices.common import models
 from webservices.resources.elections import ElectionsListView, ElectionView, ElectionSummary, StateElectionOfficeInfoView
 from webservices.common.models.elections import StateElectionOfficeInfo
 from webservices.schemas import StateElectionOfficeInfoSchema
-# class TestElectionSearch(ApiBaseTest):
+class TestElectionSearch(ApiBaseTest):
 
-#     def setUp(self):
-#         super().setUp()
-#         factories.ElectionsListFactory(office='P', state='US', district='00', incumbent_id='P12345')
-#         factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
-#         factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
-#         factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
-#         factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
-#         factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
-#         factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
-#         factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
+    def setUp(self):
+        super().setUp()
+        factories.ElectionsListFactory(office='P', state='US', district='00', incumbent_id='P12345')
+        factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
+        factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
+        factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
+        factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
+        factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
+        factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
+        factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
 
-#     def test_search_district(self):
-#         results = self._results(api.url_for(ElectionsListView, state='NJ', district='09'))
-#         self.assertEqual(len(results), 3)
-#         assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-#         assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
-#         assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
+    def test_search_district(self):
+        results = self._results(api.url_for(ElectionsListView, state='NJ', district='09'))
+        self.assertEqual(len(results), 3)
+        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
+        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
 
-#     def test_search_district_padding(self):
-#         results_padded = self._results(api.url_for(ElectionsListView, district='09'))
-#         results_unpadded = self._results(api.url_for(ElectionsListView, district=9))
-#         self.assertEqual(len(results_padded), len(results_unpadded))
-#         self.assertEqual(len(results_unpadded), 5)
+    def test_search_district_padding(self):
+        results_padded = self._results(api.url_for(ElectionsListView, district='09'))
+        results_unpadded = self._results(api.url_for(ElectionsListView, district=9))
+        self.assertEqual(len(results_padded), len(results_unpadded))
+        self.assertEqual(len(results_unpadded), 5)
 
-#     def test_search_office(self):
-#         results = self._results(api.url_for(ElectionsListView, office='senate'))
-#         self.assertEqual(len(results), 3)
-#         self.assertTrue(all([each['office'] == 'S' for each in results]))
+    def test_search_office(self):
+        results = self._results(api.url_for(ElectionsListView, office='senate'))
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all([each['office'] == 'S' for each in results]))
 
-#     def test_search_zip(self):
-#         factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
+    def test_search_zip(self):
+        factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
 
-#         results = self._results(api.url_for(ElectionsListView, zip='22902'))
-#         assert len(results) == 3
-#         assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-#         assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
-#         assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
+        results = self._results(api.url_for(ElectionsListView, zip='22902'))
+        assert len(results) == 3
+        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
+        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
 
-#     def test_counts(self):
-#         response = self._response(api.url_for(ElectionsListView))
-#         footer_count = response['pagination']['count']
-#         results_count = len(response['results'])
-#         self.assertEqual(footer_count, results_count)
+    def test_counts(self):
+        response = self._response(api.url_for(ElectionsListView))
+        footer_count = response['pagination']['count']
+        results_count = len(response['results'])
+        self.assertEqual(footer_count, results_count)
 
-#     def test_search_sort_default(self):
-#         results = self._results(api.url_for(ElectionsListView, state='VA'))
-#         self.assertEqual(results[0]['office'], 'P')
-#         self.assertEqual(results[1]['office'], 'S')
-#         self.assertEqual(results[2]['district'], '04')
-#         self.assertEqual(results[3]['district'], '05')
-#         self.assertEqual(results[4]['district'], '06')
+    def test_search_sort_default(self):
+        results = self._results(api.url_for(ElectionsListView, state='VA'))
+        self.assertEqual(results[0]['office'], 'P')
+        self.assertEqual(results[1]['office'], 'S')
+        self.assertEqual(results[2]['district'], '04')
+        self.assertEqual(results[3]['district'], '05')
+        self.assertEqual(results[4]['district'], '06')
 
-#     def test_search_sort_state(self):
-#         results = self._results(api.url_for(ElectionsListView))
-#         self.assertTrue(
-#             [each['state'] for each in results],
-#             ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
-#         )
+    def test_search_sort_state(self):
+        results = self._results(api.url_for(ElectionsListView))
+        self.assertTrue(
+            [each['state'] for each in results],
+            ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
+        )
 
 
 class TestElections(ApiBaseTest):
@@ -223,6 +223,14 @@ class TestElections(ApiBaseTest):
                 cycle=2020,
             ),
             factories.TotalsPresidentialFactory(
+                receipts=1,
+                disbursements=1,
+                committee_id=self.president_committees[1].committee_id,
+                coverage_end_date=datetime.datetime(2017, 12, 31),
+                last_cash_on_hand_end_period=100,
+                cycle=2018,
+            ),
+            factories.TotalsPresidentialFactory(
                 receipts=25,
                 disbursements=10,
                 committee_id=self.president_committees[0].committee_id,
@@ -230,35 +238,27 @@ class TestElections(ApiBaseTest):
                 last_cash_on_hand_end_period=300,
                 cycle=2018,
             ),
-            factories.TotalsPresidentialFactory(
-                receipts=5,
-                disbursements=1,
-                committee_id=self.president_committees[1].committee_id,
-                coverage_end_date=datetime.datetime(2017, 12, 31),
-                last_cash_on_hand_end_period=1,
-                cycle=2018,
-            ),
         ]
 
-    # def test_missing_params(self):
-    #     response = self.app.get(api.url_for(ElectionView))
-    #     self.assertEquals(response.status_code, 422)
+    def test_missing_params(self):
+        response = self.app.get(api.url_for(ElectionView))
+        self.assertEquals(response.status_code, 422)
 
-    # def test_conditional_missing_params(self):
-    #     response = self.app.get(api.url_for(ElectionView, office='president', cycle=2012))
-    #     self.assertEquals(response.status_code, 200)
-    #     response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
-    #     self.assertEquals(response.status_code, 422)
-    #     response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
-    #     self.assertEquals(response.status_code, 200)
-    #     response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY'))
-    #     self.assertEquals(response.status_code, 422)
-    #     response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
-    #     self.assertEquals(response.status_code, 200)
+    def test_conditional_missing_params(self):
+        response = self.app.get(api.url_for(ElectionView, office='president', cycle=2012))
+        self.assertEquals(response.status_code, 200)
+        response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
+        self.assertEquals(response.status_code, 422)
+        response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
+        self.assertEquals(response.status_code, 200)
+        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY'))
+        self.assertEquals(response.status_code, 422)
+        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
+        self.assertEquals(response.status_code, 200)
 
-    # def test_empty_query(self):
-    #     results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
-    #     assert len(results) == 0
+    def test_empty_query(self):
+        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
+        assert len(results) == 0
 
     def test_elections(self):
         results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
@@ -284,7 +284,7 @@ class TestElections(ApiBaseTest):
             )
         )
         totals = self.totals
-        cash_on_hand_totals = self.totals[:3]
+        cash_on_hand_totals = self.totals[:2]
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'candidate_name': self.candidate.name,
@@ -308,6 +308,7 @@ class TestElections(ApiBaseTest):
             )
         )
         totals = self.presidential_totals
+        cash_on_hand_totals = self.presidential_totals[:2]
         expected = {
             'candidate_id': self.president_candidate.candidate_id,
             'candidate_name': self.president_candidate.name,
@@ -315,7 +316,7 @@ class TestElections(ApiBaseTest):
             'party_full': self.president_candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in totals),
+            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
@@ -338,7 +339,7 @@ class TestElections(ApiBaseTest):
         # by including money that was raised and transferred
         # to the other committees in the joint fundraiser.
         totals_without_jfc = self.totals[1:]
-        cash_on_hand_without_jfc = self.totals[1:]
+        cash_on_hand_without_jfc = self.totals[1:2]
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'candidate_name': self.candidate.name,
@@ -360,16 +361,16 @@ class TestElections(ApiBaseTest):
         self.assertEqual(results['receipts'], sum(each.receipts for each in totals))
         self.assertEqual(results['disbursements'], sum(each.disbursements for each in totals))
 
-# class TestStateElectionOffices(ApiBaseTest):
+class TestStateElectionOffices(ApiBaseTest):
 
-#     def test_filter_match(self):
-#         # Filter for a single string value
-#         [
-#             factories.StateElectionOfficesFactory(state='TX', office_type='STATE CAMPAIGN FINANCE'),
-#             factories.StateElectionOfficesFactory(state='AK', office_type='STATE CAMPAIGN FINANCE'),
-#             factories.StateElectionOfficesFactory(state='WA', office_type='STATE CAMPAIGN FINANCE'),
-#         ]
-#         results = self._results(api.url_for(StateElectionOfficeInfoView, state='TX'))
+    def test_filter_match(self):
+        # Filter for a single string value
+        [
+            factories.StateElectionOfficesFactory(state='TX', office_type='STATE CAMPAIGN FINANCE'),
+            factories.StateElectionOfficesFactory(state='AK', office_type='STATE CAMPAIGN FINANCE'),
+            factories.StateElectionOfficesFactory(state='WA', office_type='STATE CAMPAIGN FINANCE'),
+        ]
+        results = self._results(api.url_for(StateElectionOfficeInfoView, state='TX'))
 
-#         self.assertEqual(len(results), 1)
-#         self.assertEqual(results[0]['state'], 'TX')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['state'], 'TX')

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -135,7 +135,7 @@ class TestElections(ApiBaseTest):
                 disbursements=75,
                 committee_id=self.committees[0].committee_id,
                 coverage_end_date=datetime.datetime(2012, 9, 30),
-                last_cash_on_hand_end_period=1979,
+                last_cash_on_hand_end_period=100,
                 cycle=2012,
             ),
             factories.TotalsHouseSenateFactory(
@@ -143,7 +143,7 @@ class TestElections(ApiBaseTest):
                 disbursements=75,
                 committee_id=self.committees[1].committee_id,
                 coverage_end_date=datetime.datetime(2012, 12, 31),
-                last_cash_on_hand_end_period=1979,
+                last_cash_on_hand_end_period=100,
                 cycle=2012,
             ),
             factories.TotalsHouseSenateFactory(
@@ -151,7 +151,7 @@ class TestElections(ApiBaseTest):
                 disbursements=75,
                 committee_id=self.committees[1].committee_id,
                 coverage_end_date=datetime.datetime(2012, 12, 31),
-                last_cash_on_hand_end_period=1979,
+                last_cash_on_hand_end_period=300,
                 cycle=2010,
             ),
         ]
@@ -200,7 +200,7 @@ class TestElections(ApiBaseTest):
             )
         )
         totals = self.totals
-        cash_on_hand_totals = self.totals[:2]
+        cash_on_hand_totals = self.totals[:3]
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'candidate_name': self.candidate.name,
@@ -234,7 +234,7 @@ class TestElections(ApiBaseTest):
         # by including money that was raised and transferred
         # to the other committees in the joint fundraiser.
         totals_without_jfc = self.totals[1:]
-        cash_on_hand_without_jfc = self.totals[1:2]
+        cash_on_hand_without_jfc = self.totals[1:]
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'candidate_name': self.candidate.name,
@@ -246,8 +246,9 @@ class TestElections(ApiBaseTest):
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
-        assert set(results[0]['committee_ids']) == set(each.committee_id for each in self.committees if each.designation != 'J')
-
+        assert set(results[0]['committee_ids']) == set(
+            each.committee_id for each in self.committees
+            if each.designation != 'J')
     def test_election_summary(self):
         results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY'))
         totals = [each for each in self.totals if each.cycle == 2012]

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -9,66 +9,66 @@ from webservices.common import models
 from webservices.resources.elections import ElectionsListView, ElectionView, ElectionSummary, StateElectionOfficeInfoView
 from webservices.common.models.elections import StateElectionOfficeInfo
 from webservices.schemas import StateElectionOfficeInfoSchema
-class TestElectionSearch(ApiBaseTest):
+# class TestElectionSearch(ApiBaseTest):
 
-    def setUp(self):
-        super().setUp()
-        factories.ElectionsListFactory(office='P', state='US', district='00', incumbent_id='P12345')
-        factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
-        factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
-        factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
-        factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
-        factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
-        factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
-        factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
+#     def setUp(self):
+#         super().setUp()
+#         factories.ElectionsListFactory(office='P', state='US', district='00', incumbent_id='P12345')
+#         factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
+#         factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
+#         factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
+#         factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
+#         factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
+#         factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
+#         factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
 
-    def test_search_district(self):
-        results = self._results(api.url_for(ElectionsListView, state='NJ', district='09'))
-        self.assertEqual(len(results), 3)
-        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
-        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
+#     def test_search_district(self):
+#         results = self._results(api.url_for(ElectionsListView, state='NJ', district='09'))
+#         self.assertEqual(len(results), 3)
+#         assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+#         assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
+#         assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
 
-    def test_search_district_padding(self):
-        results_padded = self._results(api.url_for(ElectionsListView, district='09'))
-        results_unpadded = self._results(api.url_for(ElectionsListView, district=9))
-        self.assertEqual(len(results_padded), len(results_unpadded))
-        self.assertEqual(len(results_unpadded), 5)
+#     def test_search_district_padding(self):
+#         results_padded = self._results(api.url_for(ElectionsListView, district='09'))
+#         results_unpadded = self._results(api.url_for(ElectionsListView, district=9))
+#         self.assertEqual(len(results_padded), len(results_unpadded))
+#         self.assertEqual(len(results_unpadded), 5)
 
-    def test_search_office(self):
-        results = self._results(api.url_for(ElectionsListView, office='senate'))
-        self.assertEqual(len(results), 3)
-        self.assertTrue(all([each['office'] == 'S' for each in results]))
+#     def test_search_office(self):
+#         results = self._results(api.url_for(ElectionsListView, office='senate'))
+#         self.assertEqual(len(results), 3)
+#         self.assertTrue(all([each['office'] == 'S' for each in results]))
 
-    def test_search_zip(self):
-        factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
+#     def test_search_zip(self):
+#         factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
 
-        results = self._results(api.url_for(ElectionsListView, zip='22902'))
-        assert len(results) == 3
-        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
-        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
+#         results = self._results(api.url_for(ElectionsListView, zip='22902'))
+#         assert len(results) == 3
+#         assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
+#         assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
+#         assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
 
-    def test_counts(self):
-        response = self._response(api.url_for(ElectionsListView))
-        footer_count = response['pagination']['count']
-        results_count = len(response['results'])
-        self.assertEqual(footer_count, results_count)
+#     def test_counts(self):
+#         response = self._response(api.url_for(ElectionsListView))
+#         footer_count = response['pagination']['count']
+#         results_count = len(response['results'])
+#         self.assertEqual(footer_count, results_count)
 
-    def test_search_sort_default(self):
-        results = self._results(api.url_for(ElectionsListView, state='VA'))
-        self.assertEqual(results[0]['office'], 'P')
-        self.assertEqual(results[1]['office'], 'S')
-        self.assertEqual(results[2]['district'], '04')
-        self.assertEqual(results[3]['district'], '05')
-        self.assertEqual(results[4]['district'], '06')
+#     def test_search_sort_default(self):
+#         results = self._results(api.url_for(ElectionsListView, state='VA'))
+#         self.assertEqual(results[0]['office'], 'P')
+#         self.assertEqual(results[1]['office'], 'S')
+#         self.assertEqual(results[2]['district'], '04')
+#         self.assertEqual(results[3]['district'], '05')
+#         self.assertEqual(results[4]['district'], '06')
 
-    def test_search_sort_state(self):
-        results = self._results(api.url_for(ElectionsListView))
-        self.assertTrue(
-            [each['state'] for each in results],
-            ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
-        )
+#     def test_search_sort_state(self):
+#         results = self._results(api.url_for(ElectionsListView))
+#         self.assertTrue(
+#             [each['state'] for each in results],
+#             ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
+#         )
 
 
 class TestElections(ApiBaseTest):
@@ -240,25 +240,25 @@ class TestElections(ApiBaseTest):
             ),
         ]
 
-    def test_missing_params(self):
-        response = self.app.get(api.url_for(ElectionView))
-        self.assertEquals(response.status_code, 422)
+    # def test_missing_params(self):
+    #     response = self.app.get(api.url_for(ElectionView))
+    #     self.assertEquals(response.status_code, 422)
 
-    def test_conditional_missing_params(self):
-        response = self.app.get(api.url_for(ElectionView, office='president', cycle=2012))
-        self.assertEquals(response.status_code, 200)
-        response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
-        self.assertEquals(response.status_code, 422)
-        response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
-        self.assertEquals(response.status_code, 200)
-        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY'))
-        self.assertEquals(response.status_code, 422)
-        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
-        self.assertEquals(response.status_code, 200)
+    # def test_conditional_missing_params(self):
+    #     response = self.app.get(api.url_for(ElectionView, office='president', cycle=2012))
+    #     self.assertEquals(response.status_code, 200)
+    #     response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
+    #     self.assertEquals(response.status_code, 422)
+    #     response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
+    #     self.assertEquals(response.status_code, 200)
+    #     response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY'))
+    #     self.assertEquals(response.status_code, 422)
+    #     response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
+    #     self.assertEquals(response.status_code, 200)
 
-    def test_empty_query(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
-        assert len(results) == 0
+    # def test_empty_query(self):
+    #     results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
+    #     assert len(results) == 0
 
     def test_elections(self):
         results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
@@ -360,16 +360,16 @@ class TestElections(ApiBaseTest):
         self.assertEqual(results['receipts'], sum(each.receipts for each in totals))
         self.assertEqual(results['disbursements'], sum(each.disbursements for each in totals))
 
-class TestStateElectionOffices(ApiBaseTest):
+# class TestStateElectionOffices(ApiBaseTest):
 
-    def test_filter_match(self):
-        # Filter for a single string value
-        [
-            factories.StateElectionOfficesFactory(state='TX', office_type='STATE CAMPAIGN FINANCE'),
-            factories.StateElectionOfficesFactory(state='AK', office_type='STATE CAMPAIGN FINANCE'),
-            factories.StateElectionOfficesFactory(state='WA', office_type='STATE CAMPAIGN FINANCE'),
-        ]
-        results = self._results(api.url_for(StateElectionOfficeInfoView, state='TX'))
+#     def test_filter_match(self):
+#         # Filter for a single string value
+#         [
+#             factories.StateElectionOfficesFactory(state='TX', office_type='STATE CAMPAIGN FINANCE'),
+#             factories.StateElectionOfficesFactory(state='AK', office_type='STATE CAMPAIGN FINANCE'),
+#             factories.StateElectionOfficesFactory(state='WA', office_type='STATE CAMPAIGN FINANCE'),
+#         ]
+#         results = self._results(api.url_for(StateElectionOfficeInfoView, state='TX'))
 
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['state'], 'TX')
+#         self.assertEqual(len(results), 1)
+#         self.assertEqual(results[0]['state'], 'TX')

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 from sqlalchemy import cast, Integer
 from flask_apispec import doc, marshal_with
 
@@ -145,23 +146,30 @@ class ElectionView(ApiResource):
     def build_query(self, **kwargs):
         utils.check_election_arguments(kwargs)
         totals_model = office_totals_map[kwargs['office']]
-        pairs = self._get_pairs(totals_model, kwargs).subquery()
+        basicPairs = self._get_basicPairs(totals_model, kwargs).subquery()
+        pairs = self._get_pairs(basicPairs).subquery()
         aggregates = self._get_aggregates(pairs).subquery()
-        latest = self._get_latest(pairs).subquery()
-        return db.session.query(
-            aggregates,
-            latest,
+        candAggregates = self._get_candAggregates(aggregates).subquery()
+        # latest = self._get_latest(pairs).subquery()
+
+        final_query = db.session.query(
+            candAggregates,
             BaseConcreteCommittee.name.label('candidate_pcc_name')
         ).outerjoin(
-            latest,
-            aggregates.c.candidate_id == latest.c.candidate_id,
-        ).outerjoin(
             BaseConcreteCommittee,
-            aggregates.c.candidate_pcc_id == BaseConcreteCommittee.committee_id
+            candAggregates.c.candidate_pcc_id == BaseConcreteCommittee.committee_id
         ).distinct()
 
-    def _get_pairs(self, totals_model, kwargs):
-        pairs = CandidateHistory.query.with_entities(
+        print('***********************Final_query')
+        print(str(final_query.statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True})))
+
+        return final_query
+
+    def _get_basicPairs(self, totals_model, kwargs):
+        # get basic data for election totals
+        basicPairs = CandidateHistory.query.with_entities(
             CandidateHistory.candidate_id,
             CandidateHistory.name,
             CandidateHistory.party_full,
@@ -169,10 +177,10 @@ class ElectionView(ApiResource):
             CandidateHistory.office,
             CandidateHistory.two_year_period,
             CandidateHistory.candidate_election_year,
-            CandidateCommitteeLink.committee_id,
-            totals_model.receipts,
-            totals_model.disbursements,
-            totals_model.last_cash_on_hand_end_period,
+            CandidateCommitteeLink.committee_id.label('committee_id'),
+            totals_model.receipts.label('receipts'),
+            totals_model.disbursements.label('disbursements'),
+            totals_model.last_cash_on_hand_end_period.label('last_cash_on_hand_end_period'),
             totals_model.coverage_end_date,
             sa.case(
                 [(CandidateCommitteeLink.committee_designation == 'P', CandidateCommitteeLink.committee_id)]  # noqa
@@ -180,49 +188,99 @@ class ElectionView(ApiResource):
         ).filter(
             CandidateCommitteeLink.committee_designation.in_(['P', 'A'])
         )
-        pairs = join_candidate_totals(pairs, kwargs, totals_model)
-        pairs = filter_candidate_totals(pairs, kwargs, totals_model)
+        basicPairs = join_candidate_totals(basicPairs, kwargs, totals_model)
+        basicPairs = filter_candidate_totals(basicPairs, kwargs, totals_model)
+
+        return basicPairs
+
+    def _get_pairs(self, basicPairs):
+        # get cash_on_hand_end_period info from the latest financial report
+        #   per candidate_id/candidate_election_year/cmte_id
+    
+        # Window params
+        window_p = {
+        'partition_by': [basicPairs.c.candidate_id, basicPairs.c.candidate_election_year, basicPairs.c.committee_id], 
+        'order_by': [sa.case([(basicPairs.c.coverage_end_date.isnot(None), basicPairs.c.two_year_period)]).desc().nullslast()]
+        }
+    
+        pairs = db.session.query(
+            basicPairs.c.candidate_id,
+            basicPairs.c.name,
+            basicPairs.c.party_full,
+            basicPairs.c.incumbent_challenge_full,
+            basicPairs.c.office,
+            basicPairs.c.two_year_period,
+            basicPairs.c.candidate_election_year,
+            basicPairs.c.committee_id,
+            basicPairs.c.receipts.label('receipts'),
+            basicPairs.c.disbursements.label('disbursements'),
+            sa.func.first_value(basicPairs.c.last_cash_on_hand_end_period).over(**window_p).label('last_cash_on_hand_end_period'),
+            sa.func.first_value(basicPairs.c.coverage_end_date).over(**window_p).label('coverage_end_date'),
+            basicPairs.c.candidate_pcc_id
+        )
         return pairs
 
-    def _get_latest(self, pairs):
-        latest = db.session.query(
-            pairs.c.last_cash_on_hand_end_period,
-            pairs.c.candidate_id,
-        ).distinct(
-            pairs.c.candidate_id,
-            pairs.c.cmte_id,
-        ).order_by(
-            pairs.c.candidate_id,
-            pairs.c.cmte_id,
-            sa.desc(pairs.c.two_year_period),
-        ).subquery()
-        return db.session.query(
-            latest.c.candidate_id,
-            sa.func.sum(sa.func.coalesce(latest.c.last_cash_on_hand_end_period, 0.0)),
-        ).group_by(
-            latest.c.candidate_id,
-        )
+    # def _get_latest(self, pairs):
+    #     latest = db.session.query(
+    #         pairs.c.last_cash_on_hand_end_period,
+    #         pairs.c.candidate_id,
+    #     ).distinct(
+    #         pairs.c.candidate_id,
+    #         pairs.c.cmte_id,
+    #     ).order_by(
+    #         pairs.c.candidate_id,
+    #         pairs.c.cmte_id,
+    #         sa.desc(pairs.c.two_year_period),
+    #     ).subquery()
+    #     return db.session.query(
+    #         latest.c.candidate_id,
+    #         sa.func.sum(sa.func.coalesce(latest.c.last_cash_on_hand_end_period, 0.0)),
+    #     ).group_by(
+    #         latest.c.candidate_id,
+    #     )
 
     def _get_aggregates(self, pairs):
-        return db.session.query(
+        # sum up values per candidate_id/candidate_election_year/cmte_id
+        aggregates = db.session.query(
             pairs.c.candidate_id,
             pairs.c.candidate_election_year,
+            pairs.c.committee_id,
             sa.func.max(pairs.c.name).label('candidate_name'),
             sa.func.max(pairs.c.party_full).label('party_full'),
             sa.func.max(pairs.c.incumbent_challenge_full).label('incumbent_challenge_full'),
             sa.func.max(pairs.c.office).label('office'),
-            sa.func.sum(sa.func.coalesce(pairs.c.receipts, 0.0)).label('total_receipts'),
-            sa.func.sum(sa.func.coalesce(pairs.c.disbursements, 0.0)).label('total_disbursements'),
-            sa.func.sum(sa.func.coalesce(pairs.c.last_cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
-            sa.func.array_agg(sa.distinct(pairs.c.cmte_id)).label('committee_ids'),
+            sa.func.sum(sa.func.coalesce(pairs.c.receipts, 0.0)).label('receipts'),
+            sa.func.sum(sa.func.coalesce(pairs.c.disbursements, 0.0)).label('disbursements'),
+            sa.func.max(sa.func.coalesce(pairs.c.last_cash_on_hand_end_period, 0.0)).label('last_cash_on_hand_end_period'),
             sa.func.max(pairs.c.coverage_end_date).label('coverage_end_date'),
             sa.func.max(pairs.c.candidate_pcc_id).label('candidate_pcc_id')
         ).group_by(
             pairs.c.candidate_id,
-            pairs.c.candidate_election_year
+            pairs.c.candidate_election_year,
+            pairs.c.committee_id
         )
+        return aggregates
 
-
+    def _get_candAggregates(self, aggregates):
+        # sum up values per candidate_id/candidate_election_year
+        candAggregates=db.session.query(
+            aggregates.c.candidate_id,
+            aggregates.c.candidate_election_year,
+            sa.func.max(aggregates.c.candidate_name).label('candidate_name'),
+            sa.func.max(aggregates.c.party_full).label('party_full'),
+            sa.func.max(aggregates.c.incumbent_challenge_full).label('incumbent_challenge_full'),
+            sa.func.max(aggregates.c.office).label('office'),
+            sa.func.sum(sa.func.coalesce(aggregates.c.receipts, 0.0)).label('total_receipts'),
+            sa.func.sum(sa.func.coalesce(aggregates.c.disbursements, 0.0)).label('total_disbursements'),
+            sa.func.sum(sa.func.coalesce(aggregates.c.last_cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
+            sa.func.array_agg(sa.distinct(aggregates.c. committee_id)).label('committee_ids'),
+            sa.func.max(aggregates.c.coverage_end_date).label('coverage_end_date'),
+            sa.func.max(aggregates.c.candidate_pcc_id).label('candidate_pcc_id')
+        ).group_by(
+            aggregates.c.candidate_id,
+            aggregates.c.candidate_election_year
+        )
+        return candAggregates
 @doc(
     description=docs.ELECTION_SEARCH,
     tags=['financial']

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -1,5 +1,4 @@
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 from sqlalchemy import cast, Integer
 from flask_apispec import doc, marshal_with
 

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -172,7 +172,7 @@ class ElectionView(ApiResource):
             CandidateCommitteeLink.committee_id,
             totals_model.receipts,
             totals_model.disbursements,
-            totals_model.last_cash_on_hand_end_period.label('cash_on_hand_end_period'),
+            totals_model.last_cash_on_hand_end_period,
             totals_model.coverage_end_date,
             sa.case(
                 [(CandidateCommitteeLink.committee_designation == 'P', CandidateCommitteeLink.committee_id)]  # noqa
@@ -186,7 +186,7 @@ class ElectionView(ApiResource):
 
     def _get_latest(self, pairs):
         latest = db.session.query(
-            pairs.c.cash_on_hand_end_period,
+            pairs.c.last_cash_on_hand_end_period,
             pairs.c.candidate_id,
         ).distinct(
             pairs.c.candidate_id,
@@ -198,7 +198,7 @@ class ElectionView(ApiResource):
         ).subquery()
         return db.session.query(
             latest.c.candidate_id,
-            sa.func.sum(sa.func.coalesce(latest.c.cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
+            sa.func.sum(sa.func.coalesce(latest.c.last_cash_on_hand_end_period, 0.0)),
         ).group_by(
             latest.c.candidate_id,
         )
@@ -213,7 +213,7 @@ class ElectionView(ApiResource):
             sa.func.max(pairs.c.office).label('office'),
             sa.func.sum(sa.func.coalesce(pairs.c.receipts, 0.0)).label('total_receipts'),
             sa.func.sum(sa.func.coalesce(pairs.c.disbursements, 0.0)).label('total_disbursements'),
-            sa.func.sum(sa.func.coalesce(pairs.c.cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
+            sa.func.sum(sa.func.coalesce(pairs.c.last_cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
             sa.func.array_agg(sa.distinct(pairs.c.cmte_id)).label('committee_ids'),
             sa.func.max(pairs.c.coverage_end_date).label('coverage_end_date'),
             sa.func.max(pairs.c.candidate_pcc_id).label('candidate_pcc_id')


### PR DESCRIPTION
## Summary (required)
Cash-on-hand(COH) for 2020 candidates is now displaying the amount on election profile pages. 

- Resolves # https://github.com/fecgov/openFEC/issues/3562

## How to test the changes locally

- checkout the branch `feature/fix-coh-on-election-profile-pages`
- export the `SQLA_CONN` to point to DEV DB
- The `/elections/` endpoint should now display amount against `cash_on_hand_end_period` column.
http://127.0.0.1:5000/v1/elections/?page=1&sort_nulls_last=false&per_page=20&election_full=true&cycle=2020&office=president&sort_null_only=false&sort=-total_receipts&sort_hide_null=false

## Impacted areas of the application
List general components of the application that this PR will affect:

- Website:  https://www.fec.gov/data/elections/president/2020/
- API : https://api.open.fec.gov/v1/elections/?api_key=DEMO_KEY&cycle=2020&election_full=true&office=president&per_page=0&sort_hide_null=true
