### PR TITLE
update python version to 3.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.6.4-stretch
+      - image: circleci/python:3.7.4-buster
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.6 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the 3.7.4 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 9.6 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,5 @@ pygments==2.2.0
 click==6.7
 
 #efiling
-pandas==0.16.2
+pandas==0.23.0 # this is a temporary upgrade to allow python 3.7.4--eventually pandas will be removed
 xlrd==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ networkx==1.11
 SQLAlchemy==1.3.1
 icalendar==3.9.1
 GitPython==1.0.1
-gunicorn==19.7.1
-gevent==1.2.2
+gunicorn==19.9.0
+gevent==1.4.0
 webargs==5.3.1
 ujson==1.33
 requests==2.21.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.x
+python-3.7.4


### PR DESCRIPTION
## Summary (required)

- Resolves #3951 

Updates `openFEC` to use `python@3.7.4` throughout the repo instead of `python@3.6.4` (`config.yml`) and `python@3.6.9` (`runtime.txt`)

## How to test the changes locally
- [ ] checkout this branch
- [ ] `pip install -r {requirements.txt, requirements-dev.txt, requirements-ci.txt, requirements-locust.txt}`
- [ ] activate a pyenv version of `python@3.7.4`
- [ ] `pytest`
- [ ] `nvm use --lts`
- [ ] `npm install -g swagger-tools`
- [ ] `npm install`
- [ ] `npm run build`
- [ ] `run local api and test swagger-ui`
- [ ] run local cms and point to local api, run redis and celery worker to test downloads
- [ ] conduct dev testing of interest at [https://dev.fec.gov](https://dev.fec.gov) with @jason-upchurch 's PR has 

## Impacted areas of the application
List general components of the application that this PR will affect:
- `api`, `api.app`
