### PR TITLE
Fix inconsistent totals derived from misfiled F3* data

### DIFF
--- a/data/migrations/V0159__ofec_candidate_totals_mv_include_all_F3_F3P_F3X_exclude_non_candidate_cmtes.sql
+++ b/data/migrations/V0159__ofec_candidate_totals_mv_include_all_F3_F3P_F3X_exclude_non_candidate_cmtes.sql
@@ -1,0 +1,241 @@
+/*
+This is part of migration files solving issues #3925
+Candidate committees supposed to report their financial activity by
+cmte_tp = H/S (filed F3)
+cmte_tp = P (filed F3P)
+However, sometimes candidate committees filed incorrect F3* forms.  
+Original the source of the totals in this MV are from 
+ofec_totals_house_senate_vw
+ofec_totals_presidential_vw
+which are both derived from ofec_totals_combined_vw, separated by Form_type.
+This will miss F3X filed by candidate committees.
+This migration file update the definition to directly takes the totals from ofec_totals_combined_vw.
+Takes all F3* forms (candidate committees also files other forms such as F10, F11, F12, F5)
+filed by cmte_dsgn P/A (exclude J, D, etc) candidate committees ('H','P','S')
+*/
+
+-- ----------------------
+-- ofec_candidate_totals_mv_tmp
+-- ----------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp;
+CREATE MATERIALIZED VIEW ofec_candidate_totals_mv_tmp AS
+WITH totals AS (
+         SELECT ofec_totals_combined_vw.committee_id,
+            ofec_totals_combined_vw.cycle,
+            ofec_totals_combined_vw.receipts,
+            ofec_totals_combined_vw.disbursements,
+            ofec_totals_combined_vw.last_cash_on_hand_end_period,
+            ofec_totals_combined_vw.last_debts_owed_by_committee,
+            ofec_totals_combined_vw.coverage_start_date,
+            ofec_totals_combined_vw.coverage_end_date,
+            ofec_totals_combined_vw.federal_funds_flag
+           FROM ofec_totals_combined_vw
+           WHERE form_type in ('F3', 'F3P', 'F3X')
+           AND committee_type in ('H','P','S')
+           AND committee_designation in ('P','A')
+        ), link AS (
+         SELECT ofec_cand_cmte_linkage_vw.cand_id,
+            ofec_cand_cmte_linkage_vw.election_yr_to_be_included + ofec_cand_cmte_linkage_vw.election_yr_to_be_included % 2::numeric AS election_yr_to_be_included,
+            ofec_cand_cmte_linkage_vw.fec_election_yr,
+            ofec_cand_cmte_linkage_vw.cmte_id
+           FROM ofec_cand_cmte_linkage_vw
+          WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn::text = ANY (ARRAY['P'::character varying::text, 'A'::character varying::text])
+          -- should only include candidate committees 
+          AND substr(ofec_cand_cmte_linkage_vw.cand_id, 1, 1) = ofec_cand_cmte_linkage_vw.cmte_tp
+          --
+          GROUP BY ofec_cand_cmte_linkage_vw.cand_id, ofec_cand_cmte_linkage_vw.election_yr_to_be_included, ofec_cand_cmte_linkage_vw.fec_election_yr, ofec_cand_cmte_linkage_vw.cmte_id
+        ), cycle_cmte_totals_basic AS (
+         SELECT link.cand_id,
+            link.cmte_id,
+            link.election_yr_to_be_included,
+            totals_1.cycle,
+            false AS is_election,
+            totals_1.receipts,
+            totals_1.disbursements,
+            first_value(totals_1.last_cash_on_hand_end_period) OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_cash_on_hand_end_period,
+            first_value(totals_1.last_debts_owed_by_committee) OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_debts_owed_by_committee,
+            totals_1.coverage_start_date,
+            totals_1.coverage_end_date,
+            totals_1.federal_funds_flag
+           FROM link
+           -- --
+             JOIN totals totals_1 ON link.cmte_id::text = totals_1.committee_id::text AND link.fec_election_yr = totals_1.cycle::numeric
+        ), cycle_cmte_totals AS (
+         SELECT cycle_cmte_totals_basic.cand_id AS candidate_id,
+            cycle_cmte_totals_basic.cmte_id,
+            cycle_cmte_totals_basic.election_yr_to_be_included AS election_year,
+            cycle_cmte_totals_basic.cycle,
+            sum(cycle_cmte_totals_basic.receipts) AS receipts,
+            sum(cycle_cmte_totals_basic.disbursements) AS disbursements,
+            max(cycle_cmte_totals_basic.last_cash_on_hand_end_period) AS cash_on_hand_end_period_per_cmte,
+            max(cycle_cmte_totals_basic.last_debts_owed_by_committee) AS debts_owed_by_committee_per_cmte,
+            min(cycle_cmte_totals_basic.coverage_start_date) AS coverage_start_date,
+            max(cycle_cmte_totals_basic.coverage_end_date) AS coverage_end_date,
+            array_agg(cycle_cmte_totals_basic.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+           FROM cycle_cmte_totals_basic
+          GROUP BY cycle_cmte_totals_basic.cand_id, cycle_cmte_totals_basic.election_yr_to_be_included, cycle_cmte_totals_basic.cycle, cycle_cmte_totals_basic.cmte_id
+        ), cycle_totals AS (
+         SELECT cycle_cmte_totals.candidate_id,
+            cycle_cmte_totals.election_year,
+            cycle_cmte_totals.cycle,
+            false AS is_election,
+            sum(cycle_cmte_totals.receipts) AS receipts,
+            sum(cycle_cmte_totals.disbursements) AS disbursements,
+            sum(cycle_cmte_totals.receipts) > 0::numeric AS has_raised_funds,
+            sum(cycle_cmte_totals.cash_on_hand_end_period_per_cmte) AS cash_on_hand_end_period,
+            sum(cycle_cmte_totals.debts_owed_by_committee_per_cmte) AS debts_owed_by_committee,
+            min(cycle_cmte_totals.coverage_start_date) AS coverage_start_date,
+            max(cycle_cmte_totals.coverage_end_date) AS coverage_end_date,
+            array_agg(cycle_cmte_totals.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+           FROM cycle_cmte_totals
+          GROUP BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cycle
+        ), election_cmte_totals_basic AS (
+         SELECT cycle_cmte_totals.candidate_id,
+            cycle_cmte_totals.cmte_id,
+            cycle_cmte_totals.cycle,
+            cycle_cmte_totals.election_year,
+            cycle_cmte_totals.receipts,
+            cycle_cmte_totals.disbursements,
+            first_value(cycle_cmte_totals.cash_on_hand_end_period_per_cmte) OVER (PARTITION BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cmte_id ORDER BY cycle_cmte_totals.cycle DESC NULLS LAST) AS last_cash_on_hand_end_period,
+            first_value(cycle_cmte_totals.debts_owed_by_committee_per_cmte) OVER (PARTITION BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cmte_id ORDER BY cycle_cmte_totals.cycle DESC NULLS LAST) AS last_debts_owed_by_committee,
+            cycle_cmte_totals.coverage_start_date,
+            cycle_cmte_totals.coverage_end_date,
+            cycle_cmte_totals.federal_funds_flag
+           FROM cycle_cmte_totals
+        ), election_cmte_totals AS (
+         SELECT election_cmte_totals_basic.candidate_id,
+            election_cmte_totals_basic.cmte_id,
+            election_cmte_totals_basic.election_year,
+            sum(election_cmte_totals_basic.receipts) AS receipts,
+            sum(election_cmte_totals_basic.disbursements) AS disbursements,
+            max(election_cmte_totals_basic.last_cash_on_hand_end_period) AS last_cash_on_hand_end_period,
+            max(election_cmte_totals_basic.last_debts_owed_by_committee) AS last_debts_owed_by_committee,
+            min(election_cmte_totals_basic.coverage_start_date) AS coverage_start_date,
+            max(election_cmte_totals_basic.coverage_end_date) AS coverage_end_date,
+            array_agg(election_cmte_totals_basic.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+           FROM election_cmte_totals_basic
+          GROUP BY election_cmte_totals_basic.candidate_id, election_cmte_totals_basic.election_year, election_cmte_totals_basic.cmte_id
+        ), combined_totals AS (
+         SELECT election_cmte_totals.candidate_id,
+            election_cmte_totals.election_year,
+            election_cmte_totals.election_year AS cycle,
+            true AS is_election,
+            sum(election_cmte_totals.receipts) AS receipts,
+            sum(election_cmte_totals.disbursements) AS disbursements,
+            sum(election_cmte_totals.receipts) > 0::numeric AS has_raised_funds,
+            sum(election_cmte_totals.last_cash_on_hand_end_period) AS cash_on_hand_end_period,
+            sum(election_cmte_totals.last_debts_owed_by_committee) AS debts_owed_by_committee,
+            min(election_cmte_totals.coverage_start_date) AS coverage_start_date,
+            max(election_cmte_totals.coverage_end_date) AS coverage_end_date,
+            array_agg(election_cmte_totals.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag
+           FROM election_cmte_totals
+          GROUP BY election_cmte_totals.candidate_id, election_cmte_totals.election_year
+        UNION ALL
+         SELECT cycle_totals.candidate_id,
+            cycle_totals.election_year,
+            cycle_totals.cycle,
+            false AS is_election,
+            cycle_totals.receipts,
+            cycle_totals.disbursements,
+            cycle_totals.has_raised_funds,
+            cycle_totals.cash_on_hand_end_period,
+            cycle_totals.debts_owed_by_committee,
+            cycle_totals.coverage_start_date,
+            cycle_totals.coverage_end_date,
+            cycle_totals.federal_funds_flag
+           FROM cycle_totals
+        )
+ SELECT cand.candidate_id,
+ -- --
+    candidate_election_year AS election_year,
+    cand.two_year_period AS cycle,
+    COALESCE(totals.is_election,
+        CASE
+        -- --
+            WHEN cand.candidate_election_year = cand.two_year_period THEN true
+            ELSE false
+        END) AS is_election,
+    COALESCE(totals.receipts, 0::numeric) AS receipts,
+    COALESCE(totals.disbursements, 0::numeric) AS disbursements,
+    COALESCE(totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE(totals.cash_on_hand_end_period, 0::numeric) AS cash_on_hand_end_period,
+    COALESCE(totals.debts_owed_by_committee, 0::numeric) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE(totals.federal_funds_flag, false) AS federal_funds_flag,
+    cand.party,
+    cand.office,
+    cand.candidate_inactive
+   FROM ofec_candidate_history_with_future_election_vw cand
+     LEFT JOIN combined_totals totals ON cand.candidate_id::text = totals.candidate_id::text AND cand.two_year_period = totals.cycle
+WITH DATA;
+
+--Permissions
+ALTER TABLE public.ofec_candidate_totals_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_totals_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_totals_mv_tmp TO fec_read;
+
+--Indexes
+CREATE UNIQUE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id, election_year, cycle, is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cycle ON public.ofec_candidate_totals_mv_tmp USING btree (cycle);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_is_election ON public.ofec_candidate_totals_mv_tmp USING btree (is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_receipts ON public.ofec_candidate_totals_mv_tmp USING btree (receipts);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_disbursements ON public.ofec_candidate_totals_mv_tmp USING btree (disbursements);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_election_year ON public.ofec_candidate_totals_mv_tmp USING btree (election_year);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_federal_funds_flag ON public.ofec_candidate_totals_mv_tmp USING btree (federal_funds_flag);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_has_raised_funds ON public.ofec_candidate_totals_mv_tmp USING btree (has_raised_funds);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_office ON public.ofec_candidate_totals_mv_tmp USING btree (office);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_party ON public.ofec_candidate_totals_mv_tmp USING btree (party);
+
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_candidate_totals_vw AS 
+SELECT * FROM public.ofec_candidate_totals_mv_tmp;
+-- ---------------
+ALTER TABLE public.ofec_candidate_totals_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_totals_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_totals_vw TO fec_read;
+
+
+-- drop old MV
+DROP MATERIALIZED VIEW public.ofec_candidate_totals_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp RENAME TO ofec_candidate_totals_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect RENAME TO idx_ofec_candidate_totals_mv_cand_id_elec_yr_cycle_is_elect;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id RENAME TO idx_ofec_candidate_totals_mv_cand_id;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cycle RENAME TO idx_ofec_candidate_totals_mv_cycle;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_is_election RENAME TO idx_ofec_candidate_totals_mv_is_election;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_receipts RENAME TO idx_ofec_candidate_totals_mv_receipts;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_disbursements RENAME TO idx_ofec_candidate_totals_mv_disbursements;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_election_year RENAME TO idx_ofec_candidate_totals_mv_election_year;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_federal_funds_flag RENAME TO idx_ofec_candidate_totals_mv_federal_funds_flag;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_has_raised_funds RENAME TO idx_ofec_candidate_totals_mv_has_raised_funds;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_office RENAME TO idx_ofec_candidate_totals_mv_office;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_party RENAME TO idx_ofec_candidate_totals_mv_party;
+
+

--- a/data/migrations/V0159__ofec_candidate_totals_mv_include_all_F3_F3P_F3X_exclude_non_candidate_cmtes.sql
+++ b/data/migrations/V0159__ofec_candidate_totals_mv_include_all_F3_F3P_F3X_exclude_non_candidate_cmtes.sql
@@ -39,9 +39,9 @@ WITH totals AS (
             ofec_cand_cmte_linkage_vw.fec_election_yr,
             ofec_cand_cmte_linkage_vw.cmte_id
            FROM ofec_cand_cmte_linkage_vw
-          WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn::text = ANY (ARRAY['P'::character varying::text, 'A'::character varying::text])
+          WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn in ('P','A')
           -- should only include candidate committees 
-          AND substr(ofec_cand_cmte_linkage_vw.cand_id, 1, 1) = ofec_cand_cmte_linkage_vw.cmte_tp
+          AND ofec_cand_cmte_linkage_vw.cmte_tp in ('H','P','S')
           --
           GROUP BY ofec_cand_cmte_linkage_vw.cand_id, ofec_cand_cmte_linkage_vw.election_yr_to_be_included, ofec_cand_cmte_linkage_vw.fec_election_yr, ofec_cand_cmte_linkage_vw.cmte_id
         ), cycle_cmte_totals_basic AS (

--- a/data/migrations/V0160__ofec_totals_house_senate_mv_include_all_F3_F3P_F3X_exclude_non_H_S_candidate_cmtes.sql
+++ b/data/migrations/V0160__ofec_totals_house_senate_mv_include_all_F3_F3P_F3X_exclude_non_H_S_candidate_cmtes.sql
@@ -1,0 +1,152 @@
+/*
+This is part of migration files solving issues #3925
+House and Senate candidate committees supposed to report their financial activity by
+cmte_tp = H/S (filed F3)
+However, sometimes candidate committees filed incorrect F3* forms.  
+
+The source of this MV is ofec_totals_combined_vw, separated by Form_type F3.
+This will miss F3P/F3X filed by house and Senate candidate committees.
+
+This migration file update the definition to takes 
+all F3* forms (candidate committees also files other forms such as F10, F11, F12, F5)
+filed by cmte_dsgn P/A (exclude J, D, etc) house and Senate candidate committees ('H','S')
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_house_senate_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_totals_house_senate_mv_tmp AS 
+WITH hs_cycle AS 
+(
+        SELECT DISTINCT ON (cmte_id, fec_election_yr) cmte_id AS committee_id,
+        election_yr_to_be_included as cand_election_yr,
+        fec_election_yr AS cycle
+        FROM ofec_cand_cmte_linkage_mv
+        where cmte_tp in ('H','S')
+        and cmte_dsgn in ('P','A')
+        and election_yr_to_be_included is not null
+        ORDER BY cmte_id, fec_election_yr, election_yr_to_be_included
+)
+SELECT f3.candidate_id,
+    f3.cycle,
+    f3.sub_id AS idx,
+    f3.committee_id,
+    hs_cycle.cand_election_yr AS election_cycle,
+    f3.coverage_start_date,
+    f3.coverage_end_date,
+    f3.all_other_loans,
+    f3.candidate_contribution,
+    f3.contribution_refunds,
+    f3.contributions,
+    f3.disbursements,
+    f3.individual_contributions,
+    f3.individual_itemized_contributions,
+    f3.individual_unitemized_contributions,
+    f3.loan_repayments,
+    f3.loan_repayments_candidate_loans,
+    f3.loan_repayments_other_loans,
+    f3.loans,
+    f3.loans_made_by_candidate,
+    f3.net_contributions,
+    f3.net_operating_expenditures,
+    f3.offsets_to_operating_expenditures,
+    f3.operating_expenditures,
+    f3.other_disbursements,
+    f3.other_political_committee_contributions,
+    f3.other_receipts,
+    f3.political_party_committee_contributions,
+    f3.receipts,
+    f3.refunded_individual_contributions,
+    f3.refunded_other_political_committee_contributions,
+    f3.refunded_political_party_committee_contributions,
+    f3.transfers_from_other_authorized_committee,
+    f3.transfers_to_other_authorized_committee,
+    f3.last_report_type_full,
+    f3.last_beginning_image_number,
+    f3.cash_on_hand_beginning_period,
+    f3.last_cash_on_hand_end_period,
+    f3.last_debts_owed_by_committee,
+    f3.last_debts_owed_to_committee,
+    f3.last_report_year,
+    f3.committee_name,
+    f3.committee_type,
+    f3.committee_designation,
+    f3.committee_type_full,
+    f3.committee_designation_full,
+    f3.party_full
+FROM ofec_totals_combined_vw f3
+    LEFT JOIN hs_cycle USING (committee_id, cycle)
+WHERE f3.form_type in ('F3', 'F3P', 'F3X')
+AND f3.committee_type in ('H','S')
+AND f3.committee_designation in ('P','A')
+WITH DATA;
+
+--Permissions
+ALTER TABLE public.ofec_totals_house_senate_mv_tmp
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_totals_house_senate_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_totals_house_senate_mv_tmp TO fec_read;
+
+--Indexes
+CREATE UNIQUE INDEX idx_ofec_totals_house_senate_mv_tmp_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (idx);
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cand_id_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (candidate_id COLLATE pg_catalog."default", idx);
+
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cmte_id_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (committee_id COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cmte_tp_full_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (committee_type_full COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cycle_cmte_id
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (cycle, committee_id COLLATE pg_catalog."default");
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cycle_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (cycle, idx);
+
+CREATE INDEX idx_ofec_totals_house_senate_mv_tmp_cmte_dsgn_full_idx
+  ON public.ofec_totals_house_senate_mv_tmp
+  USING btree
+  (committee_designation_full COLLATE pg_catalog."default", idx);
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_totals_house_senate_vw AS 
+SELECT * FROM public.ofec_totals_house_senate_mv_tmp;
+-- ---------------
+ALTER TABLE public.ofec_totals_house_senate_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_totals_house_senate_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_totals_house_senate_vw TO fec_read;
+
+-- drop old MV
+DROP MATERIALIZED VIEW public.ofec_totals_house_senate_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_totals_house_senate_mv_tmp RENAME TO ofec_totals_house_senate_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_idx RENAME TO idx_ofec_totals_house_senate_mv_idx;
+
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_cand_id_idx RENAME TO idx_ofec_totals_house_senate_mv_cand_id_idx;
+
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_cmte_id_idx RENAME TO idx_ofec_totals_house_senate_mv_cmte_id_idx;
+
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_totals_house_senate_mv_cycle_cmte_id;
+
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_cycle_idx RENAME TO idx_ofec_totals_house_senate_mv_cycle_idx;
+
+ALTER INDEX IF EXISTS idx_ofec_totals_house_senate_mv_tmp_cmte_dsgn_full_idx RENAME TO idx_ofec_totals_house_senate_mv_cmte_dsgn_full_idx;


### PR DESCRIPTION
## Summary (required)

- Resolves #[3925](https://github.com/fecgov/openFEC/issues/3925): update ofec_candidate_totals_mv and ofec_totals_house_senate_mv to include all F3/F3P/F3X and exclude non_candidate P/A committees

## How to test the changes locally
Download the branch to local machine.  
Run migration to make sure both migration files executed successfully.
A _tmp version of these two MV had been created in DEV database:
ofec_candidate_totals_mv_tmp
ofec_totals_house_senate_mv_tmp

To test API locally, on local machine, update the following two model files:
**webservices/common/models/candidates.py**
**webservices/common/models/totals.py**
**To point to the _tmp MVs**

Here are two examples of Candidate committees files incorrect F3/F3P/F3X forms so their totals are inconsistent in the 3 end-points stated in the ticket:

**H8CA35115, 2018, CA, 35**
--
Database:
--
select * from ofec_cand_cmte_linkage_mv where cmte_id = 'C00659243';
-- "H8CA35115"

select form_type, committee_type, committee_designation, receipts, disbursements, * 
from ofec_totals_combined_mv
where committee_id = 'C00659243' 
order by cycle;

select committee_type, committee_designation, receipts, disbursements, * 
from ofec_totals_house_senate_mv_tmp
where committee_id = 'C00659243' 
order by cycle;

select receipts, disbursements, * 
from ofec_candidate_totals_mv_tmp 
where candidate_id = 'H8CA35115';

select receipts, disbursements, * 
from ofec_candidate_totals_detail_mv 
where candidate_id = 'H8CA35115';

-- 
API: (compare production vs local)
--
production:
https://api.open.fec.gov/v1/elections/?api_key=DEMO_KEY&cycle=2018&election_full=true&district=35&state=CA&office=house&sort_null_only=false&sort=-total_receipts&sort_hide_null=false&sort_nulls_last=false&per_page=20&page=1

local:
http://127.0.0.1:5000/v1/elections/?state=CA&per_page=20&page=1&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&election_full=true&sort=-total_receipts&district=35&office=house&cycle=2018

production:
https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&election_full=true&election_year=2018&candidate_id=H8CA35115&office=H&sort_null_only=false&sort_nulls_last=false&sort_hide_null=false&per_page=20&page=1

local:
http://127.0.0.1:5000/v1/candidates/totals/?per_page=20&candidate_id=H8CA35115&office=H&cycle=2018&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&page=1&election_full=true

**P60003670, 2016**
Database:
select * from ofec_cand_cmte_linkage_mv where cmte_id = 'C00581876';
-- "P60003670"

select form_type, committee_type, committee_designation, receipts, disbursements, * 
from ofec_totals_combined_mv
where committee_id = 'C00581876' 
and cycle = 2016;

select receipts, disbursements, * 
from ofec_candidate_totals_mv_tmp 
where candidate_id = 'P60003670'
and cycle = 2016;

select receipts, disbursements, * 
from ofec_candidate_totals_detail_mv 
where candidate_id = 'P60003670'
and cycle = 2016;

--
API: (compare production vs local)
--
-- production
https://api.open.fec.gov/v1/candidates/totals/?api_key=DEMO_KEY&election_full=true&election_year=2016&candidate_id=P60003670&office=P&sort_null_only=false&sort_nulls_last=false&sort_hide_null=false&per_page=20&page=1

-- local:
http://127.0.0.1:5000/v1/candidates/totals/?per_page=20&candidate_id=P60003670&office=P&cycle=2016&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&page=1&election_full=true


-- production
https://api.open.fec.gov/v1/elections/?api_key=DEMO_KEY&cycle=2016&election_full=true&office=president&sort_null_only=false&sort=-total_receipts&sort_hide_null=false&sort_nulls_last=false&per_page=400&page=1

-- local:
http://127.0.0.1:5000/v1/elections/?per_page=400&page=1&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&election_full=true&sort=-total_receipts&office=president&cycle=2016

## Impacted areas of the application
List general components of the application that this PR will affect:

- No API changes directly.  The data in the following API will be corrected from the changes:
Financial/Elections/
Candidates/candidates/totals

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
