### PR TITLE
Set trusted proxies as an API environment variable.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from webservices.resources import candidate_aggregates
 from webservices.resources import audit
 from webservices.resources import elections
 from webservices.rest import db
-from webservices.tasks import utils
+from webservices import utils
 
 from sqlalchemy.dialects import postgresql
 
@@ -153,3 +153,17 @@ class TestArgs(unittest.TestCase):
         with rest.app.test_request_context('?dollars=$24.50'):
             parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request)
             self.assertEqual(parsed, {'dollars': 24.50})
+
+class TestEnvVarSplit(unittest.TestCase):
+
+    def test_env_var_split(self):
+        test_cases = [
+            "1.2.3.4, 5.6.7.8",
+            "1.2.3.4,  5.6.7.8",
+            "1.2.3.4,5.6.7.8",
+            " 1.2.3.4,  5.6.7.8 "
+        ]
+        expected = ["1.2.3.4", "5.6.7.8"]
+        for test_case in test_cases:
+            result = utils.split_env_var(test_case)
+            self.assertEqual(result, expected)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -135,7 +135,7 @@ def handle_error(error):
 
 
 # api.data.gov
-TRUSTED_PROXY_IPS = env.get_credential('TRUSTED_PROXY_IPS')
+TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('TRUSTED_PROXY_IPS', ''))
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -24,6 +24,7 @@ from webargs.flaskparser import FlaskParser
 from flask_apispec import FlaskApiSpec
 from webservices import spec
 from webservices import exceptions
+from webservices import utils
 from webservices.common import util
 from webservices.common.models import db
 from webservices.resources import totals
@@ -90,7 +91,7 @@ app.config['SQLALCHEMY_FOLLOWER_TASKS'] = [
 ]
 app.config['SQLALCHEMY_FOLLOWERS'] = [
     sa.create_engine(follower.strip())
-    for follower in env.get_credential('SQLA_FOLLOWERS', '').split(',')
+    for follower in utils.split_env_var(env.get_credential('SQLA_FOLLOWERS', ''))
     if follower.strip()
 ]
 app.config['PROPAGATE_EXCEPTIONS'] = True

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -229,6 +229,11 @@ def page_not_found(exception):
     wrapped = ResponseException(str(exception), exception.code, type(exception))
     return wrapped.wrappedException, wrapped.status
 
+@app.errorhandler(403)
+def forbidden(exception):
+    wrapped = ResponseException(str(exception), exception.code, type(exception))
+    return wrapped.wrappedException, wrapped.status
+
 api.add_resource(candidates.CandidateList, '/candidates/')
 api.add_resource(candidates.CandidateSearch, '/candidates/search/')
 api.add_resource(

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -134,7 +134,7 @@ def handle_error(error):
 
 
 # api.data.gov
-TRUSTED_PROXIES = ('54.208.160.112', '54.208.160.151')
+TRUSTED_PROXY_IPS = env.get_credential('TRUSTED_PROXY_IPS')
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
@@ -157,7 +157,7 @@ def limit_remote_addr():
         except ValueError:  # Not enough routes
             abort(403)
         else:
-            if api_data_route not in TRUSTED_PROXIES:
+            if api_data_route not in TRUSTED_PROXY_IPS:
                 abort(403)
             if source_ip in BLOCKED_IPS:
                 abort(403)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -434,3 +434,7 @@ def post_to_slack(message, channel):
     )
     if response.status_code != 200:
         logger.error('SLACK ERROR- Message failed to send:{0}'.format(message))
+
+def split_env_var(env_var):
+    """ Remove whitespace and split to a list based of comma delimiter"""
+    return env_var.replace(" ", "").split(',')


### PR DESCRIPTION
## Summary (required)
For security reasons, we do not want to show or hard code the api umbrella ip addresses in our code. 
- Add `trusted_proxy_ips` as an API environment variable in `stage` and `prod` spaces. 
- Assign the API umbrella ips to this new environment variable.
- Put splitting `env vars` into a function, add tests
- Split trusted proxies into a list
- Add handling for 403 forbidden errors when bypassing the api umbrella

Note# there is no api umbrella in `dev` space. requests directly hit the DB.

- Resolves #3757 

_Include a summary of proposed changes._

In rest.py, add a new constant `trusted_proxie_ips`. assign the  api umbrella proxie ips to this new variable.
 

## How to test the changes locally

- i did a manual deploy to `stage` space and test the `stage api` and `stage website` and make sure the endpoints return the data.
- Try hitting the `stage` server directly (ask @lbeaufort if you're not sure how to access it) and you'll get a 403 instead of 500.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  www.fec.gov