### PR TITLE
Upgrade smartopen and elasticsearch packages to fix the CRLF vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ gevent==1.2.2
 webargs==0.18.0
 ujson==1.33
 requests==2.21.0
-elasticsearch==5.5.1
+elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 git+https://github.com/18F/slate.git
 
@@ -32,7 +32,7 @@ marshmallow-sqlalchemy==0.15.0
 git+https://github.com/jmcarp/marshmallow-pagination@master
 
 # Data export
-smart_open==1.7.1
+smart_open==1.8.0
 
 # Task queue
 celery==4.1.1 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above


### PR DESCRIPTION
## Summary (required)

Upgrade python packages, smart-open and elasticsearch.

- Resolves #https://github.com/fecgov/openFEC/issues/3722

_Include a summary of proposed changes._

In requirements.txt file, bumped the packages to a version that our application can handle.

1. smart_open 1.8.0
2. elasticsearch 5.5.3


## How to test the changes locally

- run `pip install -r requirements.txt`
- export SQLA_CONN to point to DEV db
- test few api endpoints and make sure the data is returned
- test downloads(Export) 

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
openFEC | https://github.com/fecgov/openFEC/pull/3744
https://github.com/kennethreitz/requests/issues/5065
