### PR TITLE
(Release PR) Temporarily remove prance[osv] and swagger validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/fecgov/apispec.git@dev
-prance[osv]>=0.11 # use apispec[validation] once we no longer fork apispec
+#prance[osv]>=0.11 # pathlib dependency is breaking pytest
 cfenv==0.5.2
 invoke==0.15.0
 psycopg2==2.7.1

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -8,11 +8,11 @@ from webservices.spec import spec, format_docstring
 
 class TestSwagger(unittest.TestCase):
 
-    def test_swagger_valid(self):
-        try:
-            utils.validate_spec(spec)
-        except exceptions.SwaggerError as error:
-            self.fail(str(error))
+    # def test_swagger_valid(self):
+    #     try:
+    #         utils.validate_spec(spec)
+    #     except exceptions.SwaggerError as error:
+    #         self.fail(str(error))
 
     def test_format_docstring(self):
         DOCSTRING = '''


### PR DESCRIPTION
## Summary (required)

- Workaround for #3612 until we can find a better solution. #3612 is blocking the release as well as testing some urgent security issues.

- Temporarily remove `prance[osv]` which is bringing in `pathlib`, which conflicts with `pytest`. As a result, remove swagger validation

## How to test the changes locally

- Create a fresh virtual env
- `pip install -r requirements.txt -r requirements-dev.txt -r requirements-ci.txt`
- Run `pytest` and local API

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Swagger validation will be missing until we can resolve conflicts - ideally `openapi-spec-validator` will release a new version (0.2.7) where they use `pathlib2` https://pypi.org/project/openapi-spec-validator/#history



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`feature/disable-prance` > `develop` | [link](https://github.com/fecgov/openFEC/pull/3615)

