### PR TITLE
Remove credentials from migration url

### DIFF
--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -1,11 +1,8 @@
 import re
 def to_jdbc_url(dbi_url):
-    DB_URL_REGEX = re.compile(r'postgresql://(?P<username>[^:]*):?(?P<password>\S*)@(?P<host_port>\S*)$')
+    DB_URL_REGEX = re.compile(r'(?P<host_port>\S*)$')
     match = DB_URL_REGEX.match(dbi_url)
     if match:
-        jdbc_url = 'jdbc:postgresql://{}?user={}'.format(
-            match.group('host_port'), match.group('username'))
-        if match.group('password'):
-            jdbc_url += '&password={}'.format(match.group('password'))
+        jdbc_url = 'jdbc:postgresql://{}/fec'.format(match.group('host_port'))
         return jdbc_url
     return None

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -12,4 +12,7 @@ def get_jdbc_credentials(dbi_url):
 
 
 def remove_credentials(error):
-    return re.sub(r"\(.*", "", error)
+    message = "ERROR:"
+    if '(' in error:
+        message = error.split('(')[0]
+    return message

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -24,14 +24,19 @@ def to_jdbc_url(dbi_url):
 
 
 def remove_credentials(error):
-    """Remove credentials from PostgreSQL erorrs, preserve the error codes."""
+    """
+    For PostgreSQL errors, strip out everything except error code and description.
+    This prevents usernames from being printed.
+    For other Flyway-specific errors, go ahead leave them intact.
+    """
     code_lookup = {
         '08001': 'Connection attempt failed',
         '28P01': 'Password authentication failed',
+        '42501': 'Insufficient priveledge'
     }
-    message = "PostgreSQL error"
     match = re.search(r'.*(SQL State  : )+(?P<error>[a-zA-Z0-9]{0,5})', error)
     if match:
         error_code = match.group('error')
-        message += ' {}: {}'.format(error_code, code_lookup.get(error_code, "Unrecognized code. See PostgreSQL docs."))
-    return message
+        return 'PostgreSQL error code {}: {}'.format(error_code, code_lookup.get(error_code, "Unrecognized code. See PostgreSQL docs."))
+    else:
+        return error

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -7,5 +7,9 @@ def get_jdbc_credentials(dbi_url):
             match.group('host_port'))
         username = match.group('username')
         password = match.group('password')
-        return jdbc_url, username, password
+        return (jdbc_url, username, password)
     return None
+
+
+def remove_credentials(error):
+    return re.sub(r"\(.*", "", error)

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -1,5 +1,7 @@
 import re
+
 def get_jdbc_credentials(dbi_url):
+    """Extract username and password from connection string"""
     DB_URL_REGEX = re.compile(r'postgresql://(?P<username>[^:]*):?(?P<password>\S*)@(?P<host_port>\S*)$')
     match = DB_URL_REGEX.match(dbi_url)
     if match:
@@ -7,10 +9,11 @@ def get_jdbc_credentials(dbi_url):
             match.group('host_port'))
         username = match.group('username')
         password = match.group('password')
-        return (jdbc_url, username, password)
-    return (None, None, None)
+        return jdbc_url, username, password
+    return None, None, None
 
 def to_jdbc_url(dbi_url):
+    """Reformat PostgreSQL uri to JDBC uri"""
     jdbc_url, username, password = get_jdbc_credentials(dbi_url)
     if jdbc_url:
         jdbc_url = '{}?user={}'.format(jdbc_url, username)
@@ -19,8 +22,16 @@ def to_jdbc_url(dbi_url):
         return jdbc_url
     return None
 
+
 def remove_credentials(error):
-    message = "ERROR:"
-    if '(' in error:
-        message = error.split('(')[0]
+    """Remove credentials from PostgreSQL erorrs, preserve the error codes."""
+    code_lookup = {
+        '08001': 'Connection attempt failed',
+        '28P01': 'Password authentication failed',
+    }
+    message = "PostgreSQL error"
+    match = re.search(r'.*(SQL State  : )+(?P<error>[a-zA-Z0-9]{0,5})', error)
+    if match:
+        error_code = match.group('error')
+        message += ' {}: {}'.format(error_code, code_lookup.get(error_code, "Unrecognized code. See PostgreSQL docs."))
     return message

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -12,8 +12,10 @@ def get_jdbc_credentials(dbi_url):
 
 def to_jdbc_url(dbi_url):
     jdbc_url, username, password = get_jdbc_credentials(dbi_url)
-    if all((jdbc_url, username, password)):
-        jdbc_url = 'jdbc:postgresql://{}?user={}&password={}'.format(jdbc_url, username, password)
+    if jdbc_url:
+        jdbc_url = '{}?user={}'.format(jdbc_url, username)
+        if password:
+            jdbc_url += '&password={}'.format(password)
         return jdbc_url
     return None
 

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -8,8 +8,7 @@ def get_jdbc_credentials(dbi_url):
         username = match.group('username')
         password = match.group('password')
         return (jdbc_url, username, password)
-    return None
-
+    return (None, None, None)
 
 def remove_credentials(error):
     message = "ERROR:"

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -10,6 +10,13 @@ def get_jdbc_credentials(dbi_url):
         return (jdbc_url, username, password)
     return (None, None, None)
 
+def to_jdbc_url(dbi_url):
+    jdbc_url, username, password = get_jdbc_credentials(dbi_url)
+    if all((jdbc_url, username, password)):
+        jdbc_url = 'jdbc:postgresql://{}?user={}&password={}'.format(jdbc_url, username, password)
+        return jdbc_url
+    return None
+
 def remove_credentials(error):
     message = "ERROR:"
     if '(' in error:

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -1,8 +1,11 @@
 import re
