### PR TITLE
[WIP] Treat `stage` as a production environment

### DIFF
--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -6,6 +6,7 @@ buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true
   APP_NAME: fec | api | stage
+  PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
   - fec-api-search56

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -6,6 +6,7 @@ buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true
   APP_NAME: fec | api | stage
+  PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
   - fec-api-search56

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -6,6 +6,7 @@ buildpack: python_buildpack
 env:
   FEC_API_WHITELIST_IPS: true
   APP_NAME: fec | api | stage
+  PRODUCTION: True
   WEB_CONCURRENCY: 4
 services:
   - fec-api-search56


### PR DESCRIPTION
## Summary (required)

Resolves issue found in testing: Treat `stage` as a production environment

- Better testing for releases
- Adds `DEMO_KEY` as default key in Swagger for `stage`

## Testing
- I found this while trying to test something else on `stage` (try "Try it out" and note that `DEMO_KEY` isn't added: https://api-stage.open.fec.gov/developers/)
- The only true way to test this is with a manual deploy to `stage`


