### PR TITLE
Fix PR candidate totals on candidate and election profile pages

### DIFF
--- a/data/migrations/V0140__fix_cand_election.sql
+++ b/data/migrations/V0140__fix_cand_election.sql
@@ -1,12 +1,17 @@
 /*
 This migration file is to solve part of https://github.com/fecgov/openFEC/issues/3709
 
-update `ofec_candidate_election_mv` to use `candidate_election_duration` function
+`ofec_totals_candidate_committees_mv` depends on `ofec_candidate_election_vw`
+
+1) Update `ofec_candidate_election_mv` and, by extension, `ofec_candidate_election_vw`,
+ to use new `candidate_election_duration` function
+2) Drop function `election_duration` because it's no longer being used
+
 
 */
--- ---------------
--- ofec_candidate_election_mv
--- ---------------
+
+--1) Update `ofec_candidate_election_mv` and `ofec_candidate_election_vw`
+
 DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv_tmp;
 
 CREATE MATERIALIZED VIEW public.ofec_candidate_election_mv_tmp AS
@@ -23,11 +28,14 @@ CREATE MATERIALIZED VIEW public.ofec_candidate_election_mv_tmp AS
   ORDER BY years.candidate_id, years.cand_election_year, prev.cand_election_year DESC
 WITH DATA;
 
+--Permissions
+
 ALTER TABLE public.ofec_candidate_election_mv_tmp
   OWNER TO fec;
 GRANT ALL ON TABLE public.ofec_candidate_election_mv_tmp TO fec;
 GRANT SELECT ON TABLE public.ofec_candidate_election_mv_tmp TO fec_read;
 
+--Indices
 
 CREATE UNIQUE INDEX idx_ofec_candidate_election_mv_tmp_cand_id_cand_election_yr
   ON public.ofec_candidate_election_mv_tmp
@@ -48,14 +56,18 @@ CREATE INDEX idx_ofec_candidate_election_mv_tmp_prev_election_yr
   ON public.ofec_candidate_election_mv_tmp
   USING btree
   (prev_election_year);
+
 -- ---------------
 CREATE OR REPLACE VIEW public.ofec_candidate_election_vw AS
 SELECT * FROM public.ofec_candidate_election_mv_tmp;
 -- ---------------
+
 DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv;
 
 ALTER MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv_tmp RENAME TO ofec_candidate_election_mv;
+
 -- ---------------
+
 ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_id_cand_election_yr RENAME TO idx_ofec_candidate_election_mv_cand_id_cand_election_yr;
 
 ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_election_yr RENAME TO idx_ofec_candidate_election_mv_cand_election_yr;
@@ -63,3 +75,7 @@ ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_election_yr RENAME TO
 ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_id RENAME TO idx_ofec_candidate_election_mv_cand_id;
 
 ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_prev_election_yr RENAME TO idx_ofec_candidate_election_mv_prev_election_yr;
+
+-- 2) Drop function `election_duration` because it's no longer being used
+
+DROP FUNCTION IF EXISTS public.election_duration();

--- a/data/migrations/V0140__fix_cand_election.sql
+++ b/data/migrations/V0140__fix_cand_election.sql
@@ -1,0 +1,65 @@
+/*
+This migration file is to solve part of https://github.com/fecgov/openFEC/issues/3709
+
+update `ofec_candidate_election_mv` to use `candidate_election_duration` function
+
+*/
+-- ---------------
+-- ofec_candidate_election_mv
+-- ---------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_candidate_election_mv_tmp AS
+ WITH years AS (
+         SELECT cand_detail.candidate_id,
+            unnest(cand_detail.election_years) AS cand_election_year
+           FROM ofec_candidate_detail_vw cand_detail
+        )
+ SELECT DISTINCT ON (years.candidate_id, years.cand_election_year) years.candidate_id,
+    years.cand_election_year,
+    GREATEST(prev.cand_election_year, years.cand_election_year - candidate_election_duration(years.candidate_id)) AS prev_election_year
+   FROM years
+     LEFT JOIN years prev ON years.candidate_id::text = prev.candidate_id::text AND prev.cand_election_year < years.cand_election_year
+  ORDER BY years.candidate_id, years.cand_election_year, prev.cand_election_year DESC
+WITH DATA;
+
+ALTER TABLE public.ofec_candidate_election_mv_tmp
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_election_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_election_mv_tmp TO fec_read;
+
+
+CREATE UNIQUE INDEX idx_ofec_candidate_election_mv_tmp_cand_id_cand_election_yr
+  ON public.ofec_candidate_election_mv_tmp
+  USING btree
+  (candidate_id COLLATE pg_catalog."default", cand_election_year);
+
+CREATE INDEX idx_ofec_candidate_election_mv_tmp_cand_election_yr
+  ON public.ofec_candidate_election_mv_tmp
+  USING btree
+  (cand_election_year);
+
+CREATE INDEX idx_ofec_candidate_election_mv_tmp_cand_id
+  ON public.ofec_candidate_election_mv_tmp
+  USING btree
+  (candidate_id COLLATE pg_catalog."default");
+
+CREATE INDEX idx_ofec_candidate_election_mv_tmp_prev_election_yr
+  ON public.ofec_candidate_election_mv_tmp
+  USING btree
+  (prev_election_year);
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_candidate_election_vw AS
+SELECT * FROM public.ofec_candidate_election_mv_tmp;
+-- ---------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_candidate_election_mv_tmp RENAME TO ofec_candidate_election_mv;
+-- ---------------
+ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_id_cand_election_yr RENAME TO idx_ofec_candidate_election_mv_cand_id_cand_election_yr;
+
+ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_election_yr RENAME TO idx_ofec_candidate_election_mv_cand_election_yr;
+
+ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_cand_id RENAME TO idx_ofec_candidate_election_mv_cand_id;
+
+ALTER INDEX public.idx_ofec_candidate_election_mv_tmp_prev_election_yr RENAME TO idx_ofec_candidate_election_mv_prev_election_yr;

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -367,11 +367,14 @@ def filter_candidate_totals(query, kwargs, totals_model):
 
 
 def filter_candidate_totals_with_alternative_cand_election_yr(query, kwargs, totals_model):
