### PR TITLE
Add security-related headers

### DIFF
--- a/webservices/common/util.py
+++ b/webservices/common/util.py
@@ -31,6 +31,7 @@ def output_json(data, code, headers=None):
     dumped = ujson.dumps(data, **settings) + '\n'
 
     resp = flask.make_response(dumped, code)
+    resp.mimetype = 'application/json'
     resp.headers.extend(headers or {})
     return resp
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -202,7 +202,7 @@ def add_caching_headers(response):
 
 @app.after_request
 def add_secure_headers(response):
-    """Add secure headers """
+    """Add secure headers to each response"""
 
     headers = {
         "X-Content-Type-Options": "nosniff",
@@ -210,10 +210,24 @@ def add_secure_headers(response):
         "X-XSS-Protection": "1; mode=block",
     }
     if env.get_credential('PRODUCTION'):
-        headers["Content-Security-Policy"] = "default-src 'self' data: *.fec.gov *.app.cloud.gov; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src *.fec.gov *.cloud.gov"
-    # Add localhost options
+        headers["Content-Security-Policy"] = \
+            "default-src 'self' " \
+            "data: *.fec.gov *.app.cloud.gov; " \
+            "img-src 'self' data:; " \
+            "script-src 'self' 'unsafe-inline'; " \
+            "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; " \
+            "font-src 'self' https://fonts.gstatic.com data:; " \
+            "connect-src *.fec.gov *.cloud.gov"
+    # local development options
     else:
-        headers["Content-Security-Policy"] = "default-src 'self' data: *.fec.gov *.app.cloud.gov localhost:* http://127.0.0.1:*; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src *.fec.gov *.cloud.gov localhost:* http://127.0.0.1:*"
+        headers["Content-Security-Policy"] = \
+            "default-src 'self' " \
+            "data: *.fec.gov *.app.cloud.gov localhost:* http://127.0.0.1:*; " \
+            "img-src 'self' data:; " \
+            "script-src 'self' 'unsafe-inline'; " \
+            "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; " \
+            "font-src 'self' https://fonts.gstatic.com data:; " \
+            "connect-src *.fec.gov *.cloud.gov localhost:* http://127.0.0.1:*"
 
     for header, value in headers.items():
         response.headers.add(header, value)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -204,7 +204,11 @@ def add_caching_headers(response):
 
 @app.after_request
 def add_secure_headers(response):
-    """Add secure headers to each response"""
+    """
+    Add secure headers to each response.
+    The 'unsafe-inline' Content Security Policy (CSP) setting is
+    needed for Swagger docs (see https://github.com/swagger-api/swagger-ui/issues/3370)
+    """
 
     headers = {
         "X-Content-Type-Options": "nosniff",

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -208,8 +208,13 @@ def add_secure_headers(response):
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "Deny",
         "X-XSS-Protection": "1; mode=block",
-        "Content-Security-Policy": "default-src 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src localhost:5000 *.fec.gov *.cloud.gov",
     }
+    if env.get_credential('PRODUCTION'):
+        headers["Content-Security-Policy"] = "default-src 'self' data: *.fec.gov *.app.cloud.gov; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src *.fec.gov *.cloud.gov"
+    # Add localhost options
+    else:
+        headers["Content-Security-Policy"] = "default-src 'self' data: *.fec.gov *.app.cloud.gov localhost:* http://127.0.0.1:*; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src *.fec.gov *.cloud.gov localhost:* http://127.0.0.1:*"
+
     for header, value in headers.items():
         response.headers.add(header, value)
     return response

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -200,6 +200,7 @@ def add_caching_headers(response):
     response.headers.add(cache_header_type, cache_header)
     return response
 
+
 @app.after_request
 def add_secure_headers(response):
     """Add secure headers to each response"""
@@ -209,29 +210,27 @@ def add_secure_headers(response):
         "X-Frame-Options": "Deny",
         "X-XSS-Protection": "1; mode=block",
     }
