### PR TITLE
[DO NOT MERGE] Feature/remove two year restriction

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -86,19 +86,19 @@ large_records_sched_a = [
 
 # took the worst performing queries from the log https://logs.fr.cloud.gov/goto/be56820fc05ef241c62c5641f16dcd3e
 poor_performance_a = [
-    {'sort_nulls_large': True, 'contributor_name': 'paul+johnson', 'two_year_transaction_period': 2014, 'min_date': '01%2F01%2F2013', 'max_date': '12%2F31%2F2014','contributor_state': 'IN', 'sort': '-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
-    {'sort_nulls_large': True, 'contributor_name': 'Robert+F+Pence', 'two_year_transaction_period': 2014, 'min_date': '01%2F01%2F2013', 'max_date': '12%2F31%2F2014', 'sort': '-contribution_receipt_date', 'per_page': 100, 'is_individual': True},
-    {'sort_nulls_large': True, 'contributor_name': 'tom+lewis', 'contributor_name': 'thomas+lewis', 'two_year_transaction_period': 2016, 'min_date': '01%2F01%2F2015', 'max_date': '12%2F31%2F2016', 'sort': '-contribution_receipt_amount', 'per_page': 30, 'is_individual': True},
-    {'sort_nulls_large': True, 'contributor_name': 'Becher%2C+S', 'two_year_transaction_period': 2016, 'min_date': '01%2F01%2F2015', 'max_date': '12%2F31%2F2016&', 'contributor_state': 'FL', 'sort': '-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
-    {'sort_nulls_large': True, 'contributor_name': 'Becher', 'two_year_transaction_period': 2016, 'min_date': '01%2F01%2F2015', 'max_date': '12%2F31%2F2016', 'contributor_state':'FL', 'sort':'-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
+    {'sort_nulls_last': True, 'contributor_name': 'paul+johnson', 'two_year_transaction_period': 2014, 'min_date': '2013-01-01', 'max_date': '2014-12-31','contributor_state': 'IN', 'sort': '-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
+    {'sort_nulls_last': True, 'contributor_name': 'Robert+F+Pence', 'two_year_transaction_period': 2014, 'min_date': '2013-01-01', 'max_date': '2014-12-31', 'sort': '-contribution_receipt_date', 'per_page': 100, 'is_individual': True},
+    {'sort_nulls_last': True, 'contributor_name': 'tom+lewis', 'contributor_name': 'thomas+lewis', 'two_year_transaction_period': 2016, 'min_date': '2015-01-01', 'max_date': '2016-12-31', 'sort': '-contribution_receipt_amount', 'per_page': 30, 'is_individual': True},
+    {'sort_nulls_last': True, 'contributor_name': 'Becher%2C+S', 'two_year_transaction_period': 2016, 'min_date': '2015-01-01', 'max_date': '2016-12-31', 'contributor_state': 'FL', 'sort': '-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
+    {'sort_nulls_last': True, 'contributor_name': 'Becher', 'two_year_transaction_period': 2016, 'min_date': '2015-01-01', 'max_date': '2016-12-31', 'contributor_state':'FL', 'sort':'-contribution_receipt_date', 'per_page': 30, 'is_individual': True},
 ]
 
 poor_performance_b = [
-    {'sort_nulls_large': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4070720161305573871},
-    {'sort_nulls_large': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4062420161300286190},
-    {'sort_nulls_large': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4062120161299938749},
-    {'sort_nulls_large': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4061720161299122923},
-    {'sort_nulls_large': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4061720161299122723},
+    {'sort_nulls_last': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4070720161305573871},
+    {'sort_nulls_last': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4062420161300286190},
+    {'sort_nulls_last': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4062120161299938749},
+    {'sort_nulls_last': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4061720161299122923},
+    {'sort_nulls_last': True, 'two_year_transaction_period': 2016, 'per_page': 100, 'sort':'disbursement_date', 'last_disbursement_date': '2016-03-03', 'last_index': 4061720161299122723},
 ]
 
 
@@ -116,14 +116,14 @@ class Tasks(locust.TaskSet):
         print('*********fetch_ids response:{}'.format(resp))
         return [result[key] for result in resp.json()['results']]
 
-    @locust.task
+    #@locust.task
     def load_home(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('', name='home', params=params)
 
-    @locust.task
+    #@locust.task
     def load_candidates_search(self, term=None):
         term = term or random.choice(CANDIDATES)
         params = {
@@ -133,7 +133,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get('candidates/search', name='candidate_search', params=params)
 
-    @locust.task
+    #@locust.task
     def load_committees_search(self, term=None):
         term = term or random.choice(CANDIDATES)
         params = {
@@ -143,7 +143,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get('committees', name='committee_search', params=params)
 
-    @locust.task
+    #@locust.task
     def load_candidates_table(self):
         params = {
             'cycle': [random.choice(CYCLES) for _ in range(3)],
@@ -151,7 +151,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get('candidates', name='candidates_table', params=params)
 
-    @locust.task
+    #@locust.task
     def load_committees_table(self):
         params = {
             'cycle': [random.choice(CYCLES) for _ in range(3)],
@@ -159,7 +159,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get('committees', name='committees_table', params=params)
 
-    @locust.task
+    #@locust.task
     def load_candidate_detail(self, candidate_id=None):
         params = {
             'api_key': API_KEY,
@@ -167,7 +167,7 @@ class Tasks(locust.TaskSet):
         candidate_id = candidate_id or random.choice(self.candidates)
         self.client.get(os.path.join('candidate', candidate_id), name='candidate_detail', params=params)
 
-    @locust.task
+    #@locust.task
     def load_committee_detail(self, committee_id=None):
         params = {
             'api_key': API_KEY,
@@ -175,7 +175,7 @@ class Tasks(locust.TaskSet):
         committee_id = committee_id or random.choice(self.committees)
         self.client.get(os.path.join('committee', committee_id), name='committee_detail', params=params)
 
-    @locust.task
+    #@locust.task
     def load_candidate_totals(self, candidate_id=None):
         params = {
             'api_key': API_KEY,
@@ -183,7 +183,7 @@ class Tasks(locust.TaskSet):
         candidate_id = candidate_id or random.choice(self.candidates)
         self.client.get(os.path.join('candidate', candidate_id, 'totals'), name='candidate_totals', params=params)
 
-    @locust.task
+    #@locust.task
     def load_committee_totals(self, committee_id=None):
         params = {
             'api_key': API_KEY,
@@ -191,7 +191,7 @@ class Tasks(locust.TaskSet):
         committee_id = committee_id or random.choice(self.committees)
         self.client.get(os.path.join('committee', committee_id, 'totals'), name='committee_totals', params=params)
 
-    @locust.task
+    #@locust.task
     def load_legal_documents_search(self, term=None):
         term = term or random.choice(CANDIDATES)
         params = {
@@ -200,41 +200,41 @@ class Tasks(locust.TaskSet):
         }
         self.client.get('legal/search', name='legal_search', params=params)
 
-    @locust.task
+    #@locust.task
     def get_mur(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('legal/docs/murs/7074', name='legal_get_mur', params=params)
 
-    @locust.task
+    #@locust.task
     def get_adr(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('legal/docs/adrs/668', name='legal_get_adr', params=params)
 
-    @locust.task
+    #@locust.task
     def get_admin_fine(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('legal/docs/admin_fines/2274', name='legal_get_admin_fine', params=params)
 
-    @locust.task
+    #@locust.task
     def get_ao(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('legal/docs/advisory_opinions/2018-07', name='legal_get_ao', params=params)
 
-    @locust.task
+    #@locust.task
     def load_schedule_a_small(self):
         params = random.choice(small_records_sched_a)
         params['api_key'] = API_KEY
         self.client.get('schedules/schedule_a/', name='schedule_a_small', params=params)
 
-    @locust.task
+    #@locust.task
     def load_schedule_a_medium(self):
         params = random.choice(medium_records_sched_a)
         params['api_key'] = API_KEY
@@ -250,36 +250,40 @@ class Tasks(locust.TaskSet):
     def load_schedule_a_problematic(self):
         params = random.choice(poor_performance_a)
         params['api_key'] = API_KEY
-        self.client.get('schedules/schedule_a/', name='load_schedule_a_problematic', params=params)
+        print('params:{}'.format(params))
+        resp = self.client.get('schedules/schedule_a/', name='load_schedule_a_problematic', params=params)
+
+        print('*********fetch_prob_schedule_a response:{}'.format(resp))
 
     @locust.task
     def load_schedule_b_problematic(self):
         params = random.choice(poor_performance_b)
         params['api_key'] = API_KEY
-        self.client.get('schedules/schedule_b/', name='load_schedule_b_problematic', params=params)
-    
-    @locust.task
+        resp = self.client.get('schedules/schedule_b/', name='load_schedule_b_problematic', params=params)
+        print('*********fetch_schedule_b response:{}'.format(resp))
+
+    #@locust.task
     def load_audit_category(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('audit-category/', name='load_audit_category', params=params)
     
-    @locust.task
+    #@locust.task
     def load_filings(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('filings/', name='load_filings', params=params)
     
-    @locust.task
+    #@locust.task
     def load_totals(self):
         params = {
             'api_key': API_KEY,
         }
         self.client.get('totals/P/', name='load_totals', params=params)
     
-    @locust.task
+    #@locust.task
     def load_reports(self):
         params = {
             'api_key': API_KEY,

--- a/rm2year_restriction_test.py
+++ b/rm2year_restriction_test.py
@@ -1,0 +1,168 @@
+"""
+this is a simple scipt to test the status of all endpoints after deployment
+Pls note that some endpoints need required parameters and some example data
+are given hereself.
+the endpoints list could be exapanded or improved in the future.
+
+Note: on the production tier, api_key is required.
+
+quick server list for reference:
+
+local: http://127.0.0.1:5000
+prod: https://api.open.fec.gov
+stage: https://api-stage.open.fec.gov
+dev: https://fec-dev-api.app.cloud.gov
+"""
+import os
+import click
+import requests
+import time, math
+
+
+COMMITTEE_ID = "C00496067"
+CANDIDATE_ID = "P40002172"
+SUB_ID = "1"
+COMMITTEE_TYPE = "P"
+
+endpoints = [
+    # actblue across multiple partitions
+    '/schedules/schedule_a/?api_key=NICAR16&sort_hide_null=false&'+
+    'sort_nulls_last=false&data_type=processed&two_year_transaction_period'+
+    '=2016&min_date=01%2F01%2F2013&max_date=12%2F31%2F2018&sort=-contribution_receipt_date'+
+    '&per_page=30&committee_id=C00401224&two_year_transaction_period=2018'+
+    '&two_year_transaction_period=2014',
+
+    # 3 cycels with actblue
+    '/schedules/schedule_a/?api_key=NICAR16&sort_hide_null=false&'+
+    'sort_nulls_last=false&data_type=processed&two_year_transaction_period'+
+    '=2018&sort=-contribution_receipt_date&per_page=30&committee_id='+
+    'C00401224&two_year_transaction_period=2014&wo_year_transaction_period=2016',
+
+    # multiple committee ids across multiple partitions
+    '/schedules/schedule_a/?api_key=NICAR16&sort_hide_null=false&sort_nulls_last=false&'+
+    'data_type=processed&committee_id=C00577999&committee_id=C00585810'+
+    '&committee_id=C00651232&two_year_transaction_period=2016&'+
+    'min_date=01%2F01%2F2013&max_date=12%2F31%2F2018&'+
+    'sort=-contribution_receipt_date&per_page=30&two_year_transaction_period'+
+    '=2018&two_year_transaction_period=2014',
+
+    # schedule_b: actblue across  multiple partitions
+    '/schedules/schedule_b/?api_key=NICAR16&sort_hide_null=false&'+
+    'sort_nulls_last=false&data_type=processed&two_year_transaction_period'+
+    '=2018&per_page=30&committee_id=C00401224&two_year_transaction_period='+
+    '2014&wo_year_transaction_period=2016',
+
+    # multiple committee ids across multiple partitions
+    '/schedules/schedule_b/?api_key=NICAR16&sort_hide_null=false&sort_nulls_last=false&'+
+    'data_type=processed&committee_id=C00577999&committee_id=C00585810'+
+    '&committee_id=C00651232&two_year_transaction_period=2016&'+
+    'min_date=01%2F01%2F2013&max_date=12%2F31%2F2018&'+
+    'per_page=30&two_year_transaction_period'+
+    '=2018&two_year_transaction_period=2014',
+
+]
+
+# a list of endpoints pulled from rest.py
+# endpoints = [
+#     "/committees/?api_key={api_key}",
+#     "/candidates/?api_key={api_key}",
+#     "/candidates/search/?api_key={api_key}",
+#     "/candidate/{candidate_id}/?api_key={api_key}",
+#     "/committee/{committee_id}/candidates/?api_key={api_key}",
+#     "/candidate/{candidate_id}/history/?api_key={api_key}",
+#     "/candidate/{candidate_id}/history/2018/?api_key={api_key}",
+#     "/committee/{committee_id}/candidates/history/?api_key={api_key}",
+#     "/committee/{committee_id}/candidates/history/2018/?api_key={api_key}",
+#     "/committee/{committee_id}/?api_key={api_key}",
+#     "/candidate/{candidate_id}/committees/?api_key={api_key}",
+#     "/committee/{committee_id}/history/?api_key={api_key}",
+#     "/committee/{committee_id}/history/2018/?api_key={api_key}",
+#     "/candidate/{candidate_id}/committees/history/?api_key={api_key}",
+#     "/candidate/{candidate_id}/committees/history/2018/?api_key={api_key}",
+#     "/totals/{committee_type}/?api_key={api_key}",
+#     "/committee/{committee_id}/totals/?api_key={api_key}",
+#     "/candidate/{candidate_id}/totals/?api_key={api_key}",
+#     "/reports/{committee_type}/?api_key={api_key}",
+#     "/committee/{committee_id}/reports/?api_key={api_key}",
+#     "/names/candidates/?q=clinton&api_key={api_key}",
+#     "/names/committees/?q=clinton&api_key={api_key}",
+#     "/schedules/schedule_a/{sub_id}/?api_key={api_key}",
+#     "/schedules/schedule_a/efile/?api_key={api_key}",
+#     "/schedules/schedule_b/{sub_id}/?api_key={api_key}",
+#     "/schedules/schedule_b/efile/?api_key={api_key}",
+#     "/schedules/schedule_c/?api_key={api_key}",
+#     "/schedules/schedule_d/?api_key={api_key}",
+#     "/schedules/schedule_e/?api_key={api_key}",
+#     "/schedules/schedule_e/efile/?api_key={api_key}",
+#     "/schedules/schedule_f/{sub_id}/?api_key={api_key}",
+#     "/communication-costs/?api_key={api_key}",
+#     "/electioneering/?api_key={api_key}",
+#     "/elections/?cycle=2018&office=president&api_key={api_key}",
+#     "/elections/search/?api_key={api_key}",
+#     "/elections/summary/?cycle=2018&office=president&api_key={api_key}",
+#     "/state-election-office/?state=MD&api_key={api_key}",
+#     "/election-dates/?api_key={api_key}",
+#     "/reporting-dates/?api_key={api_key}",
+#     "/calendar-dates/?api_key={api_key}",
+#     "/calendar-dates/export/?api_key={api_key}",
+#     "/rad-analyst/?api_key={api_key}",
+#     "/efile/filings/?api_key={api_key}",
+#     "/totals/by_entity/?cycle=2018&api_key={api_key}",
+#     "/audit-primary-category/?api_key={api_key}",
+#     "/audit-category/?api_key={api_key}",
+#     "/audit-case/?api_key={api_key}",
+#     "/names/audit_candidates/?q=clinton&api_key={api_key}",
+#     "/names/audit_committees/?q=&clinton&api_key={api_key}",
+#     "/schedules/schedule_a/by_size/by_candidate/?candidate_id={candidate_id}&cycle=2018&api_key={api_key}",
+#     "/schedules/schedule_a/by_state/by_candidate/?candidate_id={candidate_id}&cycle=2018&api_key={api_key}",
+#     "/candidates/totals/?api_key={api_key}",
+#     "/schedules/schedule_a/by_state/totals/?api_key={api_key}",
+#     "/communication_costs/by_candidate/?api_key={api_key}",
+#     "/committee/{committee_id}/communication_costs/by_candidate/?api_key={api_key}",
+#     "/electioneering/by_candidate/?api_key={api_key}",
+#     "/committee/{committee_id}/electioneering/by_candidate/?api_key={api_key}",
+#     "/committee/{committee_id}/filings/?api_key={api_key}",
+#     "/candidate/{candidate_id}/filings/?api_key={api_key}",
+#     "/efile/reports/house-senate/?api_key={api_key}",
+#     "/efile/reports/presidential/?api_key={api_key}",
+#     "/efile/reports/pac-party/?api_key={api_key}",
+#     "/filings/?api_key={api_key}",  # this one is also shooting for trailing slash issue
+# ]
+
+
+@click.command()
+@click.option(
+    "--server",
+    default="https://fec-dev-api.app.cloud.gov",
+    help="server to check with.",
+)
+@click.option(
+    "--api_key",
+    default=lambda: os.environ.get("FEC_API_KEY", ""),
+    help="an api_key is needed for testing.",
+)
+def check_endpoints(server, api_key):
+    """Simple script to check all endpoints status quickly."""
+    for endp in endpoints:
+        t1 = time.time()
+        # curr_request = server + "/v1" + endp 
+        curr_request = (server + "/v1" + endp).format(
+                api_key=api_key,
+                # committee_id=COMMITTEE_ID,
+                # candidate_id=CANDIDATE_ID,
+                # committee_type=COMMITTEE_TYPE,
+                # sub_id=SUB_ID,
+            )
+        print('current request:\n{}'.format(curr_request))
+        r = requests.get(curr_request)
+        #import json
+        #print(r.text)
+        if r.status_code == 200:
+            t2 = time.time()
+            print("-- response comes back in: {} second.".format(round(t2-t1,2)))
+        else:
+            print("******{}: not working. Status: {}".format(endp,r.status_code))
+
+
+if __name__ == "__main__":
+    check_endpoints()

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -69,7 +69,7 @@ class TestItemized(ApiBaseTest):
         ]
 
         response = self._response(api.url_for(ScheduleAView))
-        self.assertEqual(len(response['results']), 1)
+        self.assertEqual(len(response['results']), 2)
 
     def test_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -485,8 +485,8 @@ schedule_a = {
     ),
     'two_year_transaction_period': fields.Int(
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
+        # required=True,
+        # missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
     'recipient_committee_type': fields.List(
         IStr(validate=validate.OneOf([
@@ -561,8 +561,8 @@ schedule_b = {
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'two_year_transaction_period': fields.Int(
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
+        # required=True,
+        # missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
     'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -483,7 +483,7 @@ schedule_a = {
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
         description='Filters individual or committee contributions based on line number'
     ),
-    'two_year_transaction_period': fields.Int(
+    'two_year_transaction_period': fields.List(fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
         # required=True,
         # missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
@@ -559,7 +559,7 @@ schedule_b = {
     'disbursement_purpose_category': fields.List(IStr, description='Disbursement purpose category'),
     'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'two_year_transaction_period': fields.Int(
+    'two_year_transaction_period': fields.List(fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
         # required=True,
         # missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -71,6 +71,16 @@ class ScheduleA(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_a'
 
+    # override the entry from the BaseItemized using either one of the following two
+    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleA.committee_id) == CommitteeHistory.committee_id,
+            ScheduleA.two_year_transaction_period == CommitteeHistory.cycle,
+        )'''
+    )
+
     committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_NAME)
 
     # Contributor info
@@ -78,11 +88,12 @@ class ScheduleA(BaseItemized):
     entity_type_desc = db.Column('entity_tp_desc', db.String)
     unused_contbr_id = db.Column('contbr_id', db.String)
     contributor_prefix = db.Column('contbr_prefix', db.String)
+    # bring in committee info of the contributor_id
     contributor = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
             foreign(ScheduleA.contributor_id) == CommitteeHistory.committee_id,
-            ScheduleA.report_year + ScheduleA.report_year % 2 == CommitteeHistory.cycle,
+            ScheduleA.two_year_transaction_period == CommitteeHistory.cycle,
         )'''
     )
 
@@ -243,16 +254,27 @@ class ScheduleB(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'
 
+    # override the entry from the BaseItemized using either one of the following two
+    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleB.committee_id) == CommitteeHistory.committee_id,
+            ScheduleB.two_year_transaction_period == CommitteeHistory.cycle,
+        )'''
+    )
+
     # Recipient info
     entity_type = db.Column('entity_tp', db.String)
     entity_type_desc = db.Column('entity_tp_desc', db.String)
     unused_recipient_committee_id = db.Column('recipient_cmte_id', db.String)
     recipient_committee_id = db.Column('clean_recipient_cmte_id', db.String)
+    # bring in committee info of the recipient_committee
     recipient_committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
             foreign(ScheduleB.recipient_committee_id) == CommitteeHistory.committee_id,
-            ScheduleB.report_year + ScheduleB.report_year % 2 == CommitteeHistory.cycle,
+            ScheduleB.two_year_transaction_period == CommitteeHistory.cycle,
         )'''
     )
     recipient_name = db.Column('recipient_nm', db.String)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -42,7 +42,7 @@ class ScheduleAView(ItemizedResource):
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
-        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
+        # ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleA.contribution_receipt_date),
@@ -101,6 +101,9 @@ class ScheduleAView(ItemizedResource):
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
+        if 'two_year_transaction_period' in kwargs:
+            query = filters.filter_match(query, kwargs, ['two_year_transaction_period'])
+        print(query)
         return query
 
 @doc(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -39,6 +39,7 @@ class ScheduleAView(ItemizedResource):
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
         ('recipient_committee_type', models.ScheduleA.recipient_committee_type),
+        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
@@ -106,9 +107,9 @@ class ScheduleAView(ItemizedResource):
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
         # print(query)
-        if 'two_year_transaction_period' in kwargs:
-            match_f = [('two_year_transaction_period', models.ScheduleA.two_year_transaction_period)]
-            query = filters.filter_match(query, kwargs, match_f)
+        # if 'two_year_transaction_period' in kwargs:
+        #     match_f = [('two_year_transaction_period', models.ScheduleA.two_year_transaction_period)]
+        #     query = filters.filter_match(query, kwargs, match_f)
         print(query)
         return query
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -13,6 +13,58 @@ from webservices.common.views import ItemizedResource
 from webservices import exceptions
 
 
+# 54
+
+# This works in python 2 and 3 and is a bit cleaner than before, but requires SA>=1.0.
+
+from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.sql.sqltypes import String, DateTime, NullType
+
+# python2/3 compatible.
+PY3 = str is not bytes
+text = str if PY3 else unicode
+int_type = int if PY3 else (int, long)
+str_type = str if PY3 else (str, unicode)
+
+
+class StringLiteral(String):
+    """Teach SA how to literalize various things."""
+    def literal_processor(self, dialect):
+        super_processor = super(StringLiteral, self).literal_processor(dialect)
+
+        def process(value):
+            if isinstance(value, int_type):
+                return text(value)
+            if not isinstance(value, str_type):
+                value = text(value)
+            result = super_processor(value)
+            if isinstance(result, bytes):
+                result = result.decode(dialect.encoding)
+            return result
+        return process
+
+class LiteralDialect(DefaultDialect):
+    colspecs = {
+        # prevent various encoding explosions
+        String: StringLiteral,
+        # teach SA about how to literalize a datetime
+        DateTime: StringLiteral,
+        # don't format py2 long integers to NULL
+        NullType: StringLiteral,
+    }
+
+
+def literalquery(statement):
+    """NOTE: This is entirely insecure. DO NOT execute the resulting strings."""
+    import sqlalchemy.orm
+    if isinstance(statement, sqlalchemy.orm.Query):
+        statement = statement.statement
+    return statement.compile(
+        dialect=LiteralDialect(),
+        compile_kwargs={'literal_binds': True},
+    ).string
+
+
 @doc(
     tags=['receipts'],
     description=docs.SCHEDULE_A,
@@ -114,6 +166,7 @@ class ScheduleAView(ItemizedResource):
         # print(str(query.statement.compile(
         #     dialect=postgresql.dialect(),
         #     compile_kwargs={"literal_binds": True})))
+        # print(literalquery(query))    
         return query
 
 @doc(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -110,7 +110,10 @@ class ScheduleAView(ItemizedResource):
         # if 'two_year_transaction_period' in kwargs:
         #     match_f = [('two_year_transaction_period', models.ScheduleA.two_year_transaction_period)]
         #     query = filters.filter_match(query, kwargs, match_f)
-        print(query)
+        # from sqlalchemy.dialects import postgresql
+        # print(str(query.statement.compile(
+        #     dialect=postgresql.dialect(),
+        #     compile_kwargs={"literal_binds": True})))
         return query
 
 @doc(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -80,7 +80,11 @@ class ScheduleAView(ItemizedResource):
         )
 
     def build_query(self, **kwargs):
+        for k,v in kwargs.items():
+            print(k,v)
+        print('*****done.')
         query = super().build_query(**kwargs)
+        #print(query)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
         zip_list = []
         if kwargs.get('contributor_zip'):
@@ -101,8 +105,10 @@ class ScheduleAView(ItemizedResource):
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
+        # print(query)
         if 'two_year_transaction_period' in kwargs:
-            query = filters.filter_match(query, kwargs, ['two_year_transaction_period'])
+            match_f = [('two_year_transaction_period', models.ScheduleA.two_year_transaction_period)]
+            query = filters.filter_match(query, kwargs, match_f)
         print(query)
         return query
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -36,6 +36,7 @@ class ScheduleBView(ItemizedResource):
         ('recipient_committee_id', models.ScheduleB.recipient_committee_id),
         ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
         ('spender_committee_type', models.ScheduleB.spender_committee_type),
+        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
 
     ]
     filter_match_fields = [
@@ -76,9 +77,9 @@ class ScheduleBView(ItemizedResource):
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
-        if 'two_year_transaction_period' in kwargs:
-            match_f = [('two_year_transaction_period', models.ScheduleB.two_year_transaction_period)]
-            query = filters.filter_match(query, kwargs, match_f)
+        # if 'two_year_transaction_period' in kwargs:
+        #     match_f = [('two_year_transaction_period', models.ScheduleB.two_year_transaction_period)]
+        #     query = filters.filter_match(query, kwargs, match_f)
         return query
 
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -38,7 +38,7 @@ class ScheduleBView(ItemizedResource):
 
     ]
     filter_match_fields = [
-        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
+        # ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
     ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
@@ -75,6 +75,9 @@ class ScheduleBView(ItemizedResource):
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
+        if 'two_year_transaction_period' in kwargs:
+            query = filters.filter_match_fields(query, kwargs, ['two_year_transaction_period'])
+        print(query)
         return query
 
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -5,6 +5,7 @@ from webservices import args
 from webservices import docs
 from webservices import utils
 from webservices import schemas
+from webservices import filters
 from webservices.common import models
 from webservices.common import views
 from webservices.common.views import ItemizedResource
@@ -76,8 +77,8 @@ class ScheduleBView(ItemizedResource):
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
         if 'two_year_transaction_period' in kwargs:
-            query = filters.filter_match_fields(query, kwargs, ['two_year_transaction_period'])
-        print(query)
+            match_f = [('two_year_transaction_period', models.ScheduleB.two_year_transaction_period)]
+            query = filters.filter_match(query, kwargs, match_f)
         return query
 
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -94,7 +94,7 @@ app.config['SQLALCHEMY_FOLLOWERS'] = [
 ]
 app.config['PROPAGATE_EXCEPTIONS'] = True
 
-# app.config['SQLALCHEMY_ECHO'] = True
+app.config['SQLALCHEMY_ECHO'] = True
 
 # Modify app configuration and logging level for production
 if not app.debug:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -69,6 +69,7 @@ app.url_map.strict_slashes = False
 
 def sqla_conn_string():
     sqla_conn_string = env.get_credential('SQLA_CONN')
+    print('db:{}'.format(sqla_conn_string))
     if not sqla_conn_string:
         print("Environment variable SQLA_CONN is empty; running against " + "local `cfdm_test`")
         sqla_conn_string = 'postgresql://:@/cfdm_test'


### PR DESCRIPTION
## Summary (required)
WIP, NO MERGE!!! this is a testing branch for performance testing of 2-year restriction removal
- Resolves # [_3595_]

_Include a summary of proposed changes._
two_year_transaction_period is not a required argument - this allows us to test transaction data beyond 2-year restriction.
(based on recent discussion, I'll modify further to allow for multiple two_year_transaction_periods to take advantage of query performance boost by schedule_a and schedule_b table partitioning. )
## How to test the changes locally
1. check out this branch
2. point you DB to staging server
3. run openFEC locally:
./manage.py runserver
4. test schedule_a and schedule_b endpoints(mainly on response time) with multiple cycles and/or multiple committees.
5. run rm2year_restriction_test.py against local server:
>>python rm2year_restriction_test.py --server http://127.0.0.1:5000
all the endpoints should have a valid response coming back within seconds.

-

## Impacted areas of the application
List general components of the application that this PR will affect:
schedule_a and schedule_b querying performance after lifting 2-year restriction.
-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
