### PR TITLE
Upgrade redis to version 3.2.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ smart_open==1.7.1
 # Task queue
 celery==4.1.1
 celery-once==1.2.0
-redis==2.10.6
+redis==3.2.0


### PR DESCRIPTION
## Summary (required)
upgrade redis to version3.2.0 to resolve celery worker and beat connectivity issues caused in `dev` and `stage` environments after kombu was updated to a version 4.4.0.


_Include a summary of proposed changes._
bump the **`redis version to 3.2.0`** in **`requirement.txt`**

## Impacted areas of the application
all scheduled tasks (celery worker/beat tasks), cron jobs 




