### PR TITLE
fix-mv-refresh-sequence

### DIFF
--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -55,7 +55,7 @@ def get_graph():
     graph.add_edge('candidate_detail', 'candidate_election')
     graph.add_edge('candidate_detail', 'candidate_history_future')
 
-    graph.add_edge('candidate_aggregates', 'candidate_history_future')
+    graph.add_edge('candidate_history_future', 'candidate_aggregates')
 
     graph.add_edge('committee_history', 'committee_detail')
 


### PR DESCRIPTION
## Summary (required)

- Resolves #3632 
ofec_candidate_history_with_future_election_mv need to be refreshed before ofec_candidate_totals_mv

ofec_candidate_totals_mv depends on ofec_candidate_history_with_future_election_mv. Therefore ofec_candidate_history_with_future_election_mv needs to be refreshed first in order for ofec_candidate_totals_mv to get the most updated data from ofec_candidate_history_with_future_election_mv

## How to test the changes locally
Download the branch to your local machine.  
invoke create_sample_db
The last step of create_sample_db is refreshing all the MVs.  
Review the output of MV refresh, make sure 
INFO:manager:Refreshing ofec_candidate_history_with_future_election_mv
appears **_BEFORE_** 
INFO:manager:Refreshing ofec_candidate_totals_mv

## Impacted areas of the application
List general components of the application that this PR will affect:

No API affected by this PR.



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
