### PR TITLE
Add all-day cache between 9am and 7:30pm ET

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -165,9 +165,13 @@ def get_cache_duration(url):
     DEFAULT_CACHE = 60 * 60
     PEAK_HOURS_CACHE = 60 * 60 * 5
 
-    # cloud.gov time is in UTC (add 5 for ET)
+    # cloud.gov time is in UTC (UTC = ET + 5 hours)
     PEAK_HOURS_START = time(9 + 5)  # 9:00 ET
     PEAK_HOURS_END = time(17 + 5)  # 17:00 ET
+
+    now_between_peak_hours = (
+        PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END
+    )
 
     if '/efile/' in url:
         return EFILING_CACHE
@@ -175,12 +179,7 @@ def get_cache_duration(url):
         return CALENDAR_CACHE
     elif '/legal/' in url:
         return LEGAL_CACHE
-
-    within_extra_caching_hours = (
-        PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END
-    )
-
-    if within_extra_caching_hours:
+    elif now_between_peak_hours:
         return PEAK_HOURS_CACHE
 
     return DEFAULT_CACHE

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -9,6 +9,7 @@ import os
 import sqlalchemy as sa
 import flask_cors as cors
 import flask_restful as restful
+from datetime import datetime, time
 
 from flask import abort
 from flask import request
@@ -157,10 +158,16 @@ def limit_remote_addr():
 
 def get_cache_duration(url):
 
+    # Time in seconds
     EFILING_CACHE = 0
     LEGAL_CACHE = 60 * 5
     CALENDAR_CACHE = 60 * 5
     DEFAULT_CACHE = 60 * 60
+    PEAK_HOURS_CACHE = 60 * 60 * 5
+
+    # cloud.gov time is in UTC (add 5 for ET)
+    PEAK_HOURS_START = time(9 + 5)  # 9:00 ET
+    PEAK_HOURS_END = time(17 + 5)  # 17:00 ET
 
     if '/efile/' in url:
         return EFILING_CACHE
@@ -168,6 +175,13 @@ def get_cache_duration(url):
         return CALENDAR_CACHE
     elif '/legal/' in url:
         return LEGAL_CACHE
+
+    within_extra_caching_hours = (
+        PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END
+    )
+
+    if within_extra_caching_hours:
+        return PEAK_HOURS_CACHE
 
     return DEFAULT_CACHE
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3545: Add caching between 9am and 7:30pm ET

## How to test the changes locally
 This is easiest to test with a manual deploy, because cloud.gov apps are in UTC and our local environments are on local time.
Only `stage` and `prod` have the API umbrella, so on `dev` all we can check is that the `cache-control` headers are returning the proper `max-age` value. I tested this with a manual deploy to `stage`.
- Between 9am and 7:30pm ET, `curl -I -X GET "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY"` and other queries below  should return `Expires: <today's date, ie. Mon, 18 Mar 2019> 23:00:00 GMT` (7:30pm ET)
- Outside of those times (after 7:30pm until 9am the next day), `curl -I -X GET "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY"` and other queries below  should return `cache-control: public, max-age=3600`

Test response headers:
```
curl -X GET -I "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY"

curl -X GET -I  "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&contributor_name=smith"

curl -X GET -I  "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&committee_id=C00213512"

curl -X GET -I   "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&recipient_committee_type=P"
```

Test query times:
```
 curl -s -w '\nLookup time:\t%{time_namelookup}\nConnect time:\t%{time_connect}\nPreXfer time:\t%{time_pretransfer}\nStartXfer time:\t%{time_starttransfer}\n\nTotal time:\t%{time_total}\n' -o /dev/null "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY"

 curl -s -w '\nLookup time:\t%{time_namelookup}\nConnect time:\t%{time_connect}\nPreXfer time:\t%{time_pretransfer}\nStartXfer time:\t%{time_starttransfer}\n\nTotal time:\t%{time_total}\n' -o /dev/null  "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&contributor_name=smith"

 curl -s -w '\nLookup time:\t%{time_namelookup}\nConnect time:\t%{time_connect}\nPreXfer time:\t%{time_pretransfer}\nStartXfer time:\t%{time_starttransfer}\n\nTotal time:\t%{time_total}\n' -o /dev/null  "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&committee_id=C00213512"

 curl -s -w '\nLookup time:\t%{time_namelookup}\nConnect time:\t%{time_connect}\nPreXfer time:\t%{time_pretransfer}\nStartXfer time:\t%{time_starttransfer}\n\nTotal time:\t%{time_total}\n' -o /dev/null  "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&recipient_committee_type=P"
```
## Impacted areas of the application
List general components of the application that this PR will affect:

-  All endpoints besides /efile/, /legal/, and /calendar-dates/



