### PR TITLE
OPENFEC - Add snyk links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 **Master**
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/openFEC/master.svg)](https://codecov.io/github/fecgov/openFEC)
 
-**API**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC)
-
-**Flyway**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openfec/badge.svg?targetFile=data%2Fflyway%2Fbuild.gradle)](https://snyk.io/test/github/fecgov/openfec?targetFile=data%2Fflyway%2Fbuild.gradle)
+**package.json**
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC?targetFile=package.json)
+**requirements.txt**
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC?targetFile=package.json)
+**flyway**
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openfec?targetFile=data/flyway/build.gradle)
 
 
 ## About this project


### PR DESCRIPTION
## Summary (required)

- Resolves #https://github.com/fecgov/openfec/issues/3547

_Include a summary of proposed changes._
In README.md file, added two new sync vulnerability links. These links will display the count of vulnerabilites found in `package.json` and `requirements.txt file` and in flyway/build.gradle file off the `develop` branch

## How to test

Verify vulnerabilities count in the Snyk app link(Snyk app link: https://snyk.io/org/fecgov/projects) against new links added on fec-eregs README.md file. Make sure the count matches and the links are not broken.