### PR TITLE
enabling sort null last to sched_b

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -136,6 +136,10 @@ def make_sort_args(default=None, validator=None, default_hide_null=False,
         ),
 
     }
+    
+    # this is a handy flag to turn sort_nulls_last on and off
+    # check https://github.com/fecgov/openFEC/issues/3775 and 
+    # https://github.com/fecgov/openFEC/issues/3494 for details
     if show_nulls_last_arg:
         args['sort_nulls_last'] = fields.Bool(
             missing=default_sort_nulls_last,

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -61,7 +61,7 @@ class ScheduleBView(ItemizedResource):
             args.make_sort_args(
                 default='-disbursement_date',
                 validator=args.OptionValidator(['disbursement_date', 'disbursement_amount']),
-                show_nulls_last_arg=False,
+                show_nulls_last_arg=True,
             )
         )
 


### PR DESCRIPTION
Summary (required)
a PR for enabling sort_nulls_last on sched_b endpoints

Resolves #[ 3775 ]
Include a summary of proposed changes.
re-enable sort_nulls_last on sched_b endpoints for disbursments search

How to test the changes locally
running api on local
./manage.py runserver

test schedule_b endpoints with sort_nulls_last
e.g.
http://127.0.0.1:5000/v1/schedules/schedule_b/?sort_nulls_last=true&sort_null_only=false&sort_hide_null=false&per_page=50&sort=-disbursement_date&two_year_transaction_period=2018&two_year_transaction_period=2016&min_amount=50&max_amount=5000&wo_year_transaction_period=2014


-

## Impacted areas of the application
sched_b endpoints

List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
