### PR TITLE
updateing circleci docker base image to 3.6.4-stretch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.6.4-jessie-browsers
+      - image: circleci/python:3.6.4-stretch
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test


### PR DESCRIPTION
## Summary (required)
update circleci config.yml to switch base docker image to python:3.6.4-stretch
- Resolves # [_Issue number_]
circleci build failure issue with openFEC - failed at the flyway installation step for jessie update：
https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
switch docker base image from 3.6.4-jessie to 3.6.4-stretch
_Include a summary of proposed changes._
## How to test the changes locally
push this branch to remote to invoke circleCI build and the build should be successful.
-

## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
