### PR TITLE
adding active_candidates filter to totalCandidateView with unit tests.

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -660,7 +660,7 @@ class TestCandidateAggregates(ApiBaseTest):
         assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 75})
 
         # candidate_zero
-        # by default, load all candidates
+        # by default, load all candidates, current candidate should return 
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
@@ -671,16 +671,27 @@ class TestCandidateAggregates(ApiBaseTest):
         assert len(results) == 1
         assert_dicts_subset(results[0], {'cycle': 2018, 'receipts': 0})
 
-         #active candidate test
+         #active candidate test: loading active candidates result nothing
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
                 candidate_id=self.candidate_zero.candidate_id,
                 cycle=2018,
-                active_candidates=True
+                is_active_candidate=True
             )
         )
         assert len(results) == 0
+
+         #active candidate test: loading inactive candidates result current one
+        results = self._results(
+            api.url_for(
+                TotalsCandidateView,
+                candidate_id=self.candidate_zero.candidate_id,
+                cycle=2018,
+                is_active_candidate=False
+            )
+        )
+        assert len(results) == 1
 
         # candidate_17_18
         results = self._results(
@@ -694,17 +705,16 @@ class TestCandidateAggregates(ApiBaseTest):
         assert_dicts_subset(results[0], {'cycle': 2018, 'receipts': 100})
 
 
-      # active candidats tst2
+      # active candidats tst2: load inactive candidates result nothing
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
                 candidate_id=self.candidate_17_18.candidate_id,
                 cycle=2018,
-                active_candidates=False
+                is_active_candidate=False
             )
         )
-        assert len(results) == 1
-        assert_dicts_subset(results[0], {'cycle': 2018, 'receipts': 100})
+        assert len(results) == 0
 
       # active candidats tst3: load active candidates only
         results = self._results(
@@ -712,7 +722,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_17_18.candidate_id,
                 cycle=2018,
-                active_candidates=True
+                is_active_candidate=True
             )
         )
         assert len(results) == 1

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -716,6 +716,7 @@ candidate_totals = {
     'max_debts_owed_by_committee': Currency(description='Maximum debt'),
     'federal_funds_flag': fields.Bool(description=docs.FEDERAL_FUNDS_FLAG),
     'has_raised_funds': fields.Bool(description=docs.HAS_RAISED_FUNDS),
+    'active_candidates': fields.Bool(missing=False, description=docs.ACTIVE_CANDIDATE),
 }
 
 totals_committee_aggregate = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -716,7 +716,7 @@ candidate_totals = {
     'max_debts_owed_by_committee': Currency(description='Maximum debt'),
     'federal_funds_flag': fields.Bool(description=docs.FEDERAL_FUNDS_FLAG),
     'has_raised_funds': fields.Bool(description=docs.HAS_RAISED_FUNDS),
-    'active_candidates': fields.Bool(missing=False, description=docs.ACTIVE_CANDIDATE),
+    'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
 }
 
 totals_committee_aggregate = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1555,6 +1555,7 @@ The identifier for each electioneering record.
 TOTAL_BY_OFFICE_TAG = ''' Aggregated candidate receipts and disbursements grouped by office by cycle.
 '''
 
-ACTIVE_CANDIDATE = ''' Candidates who are actively running. By default, only active candidates
-data is returned. When False is selected, active and inactive candidates data is returned.
+ACTIVE_CANDIDATE = ''' Candidates who are actively running. if no value specified, all candidates
+data is returned. When True is specified, only active candidates data are returned. When False is 
+specified, only inactive candidates data is returned.
 '''

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -203,7 +203,6 @@ class TotalsCandidateView(ApiResource):
         query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = filters.filter_match(query, kwargs, self.filter_match_fields)
-        print(query)
         return query
 
 @doc(

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -187,14 +187,23 @@ class TotalsCandidateView(ApiResource):
                 models.CandidateSearch,
                 history.candidate_id == models.CandidateSearch.id,
             )
-        if kwargs.get('active_candidates'):  #load active candidates only if True
+
+        if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):  #load active candidates only if True
             query = query.filter(
                 history.candidate_inactive == False
             )
+        elif 'is_active_candidate' in kwargs and not kwargs.get('is_active_candidate'):  #load inactive candidates only if False
+            query = query.filter(
+                history.candidate_inactive == True
+            )
+        else: #load all candidates
+            pass
+
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields(history, models.CandidateTotal))
         query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = filters.filter_match(query, kwargs, self.filter_match_fields)
+        print(query)
         return query
 
 @doc(

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -187,6 +187,10 @@ class TotalsCandidateView(ApiResource):
                 models.CandidateSearch,
                 history.candidate_id == models.CandidateSearch.id,
             )
+        if kwargs.get('active_candidates'):  #load active candidates only if True
+            query = query.filter(
+                history.candidate_inactive == False
+            )
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields(history, models.CandidateTotal))
         query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)


### PR DESCRIPTION
## Summary (required)
'is_active_candidate' filter added to 'candidates/totals' api
- Resolves # [_Issue number_]
#3572
_Include a summary of proposed changes._
'is_active_candidate' filter added to current api:
- is_active_candidates=True: load active candidates only
- active_candidates=False: load inactive candidates only
- default(argument missing): load both

files changed/added:

M webservices/args.py
M webservices/docs.py
M webservices/resources/candidate_aggregates.py
M tests/test_aggregates.py

## How to test the changes locally
pull feature/add-cand-active-filter branch to your local environment
Point SQLA_CONN to dev database
run local server
Open a browser window to http://localhost:5000 for testing:
e.g.
- load both active/inactive candidates

>>http://127.0.0.1:5000/v1/candidates/totals?api_key=NICAR16&candidate_id=H2MA05120
result: 5 returns, 4 inactivbe and 1 active

>>http://127.0.0.1:5000/v1/candidates/totals?api_key=NICAR16&candidate_id=H2MA05120&is_active_candidate=True
result: 1 return, active

>>http://127.0.0.1:5000/v1/candidates/totals?api_key=NICAR16&candidate_id=H2MA05120&is_active_candidate=False
result: 4 returns, all inactive

unit test:
test_aggregates.py updated to include auto testing for this.
run "pytest tests/test_aggregates.py" should all pass


## Impacted areas of the application
List general components of the application that this PR will affect:
https://www.fec.gov/data/raising-bythenumbers/
-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
