### PR TITLE
Update Flyway to version 5.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           command: |
             sudo apt-get update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.1.3/flyway-commandline-5.1.3-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-5.1.3:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-5.2.4:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '5.1.3'
-    compile(group: 'org.flywaydb', name: 'flyway-commandline', version: '5.1.3') {
+    compile group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '5.2.4'
+    compile(group: 'org.flywaydb', name: 'flyway-commandline', version: '5.2.4') {
         exclude group: 'com.microsoft.sqlserver', module: 'msql-jdbc'
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-5.1.3.jar:app/gradle/lib/flyway-core-5.1.3.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-5.2.4.jar:app/gradle/lib/flyway-core-5.2.4.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #3654: Update Flyway to version 5.2.4

## How to test the changes locally

- Download new version, set up: [Install version 5.2.4](https://github.com/fecgov/openFEC#project-prerequisites)
- Run`invoke create_sample_db`
- I tested this with a manual deploy to `dev`.

## Impacted areas of the application
List general components of the application that this PR will affect:

- Database migrations  

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/upgrade-flyway | https://github.com/fecgov/openFEC/pull/3223

