### PR TITLE
Update OS stack to cflinuxfs3 

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   NEW_RELIC_APP_NAME: fec | api | dev

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   NEW_RELIC_APP_NAME: fec | celery beat | dev

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   NEW_RELIC_APP_NAME: fec | celery worker | dev

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -1,7 +1,7 @@
 ---
 path: ../
 memory: 1G
-stack: cflinuxfs2
+stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -19,5 +19,5 @@ applications:
   - fec-api-search56
   - fec-creds-dev
   - fec-redis
-  stack: cflinuxfs2
+  stack: cflinuxfs3
   health-check-type: process

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -20,4 +20,4 @@ applications:
   - fec-api-search56
   - fec-creds-prod
   - fec-redis
-  stack: cflinuxfs2
+  stack: cflinuxfs3

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -19,5 +19,5 @@ applications:
   - fec-api-search56
   - fec-creds-stage
   - fec-redis
-  stack: cflinuxfs2
+  stack: cflinuxfs3
   health-check-type: process

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/fecgov/apispec.git@dev
 prance[osv]>=0.11 # use apispec[validation] once we no longer fork apispec
 cfenv==0.5.2
 invoke==0.15.0
-psycopg2==2.7.1
+psycopg2==2.7.3.2
 Flask==1.0.2
 Flask-Cors==3.0.6
 Flask-Script==2.0.6
@@ -36,4 +36,4 @@ smart_open==1.7.1
 # Task queue
 celery==4.1.1
 celery-once==1.2.0
-redis==2.10.6
+redis==3.2.0


### PR DESCRIPTION
## Summary (required)

1.  In  manifest files for **`dev/stage/prod`**, updated the stack to cflinuxfs3.
2.  In requirements.txt  : 
     -  Upgrade redis to 3.2.0 to resolve connectivity issues caused in celery worker/beat apps due to the 
         recent kombu upgrade.
    -  Upgrade psycopg2 to 2.7.3.2 : This upgrade is required to build and deploy the `api` app 
        successfully on `dev`, `stage` and `prod` spaces with the new OS-cflinuxfs3 

- Resolves #3566

_Include a summary of proposed changes._

1. manifest_api_dev.yml
2. manifest_api_prod.yml
3. manifest_api_stage.yml
4. manifest_celery_beat_dev.yml
5. manifest_celery_beat_prod.yml
6. manifest_celery_beat_stage.yml
7. manifest_celery_worker_dev.yml
8. manifest_celery_worker_prod.yml
9. manifest_celery_worker_stage.yml
10. requirements.txt

## How to test the changes
- checkout the branch `feature/update-buildpack-cflinuxfs3`
- In tasks.py, under DEPLOY_RULES : https://github.com/fecgov/openFEC/blob/develop/tasks.py#L143
   add a rule to deploy the `feature/update-buildpack-cflinuxfs3` branch to `dev` space
   Example :  ('dev', lambda _, branch: branch == 'feature/update-buildpack-cflinuxfs3'),
- run  `pytest`and make sure all tests PASS
- commit and push the changes.this will trigger a circle build
- wait until the circleci builds successfully
- open a terminal window and login to CF,  `dev` space 
- run `cf app api` command to check the `api` app **`stack`**, which should be **`cflinuxfs3`** (screenshot attached below)

<img width="1229" alt="screen shot 2019-03-07 at 1 04 42 pm" src="https://user-images.githubusercontent.com/11650355/53978806-1cb23500-40da-11e9-9b9f-0354ba44b412.png">



