### PR TITLE
Add designation filters to committee history endpoints

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -16,19 +16,10 @@ from webservices.resources.candidates import CandidateView
 
 class CommitteeFormatTest(ApiBaseTest):
 
-    # TODO: When we move to python 3.7, use datetime.date.fromisoformat('1982-12-31')
-
-    date_1982_12_31 = datetime.date(1982, 12, 31)
-    date_2012_01_01 = datetime.date(2012, 1, 1)
-    date_2015_01_01 = datetime.date(2015, 1, 1)
-    date_2015_02_01 = datetime.date(2015, 2, 1)
-    date_2015_02_03 = datetime.date(2015, 2, 3)
-    date_2015_03_01 = datetime.date(2015, 3, 1)
-    date_2015_04_01 = datetime.date(2015, 4, 1)
 
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
-            first_file_date=self.date_1982_12_31,
+            first_file_date=datetime.date.fromisoformat('1982-12-31'),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -37,7 +28,7 @@ class CommitteeFormatTest(ApiBaseTest):
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['first_file_date'], self.date_1982_12_31.isoformat())
+        self.assertEqual(result['first_file_date'], datetime.date.fromisoformat('1982-12-31').isoformat())
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -84,7 +75,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_detail_fields(self):
         committee = factories.CommitteeDetailFactory(
-            first_file_date=self.date_1982_12_31,
+            first_file_date=datetime.date.fromisoformat('1982-12-31'),
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
@@ -185,7 +176,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_year_filter_skips_null_first_file_date(self):
         # Build fixtures
-        dates = [self.date_2012_01_01, self.date_2015_01_01]
+        dates = [datetime.date.fromisoformat('2012-01-01'), datetime.date.fromisoformat('2015-01-01')]
         [
             factories.CommitteeFactory(first_file_date=None, last_file_date=None),
             factories.CommitteeFactory(first_file_date=dates[0], last_file_date=None),
@@ -290,29 +281,29 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_date_filters(self):
         [
-            factories.CommitteeFactory(first_file_date=self.date_2015_01_01),
-            factories.CommitteeFactory(first_file_date=self.date_2015_02_01),
-            factories.CommitteeFactory(first_file_date=self.date_2015_03_01),
-            factories.CommitteeFactory(first_file_date=self.date_2015_04_01),
+            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-01-01')),
+            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-02-01')),
+            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-03-01')),
+            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-04-01')),
         ]
         results = self._results(
-            api.url_for(CommitteeList, min_first_file_date=self.date_2015_02_01))
+            api.url_for(CommitteeList, min_first_file_date=datetime.date.fromisoformat('2015-02-01')))
         self.assertTrue(
-            all(each['first_file_date'] >= self.date_2015_02_01.isoformat() for each in results))
+            all(each['first_file_date'] >= datetime.date.fromisoformat('2015-02-01').isoformat() for each in results))
         results = self._results(
-            api.url_for(CommitteeList, max_first_file_date=self.date_2015_02_03))
+            api.url_for(CommitteeList, max_first_file_date=datetime.date.fromisoformat('2015-02-03')))
         self.assertTrue(
-            all(each['first_file_date'] <= self.date_2015_02_03.isoformat() for each in results))
+            all(each['first_file_date'] <= datetime.date.fromisoformat('2015-02-03').isoformat() for each in results))
         results = self._results(
             api.url_for(
                 CommitteeList,
-                min_first_file_date=self.date_2015_02_01,
-                max_first_file_date=self.date_2015_03_01,
+                min_first_file_date=datetime.date.fromisoformat('2015-02-01'),
+                max_first_file_date=datetime.date.fromisoformat('2015-03-01'),
             )
         )
         self.assertTrue(
             all(
-                self.date_2015_02_01.isoformat() <= each['first_file_date'] <= self.date_2015_03_01.isoformat()
+                datetime.date.fromisoformat('2015-02-01').isoformat() <= each['first_file_date'] <= datetime.date.fromisoformat('2015-03-01').isoformat()
                 for each in results
             )
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -297,6 +297,10 @@ committee_list = {
 
 committee_history = {
     'election_full': election_full,
+    'designation': fields.List(
+        IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
+        description=docs.DESIGNATION,
+    ),
 }
 
 filings = {

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -168,6 +168,10 @@ class CommitteeHistoryView(ApiResource):
     schema = schemas.CommitteeHistorySchema
     page_schema = schemas.CommitteeHistoryPageSchema
 
+    filter_multi_fields = [
+        ('designation', models.CommitteeHistory.designation),
+    ]
+
     @property
     def args(self):
         return utils.extend(
@@ -180,7 +184,7 @@ class CommitteeHistoryView(ApiResource):
         )
 
     def build_query(self, committee_id=None, candidate_id=None, cycle=None, **kwargs):
-        query = models.CommitteeHistory.query
+        query = super().build_query(**kwargs)
 
         if committee_id:
             # use for


### PR DESCRIPTION
## Summary (required)

Resolves #4007: Add designation filters to committee history endpoints

- Add `designation` filter to resource `committees.CommitteeHistoryView`
- Add automated tests
- Clean up awkward test syntax

## How to test the changes locally

- Test designation filters for the following endpoints: 
example: http://localhost:5000/v1/candidate/S2MA00170/committees/history/?designation=P&designation=A
example: http://localhost:5000/v1/candidate/S2MA00170/committees/history/2018/?designation=P&designation=A
- Run local CMS, point to local API, test the candidate/committee profile pages:
example: http://localhost:8000/data/candidate/S2MA00170/?cycle=2018&election_full=true
example: http://localhost:8000/data/candidate/S2MA00170/?cycle=2018&election_full=true&tab=about-candidate

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Where contributions come from map "Browse individual contributions" and state click-through
- Candidate profile pages, affiliated committees