### PR TITLE
fix tran_id and back_ref_tran_id type to String

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -167,7 +167,6 @@ class ScheduleA(BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     increased_limit = db.Column(db.String)
     load_date = db.Column('pg_date', db.DateTime)
-    # transaction_id = db.Column('tran_id', db.Integer)
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
@@ -324,7 +323,6 @@ class ScheduleB(BaseItemized):
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     load_date = db.Column('pg_date', db.DateTime)
-    # transaction_id = db.Column('tran_id', db.Integer)
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
@@ -625,7 +623,6 @@ class ScheduleE(PdfMixin, BaseItemized):
     election_type_full = db.Column('fec_election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
 
     # Transaction meta info
-    # transaction_id = db.Column('tran_id', db.Integer)
     independent_sign_name = db.Column('indt_sign_nm', db.String)
     independent_sign_date = db.Column('indt_sign_dt', db.Date)
     notary_sign_name = db.Column('notary_sign_nm', db.String)
@@ -641,7 +638,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     filer_last_name = db.Column('filer_l_nm', db.String)
     filer_suffix = db.Column(db.String)
 
-    transaction_id = db.Column('tran_id', db.Integer)
+    transaction_id = db.Column('tran_id', db.String)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
 
     action_code = db.Column('action_cd', db.String)
@@ -806,7 +803,7 @@ class ScheduleF(PdfMixin, BaseItemized):
     conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
     action_code = db.Column('action_cd', db.String)
     action_code_full = db.Column('action_cd_desc', db.String)
-    back_reference_transaction_id = db.Column('back_ref_tran_id', db.Integer)
+    back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)


### PR DESCRIPTION
## Summary
in `/common/models/itemized.py`, there are places where `transaction_id` and 'back_reference_transaction_id` are incorrectly specified as `Integer`. To make the code consistent with other occurrences of these identifiers, as well as consistent with the db datatype, change to `String`.

- Resolves #3750

Change datatype for `transaction_id` and `back_reference_transaction_id` to `String`

## How to test the changes locally

- [ ] on `/schedule_e/` verify that `transaction_id` now exists and is non-null
- [ ] verify that `back_reference_transaction_id` is now consistent in `itemized.py` (it was `Integer` in one place, and `String` in all other places--change is to `String`. Note that db has 0 non-null values for this identifier, so local testing over values is not feasible.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `/schedule_e/`
- `/schedule_f/`



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3750-fix-transaction_id | [feature/3750-fix-transaction_id](feature/3750-fix-transaction_id)
