### PR TITLE
update sched_a.py and sched_b.py and remove two year restriction.

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -52,25 +52,51 @@ class TestItemized(ApiBaseTest):
                 'last_contribution_receipt_date': receipts[0].contribution_receipt_date.isoformat(),
             }
         )
-    #This is the only test that the years will have to be bumped when in a new cycle
-    #maybe refactor to use some logic based on current year?
-    # remove this one because we are removing 2-year period restriction
-    # def test_two_year_transaction_period_default_supplied_automatically(self):
-    #     receipts = [
-    #         factories.ScheduleAFactory(
-    #             report_year=2016,
-    #             contribution_receipt_date=datetime.date(2016, 1, 1),
-    #             two_year_transaction_period=2016
-    #         ),
-    #         factories.ScheduleAFactory(
-    #             report_year=2018,
-    #             contribution_receipt_date=datetime.date(2018, 1, 1),
-    #             two_year_transaction_period=2018
-    #         ),
-    #     ]
 
-    #     response = self._response(api.url_for(ScheduleAView))
-    #     self.assertEqual(len(response['results']), 1)
+    def test_multiple_two_year_transaction_period_schedule_a(self):
+        """
+        testing schedule_a api can take multiple cyccles now
+        """
+        receipts = [
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018
+            ),
+        ]
+        response = self._response(
+            api.url_for(
+                ScheduleAView,
+                two_year_transaction_period=[2016, 2018],
+        ))
+        self.assertEqual(len(response['results']), 2)
+
+    def test_multiple_two_year_transaction_period_schedule_b(self):
+        """
+        testing schedule_b api can take multiple cyccles now
+        """
+        receipts = [
+            factories.ScheduleBFactory(
+                report_year=2016,
+                two_year_transaction_period=2016
+            ),
+            factories.ScheduleBFactory(
+                report_year=2018,
+                two_year_transaction_period=2018
+            ),
+        ]
+        response = self._response(
+            api.url_for(
+                ScheduleBView,
+                two_year_transaction_period=[2016, 2018],
+        ))
+        self.assertEqual(len(response['results']), 2)
+
 
     def test_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [
@@ -85,7 +111,6 @@ class TestItemized(ApiBaseTest):
                 two_year_transaction_period=2012
             ),
         ]
-
         response = self._response(
             api.url_for(ScheduleAView, two_year_transaction_period=2014)
         )

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -54,22 +54,23 @@ class TestItemized(ApiBaseTest):
         )
     #This is the only test that the years will have to be bumped when in a new cycle
     #maybe refactor to use some logic based on current year?
-    def test_two_year_transaction_period_default_supplied_automatically(self):
-        receipts = [
-            factories.ScheduleAFactory(
-                report_year=2016,
-                contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
-            ),
-            factories.ScheduleAFactory(
-                report_year=2018,
-                contribution_receipt_date=datetime.date(2018, 1, 1),
-                two_year_transaction_period=2018
-            ),
-        ]
+    # remove this one because we are removing 2-year period restriction
+    # def test_two_year_transaction_period_default_supplied_automatically(self):
+    #     receipts = [
+    #         factories.ScheduleAFactory(
+    #             report_year=2016,
+    #             contribution_receipt_date=datetime.date(2016, 1, 1),
+    #             two_year_transaction_period=2016
+    #         ),
+    #         factories.ScheduleAFactory(
+    #             report_year=2018,
+    #             contribution_receipt_date=datetime.date(2018, 1, 1),
+    #             two_year_transaction_period=2018
+    #         ),
+    #     ]
 
