### PR TITLE
fix privilege escalation add exclude group mysql to build.gradle

### DIFF
--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -12,6 +12,7 @@ dependencies {
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'
         exclude group: 'net.sourceforge.jtds', module: 'jtds'
+	exclude group: 'mysql', module: 'mysql-connector-java'
         exclude group: 'org.apache.derby', module: 'derby'
         exclude group: 'org.apache.derby', module: 'derbyclient'
         exclude group: 'org.hsqldb', module: 'hsqldb'


### PR DESCRIPTION
## Summary
Snyk identified vulnerability:
> Medium severity vulnerability found in mysql:mysql-connector-java
> Description: Privilege Escalation
> Info: https://snyk.io/vuln/SNYK-JAVA-MYSQL-174574
> Introduced through: org.flywaydb:flyway-commandline@5.2.4
> From: org.flywaydb:flyway-commandline@5.2.4 > mysql:mysql-connector-java@8.0.12

- Resolves #3752 

add `exclude group: 'mysql', module: 'mysql-connector-java'` to `build.gradle`
(this also resolves the `High severity vulnerability found in com.google.protobuf:protobuf-java` addressed in #3743 

## How to test the changes locally

- [ ] `cd path-to-build.gradle`
- [ ] `snyk test --file=build.gradle`
- [ ] verify that exclude group does not have implications for migrations when excluding `mysql`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `flyway`



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3752-mysql-gradle-vulnerability-privilege-escalation | [feature/3752-mysql-gradle-vulnerability-privilege-escalation](feature/3752-mysql-gradle-vulnerability-privilege-escalation)
feature/other_pr | [#3743](#3743 )
