### PR TITLE
Add contributor zip back to secondary index list

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -89,7 +89,7 @@ class ScheduleAView(ItemizedResource):
             'contributor_id',
             'contributor_name',
             'contributor_city',
-            #'contributor_zip',
+            'contributor_zip',
             'contributor_employer',
             'contributor_occupation',
             'image_number',


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/2983

Add contributor zip back to secondary index list

## How to test the changes locally

- http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&contributor_zip=20009&two_year_transaction_period=2020&two_year_transaction_period=2018&sort=-contribution_receipt_date&per_page=30 should **not** throw an error, while https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&contributor_zip=20009&two_year_transaction_period=2020&two_year_transaction_period=2018&sort=-contribution_receipt_date&per_page=30 **does** throw an error

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Receipts datatables
