### PR TITLE
Test published/unpublished cases

### DIFF
--- a/data/load_base_mur_data.sql
+++ b/data/load_base_mur_data.sql
@@ -37,4 +37,5 @@ INSERT INTO fecmur.subject VALUES (17, 'Presidential', '2016-08-26 12:12:37.9798
 INSERT INTO fecmur.subject VALUES (18, 'Reporting', '2016-08-26 12:12:37.979847');
 INSERT INTO fecmur.subject VALUES (19, 'Soft Money', '2016-08-26 12:12:37.979847');
 INSERT INTO fecmur.subject VALUES (20, 'Solicitation', '2016-08-26 12:12:37.979847');
+INSERT INTO fecmur.subject VALUES (101, 'Unpublished MUR', '2016-08-26 12:12:37.979847');
 

--- a/data/migrations/V0130__add_published_flg_to_fecmur_case.sql
+++ b/data/migrations/V0130__add_published_flg_to_fecmur_case.sql
@@ -1,0 +1,23 @@
+/*
+This is for issue #3573 Add filter to only show published cases on /legal/
+*/
+
+ALTER TABLE fecmur.case add column if not exists published_flg bool default true;
+
+
+CREATE OR REPLACE VIEW fecmur.cases_with_parsed_case_serial_numbers_vw AS 
+ SELECT "case".case_id,
+    "case".case_no,
+    regexp_replace("case".case_no::text, '(\d+).*'::text, '\1'::text)::integer AS case_serial,
+    "case".name,
+    "case".case_type,
+    "case".pg_date,
+    "case".published_flg 
+   FROM fecmur."case"
+  WHERE "case".case_type::text = ANY (ARRAY['MUR'::character varying, 'AF'::character varying, 'ADR'::character varying]::text[]);
+
+ALTER TABLE fecmur.cases_with_parsed_case_serial_numbers_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE fecmur.cases_with_parsed_case_serial_numbers_vw TO fec;
+GRANT SELECT ON TABLE fecmur.cases_with_parsed_case_serial_numbers_vw TO fec_read;
+GRANT SELECT ON TABLE fecmur.cases_with_parsed_case_serial_numbers_vw TO openfec_read;

--- a/tasks.py
+++ b/tasks.py
@@ -144,7 +144,6 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
-    # ('dev', lambda _, branch: branch == 'feature/create_bastion_host'),
 )
 
 

--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -32,6 +32,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_1',
+            'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
             'respondents': [],
@@ -44,7 +45,34 @@ class TestLoadCurrentCases(BaseTestCase):
             'sort1': -1,
             'sort2': None
         }
-        self.create_case(1, expected_mur['no'], expected_mur['name'], mur_subject)
+        self.create_case(1, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
+        actual_mur = next(get_cases('MUR'))
+
+        assert actual_mur == expected_mur
+
+    @patch('webservices.legal_docs.current_cases.get_bucket')
+    def test_unpublished_mur(self, get_bucket):
+        mur_subject = 'Unpublished MUR'
+        expected_mur = {
+            'no': '101',
+            'name': 'Test Unpublished MUR',
+            'mur_type': 'current',
+            'election_cycles': [2016],
+            'doc_id': 'mur_101',
+            'published_flg': False,
+            'participants': [],
+            'subjects': [mur_subject],
+            'respondents': [],
+            'documents': [],
+            'commission_votes': [],
+            'dispositions': [],
+            'close_date': None,
+            'open_date': None,
+            'url': '/legal/matter-under-review/101/',
+            'sort1': -101,
+            'sort2': None
+        }
+        self.create_case(101, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
         actual_mur = next(get_cases('MUR'))
 
         assert actual_mur == expected_mur
@@ -57,6 +85,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'name': 'Simple ADR',
             'election_cycles': [2016],
             'doc_id': 'adr_1',
+            'published_flg': True,
             'participants': [],
             'subjects': [adr_subject],
             'respondents': [],
@@ -69,7 +98,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'sort1': -1,
             'sort2': None
         }
-        self.create_case(1, expected_adr['no'], expected_adr['name'], adr_subject, 'ADR')
+        self.create_case(1, expected_adr['no'], expected_adr['name'], adr_subject, expected_adr['published_flg'], 'ADR')
         actual_adr = next(get_cases('ADR'))
 
         assert actual_adr == expected_adr
@@ -81,6 +110,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'no': '1',
             'name': 'Big Admin Fine',
             'doc_id': 'af_1',
+            'published_flg': True,
             'documents': [],
             'commission_votes': [{'action': None, 'vote_date': None}],
             'committee_id': 'C001',
@@ -101,7 +131,8 @@ class TestLoadCurrentCases(BaseTestCase):
             'sort1': -1,
             'sort2': None
         }
