### PR TITLE
use two_year_transaction_period in join for fec_fitem_sched_a/b

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -71,6 +71,16 @@ class ScheduleA(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_a'
 
+    # override the entry from the BaseItemized using either one of the following two
+    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleA.committee_id) == CommitteeHistory.committee_id,
+            ScheduleA.two_year_transaction_period == CommitteeHistory.cycle,
+        )'''
+    )
+
     committee_name = db.Column('cmte_nm', db.String, doc=docs.COMMITTEE_NAME)
 
     # Contributor info
@@ -78,11 +88,12 @@ class ScheduleA(BaseItemized):
     entity_type_desc = db.Column('entity_tp_desc', db.String)
     unused_contbr_id = db.Column('contbr_id', db.String)
     contributor_prefix = db.Column('contbr_prefix', db.String)
+    # bring in committee info of the contributor_id
     contributor = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
             foreign(ScheduleA.contributor_id) == CommitteeHistory.committee_id,
-            ScheduleA.report_year + ScheduleA.report_year % 2 == CommitteeHistory.cycle,
+            ScheduleA.two_year_transaction_period == CommitteeHistory.cycle,
         )'''
     )
 
@@ -243,16 +254,27 @@ class ScheduleB(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'
 
+    # override the entry from the BaseItemized using either one of the following two
+    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleB.committee_id) == CommitteeHistory.committee_id,
+            ScheduleB.two_year_transaction_period == CommitteeHistory.cycle,
+        )'''
+    )
+
     # Recipient info
     entity_type = db.Column('entity_tp', db.String)
     entity_type_desc = db.Column('entity_tp_desc', db.String)
     unused_recipient_committee_id = db.Column('recipient_cmte_id', db.String)
     recipient_committee_id = db.Column('clean_recipient_cmte_id', db.String)
+    # bring in committee info of the recipient_committee
     recipient_committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
             foreign(ScheduleB.recipient_committee_id) == CommitteeHistory.committee_id,
-            ScheduleB.report_year + ScheduleB.report_year % 2 == CommitteeHistory.cycle,
+            ScheduleB.two_year_transaction_period == CommitteeHistory.cycle,
         )'''
     )
     recipient_name = db.Column('recipient_nm', db.String)


### PR DESCRIPTION
## Summary (required)

- Resolves # [3634]
Query against processed sched tables should use two_year_transaction_period instead of re-calculated in the query.

The fec_fitem_sched_tables already have two_year_transaction_period column, which is the partition key of the huge fec_fitem_sched_a and fec_fitem_sched_b tables. It is calculated based on rpt_yr + rpt_yr % 2. The current code re-calculate the it again in the query, which slowed down the query. The model file for itemized need to updated to change the join condition for fec_fteim_sched_a/b to ofec_committee_history_mv.

## How to test the changes locally

Download the branch to the local machine. In order to verify the query generated by the SQLAlcheny correctly use the disclosure.fec_fitem_sched_a/b.two_year_transaction_period = ofec_committee_history_mv_1.cycle join condition, you can do one of the following modification to output the generated query:
Method 1)
Modify the resurces/sched_a.py and resurces/sched_b.py
Add the following lines:
In the import section of the file, add
from sqlalchemy.dialects import postgresql
Under class ScheduleAView (or class ScheduleBView)
in the build_query, right before the line
return query
add
print(str(query.statement.compile(
dialect=postgresql.dialect(),
compile_kwargs={"literal_binds": True})))

Method 2)
in rest.py file, uncomment the following line
app.config['SQLALCHEMY_ECHO'] = True

Start the local server, run the API
/schedules/schedule_a/
/schedules/schedule_b/

Review the output query from the command window,
Method 1 will output one concise query with all parameters filled in.
Method 2 will output a lot of queries alone the way SQLAlchemy built the query. Look for the final query.

Either methods should show:
FROM disclosure.fec_fitem_sched_a
LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle
LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle

FROM disclosure.fec_fitem_sched_b
LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_b.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_b.two_year_transaction_period = ofec_committee_history_mv_1.cycle
LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_b.clean_recipient_cmte_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_b.two_year_transaction_period = ofec_committee_history_mv_2.cycle


## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
