### PR TITLE
[MERGE WITH GIT FLOW] Fix candidate 404

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -250,14 +250,14 @@ class TestCandidateHistory(ApiBaseTest):
         assert results[1]['two_year_period'] == history_2008.two_year_period
 
     def test_election_full(self):
-        # When elction_full=true, two_year_period should equal to candidate_election_year
+        # When election_full=true, return all two_year_periods with that candidate_election_year
         candidate = factories.CandidateDetailFactory(candidate_id='H001')
-        history_election_full_false = factories.CandidateHistoryFactory(
+        first_two_year_period = factories.CandidateHistoryFactory(
             candidate_id=candidate.candidate_id,
             two_year_period=2018,
             candidate_election_year=2020,
         )
-        history_election_full_true = factories.CandidateHistoryFactory(
+        second_two_year_period = factories.CandidateHistoryFactory(
             candidate_id=candidate.candidate_id,
             two_year_period=2020,
             candidate_election_year=2020,
@@ -281,9 +281,9 @@ class TestCandidateHistory(ApiBaseTest):
             )
         )
         assert len(results_false) == 1
-        assert results_false[0]['candidate_id'] == history_election_full_false.candidate_id
-        assert results_false[0]['two_year_period'] == history_election_full_false.two_year_period
-        assert results_false[0]['candidate_election_year'] == history_election_full_false.candidate_election_year
+        assert results_false[0]['candidate_id'] == first_two_year_period.candidate_id
+        assert results_false[0]['two_year_period'] == first_two_year_period.two_year_period
+        assert results_false[0]['candidate_election_year'] == first_two_year_period.candidate_election_year
 
         # test election_full='true'
         results_true = self._results(
@@ -294,10 +294,14 @@ class TestCandidateHistory(ApiBaseTest):
                 election_full='true',
             )
         )
-        assert len(results_true) == 1
-        assert results_true[0]['candidate_id'] == history_election_full_true.candidate_id
-        assert results_true[0]['two_year_period'] == history_election_full_true.two_year_period
-        assert results_true[0]['candidate_election_year'] == history_election_full_true.candidate_election_year
+        assert len(results_true) == 2
+        assert results_true[0]['candidate_id'] == second_two_year_period.candidate_id
+        assert results_true[0]['two_year_period'] == second_two_year_period.two_year_period
+        assert results_true[0]['candidate_election_year'] == second_two_year_period.candidate_election_year
+        # Default sort is two_year_period descending
+        assert results_true[1]['candidate_id'] == first_two_year_period.candidate_id
+        assert results_true[1]['two_year_period'] == first_two_year_period.two_year_period
+        assert results_true[1]['candidate_election_year'] == first_two_year_period.candidate_election_year
 
     def test_committee_cycle(self):
         results = self._results(

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -242,10 +242,12 @@ class CandidateHistoryView(ApiResource):
             # use for
             # '/candidate/<string:candidate_id>/history/<int:cycle>/',
             # '/committee/<string:committee_id>/candidates/history/<int:cycle>/',
-            query = query.filter(models.CandidateHistory.two_year_period == cycle)
             if kwargs.get('election_full'):
                 query = query.filter(
                     (models.CandidateHistory.candidate_election_year % 2 +
                         models.CandidateHistory.candidate_election_year) == cycle
                 )
+            else:
+                query = query.filter(models.CandidateHistory.two_year_period == cycle)
+
         return query


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-cms/issues/3163

**Fix future candidate history query**

```
-- Before

SELECT * 
FROM ofec_candidate_history_mv 
LEFT OUTER JOIN ofec_candidate_flag_mv AS ofec_candidate_flag_mv_1 
ON ofec_candidate_flag_mv_1.candidate_id = ofec_candidate_history_mv.candidate_id 
WHERE ofec_candidate_history_mv.candidate_id = 'S2MA00170' 
--
--Extra filter on future two-year-period:
--
AND ofec_candidate_history_mv.two_year_period = 2024 
--
AND ofec_candidate_history_mv.candidate_election_year % 2 + ofec_candidate_history_mv.candidate_election_year = 2024

-- After

SELECT * 
FROM ofec_candidate_history_mv 
LEFT OUTER JOIN ofec_candidate_flag_mv AS ofec_candidate_flag_mv_1 
ON ofec_candidate_flag_mv_1.candidate_id = ofec_candidate_history_mv.candidate_id 
WHERE ofec_candidate_history_mv.candidate_id = 'S2MA00170' 
AND ofec_candidate_history_mv.candidate_election_year % 2 + ofec_candidate_history_mv.candidate_election_year = 2024
```

## How to test the changes locally

- Check out and run this branch, point to any DB
- http://127.0.0.1:5000/v1/candidate/S2MA00170/history/2024?per_page=1&election_full=True should return data
- Run CMS locally and point to local API, http://localhost:8000/data/candidate/S2MA00170/ should now load and not 404
- Test other future cycle candidates (can look at http://localhost:8000/data/candidates/?has_raised_funds=true&is_active_candidate=true for testing cases)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile pages


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`feature/refactor_ofec_totals_candidate_committees_mv` | https://github.com/fecgov/openFEC/pull/3919
`feature/fix_bug_speical_cand_profile` | https://github.com/fecgov/fec-cms/pull/3120
