### PR TITLE
Add 'is_active_candidate' to /candidates/

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -140,6 +140,7 @@ class CandidateFormatTest(ApiBaseTest):
             factories.CandidateFactory(cycles=[2006]),
             factories.CandidateFactory(candidate_id='BARLET'),
             factories.CandidateFactory(candidate_id='RITCHIE'),
+            factories.CandidateFactory(candidate_inactive=True),
         ]
 
         filter_fields = (
@@ -148,7 +149,8 @@ class CandidateFormatTest(ApiBaseTest):
             ('state', 'CA'),
             ('party', 'DEM'),
             ('cycle', '2006'),
-            ('candidate_id', ['BARTLET', 'RITCHIE'])
+            ('candidate_id', ['BARTLET', 'RITCHIE']),
+            ('is_active_candidate', False),
         )
 
         # checking one example from each field

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -249,6 +249,7 @@ candidate_list = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'min_first_file_date': fields.Date(description='Selects all candidates whose first filing was received by the FEC after this date'),
     'max_first_file_date': fields.Date(description='Selects all candidates whose first filing was received by the FEC before this date'),
+    'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
 }
 
 candidate_history = {

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -71,6 +71,7 @@ class Candidate(BaseConcreteCandidate):
     __tablename__ = 'ofec_candidate_detail_mv'
 
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
+    candidate_inactive = db.Column(db.Boolean, doc=docs.ACTIVE_CANDIDATE)
 
     # Customize join to restrict to principal committees
     principal_committees = db.relationship(

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1591,7 +1591,7 @@ TOTAL_BY_OFFICE_TAG = ''' Aggregated candidate receipts and disbursements groupe
 TOTAL_BY_OFFICE_BY_PARTY_TAG= ''' Aggregated candidate receipts and disbursements grouped by office by party by cycle.
 '''
 
-ACTIVE_CANDIDATE = ''' Candidates who are actively running. if no value specified, all candidates
-data is returned. When True is specified, only active candidates data are returned. When False is 
-specified, only inactive candidates data is returned.
+ACTIVE_CANDIDATE = ''' Candidates who are actively seeking office. If no value is specified, all candidates
+are returned. When True is specified, only active candidates are returned. When False is
+specified, only inactive candidates are returned.
 '''


### PR DESCRIPTION
## Summary (required)

- Resolves #3796 
Add `is_active_candidate` to /candidates/

## How to test the changes locally

- Filter by candidates not actively seeking office: http://localhost:5000/v1/candidates/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&election_year=2020&state=MN&office=S&sort=-first_file_date&per_page=30&page=1&is_active_candidate=false

## Impacted areas of the application
List general components of the application that this PR will affect:

- Allows us to add an active candidates filter to "All candidates" datatable   (https://www.fec.gov/data/candidates/)