### PR TITLE
Fix Financial:/elections/ to include F3 for presidential election_profile totals

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -444,6 +444,6 @@ class TransactionCoverageFactory(BaseFactory):
     class Meta:
         model = models.TransactionCoverage
 
-class TotalsPresidentialFactory_New(BaseTotalsFactory):
+class TotalsCombinedFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsCombined

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -443,3 +443,7 @@ class OperationsLogFactory(BaseFactory):
 class TransactionCoverageFactory(BaseFactory):
     class Meta:
         model = models.TransactionCoverage
+
+class TotalsPresidentialFactory_New(BaseTotalsFactory):
+    class Meta:
+        model = models.CommitteeTotalsCombined

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -213,35 +213,9 @@ class TestElections(ApiBaseTest):
                 cand_election_year=2020
             )
         ]
-        # self.presidential_totals = [
-        #     factories.TotalsPresidentialFactory(
-        #         receipts=50,
-        #         disbursements=75,
-        #         committee_id=self.president_committees[0].committee_id,
-        #         coverage_end_date=datetime.datetime(2019, 9, 30),
-        #         last_cash_on_hand_end_period=0,
-        #         cycle=2020,
-        #     ),
-        #     factories.TotalsPresidentialFactory(
-        #         receipts=1,
-        #         disbursements=1,
-        #         committee_id=self.president_committees[1].committee_id,
-        #         coverage_end_date=datetime.datetime(2017, 12, 31),
-        #         last_cash_on_hand_end_period=100,
-        #         cycle=2018,
-        #     ),
-        #     factories.TotalsPresidentialFactory(
-        #         receipts=25,
-        #         disbursements=10,
-        #         committee_id=self.president_committees[0].committee_id,
-        #         coverage_end_date=datetime.datetime(2017, 12, 31),
-        #         last_cash_on_hand_end_period=300,
-        #         cycle=2018,
-        #     ),
-        # ]
 
         self.presidential_totals = [
-            factories.TotalsPresidentialFactory_New(
+            factories.TotalsCombinedFactory(
                 receipts=50,
                 disbursements=75,
                 committee_id=self.president_committees[0].committee_id,
@@ -249,7 +223,7 @@ class TestElections(ApiBaseTest):
                 last_cash_on_hand_end_period=0,
                 cycle=2020,
             ),
-            factories.TotalsPresidentialFactory_New(
+            factories.TotalsCombinedFactory(
                 receipts=1,
                 disbursements=1,
                 committee_id=self.president_committees[1].committee_id,
@@ -257,7 +231,7 @@ class TestElections(ApiBaseTest):
                 last_cash_on_hand_end_period=100,
                 cycle=2018,
             ),
-            factories.TotalsPresidentialFactory_New(
+            factories.TotalsCombinedFactory(
                 receipts=25,
                 disbursements=10,
                 committee_id=self.president_committees[0].committee_id,

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -213,8 +213,35 @@ class TestElections(ApiBaseTest):
                 cand_election_year=2020
             )
         ]
+        # self.presidential_totals = [
+        #     factories.TotalsPresidentialFactory(
+        #         receipts=50,
+        #         disbursements=75,
+        #         committee_id=self.president_committees[0].committee_id,
+        #         coverage_end_date=datetime.datetime(2019, 9, 30),
+        #         last_cash_on_hand_end_period=0,
+        #         cycle=2020,
+        #     ),
+        #     factories.TotalsPresidentialFactory(
+        #         receipts=1,
+        #         disbursements=1,
+        #         committee_id=self.president_committees[1].committee_id,
+        #         coverage_end_date=datetime.datetime(2017, 12, 31),
+        #         last_cash_on_hand_end_period=100,
+        #         cycle=2018,
+        #     ),
+        #     factories.TotalsPresidentialFactory(
+        #         receipts=25,
+        #         disbursements=10,
+        #         committee_id=self.president_committees[0].committee_id,
+        #         coverage_end_date=datetime.datetime(2017, 12, 31),
+        #         last_cash_on_hand_end_period=300,
+        #         cycle=2018,
+        #     ),
+        # ]
+
         self.presidential_totals = [
-            factories.TotalsPresidentialFactory(
+            factories.TotalsPresidentialFactory_New(
                 receipts=50,
                 disbursements=75,
                 committee_id=self.president_committees[0].committee_id,
@@ -222,7 +249,7 @@ class TestElections(ApiBaseTest):
                 last_cash_on_hand_end_period=0,
                 cycle=2020,
             ),
-            factories.TotalsPresidentialFactory(
+            factories.TotalsPresidentialFactory_New(
                 receipts=1,
                 disbursements=1,
                 committee_id=self.president_committees[1].committee_id,
@@ -230,7 +257,7 @@ class TestElections(ApiBaseTest):
                 last_cash_on_hand_end_period=100,
                 cycle=2018,
             ),
-            factories.TotalsPresidentialFactory(
+            factories.TotalsPresidentialFactory_New(
                 receipts=25,
                 disbursements=10,
                 committee_id=self.president_committees[0].committee_id,

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -261,3 +261,26 @@ class ScheduleAByStateRecipientTotals(BaseModel):
     state_full = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
     committee_type = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
     committee_type_full = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
+
+class CommitteeTotalsCombined(CommitteeTotals):
+    __tablename__ = 'ofec_totals_combined_vw'
+
+    candidate_contribution = db.Column(db.Numeric(30, 2))
+    exempt_legal_accounting_disbursement = db.Column(db.Numeric(30, 2))
+    federal_funds = db.Column(db.Numeric(30, 2))
+    fundraising_disbursements = db.Column(db.Numeric(30, 2))
+    loan_repayments_made = db.Column(db.Numeric(30, 2))
+    loans_received = db.Column(db.Numeric(30, 2))
+    loans_received_from_candidate = db.Column(db.Numeric(30, 2))
+    offsets_to_fundraising_expenditures = db.Column(db.Numeric(30, 2))
+    offsets_to_legal_accounting = db.Column(db.Numeric(30, 2))
+    total_offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2))
+    other_loans_received = db.Column(db.Numeric(30, 2))
+    other_receipts = db.Column(db.Numeric(30, 2))
+    repayments_loans_made_by_candidate = db.Column(db.Numeric(30, 2))
+    repayments_other_loans = db.Column(db.Numeric(30, 2))
+    transfers_from_affiliated_committee = db.Column(db.Numeric(30, 2))
+    transfers_to_other_authorized_committee = db.Column(db.Numeric(30, 2))
+    cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2))
+    net_operating_expenditures = db.Column('last_net_operating_expenditures', db.Numeric(30, 2))
+    net_contributions = db.Column('last_net_contributions', db.Numeric(30, 2))


### PR DESCRIPTION
## Summary (required)

- Resolves [#3611](https://github.com/fecgov/openFEC/issues/3611) 

- Refactor Financial:/elections/ to use ofec_totals_combined_vw when calculating totals for presidential election profile page. By doing so will take care of the scenario when committee files wrong forms to FEC ( F3 or F3X).  Originally the endpoint uses ofec_totals_presidential_mv which is a subset of ofec_totals_combined_mv by setting form_type=F3P

## How to test the changes locally
- Pull feature/fix-election-profile-total to local
- Set SQLA_CONN to DEV ( page loading in DEV will be a little bit slower ( it takes about 3s ) comparing to STAGE because the latter RDS has been upgraded )
- Run endpoint:
http://127.0.0.1:5000/v1/elections/?election_full=true&sort=-total_receipts&page=1&sort_nulls_last=false&cycle=2020&office=president&sort_null_only=false&sort_hide_null=false&per_page=20

Look for John Delaney, P00006213
**"total_receipts": 6145779.44**
**"total_disbursements": 5899574.2**


Compare the above John Delaney's receipts and disbursements with these two endpoints and they should match:
datatable_url
https://api.open.fec.gov/v1/candidates/totals/?candidate_id=P00006213&election_year=2020&full_election=true&api_key=3WFCX5yqR4ZQmRKkQemdZVKEebxwWHQ6MPVc40l9&sort=-receipts

candidate_profile_url
https://api.open.fec.gov/v1/candidate/P00006213/totals/?cycle=2020&full_election=true&api_key=3WFCX5yqR4ZQmRKkQemdZVKEebxwWHQ6MPVc40l9


## Impacted areas of the application
List general components of the application that this PR will affect:

CMS:
https://www.fec.gov/data/elections/president/2020/

API:
/elections/