-        self.create_case(1, expected_admin_fine['no'], expected_admin_fine['name'], dummy_subject, 'AF')
+        self.create_case(1, expected_admin_fine['no'], expected_admin_fine['name'],
+            dummy_subject, expected_admin_fine['published_flg'], 'AF')
         self.create_admin_fine(1,
             expected_admin_fine['committee_id'],
             expected_admin_fine['report_year'],
@@ -130,6 +161,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'no': '1',
             'name': 'MUR with participants',
             'mur_type': 'current',
+            'published_flg': True,
             'election_cycles': [2016],
             'doc_id': 'mur_1',
             'subjects': [mur_subject],
@@ -148,7 +180,7 @@ class TestLoadCurrentCases(BaseTestCase):
                     filename.replace(' ', '-'))),
         ]
 
-        self.create_case(case_id, expected_mur['no'], expected_mur['name'], mur_subject)
+        self.create_case(case_id, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
         for entity_id, participant in enumerate(participants):
             role, name = participant
             self.create_participant(case_id, entity_id, role, name)
@@ -175,7 +207,8 @@ class TestLoadCurrentCases(BaseTestCase):
         name = 'Open Elections LLC'
         mur_subject = 'Fraudulent misrepresentation'
         pg_date = '2016-10-08'
-        self.create_case(case_id, case_no, name, mur_subject)
+        published_flg = True
+        self.create_case(case_id, case_no, name, mur_subject, published_flg)
 
         entity_id = 1
         event_date = '2005-01-01'
@@ -246,6 +279,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'subjects': ['Fraudulent misrepresentation'],
             'respondents': [],
             'documents': [], 'participants': [], 'no': '1', 'doc_id': 'mur_1',
+            'published_flg': True,
             'mur_type': 'current', 'name': 'Open Elections LLC', 'open_date': datetime(2005, 1, 1, 0, 0),
             'election_cycles': [2016],
             'close_date': datetime(2008, 1, 1, 0, 0),
@@ -264,6 +298,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_1',
+            'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
             'respondents': [],
@@ -282,6 +317,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_2',
+            'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
             'respondents': [],
@@ -300,6 +336,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_3',
+            'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
             'respondents': [],
@@ -312,9 +349,9 @@ class TestLoadCurrentCases(BaseTestCase):
             'sort1': -3,
             'sort2': None
         }
-        self.create_case(1, expected_mur1['no'], expected_mur1['name'], mur_subject)
-        self.create_case(2, expected_mur2['no'], expected_mur2['name'], mur_subject)
-        self.create_case(3, expected_mur3['no'], expected_mur3['name'], mur_subject)
+        self.create_case(1, expected_mur1['no'], expected_mur1['name'], mur_subject, expected_mur1['published_flg'])
+        self.create_case(2, expected_mur2['no'], expected_mur2['name'], mur_subject, expected_mur2['published_flg'])
+        self.create_case(3, expected_mur3['no'], expected_mur3['name'], mur_subject, expected_mur3['published_flg'])
 
         gen = get_cases('MUR')
         assert(next(gen)) == expected_mur1
@@ -324,13 +361,13 @@ class TestLoadCurrentCases(BaseTestCase):
         actual_murs = [mur for mur in get_cases('MUR', '2')]
         assert actual_murs == [expected_mur2]
 