-def to_jdbc_url(dbi_url):
-    DB_URL_REGEX = re.compile(r'(?P<host_port>\S*)$')
+def get_jdbc_credentials(dbi_url):
+    DB_URL_REGEX = re.compile(r'postgresql://(?P<username>[^:]*):?(?P<password>\S*)@(?P<host_port>\S*)$')
     match = DB_URL_REGEX.match(dbi_url)
     if match:
-        jdbc_url = 'jdbc:postgresql://{}/fec'.format(match.group('host_port'))
-        return jdbc_url
+        jdbc_url = 'jdbc:postgresql://{}'.format(
+            match.group('host_port'))
+        username = match.group('username')
+        password = match.group('password')
+        return jdbc_url, username, password
     return None

--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import git
 
-from invoke import task
+from invoke import task, exceptions
 from webservices.env import env
 from jdbc_utils import get_jdbc_credentials, to_jdbc_url, remove_credentials
 
@@ -196,7 +196,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
                     migration_env_var
                 )
             )
-            return
+            raise exceptions.Exit(1)
 
         print("\nMigrating database...")
 
@@ -204,7 +204,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
         if result.failed:
             print("Migration failed!")
             print(remove_credentials(result.stderr))
-            return
+            raise exceptions.Exit(1)
 
         print("Database migrated.\n")
 

--- a/tasks.py
+++ b/tasks.py
@@ -185,7 +185,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
         print("\nSkipping migrations. Database not migrated.\n")
     else:
         migration_env_var = 'FEC_MIGRATOR_SQLA_CONN_{0}'.format(space.upper())
-        migration_conn = os.getenv(migration_env_var)
+        migration_conn = os.getenv(migration_env_var, '')
         jdbc_url, migration_user, migration_password = get_jdbc_credentials(
             migration_conn
         )
@@ -231,8 +231,8 @@ def create_sample_db(ctx):
 
     print("Loading schema...")
     db_conn = os.getenv('SQLA_SAMPLE_DB_CONN')
-    jdbc_url = get_jdbc_credentials(db_conn)
-    run_migrations(ctx, jdbc_url)
+    jdbc_url, migration_user, migration_password = get_jdbc_credentials(db_conn)
+    run_migrations(ctx, jdbc_url, migration_user, migration_password)
     print("Schema loaded")
 
     print("Loading sample data...")

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,7 +12,6 @@ from webservices import rest
 from webservices.common import models
 from webservices import __API_VERSION__
 
-
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
 rest.app.config['NPLUSONE_RAISE'] = True
 NPlusOne(rest.app)

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ import unittest
 from webtest import TestApp
 from nplusone.ext.flask_sqlalchemy import NPlusOne
 
-from jdbc_utils import to_jdbc_url
+from jdbc_utils import get_jdbc_credentials
 from webservices import rest
 from webservices.common import models
 from webservices import __API_VERSION__
@@ -116,7 +116,7 @@ def get_test_jdbc_url():
     Return the JDBC URL for TEST_CONN. If TEST_CONN cannot be successfully converted,
     it is probably the default Postgres instance with trust authentication
     """
-    jdbc_url = to_jdbc_url(TEST_CONN)
+    jdbc_url = get_jdbc_credentials(TEST_CONN)
     if jdbc_url is None:
         jdbc_url = "jdbc:" + TEST_CONN
     return jdbc_url

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ import unittest
 from webtest import TestApp
 from nplusone.ext.flask_sqlalchemy import NPlusOne
 
-from jdbc_utils import get_jdbc_credentials
+from jdbc_utils import to_jdbc_url
 from webservices import rest
 from webservices.common import models
 from webservices import __API_VERSION__
@@ -116,7 +116,7 @@ def get_test_jdbc_url():
     Return the JDBC URL for TEST_CONN. If TEST_CONN cannot be successfully converted,
     it is probably the default Postgres instance with trust authentication
     """
-    jdbc_url = get_jdbc_credentials(TEST_CONN)
+    jdbc_url = to_jdbc_url(TEST_CONN)
     if jdbc_url is None:
         jdbc_url = "jdbc:" + TEST_CONN
     return jdbc_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def migrate_db(request):
 
 def run_migrations():
     subprocess.check_call(
-        ['flyway', 'migrate', '-n', '-url=%s' % get_test_jdbc_url(), '-locations=filesystem:data/migrations'],)
+        ['flyway', 'migrate', '-n', '-url={0}'.format(get_test_jdbc_url()), '-locations=filesystem:data/migrations'],)
 
 def reset_schema():
     for schema in [


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/fec-accounts/issues/182

- Remove username/password from migration url, pass as username/password parameters to prevent displaying password in URL
- Strip out username from postgres error messages, preserve Flyway-specific error messages because they don't print username and we need them for debugging
- Fail build when deploy task fails (it was failing silently with `return` and that made it look like the build passed when it really didn't. See http://docs.pyinvoke.org/en/1.2/api/exceptions.html#invoke.exceptions.Exit for info on the built-in "clean" exit without stack trace)

## How to test the changes locally

**Successful migration**
-  Set `FEC_MIGRATOR_SQLA_CONN_DEV`
- Target `dev` space
- Make sure you don't have any new migration files (you can check out this branch)
- Run `invoke deploy --space dev --migrate-database`
- Migrations should "run" even though there are new ones


**Unsuccessful migration**
- Change the `FEC_MIGRATOR_URL_DEV` to something that doesn't exist (you can test bad DB name, bad username, bad password)
- Note the error message (talk to @lbeaufort if you want to know more about how to test this properly)

## Impacted areas of the application
- DB migrations

## Related PRs
List related PRs against other branches:

Original implementation of Circle automated migrations: https://github.com/fecgov/openFEC/pull/2768

