### PR TITLE
Update Flask-SQLAlchemy to 2.4.0

### DIFF
--- a/endpoints_walk.py
+++ b/endpoints_walk.py
@@ -46,7 +46,7 @@ endpoints = [
     "/committee/{committee_id}/reports/?api_key={api_key}",
     "/names/candidates/?q=clinton&api_key={api_key}",
     "/names/committees/?q=clinton&api_key={api_key}",
-    "/schedules/schedule_a/{sub_id}/?api_key={api_key}",
+    "/schedules/schedule_a/{sub_id}/?two_year_transaction_period=2018&api_key={api_key}",
     "/schedules/schedule_a/efile/?api_key={api_key}",
     "/schedules/schedule_b/{sub_id}/?api_key={api_key}",
     "/schedules/schedule_b/efile/?api_key={api_key}",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask==1.0.2
 Flask-Cors==3.0.6
 Flask-Script==2.0.6
 Flask-RESTful==0.3.6
-Flask-SQLAlchemy==2.1
+Flask-SQLAlchemy==2.4.0
 python-dateutil==2.4.2
 sqlalchemy-postgres-copy==0.3.0
 networkx==1.11

--- a/webservices/common/models/audit.py
+++ b/webservices/common/models/audit.py
@@ -38,9 +38,9 @@ class AuditCategory(AuditPrimaryCategory):
             uselist=True,
         )
 
+
 # endpoint audit-case
 class AuditCaseSubCategory(db.Model):
-    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_sub_category_rel_mv'
     audit_case_id = db.Column(db.String, primary_key=True, doc=docs.AUDIT_CASE_ID)
     primary_category_id = db.Column(db.String, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -51,7 +51,6 @@ class AuditCaseSubCategory(db.Model):
 
 # endpoint audit-case
 class AuditCaseCategoryRelation(db.Model):
-    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_category_rel_mv'
     audit_case_id = db.Column(db.String, primary_key=True, doc=docs.AUDIT_CASE_ID)
     primary_category_id = db.Column(db.String, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -69,7 +68,6 @@ class AuditCaseCategoryRelation(db.Model):
 
 # endpoint audit-case
 class AuditCase(db.Model):
-    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_mv'
     idx = db.Column(db.Integer, primary_key=True, index=True)
     primary_category_id = db.Column(db.String, index=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -100,7 +98,6 @@ class AuditCase(db.Model):
 
 # endpoint audit/search/name/candidates
 class AuditCandidateSearch(db.Model):
-    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_candidate_fulltext_audit_mv'
 
     idx = db.Column(db.String, primary_key=True)
@@ -111,7 +108,6 @@ class AuditCandidateSearch(db.Model):
 
 # endpoint audit/search/name/committees
 class AuditCommitteeSearch(db.Model):
-    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_committee_fulltext_audit_mv'
 
     idx = db.Column(db.String, primary_key=True)

--- a/webservices/common/models/audit.py
+++ b/webservices/common/models/audit.py
@@ -6,12 +6,10 @@ from webservices import docs
 
 from .base import db
 
-class AuditBase(object):
-    __table_args__ = {"schema": "auditsearch"}
-
 
 # endpoint: audit-primary-category
-class AuditPrimaryCategory(AuditBase, db.Model):
+class AuditPrimaryCategory(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'finding_vw'
 
     primary_category_id = db.Column(db.String, index=True, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -20,7 +18,8 @@ class AuditPrimaryCategory(AuditBase, db.Model):
 
 
 # endpoint: audit-category
-class AuditCategoryRelation(AuditBase, db.Model):
+class AuditCategoryRelation(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'finding_rel_vw'
 
     primary_category_id = db.Column(db.String, index=True, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -41,6 +40,7 @@ class AuditCategory(AuditPrimaryCategory):
 
 # endpoint audit-case
 class AuditCaseSubCategory(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_sub_category_rel_mv'
     audit_case_id = db.Column(db.String, primary_key=True, doc=docs.AUDIT_CASE_ID)
     primary_category_id = db.Column(db.String, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -51,6 +51,7 @@ class AuditCaseSubCategory(db.Model):
 
 # endpoint audit-case
 class AuditCaseCategoryRelation(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_category_rel_mv'
     audit_case_id = db.Column(db.String, primary_key=True, doc=docs.AUDIT_CASE_ID)
     primary_category_id = db.Column(db.String, primary_key=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -68,6 +69,7 @@ class AuditCaseCategoryRelation(db.Model):
 
 # endpoint audit-case
 class AuditCase(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_audit_case_mv'
     idx = db.Column(db.Integer, primary_key=True, index=True)
     primary_category_id = db.Column(db.String, index=True, doc=docs.PRIMARY_CATEGORY_ID)
@@ -98,6 +100,7 @@ class AuditCase(db.Model):
 
 # endpoint audit/search/name/candidates
 class AuditCandidateSearch(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_candidate_fulltext_audit_mv'
 
     idx = db.Column(db.String, primary_key=True)
@@ -108,6 +111,7 @@ class AuditCandidateSearch(db.Model):
 
 # endpoint audit/search/name/committees
 class AuditCommitteeSearch(db.Model):
+    __table_args__ = {"schema": "auditsearch"}
     __tablename__ = 'ofec_committee_fulltext_audit_mv'
 
     idx = db.Column(db.String, primary_key=True)

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -1,7 +1,7 @@
 import random
-
 import celery
-from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import orm
+from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
 from flask_sqlalchemy import SignallingSession
 
 
@@ -47,11 +47,12 @@ class RoutingSession(SignallingSession):
         return super().get_bind(mapper=mapper, clause=clause)
 
 
-class RoutingSQLAlchemy(SQLAlchemy):
+class RoutingSQLAlchemy(SQLAlchemyBase):
+    """Override the default SQLAlchemyBase.create_session
+    to return a session factory that makes RoutingSession type sessions"""
 
     def create_session(self, options):
-        return RoutingSession(self, **options)
-
+        return orm.sessionmaker(class_=RoutingSession, db=self, **options)
 
 db = RoutingSQLAlchemy()
 


### PR DESCRIPTION
## Summary (required)

Resolves #3404 

- Update Flask-SQLAlchemy to 2.4.0
- [This commit](https://github.com/pallets/flask-sqlalchemy/commit/3fec7535922e687e0518bdbfcd24b6389ab5c3af) changed the default behavior of `create_session` from returning a `SignallingSession` class to returning a session maker factory that takes a `class` argument. This PR changes our custom `RoutingSQLAlchemy` `create_session` logic to return a session maker factory that creates `RoutingSession`-type sessions.
- SQLAlchemy 2.3 no longer supports putting `table_args` in an inherited class and throws the error `sqlalchemy.exc.ArgumentError: Can't place __table_args__ on an inherited class with no table.`. The best solution is putting the `table_args` in the subclasses explicitly. (see https://stackoverflow.com/questions/43832848/cant-define-table-args-on-a-child-class-in-a-single-table-inheritance-setup)

## How to test the changes locally

- Consider setting up another virtual env for testing this, to not mess with your default version.
- `pip install -r requirements.txt`
- Run the API locally, test some endpoints
- I tested this with a manual deploy to `dev`
- Make sure to  uninstall/reinstall Flask-SQLAlchemy when switching between this branch or switching back to your usual virtual environment

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Database queries, tasks

