### PR TITLE
Modified eFiling date range filter to use filed_date

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -175,6 +175,17 @@ class TestEfileFiles(ApiBaseTest):
                 if min_date.isoformat() <= each['filed_date'] <= max_date.isoformat()
             )
         )
+    def test_filter_receipt_date_efile(self):
+
+        [
+            factories.EFilingsFactory(committee_id='C013', beginning_image_number=5,
+                filed_date=datetime.date(2015, 1, 1)),
+            factories.EFilingsFactory(committee_id='C014', beginning_image_number=6,
+                filed_date=datetime.date(2015, 1, 2)),
+        ]
+        results = self._results(api.url_for(EFilingsView,
+            min_receipt_date=datetime.date(2015, 1, 1), max_receipt_date=datetime.date(2015, 1, 2)))
+        self.assertEqual(len(results), 2)
 
     def test_efilings(self):
         """ Check filings returns in general endpoint"""

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -155,24 +155,24 @@ class TestEfileFiles(ApiBaseTest):
 
     def test_filter_date_efile(self):
         [
-            factories.EFilingsFactory(committee_id='C010', beginning_image_number=2, receipt_date=datetime.date(2012, 1, 1)),
-            factories.EFilingsFactory(committee_id='C011', beginning_image_number=3, receipt_date=datetime.date(2013, 1, 1)),
-            factories.EFilingsFactory(committee_id='C012', beginning_image_number=4, receipt_date=datetime.date(2014, 1, 1)),
-            factories.EFilingsFactory(committee_id='C013', beginning_image_number=5, receipt_date=datetime.date(2015, 1, 1)),
+            factories.EFilingsFactory(committee_id='C010', beginning_image_number=2, filed_date=datetime.date(2012, 1, 1)),
+            factories.EFilingsFactory(committee_id='C011', beginning_image_number=3, filed_date=datetime.date(2013, 1, 1)),
+            factories.EFilingsFactory(committee_id='C012', beginning_image_number=4, filed_date=datetime.date(2014, 1, 1)),
+            factories.EFilingsFactory(committee_id='C013', beginning_image_number=5, filed_date=datetime.date(2015, 1, 1)),
         ]
 
         min_date = datetime.date(2013, 1, 1)
         r = self._results(api.url_for(EFilingsView))
         results = self._results(api.url_for(EFilingsView, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
+        self.assertTrue(all(each for each in results if each['filed_date'] >= min_date.isoformat()))
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(EFilingsView, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
+        self.assertTrue(all(each for each in results if each['filed_date'] <= max_date.isoformat()))
         results = self._results(api.url_for(EFilingsView, min_receipt_date=min_date, max_receipt_date=max_date))
         self.assertTrue(
             all(
                 each for each in results
-                if min_date.isoformat() <= each['receipt_date'] <= max_date.isoformat()
+                if min_date.isoformat() <= each['filed_date'] <= max_date.isoformat()
             )
         )
 

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -105,7 +105,7 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
     committee_name = db.Column('com_name', db.String, doc=docs.COMMITTEE_NAME)
     receipt_date = db.Column('timestamp', db.DateTime, index=True, doc=docs.RECEIPT_DATE)
-    filed_date = db.Column('filed_date', db.Date, index=True, doc=docs.RECEIPT_DATE)
+    filed_date = db.Column('filed_date', db.Date, index=True, doc=docs.FILED_DATE)
     load_timestamp = db.Column('create_dt', db.DateTime, doc=docs.LOAD_DATE)
     coverage_start_date = db.Column('from_date', db.Date, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column('through_date', db.Date, doc=docs.COVERAGE_END_DATE)

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -104,7 +104,7 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     form_type = db.Column('form', db.String, doc=docs.FORM_TYPE)
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
     committee_name = db.Column('com_name', db.String, doc=docs.COMMITTEE_NAME)
-    receipt_date = db.Column('timestamp', db.Date, index=True, doc=docs.RECEIPT_DATE)
+    receipt_date = db.Column('timestamp', db.DateTime, index=True, doc=docs.RECEIPT_DATE)
     filed_date = db.Column('filed_date', db.Date, index=True, doc=docs.RECEIPT_DATE)
     load_timestamp = db.Column('create_dt', db.DateTime, doc=docs.LOAD_DATE)
     coverage_start_date = db.Column('from_date', db.Date, doc=docs.COVERAGE_START_DATE)

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -105,6 +105,7 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
     committee_name = db.Column('com_name', db.String, doc=docs.COMMITTEE_NAME)
     receipt_date = db.Column('timestamp', db.Date, index=True, doc=docs.RECEIPT_DATE)
+    filed_date = db.Column('filed_date', db.Date, index=True, doc=docs.RECEIPT_DATE)
     load_timestamp = db.Column('create_dt', db.DateTime, doc=docs.LOAD_DATE)
     coverage_start_date = db.Column('from_date', db.Date, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column('through_date', db.Date, doc=docs.COVERAGE_END_DATE)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -912,6 +912,8 @@ BASE_REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. ' + BASE_
 
 RECEIPT_DATE = 'Date the FEC received the electronic or paper record'
 
+FILED_DATE = 'Timestamp of electronic or paper record that FEC received'
+
 STATE_GENERIC = 'US state or territory'
 
 ZIP_CODE = 'Zip code'

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -111,7 +111,7 @@ class EFilingsView(views.ApiResource):
         ('committee_id', models.EFilings.committee_id),
     ]
     filter_range_fields = [
-        (('min_receipt_date', 'max_receipt_date'), models.EFilings.receipt_date),
+        (('min_receipt_date', 'max_receipt_date'), models.EFilings.filed_date),
     ]
 
     @property


### PR DESCRIPTION
## Summary (required)
Modified eFiling date range filter to use filed_date (Date type), which enable the user to query data by a single day.

- Resolves [https://github.com/fecgov/openFEC/issues/3563](https://github.com/fecgov/openFEC/issues/3563)

_Include a summary of proposed changes._
Added filed_date to the model and filter by it
- modified:   webservices/common/models/filings.py
- modified:   webservices/resources/filings.py

## How to test the changes locally

- pull feature/filter-raw-filing-single-day branch to your local environment
- Point SQLA_CONN to dev database
- run local server
- Open a browser window to http://localhost:5000/developers/#/efiling/get_efile_filings_
- Filter records by min_receipt_date and/or max_receipt_date

## Impacted areas of the application
List general components of the application that this PR will affect:
- https://www.fec.gov/data/filings/?data_type=efiling (RAW filings tab)


