### PR TITLE
Add committee_name into 3 committee reports MV and export files

### DIFF
--- a/data/migrations/V0146__ofec_report_presidential_mv.sql
+++ b/data/migrations/V0146__ofec_report_presidential_mv.sql
@@ -1,0 +1,232 @@
+-- ---------public.ofec_reports_presidential_mv---------
+-- public.ofec_reports_presidential_mv represents Presidential committee reports(f3p).
+-- data from 3 tables: 
+-- disclosure.nml_form_3p
+-- disclosure.v_sum_and_det_sum_report
+-- disclosure.cmte_valid_fec_yr
+-- and depends on 1 view : ofec_filings_amendments_all_vw
+-- 
+-- -----------------------------------------------------
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_presidential_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3p.cmte_id AS committee_id,
+    f3p.rpt_yr + f3p.rpt_yr % 2::numeric AS cycle,
+    f3p.cvg_start_dt AS coverage_start_date,
+    f3p.cvg_end_dt AS coverage_end_date,
+    f3p.begin_image_num AS beginning_image_number,
+    f3p.cand_contb_per AS candidate_contribution_period,
+    f3p.cand_contb_ytd AS candidate_contribution_ytd,
+    f3p.coh_bop AS cash_on_hand_beginning_period,
+    f3p.coh_cop AS cash_on_hand_end_period,
+    f3p.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3p.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3p.end_image_num AS end_image_number,
+    f3p.exempt_legal_acctg_disb_per AS exempt_legal_accounting_disbursement_period,
+    f3p.exempt_legal_acctg_disb_ytd AS exempt_legal_accounting_disbursement_ytd,
+    f3p.exp_subject_limits AS expenditure_subject_to_limits,
+    f3p.fed_funds_per AS federal_funds_period,
+    f3p.fed_funds_ytd AS federal_funds_ytd,
+    f3p.fndrsg_disb_per AS fundraising_disbursements_period,
+    f3p.fndrsg_disb_ytd AS fundraising_disbursements_ytd,
+    f3p.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3p.indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3p.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3p.indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3p.indv_contb_per AS total_individual_contributions_period,
+    f3p.indv_contb_ytd AS total_individual_contributions_ytd,
+    f3p.items_on_hand_liquidated,
+    f3p.loans_received_from_cand_per AS loans_received_from_candidate_period,
+    f3p.loans_received_from_cand_ytd AS loans_received_from_candidate_ytd,
+    f3p.net_contb_sum_page_per AS net_contributions_cycle_to_date,
+    f3p.net_op_exp_sum_page_per AS net_operating_expenditures_cycle_to_date,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_exp_ytd,
+    f3p.offsets_to_fndrsg_exp_per AS offsets_to_fundraising_expenditures_period,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_expenditures_ytd,
+    f3p.offsets_to_legal_acctg_per AS offsets_to_legal_accounting_period,
+    f3p.offsets_to_legal_acctg_ytd AS offsets_to_legal_accounting_ytd,
+    f3p.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3p.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3p.op_exp_per AS operating_expenditures_period,
+    f3p.op_exp_ytd AS operating_expenditures_ytd,
+    f3p.other_disb_per AS other_disbursements_period,
+    f3p.other_disb_ytd AS other_disbursements_ytd,
+    f3p.other_loans_received_per AS other_loans_received_period,
+    f3p.other_loans_received_ytd,
+    f3p.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3p.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3p.other_receipts_per AS other_receipts_period,
+    f3p.other_receipts_ytd,
+    f3p.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3p.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3p.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3p.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3p.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3p.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3p.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3p.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3p.repymts_loans_made_by_cand_per AS repayments_loans_made_by_candidate_period,
+    f3p.repymts_loans_made_cand_ytd AS repayments_loans_made_candidate_ytd,
+    f3p.repymts_other_loans_per AS repayments_other_loans_period,
+    f3p.repymts_other_loans_ytd AS repayments_other_loans_ytd,
+    f3p.rpt_yr AS report_year,
+    f3p.subttl_sum_page_per AS subtotal_summary_period,
+    f3p.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3p.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3p.ttl_contb_per AS total_contributions_period,
+    f3p.ttl_contb_ytd AS total_contributions_ytd,
+    f3p.ttl_disb_per AS total_disbursements_period,
+    f3p.ttl_disb_ytd AS total_disbursements_ytd,
+    f3p.ttl_loan_repymts_made_per AS total_loan_repayments_made_period,
+    f3p.ttl_loan_repymts_made_ytd AS total_loan_repayments_made_ytd,
+    f3p.ttl_loans_received_per AS total_loans_received_period,
+    f3p.ttl_loans_received_ytd AS total_loans_received_ytd,
+    f3p.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3p.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3p.ttl_per AS total_period,
+    f3p.ttl_receipts_per AS total_receipts_period,
+    f3p.ttl_receipts_ytd AS total_receipts_ytd,
+    f3p.ttl_ytd AS total_ytd,
+    f3p.tranf_from_affilated_cmte_per AS transfers_from_affiliated_committee_period,
+    f3p.tranf_from_affiliated_cmte_ytd AS transfers_from_affiliated_committee_ytd,
+    f3p.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3p.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3p.rpt_tp AS report_type,
+    f3p.rpt_tp_desc AS report_type_full,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3p.receipt_dt AS receipt_date,
+    f3p.file_num AS file_number,
+    f3p.amndt_ind AS amendment_indicator,
+    f3p.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3p.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3p.begin_image_num::text), f3p.cmte_id::text, f3p.file_num::text) AS html_url,
+    report_fec_url(f3p.begin_image_num::text, f3p.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3p.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name  
+  FROM disclosure.nml_form_3p f3p
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3p.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3p.rpt_yr + f3p.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3p.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3p.file_num = amendments.file_num
+  WHERE f3p.rpt_yr >= 1979::numeric AND f3p.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_presidential_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_presidential_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_presidential_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_presidential_mv_tmp_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+ 
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_is_amen_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (is_amended, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (receipt_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+    
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_reports_presidential_vw AS 
+  SELECT * FROM public.ofec_reports_presidential_mv_tmp;
+-- ---------------
+
+
+-- drop old MV:ofec_reports_presidential_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp 
+  RENAME TO ofec_reports_presidential_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_idx RENAME TO idx_ofec_reports_presidential_mv_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_disb_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_presidential_mv_beg_image_num_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_presidential_mv_cmte_id_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_end_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_start_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_presidential_mv_cyc_cmte_id;
+ 
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_presidential_mv_cyc_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_presidential_mv_is_amen_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_presidential_mv_rcpt_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_type_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_rcpt_period_idx;

--- a/data/migrations/V0147__ofec_report_house_senate_mv.sql
+++ b/data/migrations/V0147__ofec_report_house_senate_mv.sql
@@ -214,7 +214,7 @@ ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cyc_idx RENAME TO idx_of
     
 ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_house_senate_mv_is_amen_idx;
     
-ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx RENAME TO dx_ofec_reports_house_senate_mv_rcpt_date_idx;
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_house_senate_mv_rcpt_date_idx;
     
 ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_type_idx;
     

--- a/data/migrations/V0147__ofec_report_house_senate_mv.sql
+++ b/data/migrations/V0147__ofec_report_house_senate_mv.sql
@@ -1,0 +1,224 @@
+-- --------(1)public.ofec_reports_house_senate_mv--------------
+-- public.ofec_reports_house_senate_mv represents House and Senate committee reports(f3).
+-- data from 3 tables: 
+-- disclosure.nml_form_3
+-- disclosure.v_sum_and_det_sum_report
+-- disclosure.cmte_valid_fec_yr
+-- and depends on 1 view : ofec_filings_amendments_all_vw
+-- 
+-- -----------------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS public.oofec_reports_house_senate_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_house_senate_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3.cmte_id AS committee_id,
+    f3.rpt_yr + f3.rpt_yr % 2::numeric AS cycle,
+    f3.cvg_start_dt AS coverage_start_date,
+    f3.cvg_end_dt AS coverage_end_date,
+    f3.agr_amt_pers_contrib_gen AS aggregate_amount_personal_contributions_general,
+    f3.agr_amt_contrib_pers_fund_prim AS aggregate_contributions_personal_funds_primary,
+    f3.all_other_loans_per AS all_other_loans_period,
+    f3.all_other_loans_ytd,
+    f3.begin_image_num AS beginning_image_number,
+    f3.cand_contb_per AS candidate_contribution_period,
+    f3.cand_contb_ytd AS candidate_contribution_ytd,
+    f3.coh_bop AS cash_on_hand_beginning_period,
+    GREATEST(f3.coh_cop_i, f3.coh_cop_ii) AS cash_on_hand_end_period,
+    f3.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3.end_image_num AS end_image_number,
+    f3.grs_rcpt_auth_cmte_gen AS gross_receipt_authorized_committee_general,
+    f3.grs_rcpt_auth_cmte_prim AS gross_receipt_authorized_committee_primary,
+    f3.grs_rcpt_min_pers_contrib_gen AS gross_receipt_minus_personal_contribution_general,
+    f3.grs_rcpt_min_pers_contrib_prim AS gross_receipt_minus_personal_contributions_primary,
+    f3.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3.loan_repymts_cand_loans_per AS loan_repayments_candidate_loans_period,
+    f3.loan_repymts_cand_loans_ytd AS loan_repayments_candidate_loans_ytd,
+    f3.loan_repymts_other_loans_per AS loan_repayments_other_loans_period,
+    f3.loan_repymts_other_loans_ytd AS loan_repayments_other_loans_ytd,
+    f3.loans_made_by_cand_per AS loans_made_by_candidate_period,
+    f3.loans_made_by_cand_ytd AS loans_made_by_candidate_ytd,
+    f3.net_contb_per AS net_contributions_period,
+    f3.net_contb_ytd AS net_contributions_ytd,
+    f3.net_op_exp_per AS net_operating_expenditures_period,
+    f3.net_op_exp_ytd AS net_operating_expenditures_ytd,
+    f3.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3.op_exp_per AS operating_expenditures_period,
+    f3.op_exp_ytd AS operating_expenditures_ytd,
+    f3.other_disb_per AS other_disbursements_period,
+    f3.other_disb_ytd AS other_disbursements_ytd,
+    f3.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3.other_receipts_per AS other_receipts_period,
+    f3.other_receipts_ytd,
+    f3.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3.ref_ttl_contb_col_ttl_ytd AS refunds_total_contributions_col_total_ytd,
+    f3.subttl_per AS subtotal_period,
+    f3.ttl_contb_ref_col_ttl_per AS total_contribution_refunds_col_total_period,
+    f3.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3.ttl_contb_column_ttl_per AS total_contributions_column_total_period,
+    f3.ttl_contb_per AS total_contributions_period,
+    f3.ttl_contb_ytd AS total_contributions_ytd,
+    GREATEST(f3.ttl_disb_per_i, f3.ttl_disb_per_ii) AS total_disbursements_period,
+    f3.ttl_disb_ytd AS total_disbursements_ytd,
+    f3.ttl_indv_contb_per AS total_individual_contributions_period,
+    f3.ttl_indv_contb_ytd AS total_individual_contributions_ytd,
+    f3.ttl_indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3.ttl_indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3.ttl_loan_repymts_per AS total_loan_repayments_made_period,
+    f3.ttl_loan_repymts_ytd AS total_loan_repayments_made_ytd,
+    f3.ttl_loans_per AS total_loans_received_period,
+    f3.ttl_loans_ytd AS total_loans_received_ytd,
+    f3.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3.ttl_op_exp_per AS total_operating_expenditures_period,
+    f3.ttl_op_exp_ytd AS total_operating_expenditures_ytd,
+    GREATEST(f3.ttl_receipts_per_i, f3.ttl_receipts_ii) AS total_receipts_period,
+    f3.ttl_receipts_ytd AS total_receipts_ytd,
+    f3.tranf_from_other_auth_cmte_per AS transfers_from_other_authorized_committee_period,
+    f3.tranf_from_other_auth_cmte_ytd AS transfers_from_other_authorized_committee_ytd,
+    f3.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3.rpt_tp AS report_type,
+    f3.rpt_tp_desc AS report_type_full,
+    f3.rpt_yr AS report_year,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3.receipt_dt AS receipt_date,
+    f3.file_num AS file_number,
+    f3.amndt_ind AS amendment_indicator,
+    f3.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3.begin_image_num::text), f3.cmte_id::text, f3.file_num::text) AS html_url,
+    report_fec_url(f3.begin_image_num::text, f3.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name
+  FROM disclosure.nml_form_3 f3
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3.rpt_yr + f3.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3.file_num = amendments.file_num
+  WHERE f3.rpt_yr >= 1979::numeric AND f3.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_house_senate_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_house_senate_mv_tmp_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cyc_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_is_amen_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_reports_house_senate_vw AS 
+  SELECT * FROM public.ofec_reports_house_senate_mv_tmp;
+-- ---------------
+
+
+-- drop old MV:ofec_reports_house_senate_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv_tmp 
+  RENAME TO ofec_reports_house_senate_mv;
+
+
+-- rename all indexes
+
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_idx RENAME TO idx_ofec_reports_house_senate_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_disb_period_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_house_senate_mv_beg_image_num_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_house_senate_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_house_senate_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_house_senate_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx RENAME TO dx_ofec_reports_house_senate_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_rcpt_period_idx;
+

--- a/data/migrations/V0148__ofec_report_pac_party_mv.sql
+++ b/data/migrations/V0148__ofec_report_pac_party_mv.sql
@@ -458,7 +458,7 @@ CREATE UNIQUE INDEX idx_ofec_reports_pac_party_mv_tmp_idx
     USING btree
     (idx);
     
-CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_beg_image_numb_idx
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx
     ON public.ofec_reports_pac_party_mv_tmp
     USING btree
     (beginning_image_number COLLATE pg_catalog."default", idx);
@@ -542,7 +542,7 @@ ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp
 -- rename all indexes
 ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_idx RENAME TO idx_ofec_reports_pac_party_mv_idx;
     
-ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_beg_image_numb_idx RENAME TO idx_ofec_reports_pac_party_mv_beg_image_numb_idx;
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_pac_party_mv_beg_image_num_idx;
     
 ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_pac_party_mv_cmte_id_idx;
     

--- a/data/migrations/V0148__ofec_report_pac_party_mv.sql
+++ b/data/migrations/V0148__ofec_report_pac_party_mv.sql
@@ -1,0 +1,570 @@
+-- --------(1)public.ofec_f3_filed_by_pac_party_vw----------
+-- This view includes F3, F3P, F13, and F4 filed by pac and party.
+--
+-- data from 4 tables: 
+-- disclosure.f_rpt_or_form_sub
+-- disclosure.v_sum_and_det_sum_report
+-- disclosure.cmte_valid_fec_yr
+-- staging.ref_rpt_tp
+--
+-- ---------------------------------------------------------
+
+DROP VIEW IF EXISTS public.ofec_f3_filed_by_pac_party_vw;
+
+CREATE OR REPLACE VIEW ofec_f3_filed_by_pac_party_vw AS
+    SELECT r.sub_id,
+        r.cvg_start_dt,
+        r.cvg_end_dt,
+        r.receipt_dt,
+        r.rpt_yr + r.rpt_yr % 2::numeric AS cycle,
+        r.cand_cmte_id AS committee_id,
+        c.cmte_tp,
+        CASE
+            WHEN r.form_tp::text = 'F3'::text THEN 'Form 3'::text
+            WHEN r.form_tp::text = 'F3P'::text THEN 'Form 3P'::text
+            WHEN r.form_tp::text = 'F13'::text THEN 'Form 13'::text
+            WHEN r.form_tp::text = 'F4'::text THEN 'Form 4'::text
+            ELSE NULL::text
+        END AS form_tp,
+        r.rpt_yr,
+        r.rpt_tp,
+        ref_rpt_tp.rpt_tp_desc AS report_type_full,
+        r.amndt_ind,
+        CASE
+            WHEN r.amndt_ind::text = 'N'::text THEN 'NEW'::text
+            WHEN r.amndt_ind::text = 'A'::text THEN 'AMENDMENT'::text
+            ELSE NULL::text
+        END AS amendment_indicator_full,
+        r.request_tp,
+        r.begin_image_num,
+        r.end_image_num,
+        r.ttl_receipts,
+        r.ttl_indt_contb,
+        r.ttl_disb,
+        r.coh_bop,
+        r.coh_cop,
+        r.debts_owed_by_cmte,
+        r.debts_owed_to_cmte,
+        r.file_num,
+        r.prev_file_num,
+        r.rpt_pgi AS primary_general_indicator,
+        CASE
+            WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+            ELSE 'N'::text
+        END AS most_recent_filing_flag,
+        c.cmte_nm AS committee_name  
+    FROM disclosure.f_rpt_or_form_sub r
+    JOIN disclosure.cmte_valid_fec_yr c ON c.cmte_id::text = r.cand_cmte_id::text AND c.fec_election_yr = (r.rpt_yr + r.rpt_yr % 2::numeric)
+    LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON r.sub_id = vs.orig_sub_id
+    LEFT JOIN staging.ref_rpt_tp ref_rpt_tp ON ref_rpt_tp.rpt_tp_cd::text = r.rpt_tp::text
+    WHERE r.rpt_yr >= 1979::numeric 
+        AND (c.cmte_tp::text <> ALL (ARRAY['H'::character varying::text, 'S'::character varying::text, 'P'::character varying::text, 'I'::character varying::text])) 
+        AND (r.form_tp::text = ANY (ARRAY['F3'::character varying, 'F3P'::character varying, 'F13'::character varying, 'F4'::character varying]::text[]));
+
+ALTER TABLE public.ofec_f3_filed_by_pac_party_vw OWNER TO fec;    
+GRANT SELECT ON public.ofec_f3_filed_by_pac_party_vw TO fec_read;
+
+
+
+-- --------(2)public.ofec_pac_party_report_vw--------------
+-- All financial reports from pac and party
+-- data from 3 tables: 
+-- disclosure.nml_form_3x
+-- disclosure.v_sum_and_det_sum_reportt
+-- disclosure.cmte_valid_fec_yr
+-- and 1 view:
+-- public.ofec_f3_filed_by_pac_party_vw
+-- -------------------------------------------------
+
+DROP VIEW IF EXISTS public.ofec_pac_party_report_vw;
+CREATE OR REPLACE VIEW ofec_pac_party_report_vw AS
+
+    SELECT f3x.cmte_id AS committee_id,
+        f3x.rpt_yr + f3x.rpt_yr % 2::numeric AS cycle,
+        f3x.cvg_start_dt AS coverage_start_date,
+        f3x.cvg_end_dt AS coverage_end_date,
+        f3x.all_loans_received_per AS all_loans_received_period,
+        f3x.all_loans_received_ytd,
+        f3x.shared_fed_actvy_nonfed_per AS allocated_federal_election_levin_share_period,
+        f3x.begin_image_num AS beginning_image_number,
+        f3x.calendar_yr AS calendar_ytd,
+        f3x.coh_begin_calendar_yr AS cash_on_hand_beginning_calendar_ytd,
+        f3x.coh_bop AS cash_on_hand_beginning_period,
+        f3x.coh_coy AS cash_on_hand_close_ytd,
+        f3x.coh_cop AS cash_on_hand_end_period,
+        f3x.coord_exp_by_pty_cmte_per AS coordinated_expenditures_by_party_committee_period,
+        f3x.coord_exp_by_pty_cmte_ytd AS coordinated_expenditures_by_party_committee_ytd,
+        f3x.debts_owed_by_cmte AS debts_owed_by_committee,
+        f3x.debts_owed_to_cmte AS debts_owed_to_committee,
+        f3x.end_image_num AS end_image_number,
+        f3x.fed_cand_cmte_contb_ref_ytd AS fed_candidate_committee_contribution_refunds_ytd,
+        f3x.fed_cand_cmte_contb_per AS fed_candidate_committee_contributions_period,
+        f3x.fed_cand_cmte_contb_ytd AS fed_candidate_committee_contributions_ytd,
+        f3x.fed_cand_contb_ref_per AS fed_candidate_contribution_refunds_period,
+        f3x.indt_exp_per AS independent_expenditures_period,
+        f3x.indt_exp_ytd AS independent_expenditures_ytd,
+        f3x.indv_contb_ref_per AS refunded_individual_contributions_period,
+        f3x.indv_contb_ref_ytd AS refunded_individual_contributions_ytd,
+        f3x.indv_item_contb_per AS individual_itemized_contributions_period,
+        f3x.indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+        f3x.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+        f3x.indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+        f3x.loan_repymts_made_per AS loan_repayments_made_period,
+        f3x.loan_repymts_made_ytd AS loan_repayments_made_ytd,
+        f3x.loan_repymts_received_per AS loan_repayments_received_period,
+        f3x.loan_repymts_received_ytd AS loan_repayments_received_ytd,
+        f3x.loans_made_per AS loans_made_period,
+        f3x.loans_made_ytd,
+        f3x.net_contb_per AS net_contributions_period,
+        f3x.net_contb_ytd AS net_contributions_ytd,
+        f3x.net_op_exp_per AS net_operating_expenditures_period,
+        f3x.net_op_exp_ytd AS net_operating_expenditures_ytd,
+        f3x.non_alloc_fed_elect_actvy_per AS non_allocated_fed_election_activity_period,
+        f3x.non_alloc_fed_elect_actvy_ytd AS non_allocated_fed_election_activity_ytd,
+        f3x.shared_nonfed_op_exp_per AS nonfed_share_allocated_disbursements_period,
+        GREATEST(f3x.offsets_to_op_exp_per_i, f3x.offsets_to_op_exp_per_ii) AS offsets_to_operating_expenditures_period,
+        f3x.offsets_to_op_exp_ytd_i AS offsets_to_operating_expenditures_ytd,
+        f3x.other_disb_per AS other_disbursements_period,
+        f3x.other_disb_ytd AS other_disbursements_ytd,
+        f3x.other_fed_op_exp_per AS other_fed_operating_expenditures_period,
+        f3x.other_fed_op_exp_ytd AS other_fed_operating_expenditures_ytd,
+        f3x.other_fed_receipts_per AS other_fed_receipts_period,
+        f3x.other_fed_receipts_ytd,
+        f3x.other_pol_cmte_contb_per_ii AS refunded_other_political_committee_contributions_period,
+        f3x.other_pol_cmte_contb_ytd_ii AS refunded_other_political_committee_contributions_ytd,
+        f3x.other_pol_cmte_contb_per_i AS other_political_committee_contributions_period,
+        f3x.other_pol_cmte_contb_ytd_i AS other_political_committee_contributions_ytd,
+        f3x.pol_pty_cmte_contb_per_ii AS refunded_political_party_committee_contributions_period,
+        f3x.pol_pty_cmte_contb_ytd_ii AS refunded_political_party_committee_contributions_ytd,
+        f3x.pol_pty_cmte_contb_per_i AS political_party_committee_contributions_period,
+        f3x.pol_pty_cmte_contb_ytd_i AS political_party_committee_contributions_ytd,
+        f3x.rpt_yr AS report_year,
+        f3x.shared_fed_actvy_nonfed_ytd AS shared_fed_activity_nonfed_ytd,
+        f3x.shared_fed_actvy_fed_shr_per AS shared_fed_activity_period,
+        f3x.shared_fed_actvy_fed_shr_ytd AS shared_fed_activity_ytd,
+        f3x.shared_fed_op_exp_per AS shared_fed_operating_expenditures_period,
+        f3x.shared_fed_op_exp_ytd AS shared_fed_operating_expenditures_ytd,
+        f3x.shared_nonfed_op_exp_per AS shared_nonfed_operating_expenditures_period,
+        f3x.shared_nonfed_op_exp_ytd AS shared_nonfed_operating_expenditures_ytd,
+        f3x.subttl_sum_page_per AS subtotal_summary_page_period,
+        f3x.subttl_sum_ytd AS subtotal_summary_ytd,
+        GREATEST(f3x.ttl_contb_ref_per_i, f3x.ttl_contb_ref_per_ii) AS total_contribution_refunds_period,
+        f3x.ttl_contb_ref_ytd_i AS total_contribution_refunds_ytd,
+        f3x.ttl_contb_per AS total_contributions_period,
+        f3x.ttl_contb_ytd AS total_contributions_ytd,
+        GREATEST(f3x.ttl_disb_sum_page_per, f3x.ttl_disb_per) AS total_disbursements_period,
+        f3x.ttl_disb_ytd AS total_disbursements_ytd,
+        f3x.ttl_fed_disb_per AS total_fed_disbursements_period,
+        f3x.ttl_fed_disb_ytd AS total_fed_disbursements_ytd,
+        f3x.ttl_fed_elect_actvy_per AS total_fed_election_activity_period,
+        f3x.ttl_fed_elect_actvy_ytd AS total_fed_election_activity_ytd,
+        f3x.ttl_fed_op_exp_per AS total_fed_operating_expenditures_period,
+        f3x.ttl_fed_op_exp_ytd AS total_fed_operating_expenditures_ytd,
+        f3x.ttl_fed_receipts_per AS total_fed_receipts_period,
+        f3x.ttl_fed_receipts_ytd AS total_fed_receipts_ytd,
+        f3x.ttl_indv_contb AS total_individual_contributions_period,
+        f3x.ttl_indv_contb_ytd AS total_individual_contributions_ytd,
+        f3x.ttl_nonfed_tranf_per AS total_nonfed_transfers_period,
+        f3x.ttl_nonfed_tranf_ytd AS total_nonfed_transfers_ytd,
+        f3x.ttl_op_exp_per AS total_operating_expenditures_period,
+        f3x.ttl_op_exp_ytd AS total_operating_expenditures_ytd,
+        GREATEST(f3x.ttl_receipts_sum_page_per, f3x.ttl_receipts_per) AS total_receipts_period,
+        f3x.ttl_receipts_ytd AS total_receipts_ytd,
+        f3x.tranf_from_affiliated_pty_per AS transfers_from_affiliated_party_period,
+        f3x.tranf_from_affiliated_pty_ytd AS transfers_from_affiliated_party_ytd,
+        f3x.tranf_from_nonfed_acct_per AS transfers_from_nonfed_account_period,
+        f3x.tranf_from_nonfed_acct_ytd AS transfers_from_nonfed_account_ytd,
+        f3x.tranf_from_nonfed_levin_per AS transfers_from_nonfed_levin_period,
+        f3x.tranf_from_nonfed_levin_ytd AS transfers_from_nonfed_levin_ytd,
+        f3x.tranf_to_affliliated_cmte_per AS transfers_to_affiliated_committee_period,
+        f3x.tranf_to_affilitated_cmte_ytd AS transfers_to_affilitated_committees_ytd,
+        'Form 3X'::text AS form_tp,
+        f3x.rpt_tp AS report_type,
+        f3x.rpt_tp_desc AS report_type_full,
+        CASE
+            WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+            ELSE 'N'::text
+        END ~~ 'N'::text AS is_amended,
+        f3x.receipt_dt AS receipt_date,
+        f3x.file_num AS file_number,
+        f3x.amndt_ind AS amendment_indicator,
+        f3x.amndt_ind_desc AS amendment_indicator_full,
+        means_filed(f3x.begin_image_num::text) AS means_filed,
+        report_html_url(means_filed(f3x.begin_image_num::text), f3x.cmte_id::text, f3x.file_num::text) AS html_url,
+        report_fec_url(f3x.begin_image_num::text, f3x.file_num::integer) AS fec_url,
+        cmte.cmte_nm AS committee_name
+    FROM disclosure.nml_form_3x f3x
+    LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3x.sub_id = vs.orig_sub_id
+    LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3x.rpt_yr + f3x.rpt_yr % 2::numeric) = cmte.fec_election_yr 
+        AND f3x.cmte_id::text = cmte.cmte_id::text
+    WHERE f3x.rpt_yr >= 1979::numeric AND f3x.delete_ind IS NULL
+  
+    UNION ALL
+    SELECT f3.committee_id,
+        f3.cycle,
+        f3.cvg_start_dt::text::timestamp without time zone AS cvg_start_dt,
+        f3.cvg_end_dt::text::timestamp without time zone AS cvg_end_dt,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.begin_image_num,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.coh_bop,
+        NULL::numeric AS "numeric",
+        f3.coh_cop,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.debts_owed_by_cmte,
+        f3.debts_owed_to_cmte,
+        f3.end_image_num,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.rpt_yr,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.ttl_disb,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.ttl_indt_contb,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.ttl_receipts,
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        NULL::numeric AS "numeric",
+        f3.form_tp,
+        f3.rpt_tp,
+        f3.report_type_full,
+        f3.most_recent_filing_flag ~~ 'N'::text AS is_amended,
+        f3.receipt_dt::text::timestamp without time zone AS receipt_dt,
+        f3.file_num,
+        f3.amndt_ind,
+        f3.amendment_indicator_full,
+        means_filed(f3.begin_image_num::text) AS means_filed,
+        report_html_url(means_filed(f3.begin_image_num::text), f3.committee_id::text, f3.file_num::text) AS html_url,
+        report_fec_url(f3.begin_image_num::text, f3.file_num::integer) AS fec_url,
+        f3.committee_name
+    FROM ofec_f3_filed_by_pac_party_vw f3;
+ALTER TABLE public.ofec_pac_party_report_vw OWNER TO fec;    
+GRANT SELECT ON public.ofec_pac_party_report_vw TO fec_read;
+
+
+
+-- --------(3)public.ofec_reports_pac_party_mv--------------
+-- All reports filed by pac and party, Mostly F3X, and wrongly filed F3, F3P, F13, F4.
+-- data from 2 views: 
+-- public.ofec_pac_party_report_vw
+-- public.ofec_filings_amendments_all_vw
+-- 
+-- --------------------------------------------------
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_pac_party_mv_tmp AS
+    SELECT row_number() OVER () AS idx,
+        rpt.committee_id,
+        rpt.cycle,
+        rpt.coverage_start_date,
+        rpt.coverage_end_date,
+        rpt.all_loans_received_period,
+        rpt.all_loans_received_ytd,
+        rpt.allocated_federal_election_levin_share_period,
+        rpt.beginning_image_number,
+        rpt.calendar_ytd,
+        rpt.cash_on_hand_beginning_calendar_ytd,
+        rpt.cash_on_hand_beginning_period,
+        rpt.cash_on_hand_close_ytd,
+        rpt.cash_on_hand_end_period,
+        rpt.coordinated_expenditures_by_party_committee_period,
+        rpt.coordinated_expenditures_by_party_committee_ytd,
+        rpt.debts_owed_by_committee,
+        rpt.debts_owed_to_committee,
+        rpt.end_image_number,
+        rpt.fed_candidate_committee_contribution_refunds_ytd,
+        rpt.fed_candidate_committee_contributions_period,
+        rpt.fed_candidate_committee_contributions_ytd,
+        rpt.fed_candidate_contribution_refunds_period,
+        rpt.independent_expenditures_period,
+        rpt.independent_expenditures_ytd,
+        rpt.refunded_individual_contributions_period,
+        rpt.refunded_individual_contributions_ytd,
+        rpt.individual_itemized_contributions_period,
+        rpt.individual_itemized_contributions_ytd,
+        rpt.individual_unitemized_contributions_period,
+        rpt.individual_unitemized_contributions_ytd,
+        rpt.loan_repayments_made_period,
+        rpt.loan_repayments_made_ytd,
+        rpt.loan_repayments_received_period,
+        rpt.loan_repayments_received_ytd,
+        rpt.loans_made_period,
+        rpt.loans_made_ytd,
+        rpt.net_contributions_period,
+        rpt.net_contributions_ytd,
+        rpt.net_operating_expenditures_period,
+        rpt.net_operating_expenditures_ytd,
+        rpt.non_allocated_fed_election_activity_period,
+        rpt.non_allocated_fed_election_activity_ytd,
+        rpt.nonfed_share_allocated_disbursements_period,
+        rpt.offsets_to_operating_expenditures_period,
+        rpt.offsets_to_operating_expenditures_ytd,
+        rpt.other_disbursements_period,
+        rpt.other_disbursements_ytd,
+        rpt.other_fed_operating_expenditures_period,
+        rpt.other_fed_operating_expenditures_ytd,
+        rpt.other_fed_receipts_period,
+        rpt.other_fed_receipts_ytd,
+        rpt.refunded_other_political_committee_contributions_period,
+        rpt.refunded_other_political_committee_contributions_ytd,
+        rpt.other_political_committee_contributions_period,
+        rpt.other_political_committee_contributions_ytd,
+        rpt.refunded_political_party_committee_contributions_period,
+        rpt.refunded_political_party_committee_contributions_ytd,
+        rpt.political_party_committee_contributions_period,
+        rpt.political_party_committee_contributions_ytd,
+        rpt.report_year,
+        rpt.shared_fed_activity_nonfed_ytd,
+        rpt.shared_fed_activity_period,
+        rpt.shared_fed_activity_ytd,
+        rpt.shared_fed_operating_expenditures_period,
+        rpt.shared_fed_operating_expenditures_ytd,
+        rpt.shared_nonfed_operating_expenditures_period,
+        rpt.shared_nonfed_operating_expenditures_ytd,
+        rpt.subtotal_summary_page_period,
+        rpt.subtotal_summary_ytd,
+        rpt.total_contribution_refunds_period,
+        rpt.total_contribution_refunds_ytd,
+        rpt.total_contributions_period,
+        rpt.total_contributions_ytd,
+        rpt.total_disbursements_period,
+        rpt.total_disbursements_ytd,
+        rpt.total_fed_disbursements_period,
+        rpt.total_fed_disbursements_ytd,
+        rpt.total_fed_election_activity_period,
+        rpt.total_fed_election_activity_ytd,
+        rpt.total_fed_operating_expenditures_period,
+        rpt.total_fed_operating_expenditures_ytd,
+        rpt.total_fed_receipts_period,
+        rpt.total_fed_receipts_ytd,
+        rpt.total_individual_contributions_period,
+        rpt.total_individual_contributions_ytd,
+        rpt.total_nonfed_transfers_period,
+        rpt.total_nonfed_transfers_ytd,
+        rpt.total_operating_expenditures_period,
+        rpt.total_operating_expenditures_ytd,
+        rpt.total_receipts_period,
+        rpt.total_receipts_ytd,
+        rpt.transfers_from_affiliated_party_period,
+        rpt.transfers_from_affiliated_party_ytd,
+        rpt.transfers_from_nonfed_account_period,
+        rpt.transfers_from_nonfed_account_ytd,
+        rpt.transfers_from_nonfed_levin_period,
+        rpt.transfers_from_nonfed_levin_ytd,
+        rpt.transfers_to_affiliated_committee_period,
+        rpt.transfers_to_affilitated_committees_ytd,
+        rpt.form_tp,
+        rpt.report_type,
+        rpt.report_type_full,
+        rpt.is_amended,
+        rpt.receipt_date,
+        rpt.file_number,
+        rpt.amendment_indicator,
+        rpt.amendment_indicator_full,
+        rpt.means_filed,
+        rpt.html_url,
+        rpt.fec_url,
+        amendments.amendment_chain,
+        amendments.prev_file_num AS previous_file_number,
+        amendments.mst_rct_file_num AS most_recent_file_number,
+        is_most_recent(rpt.file_number::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+        rpt.committee_name
+    FROM ofec_pac_party_report_vw rpt
+    LEFT JOIN ofec_filings_amendments_all_vw amendments ON rpt.file_number = amendments.file_num
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_pac_party_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_pac_party_mv_tmp_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_beg_image_numb_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_ie_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (independent_expenditures_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_is_amen_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_reports_pac_party_vw AS 
+  SELECT * FROM public.ofec_reports_pac_party_mv_tmp;
+-- ---------------
+
+
+-- drop old MV:ofec_reports_pac_party_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp 
+  RENAME TO ofec_reports_pac_party_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_idx RENAME TO idx_ofec_reports_pac_party_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_beg_image_numb_idx RENAME TO idx_ofec_reports_pac_party_mv_beg_image_numb_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_pac_party_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_pac_party_mv_cyc_cmte_id;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_pac_party_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_ie_period_idx RENAME TO idx_ofec_reports_pac_party_mv_ie_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_pac_party_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_pac_party_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_disb_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_rcpt_period_idx;
+

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -101,6 +101,7 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
     __abstract__ = True
 
     committee_id = db.Column(db.String, index=True, doc=docs.COMMITTEE_ID)
+    committee_name = db.Column(db.String, doc=docs.COMMITTEE_NAME)  # mapped
     committee = utils.related('CommitteeHistory', 'committee_id', 'committee_id', 'report_year', 'cycle')
 
     #These columns derived from amendments materializeds view
@@ -112,51 +113,90 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
     file_number = db.Column(db.Integer)
     amendment_indicator = db.Column('amendment_indicator', db.String)
     amendment_indicator_full = db.Column(db.String)
-    beginning_image_number = db.Column(db.BigInteger, doc=docs.BEGINNING_IMAGE_NUMBER)
-    cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2), doc=docs.CASH_ON_HAND_BEGIN_PERIOD)#P
-    cash_on_hand_end_period = db.Column('cash_on_hand_end_period', db.Numeric(30, 2), doc=docs.CASH_ON_HAND_END_PERIOD)#P
-    coverage_end_date = db.Column(db.DateTime, index=True, doc=docs.COVERAGE_END_DATE)#P
-    coverage_start_date = db.Column(db.DateTime, index=True, doc=docs.COVERAGE_START_DATE)#P
-    debts_owed_by_committee = db.Column('debts_owed_by_committee', db.Numeric(30, 2), doc=docs.DEBTS_OWED_BY_COMMITTEE)#P
-    debts_owed_to_committee = db.Column(db.Numeric(30, 2), doc=docs.DEBTS_OWED_TO_COMMITTEE)#P
-    end_image_number = db.Column(db.BigInteger, doc=docs.ENDING_IMAGE_NUMBER)
-    other_disbursements_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.OTHER_DISBURSEMENTS))#PX
-    other_disbursements_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.OTHER_DISBURSEMENTS))#PX
-    other_political_committee_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))#P
-    other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))#P
-    political_party_committee_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))#P
-    political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))#P
-    report_type = db.Column(db.String, doc=docs.REPORT_TYPE)
-    report_type_full = db.Column(db.String, doc=docs.REPORT_TYPE)
-    report_year = db.Column(db.Integer, doc=docs.REPORT_YEAR)
-    total_contribution_refunds_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.CONTRIBUTION_REFUNDS))#P
-    total_contribution_refunds_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.CONTRIBUTION_REFUNDS))#P
-    refunded_individual_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))#P
-    refunded_individual_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))#P
-    refunded_other_political_committee_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))#P
-    refunded_other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))#P
-    refunded_political_party_committee_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))#P
-    refunded_political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))#P
-    total_contributions_period = db.Column('total_contributions_period', db.Numeric(30, 2), doc=docs.add_period(docs.CONTRIBUTIONS))#P
-    total_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.CONTRIBUTIONS))#P
-    total_disbursements_period = db.Column('total_disbursements_period', db.Numeric(30, 2), doc=docs.add_period(docs.DISBURSEMENTS))#P
-    total_disbursements_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.DISBURSEMENTS))#P
-    total_receipts_period = db.Column('total_receipts_period', db.Numeric(30, 2), doc=docs.add_period(docs.RECEIPTS))#P
-    total_receipts_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.RECEIPTS))#P
-    offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.OFFSETS_TO_OPERATING_EXPENDITURES))#P
-    offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.OFFSETS_TO_OPERATING_EXPENDITURES))#P
-    total_individual_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_CONTRIBUTIONS))#P
-    total_individual_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_CONTRIBUTIONS))#P
-    individual_unitemized_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))#P
-    individual_unitemized_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))#P
-    individual_itemized_contributions_ytd = db.Column(db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))#P
-    individual_itemized_contributions_period = db.Column(db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))#P
-    is_amended = db.Column('is_amended', db.Boolean, doc='False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.')
+    beginning_image_number = db.Column(db.BigInteger,
+        doc=docs.BEGINNING_IMAGE_NUMBER)
+    cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2),
+        doc=docs.CASH_ON_HAND_BEGIN_PERIOD)  # P
+    cash_on_hand_end_period = db.Column('cash_on_hand_end_period', db.Numeric(30, 2),
+        doc=docs.CASH_ON_HAND_END_PERIOD)  # P
+    coverage_end_date = db.Column(db.DateTime, index=True,
+        doc=docs.COVERAGE_END_DATE)  # P
+    coverage_start_date = db.Column(db.DateTime, index=True,
+        doc=docs.COVERAGE_START_DATE)  # P
+    debts_owed_by_committee = db.Column('debts_owed_by_committee', db.Numeric(30, 2),
+        doc=docs.DEBTS_OWED_BY_COMMITTEE)  # P
+    debts_owed_to_committee = db.Column(db.Numeric(30, 2),
+        doc=docs.DEBTS_OWED_TO_COMMITTEE)  # P
+    end_image_number = db.Column(db.BigInteger,
+        doc=docs.ENDING_IMAGE_NUMBER)
+    other_disbursements_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.OTHER_DISBURSEMENTS))  # PX
+    other_disbursements_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.OTHER_DISBURSEMENTS))  # PX
+    other_political_committee_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
+    other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
+    political_party_committee_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
+    political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
+    report_type = db.Column(db.String,
+        doc=docs.REPORT_TYPE)
+    report_type_full = db.Column(db.String,
+        doc=docs.REPORT_TYPE)
+    report_year = db.Column(db.Integer,
+        doc=docs.REPORT_YEAR)
+    total_contribution_refunds_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.CONTRIBUTION_REFUNDS))  # P
+    total_contribution_refunds_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.CONTRIBUTION_REFUNDS))  # P
+    refunded_individual_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))  # P
+    refunded_individual_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))  # P
+    refunded_other_political_committee_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
+    refunded_other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
+    refunded_political_party_committee_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
+    refunded_political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
+    total_contributions_period = db.Column('total_contributions_period', db.Numeric(30, 2),
+        doc=docs.add_period(docs.CONTRIBUTIONS))  # P
+    total_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.CONTRIBUTIONS))  # P
+    total_disbursements_period = db.Column('total_disbursements_period', db.Numeric(30, 2),
+        doc=docs.add_period(docs.DISBURSEMENTS))  # P
+    total_disbursements_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.DISBURSEMENTS))  # P
+    total_receipts_period = db.Column('total_receipts_period', db.Numeric(30, 2),
+        doc=docs.add_period(docs.RECEIPTS))  # P
+    total_receipts_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.RECEIPTS))  # P
+    offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.OFFSETS_TO_OPERATING_EXPENDITURES))  # P
+    offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.OFFSETS_TO_OPERATING_EXPENDITURES))  # P
+    total_individual_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.INDIVIDUAL_CONTRIBUTIONS))  # P
+    total_individual_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.INDIVIDUAL_CONTRIBUTIONS))  # P
+    individual_unitemized_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))  # P \
+    individual_unitemized_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))  # P
+    individual_itemized_contributions_ytd = db.Column(db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))  # P
+    individual_itemized_contributions_period = db.Column(db.Numeric(30, 2),
+        doc=docs.add_period(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))  # P
+    is_amended = db.Column('is_amended', db.Boolean, doc=docs.IS_AMENDED)
     receipt_date = db.Column('receipt_date', db.Date, doc=docs.RECEIPT_DATE)
     means_filed = db.Column('means_filed', db.String, doc=docs.MEANS_FILED)