-    def create_case(self, case_id, case_no, name, subject_description, case_type='MUR'):
+    def create_case(self, case_id, case_no, name, subject_description, published_flg, case_type='MUR'):
         subject_id = self.connection.execute(
             "SELECT subject_id FROM fecmur.subject "
             " WHERE description = %s ", subject_description).scalar()
         self.connection.execute(
-            "INSERT INTO fecmur.case (case_id, case_no, name, case_type) "
-            "VALUES (%s, %s, %s, %s)", case_id, case_no, name, case_type)
+            "INSERT INTO fecmur.case (case_id, case_no, name, published_flg, case_type) "
+            "VALUES (%s, %s, %s, %s, %s)", case_id, case_no, name, published_flg, case_type)
         if case_type != 'AF':
             self.connection.execute(
                 "INSERT INTO fecmur.case_subject (case_id, subject_id, relatedsubject_id) "

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -61,23 +61,27 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
-                two_year_transaction_period=2014
+                two_year_transaction_period=2014,
+                committee_id='C001'
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
+                committee_id='C001'
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
-                two_year_transaction_period=2018
+                two_year_transaction_period=2018,
+                committee_id='C001'
             ),
         ]
         response = self._response(
             api.url_for(
                 ScheduleAView,
                 two_year_transaction_period=[2016, 2018],
+                committee_id='C001',
         ))
         self.assertEqual(len(response['results']), 2)
 
@@ -617,7 +621,7 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(response.status_code, 422)
 
     def test_pagination_bad_per_page(self):
-        response = self.app.get(api.url_for(ScheduleAView, per_page=999))
+        response = self.app.get(api.url_for(ScheduleAView, two_year_transaction_period=2018, per_page=999))
         self.assertEqual(response.status_code, 422)
 
     def test_image_number(self):
@@ -637,11 +641,11 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(image_number='3'),
             factories.ScheduleAFactory(image_number='4'),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2'))
+        results = self._results(api.url_for(ScheduleAView, min_image_number='2', two_year_transaction_period=2016))
         self.assertTrue(all(each['image_number'] >= '2' for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_image_number='3'))
+        results = self._results(api.url_for(ScheduleAView, max_image_number='3', two_year_transaction_period=2016))
         self.assertTrue(all(each['image_number'] <= '3' for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3'))
+        results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3', two_year_transaction_period=2016))
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
     def test_amount_sched_a(self):
@@ -651,11 +655,11 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(contribution_receipt_amount=150),
             factories.ScheduleAFactory(contribution_receipt_amount=200),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_amount=100))
+        results = self._results(api.url_for(ScheduleAView, min_amount=100, two_year_transaction_period=2016))
         self.assertTrue(all(each['contribution_receipt_amount'] >= 100 for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_amount=150))
