### PR TITLE
Fix download blank page bug for form_type=RFAI

### DIFF
--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -64,13 +64,12 @@ class BaseFilings(views.ApiResource):
             ),
         )
 
-    def get(self, **kwargs):
-        if kwargs.get('form_type') and 'RFAI' in kwargs.get('form_type'):
+    def build_query(self, **kwargs):
+        if 'RFAI' in kwargs.get('form_type', []):
             #Adds FRQ types if RFAI was requested
             kwargs.get('form_type').append('FRQ')
-        query = self.build_query(**kwargs)
-        count = counts.count_estimate(query, models.db.session)
-        return utils.fetch_page(query, kwargs, model=models.Filings, count=count, multi=True)
+        query = super().build_query(**kwargs)
+        return query
 
 
 class FilingsView(BaseFilings):

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -29,12 +29,10 @@ def call_resource(path, qs):
     resource = resource_type()
     fields, kwargs = parse_kwargs(resource, qs)
     kwargs = utils.extend(arguments, kwargs)
-    if kwargs.get('form_type') and 'RFAI' in kwargs.get('form_type'):
-        #Adds FRQ types if RFAI was requested
-        kwargs.get('form_type').append('FRQ')
 
     for field in IGNORE_FIELDS:
         kwargs.pop(field, None)
+
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
     count = counts.count_estimate(query, db.session)
     return {

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -29,6 +29,10 @@ def call_resource(path, qs):
     resource = resource_type()
     fields, kwargs = parse_kwargs(resource, qs)
     kwargs = utils.extend(arguments, kwargs)
+    if kwargs.get('form_type') and 'RFAI' in kwargs.get('form_type'):
+        #Adds FRQ types if RFAI was requested
+        kwargs.get('form_type').append('FRQ')
+
     for field in IGNORE_FIELDS:
         kwargs.pop(field, None)
     query, model, schema = unpack(resource.build_query(**kwargs), 3)


### PR DESCRIPTION
## Summary (required)
This will fix Exported excel file was blank when form_type=RFAI

- Resolves https://github.com/fecgov/openFEC/issues/3799

_Include a summary of proposed changes._
modify tasks/download.py:
when form_type=RFAI, we need append form_type=FRQ for download url. same as api endpoint url.

## How to test the changes locally
1. get `cf env api` from dev space
export access_key_id="xxxxxxx"
export secret_access_key="xxxxxxx"
export bucket="xxxxxxx"
export region="xxxxxxx"

2. setup 4 terminals on local:
1)first terminal: Redis
`redis-server `
2)second terminal: Celery Worker
active virtual env
setup 4 env variables (see above)
`celery worker --app webservices.tasks --loglevel INFO `
3)Third terminal: openFEC (point dev DB)
active virtual env
setup 4 env variables (see above)
export SQLA_CONN=dev database
./manage.py runserver
4)Forth terminal: fec-cms (point your local api)
active virtual en
export DATABASE_URL=postgresql://:@/cfdm_cms_test
export FEC_API_URL=http://localhost:5000
export FEC_WEB_API_KEY=xxxxxx
export FEC_WEB_API_KEY_PUBLIC=xxxxxxx
export FEC_CMS_ENVIRONMENT=LOCAL

3. test example url: (you can play different parameter. just make sure form_type=RFAI , click export to check csv files)
http://127.0.0.1:8000/data/filings/?data_type=processed&cycle=2018&min_receipt_date=05%2F29%2F2019&max_receipt_date=05%2F29%2F2019&form_type=RFAI

compare with production url (export blank page now):
https://www.fec.gov/data/filings/?data_type=processed&cycle=2018&min_receipt_date=05%2F29%2F2019&max_receipt_date=05%2F29%2F2019&form_type=RFAI

## Impacted areas of the application
List general components of the application that this PR will affect:
export csv data on https://www.fec.gov/data/filings/?data_type=processed