-    fec_url = db.Column(db.String)
-    html_url = db.Column(db.String, doc='HTML link to the filing.')
-    most_recent = db.Column('most_recent', db.Boolean)
+    fec_url = db.Column(db.String, doc=docs.FEC_URL)
+    html_url = db.Column(db.String, doc=docs.HTML_URL)
+    most_recent = db.Column('most_recent', db.Boolean, doc=docs.MOST_RECENT)
 
     @property
     def document_description(self):
@@ -170,47 +210,47 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
 
 class CommitteeReportsHouseSenate(CommitteeReports):
     __tablename__ = 'ofec_reports_house_senate_mv'
-
-    aggregate_amount_personal_contributions_general = db.Column(db.Numeric(30, 2))#missing
-    aggregate_contributions_personal_funds_primary = db.Column(db.Numeric(30, 2))#missing
-    all_other_loans_period = db.Column(db.Numeric(30, 2))#mapped
-    all_other_loans_ytd = db.Column(db.Numeric(30, 2))#mapped
-    candidate_contribution_period = db.Column(db.Numeric(30, 2))#mapped
-    candidate_contribution_ytd = db.Column(db.Numeric(30, 2))#mapped
-    gross_receipt_authorized_committee_general = db.Column(db.Numeric(30, 2))#missing
-    gross_receipt_authorized_committee_primary = db.Column(db.Numeric(30, 2))#missing
-    gross_receipt_minus_personal_contribution_general = db.Column(db.Numeric(30, 2))#missing
-    gross_receipt_minus_personal_contributions_primary = db.Column(db.Numeric(30, 2))#missing
-    loan_repayments_candidate_loans_period = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_candidate_loans_ytd = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_other_loans_period = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_other_loans_ytd = db.Column(db.Numeric(30, 2))#mapped
-    loans_made_by_candidate_period = db.Column(db.Numeric(30, 2))#mapped
-    loans_made_by_candidate_ytd = db.Column(db.Numeric(30, 2))#mapped
-    net_contributions_ytd = db.Column(db.Numeric(30, 2))#mapped
-    net_contributions_period = db.Column(db.Numeric(30, 2), index=True)#mapped
-    net_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    net_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    other_receipts_period = db.Column(db.Numeric(30, 2))#mapped
-    other_receipts_ytd = db.Column(db.Numeric(30, 2))#mapped
-    refunds_total_contributions_col_total_ytd = db.Column(db.Numeric(30, 2))#mapped, but maybe needs to be renamed?
-    subtotal_period = db.Column(db.Numeric(30, 2))#mapped
-    total_contribution_refunds_col_total_period = db.Column(db.Numeric(30, 2))#mapped, but rename to match column above
-    total_contributions_column_total_period = db.Column(db.Numeric(30, 2))#missing
-    total_loan_repayments_made_period = db.Column(db.Numeric(30, 2))#mapped
-    total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_loans_received_period = db.Column(db.Numeric(30, 2))#mapped
-    total_loans_received_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_other_authorized_committee_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))#mapped
+    aggregate_amount_personal_contributions_general = db.Column(db.Numeric(30, 2))  # missing
+    aggregate_contributions_personal_funds_primary = db.Column(db.Numeric(30, 2))  # missing
+    all_other_loans_period = db.Column(db.Numeric(30, 2))  # mapped
+    all_other_loans_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    candidate_contribution_period = db.Column(db.Numeric(30, 2))  # mapped
+    candidate_contribution_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    gross_receipt_authorized_committee_general = db.Column(db.Numeric(30, 2))  # missing
+    gross_receipt_authorized_committee_primary = db.Column(db.Numeric(30, 2))  # missing
+    gross_receipt_minus_personal_contribution_general = db.Column(db.Numeric(30, 2))  # missing
+    gross_receipt_minus_personal_contributions_primary = db.Column(db.Numeric(30, 2))  # missing
+    loan_repayments_candidate_loans_period = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_candidate_loans_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_other_loans_period = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_other_loans_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    loans_made_by_candidate_period = db.Column(db.Numeric(30, 2))  # mapped
+    loans_made_by_candidate_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    net_contributions_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    net_contributions_period = db.Column(db.Numeric(30, 2), index=True)  # mapped
+    net_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    net_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    other_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
+    other_receipts_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    refunds_total_contributions_col_total_ytd = db.Column(db.Numeric(30, 2))  # mapped, but maybe needs to be renamed?
+    subtotal_period = db.Column(db.Numeric(30, 2))  # mapped
+    # mapped, but rename to match column above
+    total_contribution_refunds_col_total_period = db.Column(db.Numeric(30, 2))
+    total_contributions_column_total_period = db.Column(db.Numeric(30, 2))  # missing
+    total_loan_repayments_made_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
     report_form = 'Form 3'
 
     @property
