### PR TITLE
Fix search by analyst title and email

### DIFF
--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -25,9 +25,11 @@ class TestFilerResources(ApiBaseTest):
 
     def test_filters(self):
         [
-            factories.RadAnalystFactory(telephone_ext=123, committee_id='C0001', title='xyz'),
-            factories.RadAnalystFactory(telephone_ext=456, committee_id='C0002', title='abc'),
-            factories.RadAnalystFactory(analyst_id=789, committee_id='C0003'),
+            factories.RadAnalystFactory(telephone_ext=123, committee_id='C0001', title='xyz 111'),
+            factories.RadAnalystFactory(telephone_ext=456, committee_id='C0002', title='abc',
+                                        email='test2@fec.gov'),
+            factories.RadAnalystFactory(analyst_id=789, committee_id='C0003',
+                                        email='test1@fec.gov'),
             factories.RadAnalystFactory(analyst_id=1011, analyst_short_id=11, committee_id='C0004'),
         ]
 
@@ -36,7 +38,8 @@ class TestFilerResources(ApiBaseTest):
             ('telephone_ext', 123),
             ('analyst_id', 789),
             ('analyst_short_id', 11),
-            ('title', 'abc'),
+            ('title', 'xyz 111'),
+            ('email', ['test1@fec.gov', 'test2@fec.gov']),
         )
 
         # checking one example from each field

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -25,8 +25,8 @@ class TestFilerResources(ApiBaseTest):
 
     def test_filters(self):
         [
-            factories.RadAnalystFactory(telephone_ext=123, committee_id='C0001'),
-            factories.RadAnalystFactory(telephone_ext=456, committee_id='C0002'),
+            factories.RadAnalystFactory(telephone_ext=123, committee_id='C0001', title='xyz'),
+            factories.RadAnalystFactory(telephone_ext=456, committee_id='C0002', title='abc'),
             factories.RadAnalystFactory(analyst_id=789, committee_id='C0003'),
             factories.RadAnalystFactory(analyst_id=1011, analyst_short_id=11, committee_id='C0004'),
         ]
@@ -36,6 +36,7 @@ class TestFilerResources(ApiBaseTest):
             ('telephone_ext', 123),
             ('analyst_id', 789),
             ('analyst_short_id', 11),
+            ('title', 'abc'),
         )
 
         # checking one example from each field

--- a/webservices/common/models/rad_analyst.py
+++ b/webservices/common/models/rad_analyst.py
@@ -1,6 +1,5 @@
 from .base import db
 from sqlalchemy.dialects.postgresql import TSVECTOR
-
 from webservices import docs
 
 
@@ -16,7 +15,7 @@ class RadAnalyst(db.Model):
     first_name = db.Column(db.String(255), index=True, doc='Fist name of RAD analyst')
     last_name = db.Column(db.String(100), index=True, doc='Last name of RAD analyst')
     analyst_email = db.Column(db.String(100), index=True, doc='Email of RAD analyst')
-    analyst_title = db.Column(db.String(100), index=True, doc='Title of RAD analyst')
+    title = db.Column('analyst_title', db.String(100), index=True, doc='Title of RAD analyst')
     telephone_ext = db.Column(db.Numeric(4, 0), index=True, doc='Telephone extension of RAD analyst')
     rad_branch = db.Column(db.String(100), index=True, doc='Branch of RAD analyst')
     name_txt = db.Column(TSVECTOR)

--- a/webservices/common/models/rad_analyst.py
+++ b/webservices/common/models/rad_analyst.py
@@ -14,7 +14,7 @@ class RadAnalyst(db.Model):
     analyst_short_id = db.Column(db.Numeric(4, 0), doc='Short ID of RAD analyst.')
     first_name = db.Column(db.String(255), index=True, doc='Fist name of RAD analyst')
     last_name = db.Column(db.String(100), index=True, doc='Last name of RAD analyst')
-    analyst_email = db.Column(db.String(100), index=True, doc='Email of RAD analyst')
+    email = db.Column('analyst_email', db.String(100), index=True, doc='Email of RAD analyst')
     title = db.Column('analyst_title', db.String(100), index=True, doc='Title of RAD analyst')
     telephone_ext = db.Column(db.Numeric(4, 0), index=True, doc='Telephone extension of RAD analyst')
     rad_branch = db.Column(db.String(100), index=True, doc='Branch of RAD analyst')

--- a/webservices/resources/rad_analyst.py
+++ b/webservices/resources/rad_analyst.py
@@ -20,13 +20,13 @@ class RadAnalystView(ApiResource):
 
     filter_fulltext_fields = [
         ('name', model.name_txt),
-        ('analyst_email', model.analyst_email),
         ('title', model.title),
     ]
 
     filter_multi_fields = [
         ('analyst_id', model.analyst_id),
         ('analyst_short_id', model.analyst_short_id),
+        ('email', model.email),
         ('telephone_ext', model.telephone_ext),
         ('committee_id', model.committee_id),
     ]

--- a/webservices/resources/rad_analyst.py
+++ b/webservices/resources/rad_analyst.py
@@ -21,7 +21,7 @@ class RadAnalystView(ApiResource):
     filter_fulltext_fields = [
         ('name', model.name_txt),
         ('analyst_email', model.analyst_email),
-        ('analyst_title', model.analyst_title),
+        ('title', model.title),
     ]
 
     filter_multi_fields = [


### PR DESCRIPTION
## Summary (required)

- Resolves #3699 
- [x] update `rad_analyst<models>` to reflect `title` instead of `analyst_title` to match `args.py`
- [x] update `rad_analyst<resources>` to reflect new `model.title` attribute
- [ ] update appropriate models/resources to reflect `email` instead of `analyst_email

## How to test the changes locally
- [x] verify tests/test_filing_resources.py passes
- [ ] query `/rad_analyst/` endpoint with filter by `title`

## Impacted areas of the application
List general components of the application that this PR will affect:
* swagger ui



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3699-rad_analyst-filter-bug| [https://github.com/fecgov/openFEC/issues/3699](https://github.com/fecgov/openFEC/issues/3699)
