### PR TITLE
Update celery and related packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/fecgov/apispec.git@dev
 #prance[osv]>=0.11 # pathlib dependency is breaking pytest
 cfenv==0.5.2
 invoke==0.15.0
-kombu==4.5.0
+kombu==4.6.3
 psycopg2-binary==2.7.4
 Flask==1.0.2
 Flask-Cors==3.0.6
@@ -36,6 +36,6 @@ git+https://github.com/jmcarp/marshmallow-pagination@master
 smart_open==1.7.1
 
 # Task queue
-celery==4.1.1 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
-celery-once==1.2.0
+celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
+celery-once==3.0.0
 redis==3.2.0


### PR DESCRIPTION
## Summary (required)

- Possible resolution for #3840 

_Update celery and related packages._

## How to test the changes locally

### Deploy to dev
- Install requirements with `pip install -r requirements.txt`
- Deploy to `dev`: `invoke deploy --space dev`
- Point your local CMS to `dev`, test a download
- Check for nightly refreshes

### Local testing
- Install requirements with `pip install -r requirements.txt`
- Set up celery/redis using the wiki instructions: https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads
- (optional) Set up elasticsearch locally 
- Test celery with a download from the front-end or schedule a refresh 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Downloads, reloading legal tasks, nightly refresh

