### PR TITLE
Fix doubled SA aggregate totals: by_size_by_candidate/by_state_by_candidate

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -367,6 +367,7 @@ class TestCandidateAggregates(ApiBaseTest):
             committee_designation='P',
             committee_type='S',
             fec_election_year=2012,
+            election_yr_to_be_included=2012,
         )
         factories.CandidateCommitteeLinkFactory(
             candidate_id=self.candidate.candidate_id,
@@ -374,6 +375,7 @@ class TestCandidateAggregates(ApiBaseTest):
             committee_designation='A',
             committee_type='S',
             fec_election_year=2012,
+            election_yr_to_be_included=2012,
         )
         factories.CandidateCommitteeLinkFactory(
             candidate_id=self.candidate.candidate_id,
@@ -381,6 +383,7 @@ class TestCandidateAggregates(ApiBaseTest):
             committee_designation='A',
             committee_type='S',
             fec_election_year=2010,
+            election_yr_to_be_included=2012,
         )
         # Create a candidate_zero without a committee and $0 in CandidateTotal
         self.candidate_zero = factories.CandidateHistoryFutureFactory(
@@ -602,6 +605,13 @@ class TestCandidateAggregates(ApiBaseTest):
                 size=200,
                 count=20,
             ),
+            factories.ScheduleABySizeFactory(
+                committee_id=self.committees[1].committee_id,
+                cycle=2010,
+                total=3,
+                size=200,
+                count=3,
+            ),
         ]
         results = self._results(
             api.url_for(
@@ -614,9 +624,27 @@ class TestCandidateAggregates(ApiBaseTest):
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'cycle': 2012,
+            'total': 203,
+            'size': 200,
+            'count': 43,
+        }
+        assert results[0] == expected
+
+        results = self._results(
+            api.url_for(
+                ScheduleABySizeCandidateView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                election_full=False,
+            )
+        )
+        assert len(results) == 1
+        expected = {
+            'candidate_id': self.candidate.candidate_id,
+            'cycle': 2012,
             'total': 200,
             'size': 200,
-            'count': 20,
+            'count': 40,
         }
         assert results[0] == expected
 
@@ -638,6 +666,14 @@ class TestCandidateAggregates(ApiBaseTest):
                 state_full='New York',
                 count=30,
             ),
+            factories.ScheduleAByStateFactory(
+                committee_id=self.committees[1].committee_id,
+                cycle=2010,
+                total=10.01,
+                state='NY',
+                state_full='New York',
+                count=3,
+            ),
         ]
         results = self._results(
             api.url_for(
@@ -650,10 +686,29 @@ class TestCandidateAggregates(ApiBaseTest):
         expected = {
             'candidate_id': self.candidate.candidate_id,
             'cycle': 2012,
+            'total': 210.01,
+            'state': 'NY',
+            'state_full': 'New York',
+            'count': 63,
+        }
+        assert results[0] == expected
+
+        results = self._results(
+            api.url_for(
+                ScheduleAByStateCandidateView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                election_full=False,
+            )
+        )
+        assert len(results) == 1
+        expected = {
+            'candidate_id': self.candidate.candidate_id,
+            'cycle': 2012,
             'total': 200,
             'state': 'NY',
             'state_full': 'New York',
-            'count': 30,
+            'count': 60,
         }
         assert results[0] == expected
 


### PR DESCRIPTION
## Summary (required)

- Resolves #[_3816_](https://github.com/fecgov/openFEC/issues/3816) ,  #[_3874_](https://github.com/fecgov/openFEC/issues/3874)

- API:  /schedules/schedule_a/by_state/by_candidate/ ,    ​/schedules​/schedule_a​/by_size​/by_candidate​/

- This PR mainly fixes two issues: 
    1) When candidates have two elections within the same fec_election_year, current endpoints return with doubles totals.  Subquery is ran against cand_cmte_linkage_mv to produce a distinct set of (candidate_id, committee_id, fec_election_year, election_yr_to_be_included).  This will prevent the totals being counted twice when joining happens between aggregate tables and linkage_mv
    2) When passing election_full=true, cycle=cand_election_year, current endpoints return with two entries per state, and two entries per size category. The count column is part of aggregated calculation too,  and should be summed up because it is per committee, per fec_election_year, and should not be put on group by.  
    3) Replace ofec_candidate_election_mv with column election_yr_to_be_included from cand_cmte_linkage_mv. The data pair (fec_election_year, election_yr_to_be_included) in linkage_mv has been reviewed in previous work and is more accurate, and it included the logic to handle Puerto Rico's election year already.


