### PR TITLE
pin requirements for kombu 4.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/fecgov/apispec.git@dev
 #prance[osv]>=0.11 # pathlib dependency is breaking pytest
 cfenv==0.5.2
 invoke==0.15.0
+kombu==4.3.0
 psycopg2==2.7.3.2
 Flask==1.0.2
 Flask-Cors==3.0.6
@@ -34,6 +35,6 @@ git+https://github.com/jmcarp/marshmallow-pagination@master
 smart_open==1.7.1
 
 # Task queue
-celery==4.1.1
+celery==4.1.1 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==1.2.0
 redis==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/fecgov/apispec.git@dev
 #prance[osv]>=0.11 # pathlib dependency is breaking pytest
 cfenv==0.5.2
 invoke==0.15.0
-kombu==4.3.0
+kombu==4.5.0
 psycopg2==2.7.3.2
 Flask==1.0.2
 Flask-Cors==3.0.6


### PR DESCRIPTION
## Verify pinning `kombu==4.3.0` in requirements.txt and installing requirements.txt preserved kombu. Update requirements.txt with `kombu==4.3.0` and add note to celery to verify that future updates preserve kombu compatibility.

- Resolves #3608 

* update requirements.txt with kombu version and note on celery

## How to test the changes locally

* `pip install -r requirements.txt`

## Impacted areas of the application
For local API setup, impacts dependent packages installed by requirements.txt

branch | PR
------ | ------
feature/3608-pin-requirements-kombu-4.3.0| [3608](https://github.com/fecgov/openFEC/issues/3608)

edited to include how to test locally