### PR TITLE
Add swagger tests back.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/fecgov/apispec.git@dev
-#prance[osv]>=0.11 # pathlib dependency is breaking pytest
+prance[osv]>=0.11
 cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -8,11 +8,11 @@ from webservices.spec import spec, format_docstring
 
 class TestSwagger(unittest.TestCase):
 
-    # def test_swagger_valid(self):
-    #     try:
-    #         utils.validate_spec(spec)
-    #     except exceptions.SwaggerError as error:
-    #         self.fail(str(error))
+    def test_swagger_valid(self):
+        try:
+            utils.validate_spec(spec)
+        except exceptions.SwaggerError as error:
+            self.fail(str(error))
 
     def test_format_docstring(self):
         DOCSTRING = '''


### PR DESCRIPTION
## Summary (required)
OSV is a third party package we rely on for swagger validation. There was a breaking change few months ago  on OSV  package whose dependency package pathlib got updated/replaced with pathlib2 package that impacted swagger tests in openFEC repo.

- Resolves #3612

_Include a summary of proposed changes._

add the swagger tests back in `tests/test_swagger.py`.
add forked OSV package back in requirements.txt


## How to test the changes locally

- run `pip install -r requirements.txt`
- run `pytest` make sure all the python tests run OK.
