### PR TITLE
Fix schedule_c endpoints incurred date filter not work

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -218,6 +218,22 @@ class ScheduleBFactory(BaseFactory):
         obj.disbursement_description_text = sa.func.to_tsvector(obj.disbursement_description)
 
 
+class ScheduleCFactory(BaseFactory):
+    class Meta:
+        model = models.ScheduleC
+    sub_id = factory.Sequence(lambda n: n)
+
+    @factory.post_generation
+    def update_fulltext(obj, create, extracted, **kwargs):
+        obj.candidate_name_text = sa.func.to_tsvector(obj.candidate_name)
+        obj.loan_source_name_text = sa.func.to_tsvector(obj.loan_source_name)
+
+class ScheduleCViewBySubIdFactory(BaseFactory):
+    class Meta:
+        model = models.ScheduleC
+    sub_id = factory.Sequence(lambda n: n)
+
+
 class ScheduleEFactory(BaseFactory):
     class Meta:
         model = models.ScheduleE

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -1,0 +1,190 @@
+"""Test endpoints for Schedule C which are used in loans page."""
+import datetime
+
+from tests import factories
+from tests.common import ApiBaseTest
+
+from webservices.rest import api
+from webservices.schemas import ScheduleCSchema
+from webservices.resources.sched_c import ScheduleCView, ScheduleCViewBySubId
+
+class TestScheduleCView(ApiBaseTest):
+    def test_fields(self):
+        [
+            factories.ScheduleCFactory(),
+        ]
+        results = self._results(api.url_for(ScheduleCView))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].keys(), ScheduleCSchema().fields.keys())
+
+    def test_sort_incurred_date(self):
+        [
+            factories.ScheduleCFactory(
+                incurred_date=datetime.date(2019, 1, 1),
+                payment_to_date=10.55,
+            ),
+            factories.ScheduleCFactory(
+                incurred_date=datetime.date(2019, 12, 2),
+                payment_to_date=20.55,
+            ),
+        ]
+        response1 = self._response(api.url_for(ScheduleCView, sort='-incurred_date',))
+        self.assertEqual(
+            [each['payment_to_date'] for each in response1['results']],
+            [20.55, 10.55]
+        )
+
+        response2 = self._response(api.url_for(ScheduleCView, sort='incurred_date',))
+        self.assertEqual(
+            [each['payment_to_date'] for each in response2['results']],
+            [10.55, 20.55]
+        )
+
+    def test_sort_payment_to_date(self):
+        [
+            factories.ScheduleCFactory(
+                payment_to_date=10.55,
+            ),
+            factories.ScheduleCFactory(
+                payment_to_date=20.55,
+            ),
+        ]
+        response1 = self._response(api.url_for(ScheduleCView, sort='-payment_to_date',))
+        self.assertEqual(
+            [each['payment_to_date'] for each in response1['results']],
+            [20.55, 10.55]
+        )
+
+        response2 = self._response(api.url_for(ScheduleCView, sort='payment_to_date',))
+        self.assertEqual(
+            [each['payment_to_date'] for each in response2['results']],
+            [10.55, 20.55]
+        )
+
+    def test_sort_original_loan_amount(self):
+        [
+            factories.ScheduleCFactory(
+                original_loan_amount=10.55,
+            ),
+            factories.ScheduleCFactory(
+                original_loan_amount=20.55,
+            ),
+        ]
+        response1 = self._response(api.url_for(ScheduleCView, sort='-original_loan_amount',))
+        self.assertEqual(
+            [each['original_loan_amount'] for each in response1['results']],
+            [20.55, 10.55]
+        )
+
+        response2 = self._response(api.url_for(ScheduleCView, sort='original_loan_amount',))
+        self.assertEqual(
+            [each['original_loan_amount'] for each in response2['results']],
+            [10.55, 20.55]
+        )
+
+    def test_sort_bad_column(self):
+        response = self.app.get(api.url_for(ScheduleCView, sort='bad_column'))
+        self.assertEqual(response.status_code, 422)
+        self.assertIn(b'Cannot sort on value', response.data)
+
+    def test_filter_fulltext_loaner_name(self):
+        loaner_names = ['bb cc', 'aa cc']
+        [
+            factories.ScheduleCFactory(loan_source_name=loaner_name)
+            for loaner_name in loaner_names
+        ]
+        results = self._results(api.url_for(ScheduleCView, loan_source_name='aa'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['loan_source_name'], 'aa cc')
+
+    def test_filter_fulltext_candidate_name(self):
+        candidate_names = ['bb cc', 'aa cc']
+        [
+            factories.ScheduleCFactory(candidate_name=candidate_name)
+            for candidate_name in candidate_names
+        ]
+        results = self._results(api.url_for(ScheduleCView, candidate_name='aa'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['candidate_name'], 'aa cc')
+
+    def test_filter_payment_to_date(self):
+        [
+            factories.ScheduleCFactory(payment_to_date=50),
+            factories.ScheduleCFactory(payment_to_date=100),
+            factories.ScheduleCFactory(payment_to_date=150),
+            factories.ScheduleCFactory(payment_to_date=200),
+        ]
+        results = self._results(api.url_for(ScheduleCView, min_payment_to_date=100))
+        self.assertTrue(all(each['payment_to_date'] >= 100 for each in results))
+        results = self._results(api.url_for(ScheduleCView, max_payment_to_date=150))
+        self.assertTrue(all(each['payment_to_date'] <= 150 for each in results))
+        results = self._results(api.url_for(ScheduleCView, min_payment_to_date=100, max_payment_to_date=200))
+        self.assertTrue(all(100 <= each['payment_to_date'] <= 200 for each in results))
+
+    def test_filter_original_loan_amount(self):
+        [
+            factories.ScheduleCFactory(original_loan_amount=50),
+            factories.ScheduleCFactory(original_loan_amount=100),
+            factories.ScheduleCFactory(original_loan_amount=150),
+            factories.ScheduleCFactory(original_loan_amount=200),
+        ]
+        results = self._results(api.url_for(ScheduleCView, min_amount=100))
+        self.assertTrue(all(each['original_loan_amount'] >= 100 for each in results))
+        results = self._results(api.url_for(ScheduleCView, max_amount=150))
+        self.assertTrue(all(each['original_loan_amount'] <= 150 for each in results))
+        results = self._results(api.url_for(ScheduleCView, min_amount=100, max_amount=200))
+        self.assertTrue(all(100 <= each['original_loan_amount'] <= 200 for each in results))
+
+    def test_filter_incurred_date(self):
+        [
+            factories.ScheduleCFactory(incurred_date=datetime.date(2015, 1, 1)),
+            factories.ScheduleCFactory(incurred_date=datetime.date(2016, 1, 1)),
+            factories.ScheduleCFactory(incurred_date=datetime.date(2017, 1, 1)),
+            factories.ScheduleCFactory(incurred_date=datetime.date(2018, 1, 1)),
+        ]
+        min_date = datetime.date(2015, 1, 1)
+        results = self._results(api.url_for(ScheduleCView, min_incurred_date=min_date))
+        self.assertTrue(all(each for each in results if each['incurred_date'] >= min_date.isoformat()))
+        max_date = datetime.date(2018, 1, 1)
+        results = self._results(api.url_for(ScheduleCView, max_incurred_date=max_date))
+        self.assertTrue(all(each for each in results if each['incurred_date'] <= max_date.isoformat()))
+        results = self._results(api.url_for(ScheduleCView, min_incurred_date=min_date, max_incurred_date=max_date))
+        self.assertTrue(
+            all(
+                each for each in results
+                if min_date.isoformat() <= each['incurred_date'] <= max_date.isoformat()
+            )
+        )
+
+    def test_filter_image_number(self):
+        image_number = '12345'
+        [
+            factories.ScheduleCFactory(),
+            factories.ScheduleCFactory(image_number=image_number),
+        ]
+        results = self._results(api.url_for(ScheduleCView, image_number=image_number))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['image_number'], image_number)
+
+    def test_image_number_range(self):
+        [
+            factories.ScheduleCFactory(image_number='1'),
+            factories.ScheduleCFactory(image_number='2'),
+            factories.ScheduleCFactory(image_number='3'),
+            factories.ScheduleCFactory(image_number='4'),
+        ]
+        results = self._results(api.url_for(ScheduleCView, min_image_number='2'))
+        self.assertTrue(all(each['image_number'] >= '2' for each in results))
+        results = self._results(api.url_for(ScheduleCView, max_image_number='3'))
+        self.assertTrue(all(each['image_number'] <= '3' for each in results))
+        results = self._results(api.url_for(ScheduleCView, min_image_number='2', max_image_number='3'))
+        self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
+
+class TestScheduleCViewBySubId(ApiBaseTest):
+    def test_fields(self):
+        [
+            factories.ScheduleCViewBySubIdFactory(sub_id='123'),
+        ]
+        results = self._results(api.url_for(ScheduleCViewBySubId, sub_id='123'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].keys(), ScheduleCSchema().fields.keys())

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -8,7 +8,6 @@ from webargs import ValidationError, fields, validate
 
 from webservices import docs
 from webservices.common.models import db
-from webservices.config import SQL_CONFIG
 
 def _validate_natural(value):
     if value < 0:
@@ -64,6 +63,7 @@ class OptionValidator(object):
 
     :param list values: Valid options.
     """
+
     def __init__(self, values):
         self.values = values
 
@@ -82,6 +82,7 @@ class IndexValidator(OptionValidator):
     :param list exclude: Optional list of columns to exclude.
     :param list extra: Optional list of extra columns to include.
     """
+
     def __init__(self, model, extra=None, exclude=None):
         self.model = model
         self.extra = extra or []
@@ -483,7 +484,8 @@ schedule_a = {
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
         description='Filters individual or committee contributions based on line number'
     ),
-    'two_year_transaction_period': fields.List(fields.Int,
+    'two_year_transaction_period': fields.List(
+        fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
     ),
     'recipient_committee_type': fields.List(
@@ -557,10 +559,11 @@ schedule_b = {
     'disbursement_purpose_category': fields.List(IStr, description='Disbursement purpose category'),
     'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
     'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'two_year_transaction_period': fields.List(fields.Int,
+    'two_year_transaction_period': fields.List(
+        fields.Int,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
     ),
-   'spender_committee_type': fields.List(
+    'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
@@ -570,7 +573,8 @@ schedule_b = {
 
 schedule_b_efile = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    #'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here if the contributor is registered with the FEC.'),
+    #'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here
+    # if the contributor is registered with the FEC.'),
     #'recipient_name': fields.List(fields.Str, description='Name of recipient'),
     'disbursement_description': fields.List(fields.Str, description='Description of disbursement'),
     'image_number': fields.List(
@@ -591,12 +595,23 @@ schedule_b_by_purpose = {
 }
 
 schedule_c = {
+    # TODO(jmcarp) Request integer image numbers from FEC and update argument types
+    'image_number': fields.List(
+        fields.Str,
+        description=docs.IMAGE_NUMBER,
+    ),
+    'min_image_number': fields.Str(),
+    'max_image_number': fields.Str(),
+    'min_amount': Currency(description=docs.MIN_FILTER),
+    'max_amount': Currency(description=docs.MAX_FILTER),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_name': fields.List(fields.Str, description=docs.CANDIDATE_NAME),
-    'loaner_name': fields.List(fields.Str, description=docs.LOAN_SOURCE),
-    'min_payment_to_date': fields.Int(description='Minimum payment to date'),
-    'max_payment_to_date': fields.Int(description='Maximum payment to date'),
-
+    'loan_source_name': fields.List(fields.Str, description=docs.LOAN_SOURCE),
+    'min_payment_to_date': fields.Int(description=docs.MIN_PAYMENT_DATE),
+    'max_payment_to_date': fields.Int(description=docs.MAX_PAYMENT_DATE),
+    'min_incurred_date': fields.Date(missing=None, description=docs.MIN_INCURRED_DATE),
+    'max_incurred_date': fields.Date(missing=None, description=docs.MAX_INCURRED_DATE),
 }
 
 schedule_e_by_candidate = {
@@ -612,6 +627,7 @@ schedule_e_by_candidate = {
         description='Support or opposition'
     ),
 }
+
 #These arguments will evolve with updated filtering needs
 schedule_d = {
     'min_payment_period': fields.Float(),
@@ -807,7 +823,6 @@ schedule_a_by_state_recipient_totals = {
         description=docs.COMMITTEE_TYPE_STATE_AGGREGATE_TOTALS
     ),
 }
-
 
 # endpoint audit-primary-category
 auditPrimaryCategory = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -427,14 +427,21 @@ class ScheduleBEfile(BaseRawItemized):
         lazy='joined',
     )
 
-
 class ScheduleC(PdfMixin, BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_c'
 
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleC.committee_id) == CommitteeHistory.committee_id,
+            ScheduleC.cycle == CommitteeHistory.cycle,
+        )''',
+        lazy='joined',
+    )
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
-    incurred_date = db.Column('incurred_dt', db.DateTime)
+    incurred_date = db.Column('incurred_dt', db.Date)
     loan_source_prefix = db.Column('loan_src_prefix', db.String)
     loan_source_first_name = db.Column('loan_src_f_nm', db.String)
     loan_source_middle_name = db.Column('loan_src_m_nm', db.String)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1303,9 +1303,23 @@ also incorporate any changes made by committees, if any report covering the peri
 '''
 EFILE_REPORTS += WIP_TAG
 
-MIN_FILTER = 'Filter for all amounts greater than a value.'
+LINE_NUMBER = '''
+Filter for form and line number using the following format:
+`FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter
+down to all entries from form `F3X` line number `16`.
+'''
 
-MAX_FILTER = 'Filter for all amounts less than a value.'
+IMAGE_NUMBER = '''
+The image number of the page where the schedule item is reported.
+'''
+
+MIN_FILTER = '''
+Filter for all amounts greater than a value.
+'''
+
+MAX_FILTER = '''
+Filter for all amounts less than a value.
+'''
 
 MIN_REPORT_RECEIPT_DATE = '''
 Selects all items received by FEC after this date(MM/DD/YYYY or YYYY-MM-DD)
@@ -1313,6 +1327,21 @@ Selects all items received by FEC after this date(MM/DD/YYYY or YYYY-MM-DD)
 
 MAX_REPORT_RECEIPT_DATE = '''
 Selects all items received by FEC before this date(MM/DD/YYYY or YYYY-MM-DD)
+'''
+
+MIN_PAYMENT_DATE = '''
+Minimum payment to date
+'''
+
+MAX_PAYMENT_DATE = '''
+Maximum payment to date
+'''
+
+MIN_INCURRED_DATE = '''
+Minimum incurred date
+'''
+MAX_INCURRED_DATE = '''
+Maximum incurred date
 '''
 
 ENTITY_RECEIPTS_TOTLAS = '''


### PR DESCRIPTION
## Summary (required)
This one PR will resolve two issues(two endpoints used for loans page) in sched_c.py:
- Resolves  [https://github.com/fecgov/openFEC/issues/3712](https://github.com/fecgov/openFEC/issues/3712)
ScheduleCView endpoint: Fix 'incurred date filter' not working issue

- Resolves  [https://github.com/fecgov/openFEC/issues/3696](https://github.com/fecgov/openFEC/issues/3696)
ScheduleCViewBySubId endpoint: Fix broken endpoint

- Add validators for 'incurred_date', 'payment_to_date', 'original_loan_amount'

- Create a new separated test_sched_c.py(easy to maintain in the future) to do automated test for above two endpoints.

## How to test the changes locally
1)setup openFEC repo locally, checkout branch
2)pytest
3)./manager runserver
4)Test endpoint: under Loans:/schedules/schedule_c/{sub_id}
ex: [http://127.0.0.1:5000/v1/schedules/schedule_c/1010320180036112499/?sort_null_only=false&per_page=20&sort_nulls_last=false&page=1&sort_hide_null=false](http://127.0.0.1:5000/v1/schedules/schedule_c/1010320180036112499/?sort_null_only=false&per_page=20&sort_nulls_last=false&page=1&sort_hide_null=false)
5)Test endpoint: Loans:/schedules/schedule_c/

6)setup fec-cms repo locally, checkout new branch on fec-cms: feature/change_loan_source_name
point to local api.
go to [https://www.fec.gov/data/loans/](https://www.fec.gov/data/loans/)
test all filters and sortings for loan datatable

## Impacted areas of the application
loans page:
[https://www.fec.gov/data/loans/](https://www.fec.gov/data/loans/)


