### PR TITLE
[Do not merge before PR#3688 due to migration number]Fix bernie sanders totals incorrect

### DIFF
--- a/data/migrations/V0131__ofec_cand_cmte_linkage_mv_add_column.sql
+++ b/data/migrations/V0131__ofec_cand_cmte_linkage_mv_add_column.sql
@@ -1,0 +1,161 @@
+
+CREATE OR REPLACE VIEW public.ofec_cand_cmte_linkage_vw AS 
+WITH 
+election_yr AS (
+    SELECT cand_cmte_linkage.cand_id,
+    cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric AS cand_election_yr
+    FROM disclosure.cand_cmte_linkage
+    WHERE substr(cand_cmte_linkage.cand_id::text, 1, 1) = cand_cmte_linkage.cmte_tp::text OR (cand_cmte_linkage.cmte_tp::text <> ALL (ARRAY['P'::character varying::text, 'S'::character varying::text, 'H'::character varying::text]))
+    GROUP BY cand_cmte_linkage.cand_id, (cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric)
+), cand_election_yrs AS (
+    SELECT election_yr.cand_id,
+    election_yr.cand_election_yr,
+    lead(election_yr.cand_election_yr) OVER (PARTITION BY election_yr.cand_id ORDER BY election_yr.cand_election_yr) AS next_election
+    FROM election_yr
+)
+SELECT row_number() OVER () AS idx,
+    link.linkage_id,
+    link.cand_id,
+    link.cand_election_yr,
+    link.fec_election_yr,
+    link.cmte_id,
+    link.cmte_tp,
+    link.cmte_dsgn,
+    link.linkage_type,
+    link.user_id_entered,
+    link.date_entered,
+    link.user_id_changed,
+    link.date_changed,
+    link.cmte_count_cand_yr,
+    link.efile_paper_ind,
+    link.pg_date,
+        CASE
+            WHEN link.cand_election_yr = link.fec_election_yr THEN link.cand_election_yr
+            WHEN yrs.next_election IS NULL THEN
+            CASE
+                WHEN link.fec_election_yr <= yrs.cand_election_yr THEN yrs.cand_election_yr
+                ELSE NULL::numeric
+            END
+            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr > (yrs.next_election -
+            CASE
+                WHEN link.cmte_tp::text = 'P'::text THEN 4
+                WHEN link.cmte_tp::text = 'S'::text THEN 6
+                WHEN link.cmte_tp::text = 'H'::text THEN 2
+                ELSE NULL::integer
+            END::numeric) THEN yrs.next_election
+            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr <= (yrs.next_election -
+            CASE
+                WHEN link.cmte_tp::text = 'P'::text THEN 4
+                WHEN link.cmte_tp::text = 'S'::text THEN 6
+                WHEN link.cmte_tp::text = 'H'::text THEN 2
+                ELSE NULL::integer
+            END::numeric) THEN NULL::numeric
+            ELSE NULL::numeric
+        END::numeric(4,0) AS election_yr_to_be_included
+   FROM disclosure.cand_cmte_linkage link
+     LEFT JOIN cand_election_yrs yrs ON link.cand_id::text = yrs.cand_id::text AND (link.cand_election_yr + link.cand_election_yr % 2::numeric) = yrs.cand_election_yr
+  WHERE substr(link.cand_id::text, 1, 1) = link.cmte_tp::text OR (link.cmte_tp::text <> ALL (ARRAY['P'::character varying::text, 'S'::character varying::text, 'H'::character varying::text]));
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_cand_cmte_linkage_mv_tmp;
+CREATE MATERIALIZED VIEW ofec_cand_cmte_linkage_mv_tmp AS
+WITH 
+election_yr AS (
+    SELECT cand_cmte_linkage.cand_id,
+    cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric AS cand_election_yr
+    FROM disclosure.cand_cmte_linkage
+    WHERE substr(cand_cmte_linkage.cand_id::text, 1, 1) = cand_cmte_linkage.cmte_tp::text OR (cand_cmte_linkage.cmte_tp::text <> ALL (ARRAY['P'::character varying::text, 'S'::character varying::text, 'H'::character varying::text]))
+    GROUP BY cand_cmte_linkage.cand_id, (cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric)
+), cand_election_yrs AS (
+    SELECT election_yr.cand_id,
+    election_yr.cand_election_yr,
+    lead(election_yr.cand_election_yr) OVER (PARTITION BY election_yr.cand_id ORDER BY election_yr.cand_election_yr) AS next_election
+    FROM election_yr
+)
+SELECT row_number() OVER () AS idx,
+    link.linkage_id,
+    link.cand_id,
+    link.cand_election_yr,
+    link.fec_election_yr,
+    link.cmte_id,
+    link.cmte_tp,
+    link.cmte_dsgn,
+    link.linkage_type,
+    link.user_id_entered,
+    link.date_entered,
+    link.user_id_changed,
+    link.date_changed,
+    link.cmte_count_cand_yr,
+    link.efile_paper_ind,
+    link.pg_date,
+        CASE
+            WHEN link.cand_election_yr = link.fec_election_yr THEN link.cand_election_yr
+            WHEN yrs.next_election IS NULL THEN
+            CASE
+                WHEN link.fec_election_yr <= yrs.cand_election_yr THEN yrs.cand_election_yr
+                ELSE NULL::numeric
+            END
+            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr > (yrs.next_election -
+            CASE
+                WHEN link.cmte_tp::text = 'P'::text THEN 4
+                WHEN link.cmte_tp::text = 'S'::text THEN 6
+                WHEN link.cmte_tp::text = 'H'::text THEN 2
+                ELSE NULL::integer
+            END::numeric) THEN yrs.next_election
+            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr <= (yrs.next_election -
+            CASE
+                WHEN link.cmte_tp::text = 'P'::text THEN 4
+                WHEN link.cmte_tp::text = 'S'::text THEN 6
+                WHEN link.cmte_tp::text = 'H'::text THEN 2
+                ELSE NULL::integer
+            END::numeric) THEN NULL::numeric
+            ELSE NULL::numeric
+        END::numeric(4,0) AS election_yr_to_be_included
+   FROM disclosure.cand_cmte_linkage link
+     LEFT JOIN cand_election_yrs yrs ON link.cand_id::text = yrs.cand_id::text AND (link.cand_election_yr + link.cand_election_yr % 2::numeric) = yrs.cand_election_yr
+  WHERE substr(link.cand_id::text, 1, 1) = link.cmte_tp::text OR (link.cmte_tp::text <> ALL (ARRAY['P'::character varying::text, 'S'::character varying::text, 'H'::character varying::text]));
+
+--Permissions
+ALTER TABLE public.ofec_cand_cmte_linkage_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_cand_cmte_linkage_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_cand_cmte_linkage_mv_tmp TO fec_read;
+
+--Indexes
+CREATE INDEX idx_ofec_cand_cmte_linkage_mv_tmp_cand_elec_yr
+  ON public.ofec_cand_cmte_linkage_mv_tmp
+  USING btree
+  (cand_election_yr);
+
+CREATE INDEX idx_ofec_cand_cmte_linkage_mv_tmp_cand_id
+  ON public.ofec_cand_cmte_linkage_mv_tmp
+  USING btree
+  (cand_id COLLATE pg_catalog."default");
+
+CREATE INDEX idx_ofec_cand_cmte_linkage_mv_tmp_cmte_id
+  ON public.ofec_cand_cmte_linkage_mv_tmp
+  USING btree
+  (cmte_id COLLATE pg_catalog."default");
+
+CREATE UNIQUE INDEX idx_ofec_cand_cmte_linkage_mv_tmp_idx
+  ON public.ofec_cand_cmte_linkage_mv_tmp
+  USING btree
+  (idx);
+
+-- drop old MV
+DROP MATERIALIZED VIEW public.ofec_cand_cmte_linkage_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_cand_cmte_linkage_mv_tmp RENAME TO ofec_cand_cmte_linkage_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_cand_cmte_linkage_mv_tmp_cand_elec_yr RENAME TO idx_ofec_cand_cmte_linkage_mv_cand_elec_yr;
+
+ALTER INDEX IF EXISTS idx_ofec_cand_cmte_linkage_mv_tmp_cand_id RENAME TO idx_ofec_cand_cmte_linkage_mv_cand_id;
+
+ALTER INDEX IF EXISTS idx_ofec_cand_cmte_linkage_mv_tmp_cmte_id RENAME TO idx_ofec_cand_cmte_linkage_mv_cmte_id;
+
+ALTER INDEX IF EXISTS idx_ofec_cand_cmte_linkage_mv_tmp_idx RENAME TO idx_ofec_cand_cmte_linkage_mv_idx;
+
+-- recreate ofec_candidate_totals_vw -> select * from new MV
+CREATE OR REPLACE VIEW public.ofec_cand_cmte_linkage_vw AS SELECT * FROM public.ofec_cand_cmte_linkage_mv;
+ALTER VIEW ofec_cand_cmte_linkage_vw OWNER TO fec;
+GRANT SELECT ON ofec_cand_cmte_linkage_vw TO fec_read;

--- a/data/migrations/V0131__ofec_cand_cmte_linkage_mv_add_column.sql
+++ b/data/migrations/V0131__ofec_cand_cmte_linkage_mv_add_column.sql
@@ -1,13 +1,23 @@
-
+/*
+This is to solve issue #3700
+column cand_election_yr in disclosure.cand_cmte_linkage is not designed to be used
+to represents the election_yr that the candidate's cycle(fec_election_yr) financial data should belongs to.
+election_yr_to_be_included column in this mv is a calculated field for this purpose.
+*/
 CREATE OR REPLACE VIEW public.ofec_cand_cmte_linkage_vw AS 
 WITH 
-election_yr AS (
+election_yr AS 
+-- get all cand_election_yr for each cand_id
+(
     SELECT cand_cmte_linkage.cand_id,
     cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric AS cand_election_yr
     FROM disclosure.cand_cmte_linkage
     WHERE substr(cand_cmte_linkage.cand_id::text, 1, 1) = cand_cmte_linkage.cmte_tp::text OR (cand_cmte_linkage.cmte_tp::text <> ALL (ARRAY['P'::character varying::text, 'S'::character varying::text, 'H'::character varying::text]))
     GROUP BY cand_cmte_linkage.cand_id, (cand_cmte_linkage.cand_election_yr + cand_cmte_linkage.cand_election_yr % 2::numeric)
-), cand_election_yrs AS (
+)
+, cand_election_yrs AS 
+-- get the next cand_election_yr of the cand_id (if no next cand_election_yr, then null)
+(
     SELECT election_yr.cand_id,
     election_yr.cand_election_yr,
     lead(election_yr.cand_election_yr) OVER (PARTITION BY election_yr.cand_id ORDER BY election_yr.cand_election_yr) AS next_election
@@ -29,28 +39,28 @@ SELECT row_number() OVER () AS idx,
     link.cmte_count_cand_yr,
     link.efile_paper_ind,
     link.pg_date,
-        CASE
-            WHEN link.cand_election_yr = link.fec_election_yr THEN link.cand_election_yr
-            WHEN yrs.next_election IS NULL THEN
+    CASE
+        WHEN link.cand_election_yr = link.fec_election_yr THEN link.cand_election_yr
+        WHEN yrs.next_election IS NULL THEN
             CASE
                 WHEN link.fec_election_yr <= yrs.cand_election_yr THEN yrs.cand_election_yr
                 ELSE NULL::numeric
             END
-            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr > (yrs.next_election -
+        WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr > (yrs.next_election -
             CASE
                 WHEN link.cmte_tp::text = 'P'::text THEN 4
                 WHEN link.cmte_tp::text = 'S'::text THEN 6
                 WHEN link.cmte_tp::text = 'H'::text THEN 2
                 ELSE NULL::integer
-            END::numeric) THEN yrs.next_election
-            WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr <= (yrs.next_election -
+                END::numeric) THEN yrs.next_election
+        WHEN link.fec_election_yr > link.cand_election_yr AND link.fec_election_yr <= (yrs.next_election -
             CASE
                 WHEN link.cmte_tp::text = 'P'::text THEN 4
                 WHEN link.cmte_tp::text = 'S'::text THEN 6
                 WHEN link.cmte_tp::text = 'H'::text THEN 2
                 ELSE NULL::integer
-            END::numeric) THEN NULL::numeric
-            ELSE NULL::numeric
+                END::numeric) THEN NULL::numeric
+        ELSE NULL::numeric
         END::numeric(4,0) AS election_yr_to_be_included
    FROM disclosure.cand_cmte_linkage link
      LEFT JOIN cand_election_yrs yrs ON link.cand_id::text = yrs.cand_id::text AND (link.cand_election_yr + link.cand_election_yr % 2::numeric) = yrs.cand_election_yr

--- a/data/migrations/V0132__ofec_cand_totals_mv_update.sql
+++ b/data/migrations/V0132__ofec_cand_totals_mv_update.sql
@@ -1,5 +1,8 @@
 /*
 This is to solve issue #3700
+column cand_election_yr in disclosure.cand_cmte_linkage is not designed to be used
+to represents the election_yr that the candidate's cycle(fec_election_yr) financial data should belongs to.
+new column election_yr_to_be_included in ofec_cand_cmte_linkage_mv is a calculated field for this purpose.
 */
 
 -- Replace the definition of ofec_candidate_totals_vw to have the new mv's defintion
@@ -64,7 +67,7 @@ totals AS
   totals_1.coverage_end_date,
   totals_1.federal_funds_flag
   FROM (link
-  JOIN totals totals_1 ON ((((link.cmte_id)::text = (totals_1.committee_id)::text) AND (link.fec_election_yr = (totals_1.cycle)::numeric))))
+  LEFT OUTER JOIN totals totals_1 ON ((((link.cmte_id)::text = (totals_1.committee_id)::text) AND (link.fec_election_yr = (totals_1.cycle)::numeric))))
 )
 , cycle_cmte_totals AS 
 -- sum up data per cand_id/election_year/cycle/cmte_id

--- a/data/migrations/V0132__ofec_cand_totals_mv_update.sql
+++ b/data/migrations/V0132__ofec_cand_totals_mv_update.sql
@@ -1,0 +1,455 @@
+/*
+This is to solve issue #3700
+*/
+
+-- Replace the definition of ofec_candidate_totals_vw to have the new mv's defintion
+-- to remove the dependency on ofec_candidate_totals_mv
+CREATE OR REPLACE VIEW ofec_candidate_totals_vw AS 
+WITH 
+-- basic financial info from ofec_totals_combined_mv 
+totals AS 
+(
+  SELECT ofec_totals_house_senate_vw.committee_id,
+  ofec_totals_house_senate_vw.cycle,
+  ofec_totals_house_senate_vw.receipts,
+  ofec_totals_house_senate_vw.disbursements,
+  ofec_totals_house_senate_vw.last_cash_on_hand_end_period,
+  ofec_totals_house_senate_vw.last_debts_owed_by_committee,
+  ofec_totals_house_senate_vw.coverage_start_date,
+  ofec_totals_house_senate_vw.coverage_end_date,
+  false AS federal_funds_flag
+  FROM ofec_totals_house_senate_vw
+  UNION ALL
+  SELECT ofec_totals_presidential_vw.committee_id,
+  ofec_totals_presidential_vw.cycle,
+  ofec_totals_presidential_vw.receipts,
+  ofec_totals_presidential_vw.disbursements,
+  ofec_totals_presidential_vw.last_cash_on_hand_end_period,
+  ofec_totals_presidential_vw.last_debts_owed_by_committee,
+  ofec_totals_presidential_vw.coverage_start_date,
+  ofec_totals_presidential_vw.coverage_end_date,
+  ofec_totals_presidential_vw.federal_funds_flag
+  FROM ofec_totals_presidential_vw
+)
+, link AS 
+-- Get latest cmte info for cmte_dsgn=P/A cmtes per cand_id/cmte_id/cmte_dsgn/rounded cand_election_yr/fec_election_yr
+(
+  SELECT ofec_cand_cmte_linkage_vw.cand_id,
+  ofec_cand_cmte_linkage_vw.election_yr_to_be_included+ofec_cand_cmte_linkage_vw.election_yr_to_be_included%2 as election_yr_to_be_included,
+  ofec_cand_cmte_linkage_vw.fec_election_yr,
+  ofec_cand_cmte_linkage_vw.cmte_id
+  FROM ofec_cand_cmte_linkage_vw
+  WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn::text = ANY (ARRAY['P'::character varying::text, 'A'::character varying::text])
+  group by ofec_cand_cmte_linkage_vw.cand_id,
+  ofec_cand_cmte_linkage_vw.election_yr_to_be_included,
+  ofec_cand_cmte_linkage_vw.fec_election_yr,
+  ofec_cand_cmte_linkage_vw.cmte_id 
+)
+, cycle_cmte_totals_basic AS 
+-- calculate the latest available running total items (last_cash_on_hand_end_period, last_debts_owed_by_committee) per cand_id, election_yr, cycle, cmte_id
+(
+  SELECT  
+  link.cand_id,
+  link.cmte_id,
+  link.election_yr_to_be_included,
+  totals_1.cycle,
+  false AS is_election,
+  totals_1.receipts,
+  totals_1.disbursements,
+  first_value(totals_1.last_cash_on_hand_end_period) 
+  OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_cash_on_hand_end_period,
+  first_value(totals_1.last_debts_owed_by_committee) 
+  OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_debts_owed_by_committee,
+  totals_1.coverage_start_date,
+  totals_1.coverage_end_date,
+  totals_1.federal_funds_flag
+  FROM (link
+  JOIN totals totals_1 ON ((((link.cmte_id)::text = (totals_1.committee_id)::text) AND (link.fec_election_yr = (totals_1.cycle)::numeric))))
+)
+, cycle_cmte_totals AS 
+-- sum up data per cand_id/election_year/cycle/cmte_id
+(
+  SELECT 
+  cand_id AS candidate_id,
+  cmte_id,
+  election_yr_to_be_included AS election_year,
+  cycle,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  max(last_cash_on_hand_end_period) AS cash_on_hand_end_period_per_cmte,
+  max(last_debts_owed_by_committee) AS debts_owed_by_committee_per_cmte,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  FROM cycle_cmte_totals_basic
+  GROUP BY cand_id, election_yr_to_be_included, cycle, cmte_id
+)
+, cycle_totals AS 
+-- sum up data per cand_id/election_year/cycle
+-- for candidates only have one committee, this will be the same as cycle_cmte_totals
+(
+  SELECT 
+  candidate_id,
+  election_year,
+  cycle,
+  false AS is_election,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  sum(receipts) > 0::numeric AS has_raised_funds,
+  sum(cash_on_hand_end_period_per_cmte) AS cash_on_hand_end_period,
+  sum(debts_owed_by_committee_per_cmte) AS debts_owed_by_committee,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  FROM cycle_cmte_totals
+  GROUP BY candidate_id, election_year, cycle
+)
+, election_cmte_totals_basic AS 
+-- calculate the latest available running total items (last_cash_on_hand_end_period, last_debts_owed_by_committee) per cand_id, election_yr, cmte_id
+(
+  SELECT candidate_id,
+  cmte_id,
+  cycle,
+  election_year,
+  receipts,
+  disbursements,
+  first_value(cash_on_hand_end_period_per_cmte) 
+  OVER (PARTITION BY candidate_id, election_year, cmte_id ORDER BY cycle DESC NULLS LAST) AS last_cash_on_hand_end_period,
+  first_value(debts_owed_by_committee_per_cmte) 
+  OVER (PARTITION BY candidate_id, election_year, cmte_id ORDER BY cycle DESC NULLS LAST) AS last_debts_owed_by_committee,
+  coverage_start_date,
+  coverage_end_date,
+  federal_funds_flag
+  FROM cycle_cmte_totals
+)
+, election_cmte_totals AS (
+-- sum up data per cand_id/election_year/cmte_id
+  SELECT candidate_id,
+  cmte_id,
+  election_year,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  max(last_cash_on_hand_end_period) as last_cash_on_hand_end_period,
+  max(last_debts_owed_by_committee) as last_debts_owed_by_committee,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  from election_cmte_totals_basic
+  group by candidate_id, election_year, cmte_id
+) 
+, combined_totals AS 
+(
+  -- election_totals 
+  -- sum up data per cand_id/election_year
+  SELECT candidate_id,
+  election_year,
+  election_year AS cycle,
+  true AS is_election,
+  sum(receipts) as receipts,
+  sum(disbursements) as disbursements,
+  sum(receipts) > 0::numeric AS has_raised_funds,
+  sum(last_cash_on_hand_end_period) as cash_on_hand_end_period,
+  sum(last_debts_owed_by_committee) as debts_owed_by_committee,
+  min(coverage_start_date) as coverage_start_date,
+  max(coverage_end_date) as coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  from election_cmte_totals
+  group by candidate_id, election_year 
+  --
+  union all
+  -- cycle_totals
+  SELECT candidate_id,
+  election_year,
+  cycle,
+  false AS is_election,
+  receipts,
+  disbursements,
+  has_raised_funds,
+  cash_on_hand_end_period,
+  debts_owed_by_committee,
+  coverage_start_date,
+  coverage_end_date,
+  federal_funds_flag
+  from cycle_totals
+)
+ SELECT cand.candidate_id,
+    totals.election_year,
+    cand.two_year_period AS cycle,
+    COALESCE(totals.is_election,
+        CASE
+            WHEN totals.election_year = cand.two_year_period THEN true
+            ELSE false
+        END) AS is_election,
+    COALESCE(totals.receipts, 0::numeric) AS receipts,
+    COALESCE(totals.disbursements, 0::numeric) AS disbursements,
+    COALESCE(totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE(totals.cash_on_hand_end_period, 0::numeric) AS cash_on_hand_end_period,
+    COALESCE(totals.debts_owed_by_committee, 0::numeric) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE(totals.federal_funds_flag, false) AS federal_funds_flag,
+    cand.party,
+    cand.office,
+    cand.candidate_inactive
+   FROM ofec_candidate_history_with_future_election_vw cand
+     LEFT JOIN combined_totals totals 
+     ON cand.candidate_id::text = totals.candidate_id::text 
+     AND cand.two_year_period = totals.cycle
+;
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp;
+CREATE MATERIALIZED VIEW ofec_candidate_totals_mv_tmp AS
+WITH 
+-- basic financial info from ofec_totals_combined_mv 
+totals AS 
+(
+  SELECT ofec_totals_house_senate_vw.committee_id,
+  ofec_totals_house_senate_vw.cycle,
+  ofec_totals_house_senate_vw.receipts,
+  ofec_totals_house_senate_vw.disbursements,
+  ofec_totals_house_senate_vw.last_cash_on_hand_end_period,
+  ofec_totals_house_senate_vw.last_debts_owed_by_committee,
+  ofec_totals_house_senate_vw.coverage_start_date,
+  ofec_totals_house_senate_vw.coverage_end_date,
+  false AS federal_funds_flag
+  FROM ofec_totals_house_senate_vw
+  UNION ALL
+  SELECT ofec_totals_presidential_vw.committee_id,
+  ofec_totals_presidential_vw.cycle,
+  ofec_totals_presidential_vw.receipts,
+  ofec_totals_presidential_vw.disbursements,
+  ofec_totals_presidential_vw.last_cash_on_hand_end_period,
+  ofec_totals_presidential_vw.last_debts_owed_by_committee,
+  ofec_totals_presidential_vw.coverage_start_date,
+  ofec_totals_presidential_vw.coverage_end_date,
+  ofec_totals_presidential_vw.federal_funds_flag
+  FROM ofec_totals_presidential_vw
+)
+, link AS 
+-- Get latest cmte info for cmte_dsgn=P/A cmtes per cand_id/cmte_id/cmte_dsgn/rounded cand_election_yr/fec_election_yr
+(
+  SELECT ofec_cand_cmte_linkage_vw.cand_id,
+  ofec_cand_cmte_linkage_vw.election_yr_to_be_included+ofec_cand_cmte_linkage_vw.election_yr_to_be_included%2 as election_yr_to_be_included,
+  ofec_cand_cmte_linkage_vw.fec_election_yr,
+  ofec_cand_cmte_linkage_vw.cmte_id
+  FROM ofec_cand_cmte_linkage_vw
+  WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn::text = ANY (ARRAY['P'::character varying::text, 'A'::character varying::text])
+  group by ofec_cand_cmte_linkage_vw.cand_id,
+  ofec_cand_cmte_linkage_vw.election_yr_to_be_included,
+  ofec_cand_cmte_linkage_vw.fec_election_yr,
+  ofec_cand_cmte_linkage_vw.cmte_id 
+)
+, cycle_cmte_totals_basic AS 
+-- calculate the latest available running total items (last_cash_on_hand_end_period, last_debts_owed_by_committee) per cand_id, election_yr, cycle, cmte_id
+(
+  SELECT  
+  link.cand_id,
+  link.cmte_id,
+  link.election_yr_to_be_included,
+  totals_1.cycle,
+  false AS is_election,
+  totals_1.receipts,
+  totals_1.disbursements,
+  first_value(totals_1.last_cash_on_hand_end_period) 
+  OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_cash_on_hand_end_period,
+  first_value(totals_1.last_debts_owed_by_committee) 
+  OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_debts_owed_by_committee,
+  totals_1.coverage_start_date,
+  totals_1.coverage_end_date,
+  totals_1.federal_funds_flag
+  FROM (link
+  JOIN totals totals_1 ON ((((link.cmte_id)::text = (totals_1.committee_id)::text) AND (link.fec_election_yr = (totals_1.cycle)::numeric))))
+)
+, cycle_cmte_totals AS 
+-- sum up data per cand_id/election_year/cycle/cmte_id
+(
+  SELECT 
+  cand_id AS candidate_id,
+  cmte_id,
+  election_yr_to_be_included AS election_year,
+  cycle,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  max(last_cash_on_hand_end_period) AS cash_on_hand_end_period_per_cmte,
+  max(last_debts_owed_by_committee) AS debts_owed_by_committee_per_cmte,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  FROM cycle_cmte_totals_basic
+  GROUP BY cand_id, election_yr_to_be_included, cycle, cmte_id
+)
+, cycle_totals AS 
+-- sum up data per cand_id/election_year/cycle
+-- for candidates only have one committee, this will be the same as cycle_cmte_totals
+(
+  SELECT 
+  candidate_id,
+  election_year,
+  cycle,
+  false AS is_election,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  sum(receipts) > 0::numeric AS has_raised_funds,
+  sum(cash_on_hand_end_period_per_cmte) AS cash_on_hand_end_period,
+  sum(debts_owed_by_committee_per_cmte) AS debts_owed_by_committee,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  FROM cycle_cmte_totals
+  GROUP BY candidate_id, election_year, cycle
+)
+, election_cmte_totals_basic AS 
+-- calculate the latest available running total items (last_cash_on_hand_end_period, last_debts_owed_by_committee) per cand_id, election_yr, cmte_id
+(
+  SELECT candidate_id,
+  cmte_id,
+  cycle,
+  election_year,
+  receipts,
+  disbursements,
+  first_value(cash_on_hand_end_period_per_cmte) 
+  OVER (PARTITION BY candidate_id, election_year, cmte_id ORDER BY cycle DESC NULLS LAST) AS last_cash_on_hand_end_period,
+  first_value(debts_owed_by_committee_per_cmte) 
+  OVER (PARTITION BY candidate_id, election_year, cmte_id ORDER BY cycle DESC NULLS LAST) AS last_debts_owed_by_committee,
+  coverage_start_date,
+  coverage_end_date,
+  federal_funds_flag
+  FROM cycle_cmte_totals
+)
+, election_cmte_totals AS (
+-- sum up data per cand_id/election_year/cmte_id
+  SELECT candidate_id,
+  cmte_id,
+  election_year,
+  sum(receipts) AS receipts,
+  sum(disbursements) AS disbursements,
+  max(last_cash_on_hand_end_period) as last_cash_on_hand_end_period,
+  max(last_debts_owed_by_committee) as last_debts_owed_by_committee,
+  min(coverage_start_date) AS coverage_start_date,
+  max(coverage_end_date) AS coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  from election_cmte_totals_basic
+  group by candidate_id, election_year, cmte_id
+) 
+, combined_totals AS 
+(
+  -- election_totals 
+  -- sum up data per cand_id/election_year
+  SELECT candidate_id,
+  election_year,
+  election_year AS cycle,
+  true AS is_election,
+  sum(receipts) as receipts,
+  sum(disbursements) as disbursements,
+  sum(receipts) > 0::numeric AS has_raised_funds,
+  sum(last_cash_on_hand_end_period) as cash_on_hand_end_period,
+  sum(last_debts_owed_by_committee) as debts_owed_by_committee,
+  min(coverage_start_date) as coverage_start_date,
+  max(coverage_end_date) as coverage_end_date,
+  array_agg(federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+  from election_cmte_totals
+  group by candidate_id, election_year 
+  --
+  union all
+  -- cycle_totals
+  SELECT candidate_id,
+  election_year,
+  cycle,
+  false AS is_election,
+  receipts,
+  disbursements,
+  has_raised_funds,
+  cash_on_hand_end_period,
+  debts_owed_by_committee,
+  coverage_start_date,
+  coverage_end_date,
+  federal_funds_flag
+  from cycle_totals
+)
+ SELECT cand.candidate_id,
+    totals.election_year,
+    cand.two_year_period AS cycle,
+    COALESCE(totals.is_election,
+        CASE
+            WHEN totals.election_year = cand.two_year_period THEN true
+            ELSE false
+        END) AS is_election,
+    COALESCE(totals.receipts, 0::numeric) AS receipts,
+    COALESCE(totals.disbursements, 0::numeric) AS disbursements,
+    COALESCE(totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE(totals.cash_on_hand_end_period, 0::numeric) AS cash_on_hand_end_period,
+    COALESCE(totals.debts_owed_by_committee, 0::numeric) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE(totals.federal_funds_flag, false) AS federal_funds_flag,
+    cand.party,
+    cand.office,
+    cand.candidate_inactive
+   FROM ofec_candidate_history_with_future_election_vw cand
+     LEFT JOIN combined_totals totals 
+     ON cand.candidate_id::text = totals.candidate_id::text 
+     AND cand.two_year_period = totals.cycle
+     WITH DATA;
+
+--Permissions
+ALTER TABLE public.ofec_candidate_totals_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_totals_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_totals_mv_tmp TO fec_read;
+
+--Indexes
+CREATE UNIQUE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id, election_year, cycle, is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cycle ON public.ofec_candidate_totals_mv_tmp USING btree (cycle);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_is_election ON public.ofec_candidate_totals_mv_tmp USING btree (is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_receipts ON public.ofec_candidate_totals_mv_tmp USING btree (receipts);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_disbursements ON public.ofec_candidate_totals_mv_tmp USING btree (disbursements);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_election_year ON public.ofec_candidate_totals_mv_tmp USING btree (election_year);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_federal_funds_flag ON public.ofec_candidate_totals_mv_tmp USING btree (federal_funds_flag);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_has_raised_funds ON public.ofec_candidate_totals_mv_tmp USING btree (has_raised_funds);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_office ON public.ofec_candidate_totals_mv_tmp USING btree (office);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_party ON public.ofec_candidate_totals_mv_tmp USING btree (party);
+
+
+-- drop old `MV`
+DROP MATERIALIZED VIEW public.ofec_candidate_totals_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp RENAME TO ofec_candidate_totals_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect RENAME TO idx_ofec_candidate_totals_mv_cand_id_elec_yr_cycle_is_elect;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id RENAME TO idx_ofec_candidate_totals_mv_cand_id;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cycle RENAME TO idx_ofec_candidate_totals_mv_cycle;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_is_election RENAME TO idx_ofec_candidate_totals_mv_is_election;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_receipts RENAME TO idx_ofec_candidate_totals_mv_receipts;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_disbursements RENAME TO idx_ofec_candidate_totals_mv_disbursements;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_election_year RENAME TO idx_ofec_candidate_totals_mv_election_year;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_federal_funds_flag RENAME TO idx_ofec_candidate_totals_mv_federal_funds_flag;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_has_raised_funds RENAME TO idx_ofec_candidate_totals_mv_has_raised_funds;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_office RENAME TO idx_ofec_candidate_totals_mv_office;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_party RENAME TO idx_ofec_candidate_totals_mv_party;
+
+-- recreate ofec_candidate_totals_vw -> select all from updated MV
+CREATE OR REPLACE VIEW ofec_candidate_totals_vw AS SELECT * FROM ofec_candidate_totals_mv;
+ALTER VIEW ofec_candidate_totals_vw OWNER TO fec;
+GRANT SELECT ON ofec_candidate_totals_vw TO fec_read;

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -115,12 +115,21 @@ class TestElections(ApiBaseTest):
                 committee_id=self.committees[0].committee_id,
                 committee_designation='A',
                 fec_election_year=2012,
+                election_yr_to_be_included = 2012,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[1].committee_id,
                 committee_designation='P',
                 fec_election_year=2012,
+                election_yr_to_be_included = 2012,
+            ),
+            factories.CandidateCommitteeLinkFactory(
+                candidate_id=self.candidate.candidate_id,
+                committee_id=self.committees[1].committee_id,
+                committee_designation='P',
+                fec_election_year=2010,
+                election_yr_to_be_included = 2012,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
@@ -195,7 +204,8 @@ class TestElections(ApiBaseTest):
                 committee_id=self.president_committees[0].committee_id,
                 committee_designation='P',
                 fec_election_year=2020,
-                cand_election_year=2020
+                cand_election_year=2020,
+                election_yr_to_be_included = 2020,                
             ),
 
             factories.CandidateCommitteeLinkFactory(
@@ -203,14 +213,16 @@ class TestElections(ApiBaseTest):
                 committee_id=self.president_committees[0].committee_id,
                 committee_designation='P',
                 fec_election_year=2018,
-                cand_election_year=2020
+                cand_election_year=2020,
+                election_yr_to_be_included = 2020,       
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.president_candidate.candidate_id,
                 committee_id=self.president_committees[1].committee_id,
                 committee_designation='P',
                 fec_election_year=2018,
-                cand_election_year=2020
+                cand_election_year=2020,
+                election_yr_to_be_included = 2020,       
             )
         ]
 
@@ -295,11 +307,25 @@ class TestElections(ApiBaseTest):
             'total_disbursements': sum(each.disbursements for each in totals),
             'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
         }
+        print (results[0]['total_receipts'])
+        print (results[0]['total_disbursements'])
+        print (results[0]['cash_on_hand_end_period'])
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
         assert set(results[0]['committee_ids']) == set(
             each.committee_id for each in self.committees
             if each.designation != 'J')
+
+    def test_elections_year_null(self):
+        results = self._results(
+            api.url_for(
+                ElectionView,
+                office='senate', cycle=2010, state='NY', election_full='true',
+            )
+        )
+        totals = self.totals
+        cash_on_hand_totals = self.totals[:2]
+        assert len(results) == 0
 
     def test_president_elections_full(self):
         results = self._results(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-
+from sqlalchemy.dialects import postgresql
 from flask import request
 from webargs import flaskparser
 
@@ -120,9 +120,9 @@ class TestSort(ApiBaseTest):
                                               candidate_inactive=False, district='02', office='S')
         ]
         candidateCmteLinks = [
-            factories.CandidateCommitteeLinkFactory(committee_id='H1234', candidate_id='C1234', fec_election_year=2016,committee_designation='P'),
+            factories.CandidateCommitteeLinkFactory(committee_id='H1234', candidate_id='C1234', fec_election_year=2016,committee_designation='P', election_yr_to_be_included = 2016),
             factories.CandidateCommitteeLinkFactory(committee_id='H5678', candidate_id='C5678', fec_election_year=2016,
-                                                    committee_designation='P')
+                                                    committee_designation='P', election_yr_to_be_included = 2016)
 
         ]
         cmteTotalsFactory = [

--- a/webservices/common/models/links.py
+++ b/webservices/common/models/links.py
@@ -11,3 +11,4 @@ class CandidateCommitteeLink(db.Model):
     fec_election_year = db.Column('fec_election_yr', db.Integer)
     committee_designation = db.Column('cmte_dsgn', db.String)
     committee_type = db.Column('cmte_tp', db.String)
+    election_yr_to_be_included = db.Column('election_yr_to_be_included', db.Integer)


### PR DESCRIPTION
## Summary (required)
- Resolves #3700
Bernie Sanders totals incorrect

## How to test the changes locally
-Download the branch feature/3700-fix-BernieSanders-totals-incorrect, run migration files V0131 and V0132 (or run invoke create_sample_db) to make sure migration files runs without error.

Two tmp materialized views had been created in DEV database that has the updated MVs logic.
(Note: ofec_candidate_totals_mv_tmp references ofec_cand_cmte_linkage_mv_tmp)
public.ofec_cand_cmte_linkage_mv_tmp
public.ofec_candidate_totals_mv_tmp

- To test database:
(Cand_id: 
 'P60007168':  Bernie Sandersn (runs 2016, 2020)
make sure 2018 cycle financial data is calculated as part of election_cycle 2020, not 2016)

 'P00003392': Hillary Clinton (runs 2008, 2016)
make sure 2014 cycle financial data  is calculated as part of election_cycle 2016, not 2008; 2010, 2012, 2018, and 2020 cycle data should not be calculated as part of neither election_cycle 2008 nor 2016.

--Connect to DEV database, 
SELECT ofec_cand_cmte_linkage_mv_tmp.cand_id,
  ofec_cand_cmte_linkage_mv_tmp.election_yr_to_be_included as election_yr_to_be_included,
  ofec_cand_cmte_linkage_mv_tmp.fec_election_yr,
  ofec_cand_cmte_linkage_mv_tmp.cmte_id
FROM ofec_cand_cmte_linkage_mv_tmp
WHERE ofec_cand_cmte_linkage_mv_tmp.cmte_dsgn::text = ANY (ARRAY['P'::character varying::text, 'A'::character varying::text])
and cand_id = 'P60007168'
--and cand_id = 'P00003392'
group by ofec_cand_cmte_linkage_mv_tmp.cand_id,
  ofec_cand_cmte_linkage_mv_tmp.election_yr_to_be_included,
  ofec_cand_cmte_linkage_mv_tmp.fec_election_yr,
  ofec_cand_cmte_linkage_mv_tmp.cmte_id 
order by election_yr_to_be_included, fec_election_yr;

select *
from public.ofec_candidate_totals_mv_tmp
where candidate_id = 'P60007168'
--where candidate_id = 'P00003392'
order by election_year, cycle, is_election;

- To test API: 
In models/candidates.py file, make the following changes:
    In class CandidateTotal:
    __tablename__ = 'ofec_candidate_totals_mv_tmp'

    In class Candidate:
replace ofec_cand_cmte_linkage_mv with ofec_cand_cmte_linkage_mv_tmp in
secondaryjoin=
secondaryjoin=
order_by= 

In models/links/py file, make the following changes:
In class CandidateCommitteeLink:
__tablename__ = 'ofec_cand_cmte_linkage_mv_tmp'

Point to the DEV database and start the local server.  

For /candidate/totals endpoint:
candidate_id: P60007168
election_year: 2020
election_full: true

candidate_id: P00003392
election_year: 2016
election_full: true

For /elections/  endpoint:
cycle: 2020
election_full: true
office: president
(bernie sanders is the second entry, with total receipts = 20817691.1)

cycle: 2016
election_full: true
office: president
(Hillary Clinton is the first entry, with total receipts = 585699061.27)

## Impacted areas of the application
List general components of the application that this PR will affect:

The following two endpoints would be impacted
(the API interface does not change, but the data output will be updated)
/candidate/totals
/elections/ 

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
