### PR TITLE
remove line_number from sched_a secondary index list.

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -93,7 +93,6 @@ class ScheduleAView(ItemizedResource):
             'contributor_employer',
             'contributor_occupation',
             'image_number',
-            'line_number',
         ]
         two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
         if len(two_year_transaction_periods) != 1:


### PR DESCRIPTION
## Summary (required)
remove line_number from sched_a secondary index list
- Resolves #[_3733_]

_Include a summary of proposed changes._
remove line_number from sched_a secondary index list. affected file is:
webservices/resources/sched_a.py

## How to test the changes locally:
- run pytest, all unit tests should pass
- run './manage.py runserver', then fire those two endpoints request:

request1:
http://127.0.0.1:5000/v1/schedules/schedule_a?per_page=30&two_year_transaction_period=2018&sort=-contribution_receipt_date&api_key=DEMO_KEY&line_number=12&
sort_hide_null=false&is_individual=true&two_year_transaction_period=2016&sort_nulls_last=false

request2:
http://127.0.0.1:5000/v1/schedules/schedule_a?per_page=30&two_year_transaction_period=2018&sort=-contribution_receipt_date&api_key=DEMO_KEY&sort_hide_null=false&is_individual=true&two_year_transaction_period=2016&sort_nulls_last=false

you should get this error message:
{
    "message": "Please choose a single `two_year_transaction_period` or add one of the following filters to your query: `committee_id`, `contributor_id`, `contributor_name`, `contributor_city`, `contributor_zip`, `contributor_employer`, `contributor_occupation`, `image_number`",
    "status": 400
}
MAKE SURE 'line_number' is not in the error message.
-

## Impacted areas of the application
List general components of the application that this PR will affect:

-  sched_a query with multiple 2-year-transaction-period



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
