### PR TITLE
Change default value of election_full to True

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -398,6 +398,12 @@ class TestCandidateAggregates(ApiBaseTest):
             is_election=False,
             receipts=0,
         )
+        factories.CandidateTotalFactory(
+            candidate_id=self.candidate_zero.candidate_id,
+            cycle=2018,
+            is_election=True,
+            receipts=0,
+        )
         # Create data for a candidate who ran in 2017 and 2018
 
         self.candidate_17_18 = factories.CandidateHistoryFutureFactory(
@@ -650,6 +656,19 @@ class TestCandidateAggregates(ApiBaseTest):
         assert results[0] == expected
 
     def test_totals(self):
+        # 2-year totals
+        results = self._results(
+            api.url_for(
+                TotalsCandidateView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                election_full=False
+            )
+        )
+        assert len(results) == 1
+        assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 75})
+
+        # Full-cycle totals (default is true)
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
@@ -658,10 +677,10 @@ class TestCandidateAggregates(ApiBaseTest):
             )
         )
         assert len(results) == 1
-        assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 75})
+        assert_dicts_subset(results[0], {'cycle': 2012, 'receipts': 100})
 
         # candidate_zero
-        # by default, load all candidates, current candidate should return 
+        # by default, load all candidates, current candidate should return
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
@@ -745,6 +764,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_20.candidate_id,
                 cycle=self.current_cycle,
+                election_full=False
             )
         )
         assert len(results) == 1
@@ -961,8 +981,8 @@ class TestCandidateTotalsByOfficeByParty(ApiBaseTest):
             )
         )
         assert len(results) == 2
-        assert_dicts_subset(results[0], {'election_year': 2016, 'party': 'DEM', 'total_receipts': 100, 'total_disbursements': 100})            
-        assert_dicts_subset(results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 10000, 'total_disbursements': 10000})            
+        assert_dicts_subset(results[0], {'election_year': 2016, 'party': 'DEM', 'total_receipts': 100, 'total_disbursements': 100})
+        assert_dicts_subset(results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 10000, 'total_disbursements': 10000})
 
 
         results = self._results(
@@ -973,6 +993,6 @@ class TestCandidateTotalsByOfficeByParty(ApiBaseTest):
             )
         )
         assert len(results) == 2
-        assert_dicts_subset(results[0], {'election_year': 2016, 'party': 'Other', 'total_receipts': 300, 'total_disbursements': 300})            
-        assert_dicts_subset(results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 200, 'total_disbursements': 200})            
+        assert_dicts_subset(results[0], {'election_year': 2016, 'party': 'Other', 'total_receipts': 300, 'total_disbursements': 300})
+        assert_dicts_subset(results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 200, 'total_disbursements': 200})
 

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -251,6 +251,7 @@ class TestAggregates(ApiBaseTest):
                     committee_id=self.committee.committee_id,
                     cycle=2012,
                     office='president',
+                    election_full=False,
                 )
             )
             assert len(results) == 1
@@ -708,7 +709,8 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_zero.candidate_id,
                 cycle=2018,
