### PR TITLE
fix parse_fulltext match

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -756,6 +756,34 @@ class TestItemized(ApiBaseTest):
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
+    def test_filter_fulltext_sched_e_pass(self):
+        """
+        test names that expect to be returned
+        """
+        payee_names = [
+            'Test.com', 'Test com', 'Testerosa', 'Test#com', 't&t'
+        ]
+        [
+            factories.ScheduleEFactory(payee_name=payee)
+            for payee in payee_names
+        ]
+        results = self._results(api.url_for(ScheduleEView, payee_name='t&t'))
+        self.assertEqual(len(results), len(payee_names))
+
+    # def test_filter_fulltest_sched_e_fail(self):
+    #     """
+    #     test names that expect no returns
+    #     """
+    #     payee_names = [
+    #         '#', '##', '@#$%^&*', '%', '', '  '
+    #     ]
+    #     [
+    #         factories.ScheduleEFactory(payee_name_text=payee)
+    #         for payee in payee_names
+    #     ]
+    #     results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
+    #     self.assertEquals(len(results), 0)
+
     def test_filters_sched_a_efile(self):
         filters = [
             ('image_number', ScheduleAEfile.image_number, ['123', '456']),

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -238,6 +238,30 @@ class TestItemized(ApiBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_employer'], 'Vandelay Industries')
 
+    def test_filter_fulltext_employer_dot(self):
+        employers = ['Test.com', 'Test. com', 'Test .com', 'Testcom', 'Test com']
+        [
+            factories.ScheduleAFactory(contributor_employer=employer)
+            for employer in employers
+        ]
+        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test.com', **self.kwargs))
+        self.assertEqual(results[0]['contributor_employer'], 'Test.com')
+
+    def test_filter_fulltext_employer_and(self):
+        employers = ['Test&Test', 'Test & Test', 'Test& Test', 'Test &Test']
+        [
+            factories.ScheduleAFactory(contributor_employer=employer)
+            for employer in employers
+        ]
+        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test&Test', **self.kwargs))
+        self.assertIn(results[0]['contributor_employer'], employers)
+        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test & Test', **self.kwargs))
+        self.assertIn(results[0]['contributor_employer'], employers)
+        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test& Test', **self.kwargs))
+        self.assertIn(results[0]['contributor_employer'], employers)
+        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test &Test', **self.kwargs))
+        self.assertIn(results[0]['contributor_employer'], employers)
+        
     def test_filter_fulltext_occupation(self):
         occupations = ['Attorney at Law', 'Doctor of Philosophy']
         filings = [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -761,28 +761,30 @@ class TestItemized(ApiBaseTest):
         test names that expect to be returned
         """
         payee_names = [
-            'Test.com', 'Test com', 'Testerosa', 'Test#com', 't&t'
+            'Test.com', 'Test com', 'Testerosa', 'Test#com', 'Test.com and Test.com'
         ]
         [
             factories.ScheduleEFactory(payee_name=payee)
             for payee in payee_names
         ]
-        results = self._results(api.url_for(ScheduleEView, payee_name='t&t'))
+        results = self._results(api.url_for(ScheduleEView, payee_name='test'))
+        for result in results:
+            print(result, '\n')
         self.assertEqual(len(results), len(payee_names))
 
-    # def test_filter_fulltest_sched_e_fail(self):
-    #     """
-    #     test names that expect no returns
-    #     """
-    #     payee_names = [
-    #         '#', '##', '@#$%^&*', '%', '', '  '
-    #     ]
-    #     [
-    #         factories.ScheduleEFactory(payee_name_text=payee)
-    #         for payee in payee_names
-    #     ]
-    #     results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
-    #     self.assertEquals(len(results), 0)
+    def test_filter_fulltest_sched_e_fail(self):
+        """
+        test names that expect no returns
+        """
+        payee_names = [
+            '#', '##', '@#$%^&*', '%', '', '  '
+        ]
+        [
+            factories.ScheduleEFactory(payee_name_text=payee)
+            for payee in payee_names
+        ]
+        results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
+        self.assertEquals(len(results), 0)
 
     def test_filters_sched_a_efile(self):
         filters = [

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -72,16 +72,16 @@ def filter_fulltext(query, kwargs, fields):
                     sa.not_(column.match(utils.parse_fulltext(value)))
                     for value in exclude_list
                 ]
-                for value in exclude_list:
-                    filters.append(column.match(value))
+ #               for value in exclude_list:
+ #                   filters.append(column.match(value))
                 query = query.filter(sa.and_(*filters))
             if include_list:
                 filters = [
                     column.match(utils.parse_fulltext(value))
                     for value in include_list
                 ]
-                for value in include_list:
-                    filters.append(column.match(value))
+#                for value in include_list:
+#                    filters.append(column.match(value))
                 query = query.filter(sa.or_(*filters))
     return query
 

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -72,16 +72,12 @@ def filter_fulltext(query, kwargs, fields):
                     sa.not_(column.match(utils.parse_fulltext(value)))
                     for value in exclude_list
                 ]
- #               for value in exclude_list:
- #                   filters.append(column.match(value))
                 query = query.filter(sa.and_(*filters))
             if include_list:
                 filters = [
                     column.match(utils.parse_fulltext(value))
                     for value in include_list
                 ]
-#                for value in include_list:
-#                    filters.append(column.match(value))
                 query = query.filter(sa.or_(*filters))
     return query
 

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -72,12 +72,16 @@ def filter_fulltext(query, kwargs, fields):
                     sa.not_(column.match(utils.parse_fulltext(value)))
                     for value in exclude_list
                 ]
+                for value in exclude_list:
+                    filters.append(column.match(value))
                 query = query.filter(sa.and_(*filters))
             if include_list:
                 filters = [
                     column.match(utils.parse_fulltext(value))
                     for value in include_list
                 ]
+                for value in include_list:
+                    filters.append(column.match(value))
                 query = query.filter(sa.or_(*filters))
     return query
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -240,17 +240,16 @@ def extend(*dicts):
 
 
 def parse_fulltext(text):
-    if ' ' in text:
-        return ' & '.join([
-            part + ':*'
-            for part in re.sub(r'\W', ' ', text).split()
-        ])
-    else:
-        one_word = re.sub(r'\W', ' ', text).split()
-        if one_word:
-            return one_word[0] + ':*'
-        else:
-            return ' '
+    """
+    return search string for tsquery containing the portion of each of the entered words
+    up to the first non-word character
+    """
+    # get list of entered words (in a single field)
+    words = re.split(r'\s+', text)
+    # get the portions of the words up to the first non-word character
+    word_parts = [re.match(r'(.*?)\W', word).group()[:-1] if re.match(r'(.*?)\W', word) else word for word in words]
+    # remove any empty strings from word_parts list and return the words in a formatted string
+    return ' & '.join([word_part + ':*' for word_part in word_parts if word_part])
 
 
 office_args_required = ['office', 'cycle']

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -240,10 +240,17 @@ def extend(*dicts):
 
 
 def parse_fulltext(text):
-    return ' & '.join([
-        part + ':*'
-        for part in re.sub(r'\W', ' ', text).split()
-    ])
+    if ' ' in text:
+        return ' & '.join([
+            part + ':*'
+            for part in re.sub(r'\W', ' ', text).split()
+        ])
+    else:
+        one_word = re.sub(r'\W', ' ', text).split()
+        if one_word:
+            return one_word[0] + ':*'
+        else:
+            return ' '
 
 
 office_args_required = ['office', 'cycle']


### PR DESCRIPTION
## Summary (required)

Added 
```python                
for value in include_list:
filters.append(column.match(value))
```
as well as similar code for `exclude_list` in `filters.py` to make sure literal field inputs were considered by `fulltext_filter`. Testing is ongoing.

- Resolves #3716 

Modify `parse_fulltext` definition to return search string with terms at most numbering what the user entered and includes only non-special characters.

## How to test the changes locally

- [ ] `pytest`
- [ ] `./manage.py runserver` and verify key endpoint fields return expected results

## Impacted areas of the application
List general components of the application that this PR will affect:

- Anywhere fulltext filter fields are used
- See issue #3716 for full listing of application areas using fulltext fields for filtering

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3716-parse_fulltext-bug | [link](https://github.com/fecgov/openFEC/issues/3716)
