### PR TITLE
Add retries to elasticsearch connection, fix unpublish logic for "all murs" reload

### DIFF
--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -214,10 +214,10 @@ def load_cases(case_type, case_no=None):
                     case_count += 1
                     logger.info("{0} {1}(s) loaded".format(case_count, case_type))
                 else:
-                    logger.info("Found an unpublished case - deleting from ES")
-                    es.delete_by_query(index='docs_index', body={'query': {"term": {"no": case_no}}},
+                    logger.info("Found an unpublished case - deleting {0}: {1} from ES".format(case_type, case['no']))
+                    es.delete_by_query(index='docs_index', body={'query': {"term": {"no": case['no']}}},
                         doc_type=get_es_type(case_type))
-                    logger.info('Successfully deleted {} {} from ES'.format(case_type, case_no))
+                    logger.info('Successfully deleted {} {} from ES'.format(case_type, case['no']))
     else:
         logger.error("Invalid case_type: must be 'MUR', 'ADR', or 'AF'.")
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -424,8 +424,7 @@ def get_elasticsearch_connection():
         url = es_conn.get_url(url='uri')
     else:
         url = 'http://localhost:9200'
-    es = Elasticsearch(url)
-
+    es = Elasticsearch(url, timeout=30, max_retries=10, retry_on_timeout=True)
     return es
 
 def print_literal_query_string(query):


### PR DESCRIPTION
## Summary (required)

Resolves #3985 

- Add retries to elasticsearch connection for one MUR that fails to load with some queries
- Fix unpublish logic for "all murs"

## How to test the changes locally - timeout

I couldn't figure out how to replicate this issue locally. The query to elasticsearch was timing out, so I increased the timeout to 30 seconds and manually deployed to `dev`. I entered a follow-up issue to research elasticsearch performance: https://github.com/fecgov/openFEC/issues/3999

These won't load on production, but now load with a manual deploy to `dev`:

### Production
- https://api.open.fec.gov/v1/legal/search?hits_returned=12&type=murs&from_hit=20&q=%22foreign+national%22+AND+%22ssf%22&sort=case_no&api_key=DEMO_KEY
- https://api.open.fec.gov/v1/legal/search?hits_returned=20&type=murs&from_hit=10&q=%22foreign+national%22+AND+%22ssf%22&sort=case_no&api_key=DEMO_KEY
- https://api.open.fec.gov/v1/legal/search?hits_returned=20&type=murs&from_hit=20&q=%22foreign+national%22+AND+%22ssf%22&api_key=DEMO_KEY

### Dev - may need a manual deploy to test
- https://fec-dev-api.app.cloud.gov/v1/legal/search?hits_returned=12&type=murs&from_hit=20&q=%22foreign+national%22+AND+%22ssf%22&sort=case_no
- https://fec-dev-api.app.cloud.gov/v1/legal/search?hits_returned=20&type=murs&from_hit=10&q=%22foreign+national%22+AND+%22ssf%22&sort=case_no
- https://fec-dev-api.app.cloud.gov/v1/legal/search?hits_returned=20&type=murs&from_hit=20&q=%22foreign+national%22+AND+%22ssf%22

Seemingly, the issue is MUR 2583, which loads individually but with other results causes a timeout. 
https://api.open.fec.gov/v1/legal/search?case_no=2583&type=murs&api_key=DEMO_KEY

## How to test the changes locally - MUR reload
**To replicate the bug:** 
- check out `develop`, get elasticsearch running locally, and run `./manage.py load_current_murs` **OR** rebuild the latest `develop` branch and run `cf run-task api "python manage.py load_current_murs" -m 4G --name reload-legal` 
- note that the task fails with an error like `elasticsearch.exceptions.RequestError: TransportError(400, 'illegal_argument_exception', 'field name is null or empty')`

**To test the fix** 
- check out this branch, get elasticsearch running locally,  and run `./manage.py load_current_murs` **OR** do a manual deploy of this branch and run `cf run-task api "python manage.py load_current_murs" -m 4G --name reload-legal` 
- note that the task succeeds

## Impacted areas of the application
List general components of the application that this PR will affect:

-  MUR search

