### PR TITLE
update webargs to 5.3.1 fix race condition

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Development
 # TODO(jmcarp) Install from PyPI after 0.2.4 release
 git+https://github.com/18F/rdbms-subsetter
-ipython==6.4.0
+ipython==7.5.0
 
 # Testing
 pytest==3.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ git+https://github.com/fecgov/apispec.git@dev
 cfenv==0.5.2
 invoke==0.15.0
 kombu==4.5.0
-psycopg2==2.7.3.2
+psycopg2-binary==2.7.4
 Flask==1.0.2
 Flask-Cors==3.0.6
 Flask-Script==2.0.6
@@ -18,11 +18,12 @@ icalendar==3.9.1
 GitPython==1.0.1
 gunicorn==19.7.1
 gevent==1.2.2
-webargs==0.18.0
+webargs==5.3.1
 ujson==1.33
 requests==2.21.0
 elasticsearch==5.5.1
 elasticsearch-dsl==5.4.0
+prompt-toolkit==2.0.6
 git+https://github.com/18F/slate.git
 
 # Marshalling

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1,10 +1,11 @@
 import functools
 
 from marshmallow.compat import text_type
+from marshmallow import ValidationError
 
 import sqlalchemy as sa
 
-from webargs import ValidationError, fields, validate
+from webargs import fields, validate
 
 from webservices import docs
 from webservices.common.models import db
@@ -71,7 +72,6 @@ class OptionValidator(object):
         if value.lstrip('-') not in self.values:
             raise ValidationError(
                 'Cannot sort on value "{0}"'.format(value),
-                status_code=422
             )
 
 
@@ -115,7 +115,6 @@ class IndicesValidator(IndexValidator):
             if sort_column.lstrip('-') not in self.values:
                 raise ValidationError(
                     'Cannot sort on value "{0}"'.format(value),
-                    status_code=422
                 )
 
 def make_sort_args(default=None, validator=None, default_hide_null=False,

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -108,7 +108,7 @@ cors.CORS(app)
 
 class FlaskRestParser(FlaskParser):
 
-    def handle_error(self, error):
+    def handle_error(self, error, req, schema, status_code, error_headers):
         message = error.messages
         status_code = getattr(error, 'status_code', 422)
         raise exceptions.ApiError(message, status_code)


### PR DESCRIPTION
## Summary ##
fix race condition due to `webargs@0.18.0`. Upgrade to `webargs@5.3.1` (`requirements.txt`)
- Resolves #3642 

## How to test the changes locally
- [ ] `pip install -r requirements.txt`
- [ ] cd to openFEC: `snyk test --file=requirements.txt`
- [ ] because changes to `handle_error()` signature were made (to include explicit arguments) and removal of the `status_code` from `ValidationError`, test points such that status codes behave as expected.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `requirements.txt`
- `args.py`