### PR TITLE
Use actual counts for Schedule E efile endpoint

### DIFF
--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -8,6 +8,7 @@ from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager
 from webservices.common import models
 from webservices.common import views
+from webservices.common import counts
 from webservices.common.views import ItemizedResource
 from webservices.common.models import (
     EFilings,
@@ -142,6 +143,20 @@ class ScheduleEEfileView(views.ApiResource):
                     'office_total_ytd',
                 ]),
             ),
+        )
+
+    def get(self, *args, **kwargs):
+        query = self.build_query(*args, **kwargs)
+        # Use exact count for this endpoint only because the estimate is way off
+        count = query.count()
+        multi = False
+        if isinstance(kwargs['sort'], (list, tuple)):
+            multi = True
+
+        return utils.fetch_page(
+            query, kwargs,
+            count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
+            index_column=self.index_column, cap=self.cap, multi=multi,
         )
 
     def build_query(self, **kwargs):


### PR DESCRIPTION
## Summary (required)

- Resolves #3948: Use actual counts for Schedule E efile endpoint. 

The API will use an estimated count if the estimate is greater than the threshold (defaults to 500K.) Because the estimate in this case is way off (in our example, 341,452,204 when it should be 13,227) and the Schedule E efile table isn't very big (currently 13,227 rows), we're telling the API using the **exact** count of the query. 

## How to test the changes locally

- Check out this branch, query http://localhost:5000/v1/schedules/schedule_e/efile/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&data_type=efiling&is_notice=true&sort=-expenditure_date&per_page=30&page=1
- Counts are correct 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Schedule E raw datatable


## Related PRs
List related PRs against other branches: https://github.com/fecgov/openFEC/pull/3421 Set threshold to 500K for all endpoints