-                is_active_candidate=False
+                is_active_candidate=False,
+                election_full=False,
             )
         )
         assert len(results) == 1

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -291,7 +291,7 @@ class TestCandidateHistory(ApiBaseTest):
         results = self._results(
             api.url_for(
                 CandidateHistoryView,
-                committee_id=self.committee.committee_id, cycle=2012,
+                committee_id=self.committee.committee_id, cycle=2012, election_full=False
             )
         )
         assert len(results) == 1

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -353,7 +353,7 @@ class TestCommitteeHistory(ApiBaseTest):
         results = self._results(
             api.url_for(
                 CommitteeHistoryView,
-                candidate_id=self.candidate.candidate_id, cycle=2012,
+                candidate_id=self.candidate.candidate_id, cycle=2012, election_full=False
             )
         )
         assert len(results) == 1

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -274,7 +274,7 @@ class TestElections(ApiBaseTest):
         assert len(results) == 0
 
     def test_elections(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
+        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY', election_full=False))
         self.assertEqual(len(results), 1)
         totals = [each for each in self.totals if each.cycle == 2012]
         expected = {
@@ -379,7 +379,7 @@ class TestElections(ApiBaseTest):
             each.committee_id for each in self.committees
             if each.designation != 'J')
     def test_election_summary(self):
-        results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY'))
+        results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY', election_full=False))
         totals = [each for each in self.totals if each.cycle == 2012]
         self.assertEqual(results['count'], 1)
         self.assertEqual(results['receipts'], sum(each.receipts for each in totals))
@@ -476,7 +476,7 @@ class TestPRElections(ApiBaseTest):
         db.session.flush()
 
     def test_elections_2_year(self):
-        results = self._results(api.url_for(ElectionView, office='house', district='00',cycle=2020, state='PR'))
+        results = self._results(api.url_for(ElectionView, office='house', district='00',cycle=2020, state='PR', election_full=False))
         self.assertEqual(len(results), 1)
         totals = [each for each in self.totals if each.cycle == 2020]
         expected = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -683,7 +683,7 @@ elections = {
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
     ),
-    'election_full': fields.Bool(missing=False, description='Aggregate values over full election period'),
+    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
 }
 
 state_election_office_info = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -281,7 +281,7 @@ committee_list = {
 }
 
 committee_history = {
-    'election_full': election_full,
+    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
 }
 
 filings = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -702,7 +702,7 @@ candidate_totals = {
     'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description='Governmental office candidate runs for: House, Senate or presidential'),
-    'election_full': election_full,
+    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period. Defaults to True.'),
     'state': fields.List(IStr, description='State of candidate'),
     'district': fields.List(District, description='District of candidate'),
     'party': fields.List(IStr, description='Three-letter party code'),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -51,7 +51,7 @@ class District(fields.Str):
     def _deserialize(self, value, attr, data):
         return '{0:0>2}'.format(value)
 
-election_full = fields.Bool(missing=False, description='Aggregate values over full election period')
+election_full = fields.Bool(missing=True, description='Aggregate values over full election period')
 
 paging = {
     'page': Natural(missing=1, description='For paginating through results, starting at page 1'),
@@ -241,7 +241,7 @@ candidate_list = {
 }
 
 candidate_history = {
-    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
+    'election_full': election_full,
 }
 
 committee = {
@@ -281,7 +281,7 @@ committee_list = {
 }
 
 committee_history = {
-    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
+    'election_full': election_full,
 }
 
 filings = {
@@ -683,7 +683,7 @@ elections = {
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
     ),
-    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
+    'election_full': election_full,
 }
 
 state_election_office_info = {
@@ -693,7 +693,7 @@ state_election_office_info = {
 schedule_a_candidate_aggregate = {
     'candidate_id': fields.List(IStr, required=True, description=docs.CANDIDATE_ID),
     'cycle': fields.List(fields.Int, required=True, description=docs.RECORD_CYCLE),
-    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
+    'election_full': election_full,
 }
 
 candidate_totals = {
@@ -702,7 +702,7 @@ candidate_totals = {
     'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description='Governmental office candidate runs for: House, Senate or presidential'),
-    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period. Defaults to True.'),
+    'election_full': election_full,
     'state': fields.List(IStr, description='State of candidate'),
     'district': fields.List(District, description='District of candidate'),
     'party': fields.List(IStr, description='Three-letter party code'),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -241,7 +241,7 @@ candidate_list = {
 }
 
 candidate_history = {
-    'election_full': election_full,
+    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
 }
 
 committee = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -683,7 +683,7 @@ elections = {
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
     ),
-    'election_full': election_full,
+    'election_full': fields.Bool(missing=False, description='Aggregate values over full election period'),
 }
 
 state_election_office_info = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -693,7 +693,7 @@ state_election_office_info = {
 schedule_a_candidate_aggregate = {
     'candidate_id': fields.List(IStr, required=True, description=docs.CANDIDATE_ID),
     'cycle': fields.List(fields.Int, required=True, description=docs.RECORD_CYCLE),
-    'election_full': election_full,
+    'election_full': fields.Bool(missing=True, description='Aggregate values over full election period'),
 }
 
 candidate_totals = {


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/3686

Change default value of `election_full` to `True`

## How to test the changes locally

Counts should match for /candidates/ and /candidates/totals/: 
http://localhost:5000/v1/candidates/?election_year=2019&election_year=2020&office=P
should match or be very close to 
http://localhost:5000/v1/candidates/totals/?election_year=2020&office=P
(/candidates/totals/ rounds election years and /candidates/ doesn't, which is why I've included 2019)

http://localhost:5000/v1/candidates/?election_year=2019&election_year=2020&office=H
should match or be very close to 
http://localhost:5000/v1/candidates/totals/?election_year=2020&office=H

## Impacted areas of the application
Following endpoints default to `election_full=True` if not specified:

`args.candidate_history`
- `/candidate/<candidate_id>/history/`
- `/candidate/<candidate_id>/history/<int:cycle>/`
- `/committee/<committee_id>/candidates/history/`
- `/committee/<committee_id>/candidates/history/<int:cycle>/`

`args.committee_history`
- `/committee/<committee_id>/history/`
- `/committee/<committee_id>/history/<int:cycle>/`
- `/candidate/<candidate_id>/committees/history/
-  `/candidate/<candidate_id>/committees/history/<int:cycle>/`

`args.elections`
- `/schedules/schedule_e/by_candidate/`
- `/committee/<committee_id>/schedules/schedule_e/by_candidate/`
- `/communication_costs/by_candidate/`
- `/committee/<committee_id>/communication_costs/by_candidate/`
- `/electioneering/by_candidate/`,
- `/committee/<committee_id>/electioneering/by_candidate/`
- `/elections/`
- `/elections/summary/`

`args.schedule_a_candidate_aggregate`
- `/schedules/schedule_a/by_size/by_candidate/`
- `/schedules/schedule_a/by_state/by_candidate/`

`args.candidate_totals`
- `/candidates/totals/`




## Related PRs

Front-end work: 

branch | PR
------ | ------
feature/specify-election-full | https://github.com/fecgov/fec-cms/pull/3012
