### PR TITLE
Limit access to /downloads/ to one API key

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -135,7 +135,7 @@ def handle_error(error):
 
 # api.data.gov
 TRUSTED_PROXIES = ('54.208.160.112', '54.208.160.151')
-BLOCKED_IPS = env.get_credential('BLOCKED_IPS', [])
+BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
 # Search this key_id in the API umbrella admin interface to look up the API KEY
 DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -135,6 +135,7 @@ def handle_error(error):
 
 # api.data.gov
 TRUSTED_PROXIES = ('54.208.160.112', '54.208.160.151')
+# Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
 # Search this key_id in the API umbrella admin interface to look up the API KEY
@@ -143,8 +144,11 @@ RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS')
 
 @app.before_request
 def limit_remote_addr():
-    """If `FEC_API_WHITELIST_IPS` is set, reject all requests that are not
-    routed through the API Umbrella.
+    """
+    If `FEC_API_WHITELIST_IPS` is set:
+    - Reject all requests that are not routed through the API Umbrella
+    - Block any flagged IPs
+    - If we're restricting downloads, only allow requests from whitelisted key
     """
     falses = (False, 'False', 'false', 'f')
     if FEC_API_WHITELIST_IPS not in falses:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -135,10 +135,11 @@ def handle_error(error):
 
 # api.data.gov
 TRUSTED_PROXIES = ('54.208.160.112', '54.208.160.151')
-BLOCKED_IPS = ('95.216.186.66', '109.252.57.42')
+BLOCKED_IPS = env.get_credential('BLOCKED_IPS', [])
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
 # Search this key_id in the API umbrella admin interface to look up the API KEY
 DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
+RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS')
 
 @app.before_request
 def limit_remote_addr():
@@ -156,12 +157,11 @@ def limit_remote_addr():
                 abort(403)
             if source_ip in BLOCKED_IPS:
                 abort(403)
-            if '/download/' in request.url:
+            if RESTRICT_DOWNLOADS and '/download/' in request.url:
                 # 'X-Api-User-Id' header is passed through by the API umbrella
                 request_api_key_id = request.headers.get('X-Api-User-Id')
                 if request_api_key_id != DOWNLOAD_WHITELIST_API_KEY_ID:
                     abort(403)
-
 
 
 def get_cache_header(url):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -161,7 +161,7 @@ def limit_remote_addr():
                 abort(403)
             if source_ip in BLOCKED_IPS:
                 abort(403)
-            if RESTRICT_DOWNLOADS and '/download/' in request.url:
+            if RESTRICT_DOWNLOADS not in falses and '/download/' in request.url:
                 # 'X-Api-User-Id' header is passed through by the API umbrella
                 request_api_key_id = request.headers.get('X-Api-User-Id')
                 if request_api_key_id != DOWNLOAD_WHITELIST_API_KEY_ID:

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -137,6 +137,8 @@ def handle_error(error):
 TRUSTED_PROXIES = ('54.208.160.112', '54.208.160.151')
 BLOCKED_IPS = ('95.216.186.66', '109.252.57.42')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
+# Search this key_id in the API umbrella admin interface to look up the API KEY
+DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
 
 @app.before_request
 def limit_remote_addr():
@@ -154,6 +156,12 @@ def limit_remote_addr():
                 abort(403)
             if source_ip in BLOCKED_IPS:
                 abort(403)
+            if '/download/' in request.url:
+                # 'X-Api-User-Id' header is passed through by the API umbrella
+                request_api_key_id = request.headers.get('X-Api-User-Id')
+                if request_api_key_id != DOWNLOAD_WHITELIST_API_KEY_ID:
+                    abort(403)
+
 
 
 def get_cache_header(url):


### PR DESCRIPTION
## Summary (required)

Resolves #3651 

- Limit access to /downloads/ to one API key, only when `RESTRICT_DOWNLOADS` is turned on
- Turn `BLOCKED_IPS` into an `env var`

## How to test the changes locally

- This is hard to test locally because it needs the API umbrella in place. There's currently a manual deploy on `stage` (`invoke deploy --space stage --skip-migrations`)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Downloads


