### PR TITLE
Update deploy task to skip migrations by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,9 @@ jobs:
       - run: echo $FEC_BASTION_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts # copy Bastion host public key
 
       - run: $FEC_BASTION_DEV_TUNNEL # establsh tunnel/port mapping to 'dev' RDS from CircleCI container through Bastion host.
- 
+
       - run: $FEC_BASTION_STAGE_TUNNEL # establsh tunnel/port mapping to 'stage' RDS from CircleCI container through Bastion host.
- 
+
       - run: $FEC_BASTION_PROD_TUNNEL # establsh tunnel/port mapping to 'prod' RDS from CircleCI container through Bastion host.
 
       - deploy:
@@ -121,4 +121,4 @@ jobs:
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             . venv/bin/activate
             nvm use default
-            invoke deploy --branch $CIRCLE_BRANCH --login True --yes
+            invoke deploy --branch $CIRCLE_BRANCH --login True --yes --migrate-database

--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ We are always trying to improve our documentation. If you have suggestions or ru
 		* After downloading, open `flyway5.2.4/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
-		   
+
 		   ```
 		   flyway.locations=filesystem:/Users/<user>/<project>/api/openFEC/data/migrations
 		   flyway.url=jdbc:postgresql://localhost:5432/cfdm_test?user=<your local database username>&password=<your local database password>
 		   ```
-		   
+
 		   to enable connection to a local database (e.g., `cfdm_test` from [Create
            a test database](https://github.com/fecgov/openFEC#create-a-development-database), below) and specify the location of the database migration files (*SQL)
        * See [Database migrations](https://github.com/fecgov/openFEC#database-migration) for more information on installing and configuring flyway
-        
+
 
 2. Set up your Node environment—  learn how to do this with our [Javascript Ecosystem Guide](https://github.com/18F/dev-environment-standardization/blob/18f-pages/pages/languages/javascript.md).
 
@@ -338,10 +338,10 @@ invoke deploy --space dev
 
 This command will explicitly target the `dev` space.
 
-To skip migrations with a manual deploy, run:
+To run migrations with a manual deploy, run:
 
 ```
-invoke deploy --space dev --skip-migrations
+invoke deploy --space dev --migrate-database
 ```
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -155,12 +155,12 @@ SPACE_URLS = {
 
 
 @task
-def deploy(ctx, space=None, branch=None, login=None, yes=False, skip_migrations=False):
+def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database=False):
     """Deploy app to Cloud Foundry. Log in using credentials stored per environment
     like `FEC_CF_USERNAME_DEV` and `FEC_CF_PASSWORD_DEV`; push to either `space` or t
     he space detected from the name and tags of the current branch. Note: Must pass `space`
     or `branch` if repo is in detached HEAD mode, e.g. when running on Circle.
-    To skip migrations, pass the flag `--skip-migrations`.
+    To run migrations, pass the flag `--migrate-database`.
     """
     # Detect space
     repo = git.Repo('.')
@@ -181,7 +181,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, skip_migrations=
     # Target space
     ctx.run('cf target -o fec-beta-fec -s {0}'.format(space), echo=True)
 
-    if skip_migrations:
+    if not migrate_database:
         print("\nSkipping migrations. Database not migrated.\n")
     else:
         migration_env_var = 'FEC_MIGRATOR_SQLA_CONN_{0}'.format(space.upper())


### PR DESCRIPTION
## Summary

Resolves https://github.com/fecgov/openFEC/issues/3754. Prevents accidentally running migrations in environments that aren't ready for them during manual deploys

To run migrations with a manual deploy, run:
 ```	
invoke deploy --space dev --migrate-database
```

- By default, deploy task skips migrations
- Change Circle command to always run migrations
- Update docs

## How to test the changes locally

- Manually: I tested this with `invoke deploy --space dev` and `invoke deploy --space dev --migrate-database` 
- Circle: I tested a Circle build with a temporary change to the deploy rules

## Impacted areas of the application
List general components of the application that this PR will affect:

- Manual deploy
- Circle deploys  



## Related PRs
List related PRs against other branches:

https://github.com/fecgov/openFEC/pull/3325 Originally implemented `--skip-migrations` flag
