### PR TITLE
Add ofec_sched_a_agg_state_mv to solve the slowness of ScheduleAByStateCandidate

### DIFF
--- a/data/migrations/V0165__ofec_sched_a_agg_state_mv.sql
+++ b/data/migrations/V0165__ofec_sched_a_agg_state_mv.sql
@@ -1,0 +1,61 @@
+/*
+This migration file solve issue #3970 ScheduleAByStateCandidateView slowness
+
+Originally, this endpoint use a view public.ofec_sched_a_agg_state_vw to sum up all the non-real state as 'OT'
+Although views can not have indexes, they will take advantage from the indexes of its base tables. 
+However, the original query use a subquery and a view composed of multiple base tables and database optimizer somehow decided not to use the view's base tables' indexes and cause the slowness.
+We can choose to re-write the query or create a MV to replace the view.
+
+There are more than one endpoints share the same function in resource file to generate final query, it would be less impact to create a MV to replace the view.
+Also for better readability.
+
+Since this is a new MV, flow.py and manage.py had been updated to add the refresh of MV
+*/
+
+-- ------------------------------------------------
+-- ofec_sched_a_agg_state_mv
+-- this is a new MATERIALIZED VIEW so there is no need to go through _tmp process
+-- ------------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_a_agg_state_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.ofec_sched_a_agg_state_mv AS 
+ SELECT sa.cmte_id,
+    sa.cycle,
+    COALESCE(st.st, 'OT'::character varying) AS state,
+    COALESCE(sa.state_full, 'Other'::text) AS state_full,
+    sum(sa.total) AS total,
+    sum(sa.count) AS count
+   FROM disclosure.dsc_sched_a_aggregate_state sa
+     LEFT JOIN staging.ref_st st ON sa.state::text = st.st::text
+  GROUP BY sa.cmte_id, sa.cycle, st.st, sa.state_full;
+  
+ALTER TABLE public.ofec_sched_a_agg_state_mv OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_a_agg_state_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_a_agg_state_mv TO fec_read;
+
+-- indexes
+CREATE UNIQUE INDEX idx_ofec_sched_a_agg_state_mv_cmte_id_cycle_state
+  ON public.ofec_sched_a_agg_state_mv
+  USING btree
+  (cmte_id, cycle, state);
+
+ANALYZE public.ofec_sched_a_agg_state_mv;
+
+-- ------------------
+-- recreate the view 
+-- the new MV removed one unnecessary column 
+--	(which was created for historical reason but we don't use it here)
+-- 	max(sa.idx) AS idx
+-- So view need to be recreate instead of create or replace
+-- there is no other MV depending on this view, it is better to clean it now
+-- ------------------
+DROP VIEW IF EXISTS public.ofec_sched_a_agg_state_vw;
+CREATE OR REPLACE VIEW public.ofec_sched_a_agg_state_vw AS 
+ SELECT * FROM public.ofec_sched_a_agg_state_mv;
+
+ALTER TABLE public.ofec_sched_a_agg_state_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_a_agg_state_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_a_agg_state_vw TO fec_read;
+
+

--- a/manage.py
+++ b/manage.py
@@ -208,6 +208,7 @@ def refresh_materialized(concurrent=True):
                     'ofec_filings_mv',
                     'ofec_filings_all_mv'],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],
+        'ofec_sched_a_agg_state': ['ofec_sched_a_agg_state_mv'],
         'ofec_sched_e_mv': ['ofec_sched_e_mv'],
         'reports_house_senate': ['ofec_reports_house_senate_mv'],
         'reports_ie': ['ofec_reports_ie_only_mv'],

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -31,6 +31,7 @@ def get_graph():
         'filing_amendments_presidential',
         'filings',
         'ofec_agg_coverage_date',
+        'ofec_sched_a_agg_state',
         'ofec_sched_e_mv',
         'reports_house_senate',
         'reports_ie',


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/3970

/schedules/schedule_a/by_state/by_candidate slowness problem

Originally, this endpoint use a view public.ofec_sched_a_agg_state_vw to sum up all the non-real state as 'OT'
Although views can not have indexes, they will take advantage from the indexes of its base tables. 
However, the original query use a subquery and a view composed of multiple base tables and database optimizer somehow decided not to use the view's base tables' indexes and cause the slowness.
We can choose to re-write the query or create a MV to replace the view.

There are more than one endpoints share the same function in resource file to generate final query, it would be less impact to create a MV to replace the view.
Also for better readability.

Since this is a new MV, flow.py and manage.py had been updated to add the refresh of MV

## How to test the changes locally

- Download the branch to your local machine.  Run `invoke create_sample_db` to make sure
1. the migration file V0165 executed successfully
2. review the output and verify the refresh of ofec_sched_a_agg_state_mv is part of the materialized view refresh process

-- ################
There is a tmp version of the MV/VW created in the DEV database
public.ofec_sched_a_agg_state_mv_jj/public.ofec_sched_a_agg_state_vw_jj
-- ################

- To test in database, run the following query and compare with the original view (comment/uncomment line between the -- ### lines )
explain analyze
SELECT anon_1.candidate_id, 
anon_1.election_yr_to_be_included AS cycle, 
sa.state, 
sum(sa.total) AS total, 
max(sa.state_full) AS state_full, 
sum(sa.count) AS count
-- ###
FROM ofec_sched_a_agg_state_vw_jj sa
-- FROM ofec_sched_a_agg_state_vw sa
-- ###
JOIN
(
	SELECT DISTINCT ofec_cand_cmte_linkage_mv.cand_id AS candidate_id, ofec_cand_cmte_linkage_mv.cmte_id AS committee_id, ofec_cand_cmte_linkage_mv.fec_election_yr AS fec_election_year, ofec_cand_cmte_linkage_mv.election_yr_to_be_included AS election_yr_to_be_included 
	FROM ofec_cand_cmte_linkage_mv 
	WHERE ofec_cand_cmte_linkage_mv.election_yr_to_be_included IN (2016) 
	AND ofec_cand_cmte_linkage_mv.cand_id IN ('P00003392') 
	AND ofec_cand_cmte_linkage_mv.cmte_dsgn IN ('P', 'A')
) AS anon_1 
ON anon_1.committee_id = sa.cmte_id 
AND anon_1.fec_election_year = sa.cycle 
GROUP BY anon_1.candidate_id, anon_1.election_yr_to_be_included, sa.state

- to test API:
On your local server, 
in webservices/common/models/aggregates.py
replacde the following line 
__tablename__ = 'ofec_sched_a_agg_state_vw'
with 
__tablename__ = 'ofec_sched_a_agg_state_vw_jj'

Start the local server and test the endpoint /schedules/schedule_a/by_state/by_candidate and verify it is successfully executed with improved performance.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /schedules/schedule_a/by_state/by_candidate

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
