### PR TITLE
[WIP] feature/add efile filters

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -783,11 +783,18 @@ schedule_e_efile = {
         IStr(validate=validate.OneOf(['S', 'O'])),
         description='Support or opposition',
     ),
-    'min_expenditure_date': fields.Date(description=docs.EXPENDITURE_MAX_DATE),
-    'max_expenditure_date': fields.Date(description=docs.EXPENDITURE_MIN_DATE),
+    'min_expenditure_date': fields.Date(description=docs.EXPENDITURE_MIN_DATE),
+    'max_expenditure_date': fields.Date(description=docs.EXPENDITURE_MAX_DATE),
+    'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
+    'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
     'min_expenditure_amount': fields.Date(description=docs.EXPENDITURE_MIN_AMOUNT),
     'max_expenditure_amount': fields.Date(description=docs.EXPENDITURE_MAX_AMOUNT),
-    'spender_name': fields.Str(description=docs.COMMITTEE_NAME)
+    'spender_name': fields.List(IStr, description=docs.COMMITTEE_NAME),
+    'candidate_party': fields.List(IStr, description=docs.PARTY),
+    'candidate_office': fields.List(IStr, description=docs.OFFICE),
+    'candidate_office_state': fields.List(IStr, description=docs.STATE),
+    'candidate_office_district': fields.List(IStr, description=docs.DISTRICT),
+    'most_recent': fields.Bool(description=docs.MOST_RECENT)
 }
 
 rad_analyst = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -787,6 +787,7 @@ schedule_e_efile = {
     'max_expenditure_date': fields.Date(description=docs.EXPENDITURE_MIN_DATE),
     'min_expenditure_amount': fields.Date(description=docs.EXPENDITURE_MIN_AMOUNT),
     'max_expenditure_amount': fields.Date(description=docs.EXPENDITURE_MAX_AMOUNT),
+    'spender_name': fields.Str(description=docs.COMMITTEE_NAME)
 }
 
 rad_analyst = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -653,6 +653,7 @@ class ScheduleE(PdfMixin, BaseItemized):
 
 class ScheduleEEfile(BaseRawItemized):
     __tablename__ = 'real_efile_se_f57_vw'
+    # __tablename__ = 'real_efile_se_f57_vw_tmp_hc'
 
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
@@ -700,6 +701,12 @@ class ScheduleEEfile(BaseRawItemized):
     notary_sign_date = db.Column('not_date', db.Date)
 
     dissemination_date = db.Column('dissem_dt', db.Date)
+
+    ###new columns
+    # spender_name = db.Column('com_name', db.String)
+    # filing_date = db.Column('filed_date', db.Date)
+    # candidate_party = db.Column('party', db.String)
+    # most_recent_filing = db.Column('most_recent', db.Boolean)
 
     filing = db.relationship(
         'EFilings',

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -652,8 +652,8 @@ class ScheduleE(PdfMixin, BaseItemized):
 
 
 class ScheduleEEfile(BaseRawItemized):
-    __tablename__ = 'real_efile_se_f57_vw'
-    # __tablename__ = 'real_efile_se_f57_vw_tmp_hc'
+    # __tablename__ = 'real_efile_se_f57_vw'
+    __tablename__ = 'real_efile_se_f57_vw_tmp_hc'
 
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
@@ -700,13 +700,13 @@ class ScheduleEEfile(BaseRawItemized):
 
     notary_sign_date = db.Column('not_date', db.Date)
 
-    dissemination_date = db.Column('dissem_dt', db.Date)
+    dissemination_date = db.Column('dissem_dt', db.Date, doc=docs.DISSEMINATION_DATE)
 
     ###new columns
     # spender_name = db.Column('com_name', db.String)
     # filing_date = db.Column('filed_date', db.Date)
-    # candidate_party = db.Column('party', db.String)
-    # most_recent_filing = db.Column('most_recent', db.Boolean)
+    candidate_party = db.Column('cand_pty_affiliation', db.String)
+    most_recent = db.Column('most_recent', db.Boolean)
 
     filing = db.relationship(
         'EFilings',

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -8,6 +8,7 @@ from webservices import exceptions
 from webservices.common import counts
 from webservices.common import models
 from webservices.utils import use_kwargs
+from sqlalchemy.dialects import postgresql
 
 class ApiResource(utils.Resource):
 
@@ -49,6 +50,9 @@ class ApiResource(utils.Resource):
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         if _apply_options:
             query = query.options(*self.query_options)
+        # print(str(query.statement.compile(
+        #     dialect=postgresql.dialect(),
+        #     compile_kwargs={'literal_binds': True})))
         return query
 
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1074,6 +1074,8 @@ EXPENDITURE_MAX_DATE = 'Selects all items expended by this committee before this
 EXPENDITURE_MIN_DATE = 'Selects all items expended by this committee after this date'
 EXPENDITURE_MIN_AMOUNT = 'Selects all items expended by this committee greater than this amount'
 EXPENDITURE_MAX_AMOUNT = 'Selects all items expended by this committee less than this amount'
+DISSEMINATION_MAX_DATE = 'Selects all items distributed by this committee before this date'
+DISSEMINATION_MIN_DATE = 'Selects all items distributed by this committee after this date'
 
 
 # dates
@@ -1594,4 +1596,8 @@ TOTAL_BY_OFFICE_BY_PARTY_TAG= ''' Aggregated candidate receipts and disbursement
 ACTIVE_CANDIDATE = ''' Candidates who are actively seeking office. If no value is specified, all candidates
 are returned. When True is specified, only active candidates are returned. When False is
 specified, only inactive candidates are returned.
+'''
+DISSEMINATION_DATE = '''
+Date when a PAC distrubutes or disseminates an independent expenditure
+and pays for it in the same reporting period
 '''


### PR DESCRIPTION
## Summary (required)

- Resolves #3813 

_Include a summary of proposed changes._

## How to test the changes locally

- checkout the branch `feature/add-efile-filters`
- export SQLA_CONN to point to DEV DB
- start server ./manage.py runserver
- on Swagger API specs, go to Independent Expenditure section, 
`/schedules/schedule_e/efile/` endpoint.
- test the filters.

## Impacted areas of the application
- Swagger api spec
-  Independent Expenditures raw efilings