### PR TITLE
Update SQLA_SAMPLE_DB_CONN instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ createdb cfdm_test
 Set the environment variable SQLA_SAMPLE_DB_CONN to point to this database, using:
 
 ```
-export SQLA_SAMPLE_DB_CONN=<psql:address-to-box>
+export SQLA_SAMPLE_DB_CONN="postgresql://<username>:<password>@localhost:<port - default is 5432>/cfdm_test"
 ```
 
 Load our sample data into the development database (`cfdm_test`) by running:


### PR DESCRIPTION
Update `SQLA_SAMPLE_DB_CONN` instructions
https://stackoverflow.com/questions/5598517/find-the-host-name-and-port-using-psql-commands

```
export SQLA_SAMPLE_DB_CONN="postgresql://<username>:<password>@localhost:<port - default is 5432>/cfdm_test"
```

@jason-upchurch please let me know if you think this adds clarity.
