### PR TITLE
update apispec to nonforked version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/fecgov/apispec.git@dev
+apispec==0.39.0
 prance[osv]>=0.11
 cfenv==0.5.2
 invoke==0.15.0


### PR DESCRIPTION
## Summary (required)

- Resolves #3776 
replace forked version of `apispec` with `apispec@0.39.0`. 

## How to test the changes locally
- checkout `feature/3776-update-apispec`
- in a clean `python@3.7.4` environment:
  - `pip install -r requirements.txt`
  - `pip install -r requirements-dev.txt`
  - start postgres
  - `pytest`
  - from `openFEC`: `snyk test --file=requirements.txt`
  - run local api, check that ui looks "normal"
