### PR TITLE
[MERGE WITH GIT FLOW] Hotfix: Limit large Schedule A queries

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -61,23 +61,27 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
-                two_year_transaction_period=2014
+                two_year_transaction_period=2014,
+                committee_id='C001'
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
+                committee_id='C001'
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
-                two_year_transaction_period=2018
+                two_year_transaction_period=2018,
+                committee_id='C001'
             ),
         ]
         response = self._response(
             api.url_for(
                 ScheduleAView,
                 two_year_transaction_period=[2016, 2018],
+                committee_id='C001',
         ))
         self.assertEqual(len(response['results']), 2)
 
@@ -617,7 +621,7 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(response.status_code, 422)
 
     def test_pagination_bad_per_page(self):
-        response = self.app.get(api.url_for(ScheduleAView, per_page=999))
+        response = self.app.get(api.url_for(ScheduleAView, two_year_transaction_period=2018, per_page=999))
         self.assertEqual(response.status_code, 422)
 
     def test_image_number(self):
@@ -637,11 +641,11 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(image_number='3'),
             factories.ScheduleAFactory(image_number='4'),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2'))
+        results = self._results(api.url_for(ScheduleAView, min_image_number='2', two_year_transaction_period=2016))
         self.assertTrue(all(each['image_number'] >= '2' for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_image_number='3'))
+        results = self._results(api.url_for(ScheduleAView, max_image_number='3', two_year_transaction_period=2016))
         self.assertTrue(all(each['image_number'] <= '3' for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3'))
+        results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3', two_year_transaction_period=2016))
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
     def test_amount_sched_a(self):
@@ -651,11 +655,11 @@ class TestItemized(ApiBaseTest):
             factories.ScheduleAFactory(contribution_receipt_amount=150),
             factories.ScheduleAFactory(contribution_receipt_amount=200),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_amount=100))
+        results = self._results(api.url_for(ScheduleAView, min_amount=100, two_year_transaction_period=2016))
         self.assertTrue(all(each['contribution_receipt_amount'] >= 100 for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_amount=150))
+        results = self._results(api.url_for(ScheduleAView, max_amount=150, two_year_transaction_period=2016))
         self.assertTrue(all(each['contribution_receipt_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_amount=100, max_amount=150))
+        results = self._results(api.url_for(ScheduleAView, min_amount=100, max_amount=150, two_year_transaction_period=2016))
         self.assertTrue(all(100 <= each['contribution_receipt_amount'] <= 150 for each in results))
 
     def test_amount_sched_b(self):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -84,6 +84,24 @@ class ScheduleAView(ItemizedResource):
         )
 
     def build_query(self, **kwargs):
+        secondary_index_options = [
+            'committee_id',
+            'contributor_id',
+            'contributor_name',
+            'contributor_city',
+            'contributor_zip',
+            'contributor_employer',
+            'contributor_occupation',
+            'image_number',
+            'line_number',
+        ]
+        two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
+        if len(two_year_transaction_periods) != 1:
+            if not any(kwargs.get(field) for field in secondary_index_options):
+                raise exceptions.ApiError(
+                    "Please choose a single `two_year_transaction_period` or add one of the following filters to your query: `{}`".format("`, `".join(secondary_index_options)),
+                    status_code=400,
+                )
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
         zip_list = []


### PR DESCRIPTION
## Todos
- [x] do a manual deploy to dev and check the front end
- [x] Consider that we are making what could be considered a breaking change (see all the changed tests) in that the default behavior has changed and now requires either a two-year-period or secondary criteria. Does this merit reaching out to our API users? Per Paul, let’s reach out to anyone who has queried sch a in the past 6 months
 
## Summary (required)

- Resolves #3717 

Require secondary filter for Schedule A when searching more than one 2-year period

## How to test the changes locally

- Connect to `stage` DB with `SQLA_CONN`
- Check out and run this branch
-  Queries with secondary criteria should work: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&committee_id=C00213512&sort_hide_null=false&sort=contribution_receipt_date&per_page=20
- Queries without secondary criteria should throw 400 error: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&sort_hide_null=false&sort=contribution_receipt_date&per_page=20
- Queries with multiple 2-year transaction periods and no secondary criteria should error: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&sort_hide_null=false&sort=contribution_receipt_date&per_page=20&two_year_transaction_period=2018&two_year_transaction_period=2020
- No change to default behavior with 2-year criteria specified: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&sort_hide_null=false&sort=contribution_receipt_date&per_page=20&two_year_transaction_period=2018
- No change to behavior when the same 2-year transaction period is supplied twice: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&sort_hide_null=false&sort=contribution_receipt_date&per_page=20&two_year_transaction_period=2018&two_year_transaction_period=2018
- Multiple "secondary" criteria ok: http://localhost:5000/v1/schedules/schedule_a/?sort_null_only=false&sort_hide_null=false&sort=contribution_receipt_date&per_page=20&contributor_city=Chigago&contributor_name=Smith

## Impacted areas of the application
List general components of the application that this PR will affect:

- /schedules/schedule_a/ expanded time period search
- Should be no change to existing front-end interaction - only restricts queries by API users.

