### PR TITLE
Increase maximum number of committeeIDs to 10

### DIFF
--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -64,9 +64,9 @@ class ItemizedResource(ApiResource):
         records.
         """
         committee_ids = kwargs.get('committee_id', [])
-        if len(committee_ids) > 5:
+        if len(committee_ids) > 10:
             raise exceptions.ApiError(
-                'Can only specify up to five values for "committee_id".',
+                'Can only specify up to ten values for "committee_id".',
                 status_code=422,
             )
         if len(committee_ids) > 1:


### PR DESCRIPTION
## Summary (required)

- Resolves #3996

Increase maximum number of committeeIDs for itemized resource tables

## How to test the changes locally

-  Make sure transaction endpoints return results for up to 10 committee IDs
http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00031781&committee_id=C00107391&committee_id=C00139998&committee_id=C00171538&committee_id=C00187435&committee_id=C00188888&committee_id=C00250191&committee_id=C00329706&committee_id=C00364091&committee_id=C00401224&committee_id=C00412304&committee_id=C00547679&sort=-contribution_receipt_date&per_page=30

- Make sure transaction endpoints return validation error message for **over** 10 committee IDs
http://localhost:5000/v1/schedules/schedule_a/?api_key=28Y8q8XFocq8yhKfBzzhUJXjFj2JHCZzIv4P2KIK&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00031781&committee_id=C00107391&committee_id=C00139998&committee_id=C00171538&committee_id=C00187435&committee_id=C00188888&committee_id=C00250191&committee_id=C00329706&committee_id=C00364091&committee_id=C00401224&committee_id=C00412304&committee_id=C00547679&sort=-contribution_receipt_date&per_page=30

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Transaction datatabes
- Click-through for "Where contributions come from" map