## How to test the changes locally

- Download the feature branch, and set SQLA_CONN to DEV
1.  To test doubled totals for special elections:
    **"H0PA12181"**
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?page=1&election_full=false&sort_nulls_last=false&per_page=20&sort_null_only=false&sort_hide_null=false&candidate_id=H0PA12181&cycle=2020
results": [
    {
      "count": null,
      "total": 78886.58,
      "cycle": 2020,
      "candidate_id": "H0PA12181",
      "size": 0
    },
    {
      "count": 142,
      "total": 37866.25,
      "cycle": 2020,
      "candidate_id": "H0PA12181",
      "size": 200
    },
    {
      "count": 91,
      "total": 46426.9,
      "cycle": 2020,
      "candidate_id": "H0PA12181",
      "size": 500
    },
    {
      "count": 117,
      "total": 121042.6,
      "cycle": 2020,
      "candidate_id": "H0PA12181",
      "size": 1000
    },
    {
      "count": 52,
      "total": 141421.46,
      "cycle": 2020,
      "candidate_id": "H0PA12181",
      "size": 2000
    }

The total above is half of the one in this endpoint: 
https://api.open.fec.gov/v1/schedules/schedule_a/by_size/by_candidate/?candidate_id=H0PA12181&cycle=2020&election_full=False&per_page=20&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort_null_only=false&page=1&per_page=100&sort_hide_null=false&election_full=false&candidate_id=H0PA12181&cycle=2020&sort_nulls_last=false
**compare with**
https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/?page=1&sort_nulls_last=false&candidate_id=H0PA12181&sort_null_only=false&sort_hide_null=false&election_full=false&cycle=2020&per_page=200&api_key=DEMO_KEY

 **"H8NC09123"**
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?page=1&election_full=false&sort_nulls_last=false&per_page=20&sort_null_only=false&sort_hide_null=false&candidate_id=H8NC09123&cycle=2020
**compare with**
https://api.open.fec.gov/v1/schedules/schedule_a/by_size/by_candidate/?candidate_id=H0PA12181&cycle=2020&election_full=False&per_page=20&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort_null_only=false&page=1&per_page=100&sort_hide_null=false&election_full=False&candidate_id=H8NC09123&cycle=2020&sort_nulls_last=false
**compare with**
https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/?page=1&sort_nulls_last=false&candidate_id=H8NC09123&sort_null_only=false&sort_hide_null=false&election_full=false&cycle=2020&per_page=200&api_key=DEMO_KEY


2. To test two entries for each state/size:
      For each state, or each size, only one entry is returned by api after change

size| Before change | After change
----- | ------------- | -------------
200 |250.0 AND 45472032.719 | 45472282.719
500|800 AND 34876944.99 | 34877744.99

http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?page=1&election_full=true&&sort_nulls_last=false&per_page=20&sort_null_only=false&sort_hide_null=false&candidate_id=P00003392&cycle=2016
**compare with**
https://api.open.fec.gov/v1/schedules/schedule_a/by_size/by_candidate/?api_key=DEMO_KEY&sort_hide_null=false&election_full=true&sort_nulls_last=false&per_page=20&candidate_id=P00003392&page=1&sort_null_only=false&cycle=2016


http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort_null_only=false&page=1&per_page=100&sort_hide_null=false&election_full=true&candidate_id=P80001571&cycle=2020&sort_nulls_last=false
**compare with**
https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/?api_key=DEMO_KEY&sort_hide_null=false&election_full=true&sort_nulls_last=false&per_page=20&candidate_id=P80001571&page=1&sort_null_only=false&cycle=2020&per_page=200


