### PR TITLE
Remove eslint-plugin-no-unsanitized from package due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "eslint-loader": "^2.0.0",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-no-unsanitized": "^3.0.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",


### PR DESCRIPTION
## Summary

- Resolves #3921 

_We do not appear to be using this package in our development. It is not imported into our eslint plugins, so we are not enabling it. See eslint-plugin-no-unsanitized [docs](https://github.com/mozilla/eslint-plugin-no-unsanitized#usage)._

Once the patch for this vulnerability is pushed into a new release, we can think about re-adding and enabling this plugin.

## How to test the changes locally

- [ ] Delete the `/node_modules/` directory locally from openFEC
- [ ] Do `npm install`
- [ ] Go into the `/node_modules/` directory on your local and make sure there is no `/eslint-plugin-no-unsanitized/` package directory there
- [ ] Do `npm run build` and things should still build without error.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Should not effect anything as we were not enabling it for eslint