### PR TITLE
fix the synk links to show the vulnerabilities counts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![Test Coverage](https://img.shields.io/codecov/c/github/fecgov/openFEC/master.svg)](https://codecov.io/github/fecgov/openFEC)
 
 **package.json**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC?targetFile=package.json)
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg?targetFile=package.json)](https://snyk.io/test/github/fecgov/openFEC?targetFile=package.json)
 **requirements.txt**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openFEC?targetFile=package.json)
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/fecgov/openFEC?targetFile=requirements.txt)
 **flyway**
-[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg)](https://snyk.io/test/github/fecgov/openfec?targetFile=data/flyway/build.gradle)
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/openFEC/badge.svg?targetFile=data/flyway/build.gradle)](https://snyk.io/test/github/fecgov/openfec?targetFile=data/flyway/build.gradle)
 
 
 ## About this project


### PR DESCRIPTION

Resolves ##3547

_Include a summary of proposed changes._

Updated sync vulnerability links In README.md file. These links will display the count of vulnerabilities found in package.json and requirements.txt file and in flyway/build.gradle files

## How to test the changes locally

- on github/openfec repo, edit the README.md file, copy and paste the above links. Click on the preview tab and see if the counts are displaying properly and make sure the links are not broken. DO NOT SAVE THE CHANGES. 