@@ -226,116 +266,118 @@ class CommitteeReportsHouseSenate(CommitteeReports):
 
 
 class CommitteeReportsPacParty(CommitteeReports):
-    __tablename__ = 'ofec_report_pac_party_all_mv'
+    __tablename__ = 'ofec_reports_pac_party_mv'
 
-    all_loans_received_period = db.Column(db.Numeric(30, 2))#mapped
-    all_loans_received_ytd = db.Column(db.Numeric(30, 2))#mapped
-    allocated_federal_election_levin_share_period = db.Column(db.Numeric(30, 2))#missing
-    calendar_ytd = db.Column(db.Integer)#missing
-    cash_on_hand_beginning_calendar_ytd = db.Column(db.Numeric(30, 2))#mapped, but it's period not ytd
-    cash_on_hand_close_ytd = db.Column(db.Numeric(30, 2))#mapped
-    coordinated_expenditures_by_party_committee_period = db.Column('coordinated_expenditures_by_party_committee_period', db.Numeric(30, 2))#mapped
-    coordinated_expenditures_by_party_committee_ytd = db.Column(db.Numeric(30, 2))#mapped
-    fed_candidate_committee_contribution_refunds_ytd = db.Column(db.Numeric(30, 2))#mapped, should this match line 164
-    fed_candidate_committee_contributions_period = db.Column(db.Numeric(30, 2))#mapped
-    fed_candidate_committee_contributions_ytd = db.Column(db.Numeric(30, 2))#mapped
-    fed_candidate_contribution_refunds_period = db.Column(db.Numeric(30, 2))#mapped
-    independent_expenditures_period = db.Column('independent_expenditures_period', db.Numeric(30, 2))#mapped
-    independent_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_made_period = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_received_period = db.Column(db.Numeric(30, 2))#mapped
-    loan_repayments_received_ytd = db.Column(db.Numeric(30, 2))#mapped
-    loans_made_period = db.Column(db.Numeric(30, 2))#mapped
-    loans_made_ytd = db.Column(db.Numeric(30, 2))#mapped
-    net_contributions_period = db.Column(db.Numeric(30, 2), index=True)#mapped
-    net_contributions_ytd = db.Column(db.Numeric(30, 2))#mapped
-    net_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    net_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    non_allocated_fed_election_activity_period = db.Column(db.Numeric(30, 2))#mapped
-    non_allocated_fed_election_activity_ytd = db.Column(db.Numeric(30, 2))#mapped
-    nonfed_share_allocated_disbursements_period = db.Column(db.Numeric(30, 2))#missing!
-    other_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    other_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    other_fed_receipts_period = db.Column(db.Numeric(30, 2))#mapped
-    other_fed_receipts_ytd = db.Column(db.Numeric(30, 2))#mapped
-    shared_fed_activity_nonfed_ytd = db.Column(db.Numeric(30, 2))#mapped
-    shared_fed_activity_period = db.Column(db.Numeric(30, 2))#mapped
-    shared_fed_activity_ytd = db.Column(db.Numeric(30, 2))#mapped
-    shared_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    shared_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    shared_nonfed_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    shared_nonfed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    subtotal_summary_page_period = db.Column(db.Numeric(30, 2))#check this one in the json
-    subtotal_summary_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_disbursements_period = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_disbursements_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_election_activity_period = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_election_activity_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_receipts_period = db.Column(db.Numeric(30, 2))#mapped
-    total_fed_receipts_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_nonfed_transfers_period = db.Column(db.Numeric(30, 2))#mapped
-    total_nonfed_transfers_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_affiliated_party_period = db.Column(db.Numeric(30, 2))#this should be committee not party
-    transfers_from_affiliated_party_ytd = db.Column(db.Numeric(30, 2))#ditto
-    transfers_from_nonfed_account_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_nonfed_account_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_nonfed_levin_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_nonfed_levin_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_to_affiliated_committee_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_to_affilitated_committees_ytd = db.Column(db.Numeric(30, 2))#mapped
-    report_form = db.Column('form_tp', db.String)#mapped
+    all_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
+    all_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    allocated_federal_election_levin_share_period = db.Column(db.Numeric(30, 2))  # missing
+    calendar_ytd = db.Column(db.Integer)  # missing
+    cash_on_hand_beginning_calendar_ytd = db.Column(db.Numeric(30, 2))  # mapped, but it's period not ytd
+    cash_on_hand_close_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    coordinated_expenditures_by_party_committee_period = db.Column('coordinated_expenditures_by_party_committee_period',
+        db.Numeric(30, 2))  # mapped
+    coordinated_expenditures_by_party_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    fed_candidate_committee_contribution_refunds_ytd = db.Column(db.Numeric(30, 2))  # mapped,should this match line 164
+    fed_candidate_committee_contributions_period = db.Column(db.Numeric(30, 2))  # mapped
+    fed_candidate_committee_contributions_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    fed_candidate_contribution_refunds_period = db.Column(db.Numeric(30, 2))  # mapped
+    independent_expenditures_period = db.Column('independent_expenditures_period',
+        db.Numeric(30, 2))  # mapped
+    independent_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_made_period = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_received_period = db.Column(db.Numeric(30, 2))  # mapped
+    loan_repayments_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    loans_made_period = db.Column(db.Numeric(30, 2))  # mapped
+    loans_made_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    net_contributions_period = db.Column(db.Numeric(30, 2), index=True)  # mapped
+    net_contributions_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    net_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    net_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    non_allocated_fed_election_activity_period = db.Column(db.Numeric(30, 2))  # mapped
+    non_allocated_fed_election_activity_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    nonfed_share_allocated_disbursements_period = db.Column(db.Numeric(30, 2))  # missing!
+    other_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    other_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    other_fed_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
+    other_fed_receipts_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    shared_fed_activity_nonfed_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    shared_fed_activity_period = db.Column(db.Numeric(30, 2))  # mapped
+    shared_fed_activity_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    shared_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    shared_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    shared_nonfed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    shared_nonfed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    subtotal_summary_page_period = db.Column(db.Numeric(30, 2))  # check this one in the json
+    subtotal_summary_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_disbursements_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_disbursements_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_election_activity_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_election_activity_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_fed_receipts_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_nonfed_transfers_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_nonfed_transfers_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_affiliated_party_period = db.Column(db.Numeric(30, 2))  # this should be committee not party
+    transfers_from_affiliated_party_ytd = db.Column(db.Numeric(30, 2))  # ditto
+    transfers_from_nonfed_account_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_nonfed_account_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_nonfed_levin_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_nonfed_levin_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_affiliated_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_affilitated_committees_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    report_form = db.Column('form_tp', db.String)  # mapped
 
 
 class CommitteeReportsPresidential(CommitteeReports):
     __tablename__ = 'ofec_reports_presidential_mv'
 