-    duration = (
-        election_durations.get(kwargs['office'], 2)
-        if kwargs.get('election_full')
-        else 2
-    )
+    if kwargs.get('election_full'):
+        if kwargs.get('state', '').upper() == 'PR':
+            # PR house commissioners have 4-year cycles
+            duration = 4
+        else:
+            duration = election_durations.get(kwargs['office'], 2)
+    else:
+        duration = 2
     query = query.filter(
         CandidateHistory.two_year_period <= kwargs['cycle'],
         CandidateHistory.two_year_period > (kwargs['cycle'] - duration),

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -89,7 +89,7 @@ class ScheduleAView(ItemizedResource):
             'contributor_id',
             'contributor_name',
             'contributor_city',
-            'contributor_zip',
+            #'contributor_zip',
             'contributor_employer',
             'contributor_occupation',
             'image_number',


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/openFEC/issues/3709
Resolves https://github.com/fecgov/openFEC/issues/3823

Puerto Rico's house candidates (called "resident commissioners") have 4-year election cycles, unlike other house candidates that have 2-year cycles.

- Fix `candidate/id/totals` by using the new `candidate_election_duration` function that takes PR into consideration
- Drop unused `election_duration` database function
- Fix `/elections/` by adding handling for PR 4-year cycles
- Refactoring `/elections/`

## How to test the changes locally

- Drop/create `cfdm_test` and run `invoke create_sample_db` task to check migrations

### **/candidate/id/totals**
-  point `class CandidateCommitteeTotalsHouseSenate` to ` __tablename__ = 'ofec_totals_candidate_committees_mv_lb_tmp'` 
- check totals for http://localhost:5000/v1/candidate/H6PR00082/totals/?cycle=2020&api_key=DEMO_KEY&full_election=True should match http://localhost:5000/v1/candidates/totals/?candidate_id=H6PR00082&election_year=2020&election_full=true&sort=-receipts&api_key=DEMO_KEY
- You can check the front end candidate profile page by running the CMS locally, pointing to your local API, and going to http://localhost:8000/data/candidate/H6PR00082/

### **/elections/**
- Check that totals for `H6PR00082` on /elections/ http://localhost:5000/v1/elections/?candidate_id=H6PR00082&cycle=2020&election_full=true&office=house&sort_nulls_last=true&sort=-total_receipts&per_page=100&api_key=DEMO_KEY&state=PR&district=00&election_full=True match candidate totals http://localhost:5000/v1/candidate/H6PR00082/totals/?cycle=2020&api_key=DEMO_KEY&full_election=True
- You can check the front end election profile page by by running the CMS locally, pointing to your local API, and going to http://localhost:8000/data/elections/house/PR/00/2020/

## Impacted areas of the application
List general components of the application that this PR will affect:

- Candidate profile pages
- Election profile pages

## Related PRs
List related PRs against other branches:

- Original implementation of /elections/ `filter_candidate_totals` alternative logic: https://github.com/fecgov/openFEC/pull/3726/files
- Original implementation of database `candidate_election_duration` function: https://github.com/fecgov/openFEC/pull/3808/files