### PR TITLE
Use API error instead of marshmallow error, mild refactor for /reports/

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1,19 +1,21 @@
 import functools
 
 from marshmallow.compat import text_type
-from marshmallow import ValidationError
 
 import sqlalchemy as sa
 
 from webargs import fields, validate
 
 from webservices import docs
+from webservices import exceptions
 from webservices.common.models import db
 
 def _validate_natural(value):
     if value < 0:
-        raise ValidationError('Must be a natural number')
-
+        raise exceptions.ApiError(
+            'Must be a natural number',
+            status_code=422
+        )
 Natural = functools.partial(fields.Int, validate=_validate_natural)
 
 per_page = Natural(
@@ -44,9 +46,13 @@ class District(fields.Str):
         try:
             value = int(value)
         except (TypeError, ValueError):
-            raise ValidationError('District must be a number')
+            raise exceptions.ApiError(
+                'District must be a number',
+                status_code=422)
         if value < 0:
-            raise ValidationError('District must be a natural number')
+            raise exceptions.ApiError(
+                'District must be a natural number',
+                status_code=422)
 
     def _deserialize(self, value, attr, data):
         return '{0:0>2}'.format(value)
@@ -70,8 +76,9 @@ class OptionValidator(object):
 
     def __call__(self, value):
         if value.lstrip('-') not in self.values:
-            raise ValidationError(
+            raise exceptions.ApiError(
                 'Cannot sort on value "{0}"'.format(value),
+                status_code=422,
             )
 
 
@@ -113,8 +120,9 @@ class IndicesValidator(IndexValidator):
     def __call__(self, value):
         for sort_column in value:
             if sort_column.lstrip('-') not in self.values:
-                raise ValidationError(
+                raise exceptions.ApiError(
                     'Cannot sort on value "{0}"'.format(value),
+                    status_code=422,
                 )
 
 def make_sort_args(default=None, validator=None, default_hide_null=False,

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -121,7 +121,7 @@ class IndicesValidator(IndexValidator):
         for sort_column in value:
             if sort_column.lstrip('-') not in self.values:
                 raise exceptions.ApiError(
-                    'Cannot sort on value "{0}"'.format(value),
+                    'Cannot sort on value "{0}"'.format(sort_column),
                     status_code=422,
                 )
 


### PR DESCRIPTION
## Summary (required)

Resolves #3785 
- Use API error instead of marshmallow error - marshmallow's built-in `ValidationError` was getting picked up by our generic `handle_exception` function that always throws a 500 error
- Clean up `/reports/<committee_type>/` code

## How to test the changes locally

**API**
- http://localhost:5000/v1/reports/pac-party/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&data_type=processed&two_year_transaction_period=2018&min_receipt_date=01%2F01%2F2017&max_receipt_date=12%2F31%2F2018&sort=-name&per_page=30&page=1 should now throw a 422 error
-  Sort still works: http://localhost:5000/v1/reports/pac-party/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&data_type=processed&two_year_transaction_period=2018&min_receipt_date=01%2F01%2F2017&max_receipt_date=12%2F31%2F2018&sort=-receipt_date&per_page=30&page=1

**CMS**
- Set up your local CMS to point to your local API and test out the following data tables:
- http://localhost:8000/data/reports/presidential/?data_type=processed
- http://localhost:8000/data/reports/house-senate/?data_type=processed
- http://localhost:8000/data/reports/pac-party/?two_year_transaction_period=2020&data_type=processed&min_receipt_date=01%2F01%2F2019&max_receipt_date=12%2F31%2F2020


## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/data/reports/presidential/?data_type=processed
- https://www.fec.gov/data/reports/house-senate/?data_type=processed
- https://www.fec.gov/data/reports/pac-party/?two_year_transaction_period=2020&data_type=processed&min_receipt_date=01%2F01%2F2019&max_receipt_date=12%2F31%2F2020