-    candidate_contribution_period = db.Column(db.Numeric(30, 2))#mapped
-    candidate_contribution_ytd = db.Column(db.Numeric(30, 2))#mapped
-    exempt_legal_accounting_disbursement_period = db.Column(db.Numeric(30, 2))#mapped
-    exempt_legal_accounting_disbursement_ytd = db.Column(db.Numeric(30, 2))#"""
-    expenditure_subject_to_limits = db.Column(db.Numeric(30, 2))#mapped
-    federal_funds_period = db.Column(db.Numeric(30, 2))#mapped
-    federal_funds_ytd = db.Column(db.Numeric(30, 2))#"""
-    fundraising_disbursements_period = db.Column(db.Numeric(30, 2))#mapped
-    fundraising_disbursements_ytd = db.Column(db.Numeric(30, 2))#"""
-    items_on_hand_liquidated = db.Column(db.Numeric(30, 2))#mapped
-    loans_received_from_candidate_period = db.Column(db.Numeric(30, 2))#mapped
-    loans_received_from_candidate_ytd = db.Column(db.Numeric(30, 2))#"""
-    offsets_to_fundraising_expenditures_ytd = db.Column(db.Numeric(30, 2))#mapped
-    offsets_to_fundraising_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    offsets_to_legal_accounting_period = db.Column(db.Numeric(30, 2))#mapped
-    offsets_to_legal_accounting_ytd = db.Column(db.Numeric(30, 2))#mapped
-    operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#"""
-    other_loans_received_period = db.Column(db.Numeric(30, 2))#mapped
-    other_loans_received_ytd = db.Column(db.Numeric(30, 2))#"""
-    other_receipts_period = db.Column(db.Numeric(30, 2))#mapped
-    other_receipts_ytd = db.Column(db.Numeric(30, 2))#"""
-    repayments_loans_made_by_candidate_period = db.Column(db.Numeric(30, 2))#mapped
-    repayments_loans_made_candidate_ytd = db.Column(db.Numeric(30, 2))#"""
-    repayments_other_loans_period = db.Column(db.Numeric(30, 2))#mapped
-    repayments_other_loans_ytd = db.Column(db.Numeric(30, 2))#"""
-    subtotal_summary_period = db.Column(db.Numeric(30, 2))#mapped
-    total_loan_repayments_made_period = db.Column(db.Numeric(30, 2))#mapped
-    total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))#"""
-    total_loans_received_period = db.Column(db.Numeric(30, 2))#mapped
-    total_loans_received_ytd = db.Column(db.Numeric(30, 2))#mapped
-    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))#mapped
-    total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))#"""
-    total_period = db.Column(db.Numeric(30, 2))#mapped
-    total_ytd = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_affiliated_committee_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_from_affiliated_committee_ytd = db.Column(db.Numeric(30, 2))#"""
-    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))#mapped
-    transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))#"""
-    net_contributions_cycle_to_date = db.Column(db.Numeric(30, 2))#mapped
-    net_operating_expenditures_cycle_to_date = db.Column(db.Numeric(30, 2))#mapped
-    report_form = 'Form 3P'#do we want this for the efile tables?
+    candidate_contribution_period = db.Column(db.Numeric(30, 2))  # mapped
+    candidate_contribution_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    exempt_legal_accounting_disbursement_period = db.Column(db.Numeric(30, 2))  # mapped
+    exempt_legal_accounting_disbursement_ytd = db.Column(db.Numeric(30, 2))  # """
+    expenditure_subject_to_limits = db.Column(db.Numeric(30, 2))  # mapped
+    federal_funds_period = db.Column(db.Numeric(30, 2))  # mapped
+    federal_funds_ytd = db.Column(db.Numeric(30, 2))  # """
+    fundraising_disbursements_period = db.Column(db.Numeric(30, 2))  # mapped
+    fundraising_disbursements_ytd = db.Column(db.Numeric(30, 2))  # """
+    items_on_hand_liquidated = db.Column(db.Numeric(30, 2))  # mapped
+    loans_received_from_candidate_period = db.Column(db.Numeric(30, 2))  # mapped
+    loans_received_from_candidate_ytd = db.Column(db.Numeric(30, 2))  # """
+    offsets_to_fundraising_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    offsets_to_fundraising_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    offsets_to_legal_accounting_period = db.Column(db.Numeric(30, 2))  # mapped
+    offsets_to_legal_accounting_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # """
+    other_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
+    other_loans_received_ytd = db.Column(db.Numeric(30, 2))  # """
+    other_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
+    other_receipts_ytd = db.Column(db.Numeric(30, 2))  # """
+    repayments_loans_made_by_candidate_period = db.Column(db.Numeric(30, 2))  # mapped
+    repayments_loans_made_candidate_ytd = db.Column(db.Numeric(30, 2))  # """
+    repayments_other_loans_period = db.Column(db.Numeric(30, 2))  # mapped
+    repayments_other_loans_ytd = db.Column(db.Numeric(30, 2))  # """
+    subtotal_summary_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_loan_repayments_made_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # """
+    total_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # """
+    total_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_ytd = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_affiliated_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_affiliated_committee_ytd = db.Column(db.Numeric(30, 2))  # """
+    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # """
+    net_contributions_cycle_to_date = db.Column(db.Numeric(30, 2))  # mapped
+    net_operating_expenditures_cycle_to_date = db.Column(db.Numeric(30, 2))  # mapped
+    report_form = 'Form 3P'  # do we want this for the efile tables?
 
 
 class CommitteeReportsIEOnly(PdfMixin, BaseModel):
