### PR TITLE
adding line_number validation code

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -219,6 +219,16 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleBView, line_number='f3X-21', **self.kwargs))
         self.assertEqual(len(results), 1)
 
+        # invalid line_number testing for sched_b
+        response = self.app.get(api.url_for(ScheduleBView, line_number='f3x21', **self.kwargs))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid line_number', response.data)
+
+        # invalid line_number testing for sched_a
+        response = self.app.get(api.url_for(ScheduleAView, line_number='f3x16', **self.kwargs))
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid line_number', response.data)
+
     def test_sched_b_spender_committee_type_filter(self):
         [
             factories.ScheduleBFactory(spender_committee_type='S'),

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -11,7 +11,6 @@ from webservices.resources.sched_a import ScheduleAView, ScheduleAEfileView
 from webservices.resources.sched_b import ScheduleBView, ScheduleBEfileView
 from webservices.resources.sched_e import ScheduleEView, ScheduleEEfileView
 
-
 class TestItemized(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
 

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,3 +1,9 @@
+
+LINE_NUMBER_ERROR = """
+Invalid line_number detected. A valid line_number is using the following format:
+'FORM-LINENUMBER'.  Check the api doc for more info.
+"""
+
 class ApiError(Exception):
     status_code = 400
 

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,7 +1,7 @@
 
-LINE_NUMBER_ERROR = """
-Invalid line_number detected. A valid line_number is using the following format:
-'FORM-LINENUMBER'.  Check the api doc for more info.
+LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is using the following format:
+'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries
+from formF 3X line number 16.
 """
 
 class ApiError(Exception):

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,7 +1,7 @@
 
 LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is using the following format:
 'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries
-from formF 3X line number 16.
+from form F3X line number 16.
 """
 
 class ApiError(Exception):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -78,7 +78,7 @@ class ScheduleAView(ItemizedResource):
                     'contribution_receipt_date',
                     'contribution_receipt_amount',
                     'contributor_aggregate_ytd',
-                ]),
+               ]),
                 show_nulls_last_arg=False,
             )
         )
@@ -93,6 +93,7 @@ class ScheduleAView(ItemizedResource):
             'contributor_employer',
             'contributor_occupation',
             'image_number',
+            'line_number',
         ]
         two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
         if len(two_year_transaction_periods) != 1:
@@ -118,10 +119,16 @@ class ScheduleAView(ItemizedResource):
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
+            # line_number is a composite value of 'filing_form-line_number'
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    "Invalid line_number detected.",
+                    status_code=400,
+                )
         return query
 
 @doc(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -125,7 +125,7 @@ class ScheduleAView(ItemizedResource):
                 query = query.filter_by(line_number=line_no)
             else:
                 raise exceptions.ApiError(
-                    "Invalid line_number detected.",
+                    exceptions.LINE_NUMBER_ERROR,
                     status_code=400,
                 )
         return query

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -93,7 +93,6 @@ class ScheduleAView(ItemizedResource):
             'contributor_employer',
             'contributor_occupation',
             'image_number',
-            'line_number',
         ]
         two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
         if len(two_year_transaction_periods) != 1:

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -8,7 +8,7 @@ from webservices import schemas
 from webservices.common import models
 from webservices.common import views
 from webservices.common.views import ItemizedResource
-
+from webservices import exceptions
 """
 two years restriction removed from schedule_b. For details, refer:
 https://github.com/fecgov/openFEC/issues/3595
@@ -73,10 +73,16 @@ class ScheduleBView(ItemizedResource):
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id = int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
+            # line number is a composite value of 'filing_form-line_number'
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())
                 query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    'Invalid line_number detected.',
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -13,9 +13,7 @@ from webservices import exceptions
 two years restriction removed from schedule_b. For details, refer:
 https://github.com/fecgov/openFEC/issues/3595
 """
-LINE_NUMBER_ERROR = """
 
-"""
 
 @doc(
     tags=['disbursements'],
@@ -30,6 +28,7 @@ class ScheduleBView(ItemizedResource):
     @property
     def year_column(self):
         return self.model.two_year_transaction_period
+
     @property
     def index_column(self):
         return self.model.sub_id
@@ -40,41 +39,43 @@ class ScheduleBView(ItemizedResource):
         ('recipient_city', models.ScheduleB.recipient_city),
         ('recipient_state', models.ScheduleB.recipient_state),
         ('recipient_committee_id', models.ScheduleB.recipient_committee_id),
-        ('disbursement_purpose_category', models.ScheduleB.disbursement_purpose_category),
+        ('disbursement_purpose_category',
+         models.ScheduleB.disbursement_purpose_category),
         ('spender_committee_type', models.ScheduleB.spender_committee_type),
-        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
-
+        ('two_year_transaction_period',
+         models.ScheduleB.two_year_transaction_period),
     ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
-        ('disbursement_description', models.ScheduleB.disbursement_description_text),
+        ('disbursement_description',
+         models.ScheduleB.disbursement_description_text),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleB.disbursement_date),
         (('min_amount', 'max_amount'), models.ScheduleB.disbursement_amount),
-        (('min_image_number', 'max_image_number'), models.ScheduleB.image_number),
+        (('min_image_number', 'max_image_number'),
+         models.ScheduleB.image_number),
     ]
 
     @property
     def args(self):
         return utils.extend(
-            args.itemized,
-            args.schedule_b,
-            args.make_seek_args(),
+            args.itemized, args.schedule_b, args.make_seek_args(),
             args.make_sort_args(
                 default='-disbursement_date',
-                validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
+                validator=args.OptionValidator(
+                    ['disbursement_date', 'disbursement_amount']),
                 show_nulls_last_arg=False,
-            )
-        )
+            ))
 
     def build_query(self, **kwargs):
         query = super(ScheduleBView, self).build_query(**kwargs)
         query = query.options(sa.orm.joinedload(models.ScheduleB.committee))
-        query = query.options(sa.orm.joinedload(models.ScheduleB.recipient_committee))
+        query = query.options(
+            sa.orm.joinedload(models.ScheduleB.recipient_committee))
         #might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
-            query = query.filter_by(sub_id = int(kwargs.get('sub_id')))
+            query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
             # line number is a composite value of 'filing_form-line_number'
             if len(kwargs.get('line_number').split('-')) == 2:
@@ -89,10 +90,7 @@ class ScheduleBView(ItemizedResource):
         return query
 
 
-@doc(
-    tags=['disbursements'],
-    description=docs.EFILING_TAG
-)
+@doc(tags=['disbursements'], description=docs.EFILING_TAG)
 class ScheduleBEfileView(views.ApiResource):
     model = models.ScheduleBEfile
     schema = schemas.ItemizedScheduleBfilingsSchema
@@ -106,12 +104,14 @@ class ScheduleBEfileView(views.ApiResource):
     ]
 
     filter_fulltext_fields = [
-        ('disbursement_description', models.ScheduleBEfile.disbursement_description),
+        ('disbursement_description',
+         models.ScheduleBEfile.disbursement_description),
     ]
 
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleBEfile.disbursement_date),
-        (('min_amount', 'max_amount'), models.ScheduleBEfile.disbursement_amount),
+        (('min_amount', 'max_amount'),
+         models.ScheduleBEfile.disbursement_amount),
     ]
 
     @property
@@ -121,6 +121,7 @@ class ScheduleBEfileView(views.ApiResource):
             args.schedule_b_efile,
             args.make_sort_args(
                 default='-disbursement_date',
-                validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
+                validator=args.OptionValidator(
+                    ['disbursement_date', 'disbursement_amount']),
             ),
         )

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -13,6 +13,9 @@ from webservices import exceptions
 two years restriction removed from schedule_b. For details, refer:
 https://github.com/fecgov/openFEC/issues/3595
 """
+LINE_NUMBER_ERROR = """
+
+"""
 
 @doc(
     tags=['disbursements'],
@@ -80,7 +83,7 @@ class ScheduleBView(ItemizedResource):
                 query = query.filter_by(line_number=line_no)
             else:
                 raise exceptions.ApiError(
-                    'Invalid line_number detected.',
+                    exceptions.LINE_NUMBER_ERROR,
                     status_code=400,
                 )
         return query


### PR DESCRIPTION
## Summary (required)
adding line_number validation code and add line_number back to sched_a secondary index list
- Resolves #3741

_Include a summary of proposed changes._
1. line_number validation code added to both sched_a and sched_b
2. unit tests updated
## How to test the changes locally

1. start local server and connect to stage db
./manage.py runserver

2. the local requests should give you error messages:

request:
http://127.0.0.1:5000/v1/schedules/schedule_b/?per_page=50&sort_null_only=false&sort_hide_null=false&api_key=DEMO_KEY&two_year_transaction_period=2018&two_year_transaction_period=2016&two_year_transaction_period=2014&line_number=F3X23
response:
{
    "message": "Invalid line_number detected.",
    "status": 400
}

request:
http://127.0.0.1:5000/v1/schedules/schedule_a/?per_page=50&sort_null_only=false&sort_hide_null=false&api_key=DEMO_KEY&two_year_transaction_period=2018&two_year_transaction_period=2016&two_year_transaction_period=2014&line_number=F3X11AI
response:
{
    "message": "Invalid line_number detected.",
    "status": 400
}

3. all unit tests should pass

-

## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