-        response = self._response(api.url_for(ScheduleAView))
-        self.assertEqual(len(response['results']), 1)
+    #     response = self._response(api.url_for(ScheduleAView))
+    #     self.assertEqual(len(response['results']), 1)
 
     def test_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -55,9 +55,14 @@ class TestItemized(ApiBaseTest):
 
     def test_multiple_two_year_transaction_period_schedule_a(self):
         """
-        testing schedule_a api can take multiple cyccles now
+        testing schedule_a api can take multiple cycles now
         """
         receipts = [
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014
+            ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
@@ -81,6 +86,10 @@ class TestItemized(ApiBaseTest):
         testing schedule_b api can take multiple cyccles now
         """
         receipts = [
+            factories.ScheduleBFactory(
+                report_year=2014,
+                two_year_transaction_period=2014
+            ),
             factories.ScheduleBFactory(
                 report_year=2016,
                 two_year_transaction_period=2016

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -483,10 +483,8 @@ schedule_a = {
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
         description='Filters individual or committee contributions based on line number'
     ),
-    'two_year_transaction_period': fields.Int(
+    'two_year_transaction_period': fields.List(fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
     'recipient_committee_type': fields.List(
         IStr(validate=validate.OneOf([
@@ -559,12 +557,10 @@ schedule_b = {
     'disbursement_purpose_category': fields.List(IStr, description='Disbursement purpose category'),
     'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'two_year_transaction_period': fields.Int(
+    'two_year_transaction_period': fields.List(fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
-        required=True,
-        missing=SQL_CONFIG['CYCLE_END_YEAR_ITEMIZED']
     ),
-    'spender_committee_type': fields.List(
+   'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -24,9 +24,6 @@ SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
     'END_YEAR_ITEMIZED': get_cycle_start(CURRENT_YEAR),
-    # CYCLE_END_YEAR_ITEMIZED will need to be updated every cycle
-    # once we have meaningful data
-    'CYCLE_END_YEAR_ITEMIZED': 2018,
     'PARTITION_START_YEAR': 1978,
     'PARTITION_END_YEAR': 2018,
 }

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -24,8 +24,6 @@ SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
     'END_YEAR_ITEMIZED': get_cycle_start(CURRENT_YEAR),
-    'PARTITION_START_YEAR': 1978,
-    'PARTITION_END_YEAR': 2018,
 }
 
 REQUIRED_CREDS = (

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -12,6 +12,10 @@ from webservices.common import views
 from webservices.common.views import ItemizedResource
 from webservices import exceptions
 
+"""
+two years restriction removed from schedule_a. For details, refer:
+https://github.com/fecgov/openFEC/issues/3595
+"""
 
 @doc(
     tags=['receipts'],
@@ -117,7 +121,6 @@ class ScheduleAEfileView(views.ApiResource):
         ('committee_id', models.ScheduleAEfile.committee_id),
         ('contributor_city', models.ScheduleAEfile.contributor_city),
         ('contributor_state', models.ScheduleAEfile.contributor_state),
-        #('contributor_name', models.ScheduleAEfile.contr)
     ]
 
     filter_range_fields = [

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -39,10 +39,10 @@ class ScheduleAView(ItemizedResource):
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
         ('recipient_committee_type', models.ScheduleA.recipient_committee_type),
+        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
-        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleA.contribution_receipt_date),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -35,11 +35,12 @@ class ScheduleBView(ItemizedResource):
         ('recipient_committee_id', models.ScheduleB.recipient_committee_id),
         ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
         ('spender_committee_type', models.ScheduleB.spender_committee_type),
+        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
 
     ]
-    filter_match_fields = [
-        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
-    ]
+    # filter_match_fields = [
+    #     ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
+    # ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
         ('disbursement_description', models.ScheduleB.disbursement_description_text),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -9,6 +9,10 @@ from webservices.common import models
 from webservices.common import views
 from webservices.common.views import ItemizedResource
 
+"""
+two years restriction removed from schedule_b. For details, refer:
+https://github.com/fecgov/openFEC/issues/3595
+"""
 
 @doc(
     tags=['disbursements'],
@@ -38,9 +42,6 @@ class ScheduleBView(ItemizedResource):
         ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
 
     ]
-    # filter_match_fields = [
-    #     ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
-    # ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
         ('disbursement_description', models.ScheduleB.disbursement_description_text),
@@ -70,7 +71,7 @@ class ScheduleBView(ItemizedResource):
         query = query.options(sa.orm.joinedload(models.ScheduleB.recipient_committee))
         #might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
-            query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
+            query = query.filter_by(sub_id = int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
@@ -93,19 +94,15 @@ class ScheduleBEfileView(views.ApiResource):
         ('committee_id', models.ScheduleBEfile.committee_id),
         ('recipient_city', models.ScheduleBEfile.recipient_city),
         ('recipient_state', models.ScheduleBEfile.recipient_state),
-        #('recipient_committee_id', models.ScheduleBEfile.recipient_committee_id),
-        #('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
     ]
 
     filter_fulltext_fields = [
-        #('recipient_name', models.ScheduleB.recipient_name_text),
         ('disbursement_description', models.ScheduleBEfile.disbursement_description),
     ]
 
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleBEfile.disbursement_date),
         (('min_amount', 'max_amount'), models.ScheduleBEfile.disbursement_amount),
-        #(('min_image_number', 'max_image_number'), models.ScheduleBE.image_number),
     ]
 
     @property


### PR DESCRIPTION
## Summary (required)
remove two-year restriction from sched_a and sched_b endpoints but don't update the api docs
- Resolves #3595

_Include a summary of proposed changes._
1. two_year_transaction_period: required --> not required
2. update two_year_transaction_period to allow for multiple value
3. one pytest disabled - checking for default two_year_transaction_period missing value
## How to test the changes locally
- pytest should pasd
- test on local server:
 1. manage.py runserver
2. test the following api for multiple two_year_transaction_period values:
    >>http://127.0.0.1:5000/v1/schedules/schedule_b/?sort_hide_null=false&per_page=20&max_date=12%2F31%2F2018&api_key=DEMO_KEY&min_date=1%2F1%2F2014&is_individual=true&two_year_transaction_period=2018&sort_null_only=false&min_amount=500&two_year_transaction_period=2016&two_year_transaction_period=2014&contributor_state=CA
   >>http://127.0.0.1:5000/v1/schedules/schedule_b/?sort_hide_null=false&per_page=20&max_date=12%2F31%2F2018&api_key=DEMO_KEY&min_date=1%2F1%2F2014&is_individual=true&two_year_transaction_period=2018&sort_null_only=false&min_amount=500&two_year_transaction_period=2016&two_year_transaction_period=2014&contributor_state=CA
3. test this one for no two_year_trsaction_period:
http://127.0.0.1:5000/v1/schedules/schedule_a/?sort_hide_null=false&per_page=50&max_date=12%2F31%2F2018&api_key=DEMO_KEY&min_date=1%2F1%2F2017&is_individual=true&sort_null_only=false&min_amount=1000&contributor_state=CA
-

## Impacted areas of the application
List general components of the application that this PR will affect:
sched_a and sched_b endpoinits and all the related API calls.

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