@@ -352,14 +394,14 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     report_type = db.Column(db.String)
     report_type_full = db.Column(db.String)
     report_form = 'Form 5'
-    is_amended = db.Column(db.Boolean, doc='False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.')
+    is_amended = db.Column(db.Boolean, doc=docs.IS_AMENDED)
     receipt_date = db.Column(db.Date, doc=docs.RECEIPT_DATE)
     means_filed = db.Column(db.String, doc=docs.MEANS_FILED)
     fec_url = db.Column(db.String)
 
 
 class BaseFilingSummary(db.Model):
-    __table_args__ = {'schema' : 'real_efile'}
+    __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'summary'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
     line_number = db.Column('lineno', db.Integer, primary_key=True)
@@ -418,7 +460,7 @@ def name_generator(*args):
     return name.strip()
 
 class BaseF3PFiling(TreasurerMixin, BaseFiling):
-    __table_args__ = {'schema' : 'real_efile'}
+    __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'f3p'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
     committee_name = db.Column('c_name', db.String, index=True, doc=docs.COMMITTEE_NAME)
@@ -462,16 +504,16 @@ class BaseF3PFiling(TreasurerMixin, BaseFiling):
 
     @declared_attr
     def report(self):
-        return db.relationship(ReportType,
-                               primaryjoin="and_(BaseF3PFiling.report_type==ReportType.report_type)",
-                               foreign_keys=self.report_type,
-                               lazy='subquery',
+        return db.relationship(
+            ReportType,
+            primaryjoin="and_(BaseF3PFiling.report_type==ReportType.report_type)",
+            foreign_keys=self.report_type,
+            lazy='subquery',
         )
 
 
-
 class BaseF3Filing(TreasurerMixin, BaseFiling):
-    __table_args__ = {'schema' : 'real_efile'}
+    __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'f3'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
     committee_name = db.Column('com_name', db.String, index=True, doc=docs.COMMITTEE_NAME)
@@ -493,12 +535,12 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
     @hybrid_property
     def candidate_name(self):
         name = name_generator(
-                              self.candidate_last_name,
-                              self.candidate_prefix,
-                              self.candidate_first_name,
-                              self.candidate_middle_name,
-                              self.candidate_suffix
-                              )
+            self.candidate_last_name,
+            self.candidate_prefix,
+            self.candidate_first_name,
+            self.candidate_middle_name,
+            self.candidate_suffix
+        )
         name = (
             name
             if name
@@ -535,7 +577,7 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
         )
 
 class BaseF3XFiling(BaseFiling):