+        results = self._results(api.url_for(ScheduleAView, max_amount=150, two_year_transaction_period=2016))
         self.assertTrue(all(each['contribution_receipt_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_amount=100, max_amount=150))
+        results = self._results(api.url_for(ScheduleAView, min_amount=100, max_amount=150, two_year_transaction_period=2016))
         self.assertTrue(all(100 <= each['contribution_receipt_amount'] <= 150 for each in results))
 
     def test_amount_sched_b(self):

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -17,7 +17,8 @@ ALL_CASES = """
         case_id,
         case_no,
         name,
-        case_type
+        case_type,
+        published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE case_type = %s
     ORDER BY case_serial
@@ -28,7 +29,8 @@ SINGLE_CASE = """
         case_id,
         case_no,
         name,
-        case_type
+        case_type,
+        published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE case_type = %s
     AND case_no = %s
@@ -206,10 +208,15 @@ def load_cases(case_type, case_no=None):
         case_count = 0
         for case in get_cases(case_type, case_no):
             if case is not None:
-                logger.info("Loading {0}: {1}".format(case_type, case['no']))
-                es.index('docs_index', get_es_type(case_type), case, id=case['doc_id'])
-                case_count += 1
-        logger.info("{0} {1}(s) loaded".format(case_count, case_type))
+                if case.get('published_flg'):
+                    logger.info("Loading {0}: {1}".format(case_type, case['no']))
+                    es.index('docs_index', get_es_type(case_type), case, id=case['doc_id'])
+                    case_count += 1
+                    logger.info("{0} {1}(s) loaded".format(case_count, case_type))
+                else:
+                    logger.info("Found an unpublished case - deleting from ES")
+                    es.delete_by_query(index='docs_index', body={'query': {"term" : { "no" : case_no }}}, doc_type=get_es_type(case_type))
+                    logger.info('Sucessfully deleted {} {} from ES'.format(case_type, case_no))
     else:
         logger.error("Invalid case_type: must be 'MUR', 'ADR', or 'AF'.")
 
@@ -242,6 +249,7 @@ def get_single_case(case_type, case_no):
                 'doc_id': '{0}_{1}'.format(case_type.lower(), row['case_no']),
                 'no': row['case_no'],
                 'name': row['name'],
+                'published_flg': row['published_flg'],
                 'sort1': sort1,
                 'sort2': sort2,
             }

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -215,8 +215,9 @@ def load_cases(case_type, case_no=None):
                     logger.info("{0} {1}(s) loaded".format(case_count, case_type))
                 else:
                     logger.info("Found an unpublished case - deleting from ES")
-                    es.delete_by_query(index='docs_index', body={'query': {"term" : { "no" : case_no }}}, doc_type=get_es_type(case_type))
-                    logger.info('Sucessfully deleted {} {} from ES'.format(case_type, case_no))
+                    es.delete_by_query(index='docs_index', body={'query': {"term": {"no": case_no}}},
+                        doc_type=get_es_type(case_type))
+                    logger.info('Successfully deleted {} {} from ES'.format(case_type, case_no))
     else:
         logger.error("Invalid case_type: must be 'MUR', 'ADR', or 'AF'.")
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -93,7 +93,6 @@ class ScheduleAView(ItemizedResource):
             'contributor_employer',
             'contributor_occupation',
             'image_number',
-            'line_number',
         ]
         two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
         if len(two_year_transaction_periods) != 1:

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -84,6 +84,24 @@ class ScheduleAView(ItemizedResource):
         )
 
     def build_query(self, **kwargs):
+        secondary_index_options = [
+            'committee_id',
+            'contributor_id',
+            'contributor_name',
+            'contributor_city',
+            'contributor_zip',
+            'contributor_employer',
+            'contributor_occupation',
+            'image_number',
+            'line_number',
+        ]
+        two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
+        if len(two_year_transaction_periods) != 1:
+            if not any(kwargs.get(field) for field in secondary_index_options):
+                raise exceptions.ApiError(
+                    "Please choose a single `two_year_transaction_period` or add one of the following filters to your query: `{}`".format("`, `".join(secondary_index_options)),
+                    status_code=400,
+                )
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
         zip_list = []


### PR DESCRIPTION
## Summary (required)
A case (ADR, AF or MUR) is purged on  DB, by setting the `published_flg=false` and updating `pg_date` column in case table. This will initiate a celery task which deletes the case from elasticsearch service.

- Resolves #3573 

_Include a summary of proposed changes._

  1. Modify the case queries to fetch the new boolean column published_flg
  2. Update the `load_cases` script to check if `published_flg=false` set  on a case and delete it from ES service.
  3. Update `test_current_cases.py` test to return the published_flg for a given case 
 
## How to test the changes locally
  1.Follow the instructions and set up your workspace with the following services:
       (https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads#testing-queued-tasks-locally)
  2.start your local elasticsearch service
  3.get the API s3 bucket env variables from `dev` space (`cf env api`)
  4.export the access, secretaccesskey, bucket, region env variables in  `celery worker` and `api` 
    terminals
5.export sqla_conn to point to your local db
6. load a case(ex: mur 7278) onto your local elasticsearch service 
7. verified that 7278 existing on  local ES service
8. on cfdm_test db, updated the two columns `pg_date` and `processed_flg=false` (which means that the case is purged in the DB) this will initiate the celery task.
9. refresh the local ES service and make sure the mur 7278 is deleted.
10. try to reload the deleted mur 7278 again. the load_cases script will not LOAD this MUR since its already deleted. 
11. Run the steps 6-10 to test ADR's or AF's

## Impacted areas of the application
List general components of the application that this PR will affect:
- Legal Resources/ Enforcements
 https://www.fec.gov/data/legal/search/enforcement/?case_no=