### PR TITLE
Add org_type and designation to schedules a and b

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -172,6 +172,24 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleAView, recipient_committee_type='S', **self.kwargs))
         self.assertEqual(len(results), 2)
 
+    def test_sched_a_recipient_org_type_filter(self):
+        [
+            factories.ScheduleAFactory(recipient_committee_org_type='W'),
+            factories.ScheduleAFactory(recipient_committee_org_type='W'),
+            factories.ScheduleAFactory(recipient_committee_org_type='C'),
+        ]
+        results = self._results(api.url_for(ScheduleAView, recipient_committee_org_type='W', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
+    def test_sched_a_recipient_designation_filter(self):
+        [
+            factories.ScheduleAFactory(recipient_committee_designation='P'),
+            factories.ScheduleAFactory(recipient_committee_designation='P'),
+            factories.ScheduleAFactory(recipient_committee_designation='A'),
+        ]
+        results = self._results(api.url_for(ScheduleAView, recipient_committee_designation='P', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
     def test_filter_multi_start_with(self):
         [
             factories.ScheduleAFactory(contributor_zip=1296789)
@@ -237,6 +255,24 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleBView, spender_committee_type='S', **self.kwargs))
         self.assertEqual(len(results), 2)
 
+    def test_sched_b_spender_org_type_filter(self):
+        [
+            factories.ScheduleBFactory(spender_committee_org_type='W'),
+            factories.ScheduleBFactory(spender_committee_org_type='W'),
+            factories.ScheduleBFactory(spender_committee_org_type='C'),
+        ]
+        results = self._results(api.url_for(ScheduleBView, spender_committee_org_type='W', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
+    def test_sched_b_spender_designation_filter(self):
+        [
+            factories.ScheduleBFactory(spender_committee_designation='P'),
+            factories.ScheduleBFactory(spender_committee_designation='P'),
+            factories.ScheduleBFactory(spender_committee_designation='A'),
+        ]
+        results = self._results(api.url_for(ScheduleBView, spender_committee_designation='P', **self.kwargs))
+        self.assertEqual(len(results), 2)
+
     def test_filter_fulltext_employer(self):
         employers = ['Acme Corporation', 'Vandelay Industries']
         filings = [
@@ -261,7 +297,7 @@ class TestItemized(ApiBaseTest):
         self.assertIn(results[0]['contributor_employer'], employers)
         results = self._results(api.url_for(ScheduleAView, contributor_employer='Test &Test', **self.kwargs))
         self.assertIn(results[0]['contributor_employer'], employers)
-        
+
     def test_filter_fulltext_occupation(self):
         occupations = ['Attorney at Law', 'Doctor of Philosophy']
         filings = [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -482,6 +482,15 @@ schedule_a = {
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
         description=docs.COMMITTEE_TYPE,
     ),
+    'recipient_committee_org_type': fields.List(
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        description=docs.ORGANIZATION_TYPE,
+    ),
+    'recipient_committee_designation': fields.List(
+        IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
+        description=docs.DESIGNATION,
+    ),
+
 }
 
 schedule_a_e_file = {
@@ -557,6 +566,15 @@ schedule_b = {
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
         description=docs.COMMITTEE_TYPE,
     ),
+    'spender_committee_org_type': fields.List(
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        description=docs.ORGANIZATION_TYPE,
+    ),
+    'spender_committee_designation': fields.List(
+        IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
+        description=docs.DESIGNATION,
+    ),
+
 }
 
 schedule_b_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -99,6 +99,8 @@ class ScheduleA(BaseItemized):
 
     contributor_name = db.Column('contbr_nm', db.String, doc=docs.CONTRIBUTOR_NAME)
     recipient_committee_type = db.Column('cmte_tp', db.String(1), index=True)
+    recipient_committee_org_type = db.Column('org_tp', db.String(1), index=True)
+    recipient_committee_designation = db.Column('cmte_dsgn', db.String(1), index=True)
 
     contributor_name_text = db.Column(TSVECTOR)
     contributor_first_name = db.Column('contbr_nm_first', db.String)
@@ -359,6 +361,8 @@ class ScheduleB(BaseItemized):
     comm_dt = db.Column('comm_dt', db.Date)
 
     spender_committee_type = db.Column('cmte_tp', db.String(1), index=True)
+    spender_committee_org_type = db.Column('org_tp', db.String(1), index=True)
+    spender_committee_designation = db.Column('cmte_dsgn', db.String(1), index=True)
 
     @hybrid_property
     def sort_expressions(self):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -43,6 +43,8 @@ class ScheduleAView(ItemizedResource):
         ('contributor_city', models.ScheduleA.contributor_city),
         ('contributor_state', models.ScheduleA.contributor_state),
         ('recipient_committee_type', models.ScheduleA.recipient_committee_type),
+        ('recipient_committee_org_type', models.ScheduleA.recipient_committee_org_type),
+        ('recipient_committee_designation', models.ScheduleA.recipient_committee_designation),
         ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_match_fields = [

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -42,6 +42,8 @@ class ScheduleBView(ItemizedResource):
         ('disbursement_purpose_category',
          models.ScheduleB.disbursement_purpose_category),
         ('spender_committee_type', models.ScheduleB.spender_committee_type),
+        ('spender_committee_org_type', models.ScheduleB.spender_committee_org_type),
+        ('spender_committee_designation', models.ScheduleB.spender_committee_designation),
         ('two_year_transaction_period',
          models.ScheduleB.two_year_transaction_period),
     ]


### PR DESCRIPTION
## Summary (required)

- Resolves #3841

Add org_type and designation to schedules A and B: filters are:
**Schedule A**
`recipient_committee_org_type`
`recipient_committee_designation `
**Schedule B**
`spender_committee_org_type`
`spender_committee_designation `

## How to test the changes locally

- point to `dev` database

**Leadership PACs**
- Schedule A: http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&recipient_committee_designation=D&per_page=30
- Schedule B: http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&spender_committee_designation=D&per_page=30

**Lobbyist registrant PACs**
- Schedule A: http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&recipient_committee_designation=B&per_page=30
- Schedule B: http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&spender_committee_designation=B&per_page=30

**SSFs**

- C corporation
- L labor organization
- M membership organization
- T trade association
- V cooperative
- W corporation without capital stock

Example but you can test all of the above
- Schedule A: http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&recipient_committee_org_type=C&per_page=30
- Schedule B: http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&two_year_transaction_period=2020&spender_committee_org_type=C&per_page=30

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Receipts, Individual Contributions, and Disbursements datatables