-    __table_args__ = {'schema' : 'real_efile'}
+    __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'f3x'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
 
@@ -543,7 +585,6 @@ class BaseF3XFiling(BaseFiling):
     sign_date = db.Column('date_signed', db.Date)
     amend_address = db.Column('amend_addr', db.String)
     qualified_multicandidate_committee = db.Column('qual', db.String)
-
 
     summary_lines = db.relationship(
         'BaseFilingSummary',

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -265,11 +265,19 @@ years so this can differ from underlying form's receipt date.
 '''
 
 IS_AMENDED = '''
-Report has been amended
+False indicates that a report is the most recent. True indicates that the report has been superseded by an amendment.
 '''
 
 MOST_RECENT = '''
 Report is either new or is the most-recently filed amendment
+'''
+
+HTML_URL = '''
+HTML link to the filing.
+'''
+
+FEC_URL = '''
+fec link to the filing.
 '''
 
 TWO_YEAR_TRANSACTION_PERIOD = '''

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -444,7 +444,6 @@ make_reports_schema = functools.partial(
         'report_form': ma.fields.Str(),
         'document_description': ma.fields.Str(),
         'committee_type': ma.fields.Str(attribute='committee.committee_type'),
-        'committee_name': ma.fields.Str(attribute='committee.name'),
         'beginning_image_number': ma.fields.Str(),
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),


### PR DESCRIPTION
## Summary (required)
House and Senate committee reports, presidential committee reports and PAC and party committee reports downloads do not include names, just IDs
so we need add committee_name column into csv download file.

- Resolves #[[3844]](https://github.com/fecgov/openFEC/issues/3844)

_Include a summary of proposed changes._
modify/create three report committee MV to add `committee_name` column:
a)ofec_reports_presidential_mv
b)ofec_reports_house_senate_mv
c)ofec_reports_pac_party_mv

