### PR TITLE
Add postgres@9.6 login errors and change default return

### DIFF
--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -25,18 +25,29 @@ def to_jdbc_url(dbi_url):
 
 def remove_credentials(error):
     """
-    For PostgreSQL errors, strip out everything except error code and description.
+    For PostgreSQL login errors, strip out everything except error code and description.
     This prevents usernames from being printed.
     For other Flyway-specific errors, go ahead leave them intact.
     """
-    code_lookup = {
-        '08001': 'Connection attempt failed',
-        '28P01': 'Password authentication failed',
-        '42501': 'Insufficient priveledge'
+    login_related_error_codes = {
+        '08000': 'connection_exception',
+        '08001': 'sqlclient_unable_to_establish_sqlconnection',
+        '08003': 'connection_does_not_exist',
+        '08004': 'sqlserver_rejected_establishment_of_sqlconnection',
+        '08006': 'connection_failure',
+        '08007': 'transaction_resolution_unknown',
+        '08P01': 'protocol_violation',
+        '28000': 'invalid_authorization_specificiation',
+        '28P01': 'invalid_password',
+        '3D000': 'invalid_catalog_name',
+        '42000': 'syntax_error_or_access_rule_violation',
+        '42501': 'insufficient_privilege',
+        '42601': 'syntax_error'
     }
     match = re.search(r'.*(SQL State  : )+(?P<error>[a-zA-Z0-9]{0,5})', error)
     if match:
         error_code = match.group('error')
-        return 'PostgreSQL error code {}: {}'.format(error_code, code_lookup.get(error_code, "Unrecognized code. See PostgreSQL docs."))
+        return 'PostgreSQL error code {}: {}'.format(
+            error_code, login_related_error_codes.get(error_code, error))
     else:
         return error


### PR DESCRIPTION
## Summary

- Resolves #3869

add more `postgresql@9.6` error codes, change default return message.

## How to test the changes locally
- set `FEC_MIGRATOR_SQLA_CONN_DEV`
- Change the `FEC_MIGRATOR_SQLA_CONN_DEV` to something that doesn't exist (you can test bad DB name, bad username, bad password)
- no username should be passed in any error messages
- for cases where the error message is not one explicitly listed in `jdbc_utils.py`, the full non-stripped error message should be displayed.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `flyway` migration, `dev`, `stg`, `prd` spaces



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/other_pr | [https://github.com/fecgov/openFEC/pull/3827](https://github.com/fecgov/openFEC/pull/3827)
