### PR TITLE
Limit extra caching to /schedules/

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -166,7 +166,7 @@ def get_cache_header(url):
 
     # cloud.gov time is in UTC (UTC = ET + 4 or 5 hours, depending on DST)
     PEAK_HOURS_START = time(13)  # 9:00 ET + 4 = 13:00 UTC
-    PEAK_HOURS_END = time(23, 30)    # 19:30 ET + 4 = 23:30 UTC
+    PEAK_HOURS_END = time(23, 30)  # 19:30 ET + 4 = 23:30 UTC
 
     DEFAULT_HEADER_TYPE = 'Cache-Control'
     DEFAULT_HEADER_PREFIX = 'public, max-age='
@@ -178,7 +178,10 @@ def get_cache_header(url):
     elif '/legal/' in url:
         return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, LEGAL_CACHE)
     # This will work differently in local environment - will use local timezone
-    elif PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END:
+    elif (
+        '/schedules/' in url
+        and PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END
+    ):
         peak_hours_expiration_time = datetime.combine(
             datetime.now().date(), PEAK_HOURS_END
         ).strftime('%a, %d %b %Y %H:%M:%S GMT')


### PR DESCRIPTION
## Summary (required)

- Resolves #3545 

Limit extra caching to /schedules/

## How to test the changes locally

- I tested this with a deploy to `stage`. 
- During peak hours (9am-7:30pm ET), `/schedules/` endpoints should return an `Expires: <today's date, ie. Mon, 18 Mar 2019> 23:00:00 GMT` (7:30pm ET) header:

`curl -X GET -I "https://api-stage.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY"`

-  During peak hours (9am-7:30pm ET),  endopoints that aren't `/schedules/` `/efile/`, `/legal/`, or `/calendar-dates/` endpoints (ie. /filings/) should return the default header:  `Cache-Control: public, max-age=3600`:

`curl -X GET -I "https://api-stage.open.fec.gov/v1/committees/?api_key=DEMO_KEY"`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Caching /schedules/ data during peak hours

## Related PRs
List related PRs against other branches: https://github.com/fecgov/openFEC/pull/3610
