### PR TITLE
Upgrade requests package to latest version 2.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gunicorn==19.7.1
 gevent==1.2.2
 webargs==0.18.0
 ujson==1.33
-requests==2.20.1
+requests==2.21.0
 elasticsearch==5.5.1
 elasticsearch-dsl==5.4.0
 git+https://github.com/18F/slate.git


### PR DESCRIPTION
## Summary (required)

Upgrade python requests package to latest version 2.21.0

- Resolves #https://github.com/fecgov/openFEC/issues/3722

_Include a summary of proposed changes._

In requirements.txt file, pin requests package to the latest v2.21.0

## How to test the changes locally

- run `pip install -r requirements.txt`
- export SQLA_CONN to point to DEV db
- test few api endpoints and make sure the data is returned

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
https://github.com/kennethreitz/requests/issues/5065
