### PR TITLE
resolve integer overflow vulnerability by adding exclude group to bui…

### DIFF
--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -17,6 +17,7 @@ dependencies {
         exclude group: 'org.hsqldb', module: 'hsqldb'
         exclude group: 'org.mariadb.jdbc', module: 'mariadb-java-client'
         exclude group: 'org.xerial', module: 'sqlite-jdbc'
+	exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
 }
 


### PR DESCRIPTION
## Summary
Resolve flyway Integer Overflow vulnerability by adding `exclude group: 'com.google.protobuf', module: 'protobuf-java'` to `build.gradle`

- Resolves #3706 

Add `exclude group: 'com.google.protobuf', module: 'protobuf-java'` to `build.gradle`

## How to test the changes locally

- [ ] checkout feature/3706-fix-flyway-vulnerability-protobuf-java
- [ ] if `gradle` is not installed locally:
  - 1. `brew install gradle` (from home)
  - 2. `cd <path to project>/data/flyway`
  - 3. `gradle clean` (from home)
  - 4. `gradle distZip` (from home)
- [ ] if `snyk` is not installed locally:
  - 1. `npm install -g snyk` (from home)
  - 2. `snyk auth` (from home)
  - 3. go to `dir` you want to test (I think it's a shallow test), e.g., `cd <path to project>/data/flyway`
  - 4. `snyk test`## Impacted areas of the application
- [ ] Verify that following warning does not appear:
```
✗ High severity vulnerability found in com.google.protobuf:protobuf-java
  Description: Integer Overflow
  Info: https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-173761
  Introduced through: org.flywaydb:flyway-commandline@5.2.4
  From: org.flywaydb:flyway-commandline@5.2.4 > mysql:mysql-connector-java@8.0.12 > com.google.protobuf:protobuf-java@2.6.0
```

-  flyway migrations

## Related PRs

branch | PR
------ | ------
feature/3706-fix-flyway-vulnerability-protobuf-java | [https://github.com/fecgov/openFEC/issues/3706](https://github.com/fecgov/openFEC/issues/3706)

[edit: how to test locally]