-    if env.get_credential('PRODUCTION'):
-        headers["Content-Security-Policy"] = \
-            "default-src 'self' " \
-            "data: *.fec.gov *.app.cloud.gov; " \
-            "img-src 'self' data:; " \
-            "script-src 'self' 'unsafe-inline'; " \
-            "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; " \
-            "font-src 'self' https://fonts.gstatic.com data:; " \
-            "connect-src *.fec.gov *.cloud.gov"
-    # local development options
-    else:
-        headers["Content-Security-Policy"] = \
-            "default-src 'self' " \
-            "data: *.fec.gov *.app.cloud.gov localhost:* http://127.0.0.1:*; " \
-            "img-src 'self' data:; " \
-            "script-src 'self' 'unsafe-inline'; " \
-            "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; " \
-            "font-src 'self' https://fonts.gstatic.com data:; " \
-            "connect-src *.fec.gov *.cloud.gov localhost:* http://127.0.0.1:*"
+    content_security_policy = {
+        "default-src": "'self' data: *.fec.gov *.app.cloud.gov",
+        "img-src": "'self' data:",
+        "script-src": "'self' 'unsafe-inline'",
+        "style-src": "'self' https://fonts.googleapis.com 'unsafe-inline'",
+        "font-src": "'self' https://fonts.gstatic.com data:",
+        "connect-src": "*.fec.gov *.cloud.gov",
+    }
+    if env.app.get('space_name', 'local').lower() == 'local':
+        content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
+        content_security_policy["connect-src"] += " localhost:* http://127.0.0.1:*"
+
+    headers["Content-Security-Policy"] = "".join(
+        "{0} {1}; ".format(directive, value)
+        for directive, value in content_security_policy.items()
+    )
 
     for header, value in headers.items():
         response.headers.add(header, value)
     return response
+
 
 @app.errorhandler(Exception)
 def handle_exception(exception):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -211,12 +211,13 @@ def add_secure_headers(response):
         "X-XSS-Protection": "1; mode=block",
     }
     content_security_policy = {
-        "default-src": "'self' data: *.fec.gov *.app.cloud.gov",
+        "default-src": "'self' *.fec.gov *.app.cloud.gov",
         "img-src": "'self' data:",
         "script-src": "'self' 'unsafe-inline'",
         "style-src": "'self' https://fonts.googleapis.com 'unsafe-inline'",
         "font-src": "'self' https://fonts.gstatic.com data:",
         "connect-src": "*.fec.gov *.cloud.gov",
+        "object-src": "'none'",
     }
     if env.app.get('space_name', 'local').lower() == 'local':
         content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -200,6 +200,19 @@ def add_caching_headers(response):
     response.headers.add(cache_header_type, cache_header)
     return response
 
+@app.after_request
+def add_secure_headers(response):
+    """Add secure headers """
+
+    headers = {
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "Deny",
+        "X-XSS-Protection": "1; mode=block",
+        "Content-Security-Policy": "default-src 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; connect-src localhost:5000 *.fec.gov *.cloud.gov",
+    }
+    for header, value in headers.items():
+        response.headers.add(header, value)
+    return response
 
 @app.errorhandler(Exception)
 def handle_exception(exception):
@@ -298,7 +311,7 @@ def add_aggregate_resource(api, view, schedule, label):
         '/committee/<committee_id>/schedules/schedule_{schedule}/by_{label}/'.format(**locals()),
     )
 
-    
+
 add_aggregate_resource(api, aggregates.ScheduleABySizeView, 'a', 'size')
 add_aggregate_resource(api, aggregates.ScheduleAByStateView, 'a', 'state')
 add_aggregate_resource(api, aggregates.ScheduleAByZipView, 'a', 'zip')


### PR DESCRIPTION
## Summary (required)

Resolves #3876 

- Add security-related headers to all responses (keep `Access-Control-Allow-Origin: *` header unchanged because this is a public API). See original issue for background information.
- Add endpoint for Content Security Policy (CSP) violation reporting
- Currently deployed to stage: https://api-stage.open.fec.gov/developers/

## How to test the changes locally

- run the API locally, check swagger UI browser errors
- `curl -I "http://localhost:5000/v1/committees"` to check headers

## How to test the changes on stage

- I pushed a deploy to `stage` with Circle (as of 8/28)
- Test API for console errors
- Curl API to check headers
- Run scan like https://securityheaders.com/ and https://csp-evaluator.withgoogle.com/ results
- Make sure CMS can still access what it needs
- For developers, open up your inspector console and look for errors like this: `Refused to load the script 'https://example.gov' because it violates the following Content Security Policy directive:...`