## How to test the changes locally
1)api test locally
checkout branch, point to dev. 
modify models/reports.py:
ofec_reports_presidential_mv ==> ofec_reports_presidential_mv_jl
ofec_reports_house_senate_mv ==>ofec_reports_house_senate_mv_jl
ofec_reports_pac_party_mv ==>ofec_reports_pac_party_mv_jl

go to swagger under tag: **financial**
path: /reports/{committee_type}/

2)test download csv file
option 1, deploy your feature branch to dev space.
go to https://fec-dev-proxy.app.cloud.gov/data/browse-data/?tab=filings
click each of three committee type reports to export csv file to see `committee_name` column.

option 2, test locally:
1. get `cf env api` from dev space
export access_key_id="xxxxxxx"
export secret_access_key="xxxxxxx"
export bucket="xxxxxxx"
export region="xxxxxxx"

2. setup 4 terminals on local:
1)first terminal: Redis
`redis-server`
2)second terminal: Celery Worker
active virtual env
setup 4 env variables (see above)
`celery worker --app webservices.tasks --loglevel INFO `
3)Third terminal: openFEC (point dev DB)
active virtual env
setup 4 env variables (see above)
export SQLA_CONN=dev database
./manage.py runserver
4)Forth terminal: fec-cms (point your local api)
active virtual en
export DATABASE_URL=postgresql://:@/cfdm_cms_test
export FEC_API_URL=http://localhost:5000
export FEC_WEB_API_KEY=xxxxxx
export FEC_WEB_API_KEY_PUBLIC=xxxxxxx
export FEC_CMS_ENVIRONMENT=LOCAL

3. test export csv file for three committee type reports.
http://127.0.0.1:8000/data/browse-data/?tab=filings
click each of three committee type reports to export csv file to see `committee_name` column.

4. compare with production website export.

## Impacted areas of the application
List general components of the application that this PR will affect:
Filings and reports page:
https://www.fec.gov/data/browse-data/?tab=filings
 
