### PR TITLE
Upgrade SQLAlchemy to latest version 1.3.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-dateutil==2.4.2
 sqlalchemy-postgres-copy==0.3.0
 networkx==1.11
 newrelic==2.96.0.80
-SQLAlchemy==1.2.8
+SQLAlchemy==1.3.1
 icalendar==3.9.1
 GitPython==1.0.1
 gunicorn==19.7.1


### PR DESCRIPTION
## Summary (required)

Upgrade SQLAlchemy to the latest version 1.3.1

- Resolves #3589

_Include a summary of proposed changes._

Update the SQLAlchemy library in `requirements.txt` 
## How to test the changes locally

- checkout `feature/upgrade-sqlalchemy`
- run `pip freeze`. Local virtual env should have SQLAlchemy1.2.8
- run  `pip install -r requirements.txt`
- run `pip freeze`. Local virtual env should have new version SQLAlchemy1.3.1
- run `pytest`. Make sure all the tests PASS
- start the local server : `./manage.py runserver` and test few API endpoints. 
For example: 
- http://127.0.0.1:5000/v1/candidates/totals/by_office/?sort_hide_null=false&active_candidates=true&per_page=20&sort_nulls_last=false&page=1&sort_null_only=false
- http://127.0.0.1:5000/v1/elections/search/?sort_hide_null=false&per_page=20&page=1&sort=sort_order&sort=district&sort_null_only=false&sort_nulls_last=false
- http://127.0.0.1:5000/v1/elections/?sort_hide_null=false&sort=-total_receipts&per_page=20&sort_nulls_last=false&cycle=2020&office=president&page=1&sort_null_only=false&election_full=false
