### PR TITLE
Add filter by committee_id on aggregate schedule A, B, E and Deprecate 9 endpoints 

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -249,8 +249,8 @@ candidate_detail = {
 candidate_list = {
     'q': fields.List(fields.Str, description=docs.CANDIDATE_NAME),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'min_first_file_date': fields.Date(description='Selects all candidates whose first filing was received by the FEC after this date'),
-    'max_first_file_date': fields.Date(description='Selects all candidates whose first filing was received by the FEC before this date'),
+    'min_first_file_date': fields.Date(description=docs.CANDIDATE_MIN_FIRST_FILE_DATE),
+    'max_first_file_date': fields.Date(description=docs.CANDIDATE_MAX_FIRST_FILE_DATE),
     'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
 }
 
@@ -306,15 +306,15 @@ committee_history = {
 filings = {
     'committee_type': fields.Str(description=docs.COMMITTEE_TYPE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'is_amended': fields.Bool(description='Filing has been amended'),
-    'most_recent': fields.Bool(description='Filing is either new or is the most-recently filed amendment'),
+    'is_amended': fields.Bool(description=docs.IS_AMENDED),
+    'most_recent': fields.Bool(description=docs.MOST_RECENT),
     'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
     'request_type': fields.List(IStr, description=docs.REQUEST_TYPE),
     'document_type': fields.List(IStr, description=docs.DOC_TYPE),
     'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'min_receipt_date': fields.Date(description='Selects all items received by FEC after this date'),
-    'max_receipt_date': fields.Date(description='Selects all items received by FEC before this date'),
+    'min_receipt_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
+    'max_receipt_date': fields.Date(description=docs.MAX_RECEIPT_DATE),
     'form_type': fields.List(IStr, description=docs.FORM_TYPE),
     'state': fields.List(IStr, description=docs.STATE),
     'district': fields.List(IStr, description=docs.DISTRICT),
@@ -528,28 +528,33 @@ schedule_a_e_file = {
 schedule_a_by_size = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_state = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'state': fields.List(IStr, description='State of contributor'),
-    'hide_null': fields.Bool(missing=False, description='Exclude values with missing state'),
+    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'hide_null': fields.Bool(missing=False, description=docs.MISSING_STATE),
 }
 
 schedule_a_by_zip = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'zip': fields.List(fields.Str, description='Zip code'),
-    'state': fields.List(IStr, description='State of contributor'),
+    'zip': fields.List(fields.Str, description=docs.CONTRIBUTOR_ZIP),
+    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_employer = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'employer': fields.List(IStr, description=docs.EMPLOYER),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_occupation = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'occupation': fields.List(IStr, description=docs.OCCUPATION),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_contributor = {
@@ -557,29 +562,99 @@ schedule_a_by_contributor = {
     'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
 }
 
+schedule_b_by_purpose = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'purpose': fields.List(fields.Str, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+}
+
 schedule_b_by_recipient = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'recipient_name': fields.List(fields.Str, description=docs.RECIPIENT_NAME),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
 
 schedule_b_by_recipient_id = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'recipient_id': fields.List(IStr, description=docs.RECIPIENT_ID),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
 }
+
+# start --- These 9 args will be DEPRECATED soon.
+schedule_a_by_size_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
+}
+
+schedule_a_by_state_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+    'hide_null': fields.Bool(missing=False, description=docs.MISSING_STATE),
+}
+
+schedule_a_by_zip_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'zip': fields.List(fields.Str, description=docs.CONTRIBUTOR_ZIP),
+    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+}
+
+schedule_a_by_employer_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'employer': fields.List(IStr, description=docs.EMPLOYER),
+}
+
+schedule_a_by_occupation_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'occupation': fields.List(IStr, description=docs.OCCUPATION),
+}
+
+schedule_b_by_purpose_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'purpose': fields.List(fields.Str, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+}
+
+schedule_b_by_recipient_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'recipient_name': fields.List(fields.Str, description=docs.RECIPIENT_NAME),
+}
+
+schedule_b_by_recipient_id_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'recipient_id': fields.List(IStr, description=docs.RECIPIENT_ID),
+}
+
+schedule_e_by_candidate_committee_id = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'office': fields.Str(
+        validate=validate.OneOf(['house', 'senate', 'president']),
+        description=docs.OFFICE,
+    ),
+    'support_oppose': IStr(
+        missing=None,
+        validate=validate.OneOf(['S', 'O']),
+        description=docs.SUPPORT_OPPOSE,
+    ),
+}
+# end --- This 9 args will be DEPRECATED soon.
 
 schedule_b = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here if the contributor is registered with the FEC.'),
-    'recipient_name': fields.List(fields.Str, description='Name of recipient'),
-    'disbursement_description': fields.List(fields.Str, description='Description of disbursement'),
-    'recipient_city': fields.List(IStr, description='City of recipient'),
-    'recipient_state': fields.List(IStr, description='State of recipient'),
-    'disbursement_purpose_category': fields.List(IStr, description='Disbursement purpose category'),
-    'last_disbursement_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'last_disbursement_amount': fields.Float(missing=None, description='When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'two_year_transaction_period': fields.List(
-        fields.Int,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+    'disbursement_description': fields.List(fields.Str, description=docs.DISBURSEMENT_DESCRIPTION),
+    'disbursement_purpose_category': fields.List(IStr, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+    'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
+    'last_disbursement_date': fields.Date(missing=None, description=docs.LAST_DISBURSEMENT_DATE),
+    'recipient_city': fields.List(IStr, description=docs.RECIPIENT_CITY),
+    'recipient_committee_id': fields.List(IStr, description=docs.RECIPIENT_COMMITTEE_ID),
+    'recipient_name': fields.List(fields.Str, description=docs.RECIPIENT_NAME),
+    'recipient_state': fields.List(IStr, description=docs.RECIPIENT_STATE),
+    'spender_committee_designation': fields.List(
+        IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
+        description=docs.DESIGNATION,
+    ),
+    'spender_committee_org_type': fields.List(
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        description=docs.ORGANIZATION_TYPE,
     ),
     'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([
@@ -587,15 +662,10 @@ schedule_b = {
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
         description=docs.COMMITTEE_TYPE,
     ),
-    'spender_committee_org_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+    'two_year_transaction_period': fields.List(
+        fields.Int,
+        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
     ),
-    'spender_committee_designation': fields.List(
-        IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
-    ),
-
 }
 
 schedule_b_efile = {
@@ -616,10 +686,6 @@ schedule_b_efile = {
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
 }
 
-schedule_b_by_purpose = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'purpose': fields.List(fields.Str, description='Disbursement purpose category'),
-}
 
 schedule_c = {
     # TODO(jmcarp) Request integer image numbers from FEC and update argument types
@@ -641,20 +707,6 @@ schedule_c = {
     'max_incurred_date': fields.Date(missing=None, description=docs.MAX_INCURRED_DATE),
 }
 
-schedule_e_by_candidate = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'office': fields.Str(
-        validate=validate.OneOf(['house', 'senate', 'president']),
-        description=docs.OFFICE,
-    ),
-    'support_oppose': IStr(
-        missing=None,
-        validate=validate.OneOf(['S', 'O']),
-        description='Support or opposition'
-    ),
-}
-
 #These arguments will evolve with updated filtering needs
 schedule_d = {
     'min_payment_period': fields.Float(),
@@ -665,6 +717,20 @@ schedule_d = {
     'creditor_debtor_name': fields.List(fields.Str),
     'nature_of_debt': fields.Str(),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+}
+schedule_e_by_candidate = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'office': fields.Str(
+        validate=validate.OneOf(['house', 'senate', 'president']),
+        description=docs.OFFICE,
+    ),
+    'support_oppose': IStr(
+        missing=None,
+        validate=validate.OneOf(['S', 'O']),
+        description=docs.SUPPORT_OPPOSE,
+    ),
 }
 
 schedule_f = {
@@ -679,7 +745,7 @@ communication_cost = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
-        description='Support or opposition',
+        description=docs.SUPPORT_OPPOSE,
     ),
 }
 
@@ -740,7 +806,7 @@ candidate_totals = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description='Governmental office candidate runs for: House, Senate or presidential'),
+    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
     'election_full': election_full,
     'state': fields.List(IStr, description='State of candidate'),
     'district': fields.List(District, description='District of candidate'),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -537,8 +537,8 @@ large result sets are approximate; you will want to page through the records unt
 '''
 
 SCHEDULE_E_BY_CANDIDATE = '''
-'Schedule E receipts aggregated by recipient candidate. To avoid double '
-'counting, memoed items are not included.'
+Schedule E receipts aggregated by recipient candidate. To avoid double
+counting, memoed items are not included.
 '''
 
 SCHEDULE_F_TAG = '''
@@ -567,23 +567,6 @@ from the summary section of the forms. It represents the total money brought in 
 donors that are not reported on Schedule A and have given $200 or less.
 '''
 
-# These will be DEPRECATED soon.
-SCHEDULE_A_BY_SIZE_COMMITTEE_ID = '''
-This endpoint aggregates Schedule A donations based on size:
-```
- - $200 and under\n\
- - $200.01 - $499.99\n\
- - $500 - $999.99\n\
- - $1000 - $1999.99\n\
- - $2000 +\n\
-```
-In cases where the donations are $200 or less, the results include small donations
-that are reported on Schedule A, but filers are not required to itemize those small
-donations, so we also add unitemized contributions. Unitemized contributions come
-from the summary section of the forms. It represents the total money brought in from
-donors that are not reported on Schedule A and have given $200 or less.
-'''
-
 SCHEDULE_A_BY_STATE = '''
 Schedule A individual receipts aggregated by contributor state.
 This is an aggregate of only individual contributions. To avoid double counting,
@@ -593,18 +576,18 @@ state totals.
 '''
 
 SCHEDULE_A_BY_ZIP = '''
-'Schedule A receipts aggregated by contributor zip code. To avoid double '
-'counting, memoed items are not included.'
+Schedule A receipts aggregated by contributor zip code. To avoid double
+counting, memoed items are not included.
 '''
 
 SCHEDULE_A_BY_EMPLOYER = '''
-'Schedule A receipts aggregated by contributor employer name. To avoid double '
-'counting, memoed items are not included.'
+Schedule A receipts aggregated by contributor employer name. To avoid double
+counting, memoed items are not included.
 '''
 
 SCHEDULE_A_BY_OCCUPATION = '''
-'Schedule A receipts aggregated by contributor occupation. To avoid double '
-'counting, memoed items are not included.'
+Schedule A receipts aggregated by contributor occupation. To avoid double
+counting, memoed items are not included.'
 '''
 
 SIZE = '''

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -447,14 +447,6 @@ Note: because the Schedule B data includes many records, counts for
 large result sets are approximate; you will want to page through the records until no records are returned.
 '''
 
-MEMO_TOTAL = '''
-Schedule B disbursements aggregated by memoed items only
-'''
-
-NON_MEMO_TOTAL = '''
-Schedule B disbursements aggregated by non-memoed items only
-'''
-
 SCHEDULE_B_BY_PURPOSE = '''
 Schedule B disbursements aggregated by disbursement purpose category. To avoid double counting,
 memoed items are not included.
@@ -462,14 +454,22 @@ Purpose is a combination of transaction codes, category codes and disbursement d
 See the `disbursement_purpose` sql function within the migrations for more details.
 '''
 
-SCHEDULE_B_BY_RECIPIENT_TAG = '''
+SCHEDULE_B_BY_RECIPIENT = '''
 Schedule B disbursements aggregated by recipient name. To avoid double counting,
 memoed items are not included.
 '''
 
-SCHEDULE_B_BY_RECIPIENT_ID_TAG = '''
+SCHEDULE_B_BY_RECIPIENT_ID = '''
 Schedule B disbursements aggregated by recipient committee ID, if applicable.
 To avoid double counting, memoed items are not included.
+'''
+
+MEMO_TOTAL = '''
+Schedule B disbursements aggregated by memoed items only
+'''
+
+NON_MEMO_TOTAL = '''
+Schedule B disbursements aggregated by non-memoed items only
 '''
 
 SCHEDULE_C_TAG = '''
@@ -527,12 +527,18 @@ results with the following pagination information:
 
 To fetch the next page of sorted results, append `last_index=3023037` and
 `last_expenditure_amount=` to the URL.  We strongly advise paging through
-these results by using the sort indices (defaults to sort by disbursement date, e.g. `last_disbursement_date`), otherwise
-some resources may be unintentionally filtered out.  This resource uses keyset pagination to improve query performance
+these results by using the sort indices (defaults to sort by disbursement date,
+e.g. `last_disbursement_date`), otherwise some resources may be unintentionally
+filtered out.  This resource uses keyset pagination to improve query performance
 and these indices are required to properly page through this large dataset.
 
 Note: because the Schedule E data includes many records, counts for
 large result sets are approximate; you will want to page through the records until no records are returned.
+'''
+
+SCHEDULE_E_BY_CANDIDATE = '''
+'Schedule E receipts aggregated by recipient candidate. To avoid double '
+'counting, memoed items are not included.'
 '''
 
 SCHEDULE_F_TAG = '''
@@ -545,7 +551,7 @@ These coordinated party expenditures do not count against the contribution limit
 these limits are detailed in Chapter 7 of the FEC Campaign Guide for Political Party Committees.
 '''
 
-SIZE_DESCRIPTION = '''
+SCHEDULE_A_BY_SIZE = '''
 This endpoint aggregates Schedule A donations based on size:
 ```
  - $200 and under\n\
@@ -559,6 +565,46 @@ that are reported on Schedule A, but filers are not required to itemize those sm
 donations, so we also add unitemized contributions. Unitemized contributions come
 from the summary section of the forms. It represents the total money brought in from
 donors that are not reported on Schedule A and have given $200 or less.
+'''
+
+# These will be DEPRECATED soon.
+SCHEDULE_A_BY_SIZE_COMMITTEE_ID = '''
+This endpoint aggregates Schedule A donations based on size:
+```
+ - $200 and under\n\
+ - $200.01 - $499.99\n\
+ - $500 - $999.99\n\
+ - $1000 - $1999.99\n\
+ - $2000 +\n\
+```
+In cases where the donations are $200 or less, the results include small donations
+that are reported on Schedule A, but filers are not required to itemize those small
+donations, so we also add unitemized contributions. Unitemized contributions come
+from the summary section of the forms. It represents the total money brought in from
+donors that are not reported on Schedule A and have given $200 or less.
+'''
+
+SCHEDULE_A_BY_STATE = '''
+Schedule A individual receipts aggregated by contributor state.
+This is an aggregate of only individual contributions. To avoid double counting,
+memoed items are not included. Transactions $200 and under do not have to be
+itemized, if those contributions are not itemized, they will not be included in the
+state totals.
+'''
+
+SCHEDULE_A_BY_ZIP = '''
+'Schedule A receipts aggregated by contributor zip code. To avoid double '
+'counting, memoed items are not included.'
+'''
+
+SCHEDULE_A_BY_EMPLOYER = '''
+'Schedule A receipts aggregated by contributor employer name. To avoid double '
+'counting, memoed items are not included.'
+'''
+
+SCHEDULE_A_BY_OCCUPATION = '''
+'Schedule A receipts aggregated by contributor occupation. To avoid double '
+'counting, memoed items are not included.'
 '''
 
 SIZE = '''
@@ -593,15 +639,7 @@ TOTAL_CANDIDATE_TAG = '''
 Aggregated candidate receipts and disbursements grouped by cycle.
 '''
 
-STATE_AGGREGATE = '''
-Schedule A individual receipts aggregated by contributor state.
-This is an aggregate of only individual contributions. To avoid double counting,
-memoed items are not included. Transactions $200 and under do not have to be
-itemized, if those contributions are not itemized, they will not be included in the
-state totals.
-'''
-
-STATE_AGGREGATE_RECIPIENT_TOTALS = STATE_AGGREGATE + '''
+STATE_AGGREGATE_RECIPIENT_TOTALS = SCHEDULE_A_BY_STATE + '''
 These receipts are then added together by committee type for the total amount
 of each type, grouped by state and cycle.
 '''
@@ -808,6 +846,8 @@ _The communication is distributed within 60 days prior to a general election or 
 to a primary election to federal office._
 '''
 
+ELECTIONEERING_AGGREGATE = 'Electioneering costs aggregated by candidate'
+
 COMMUNICATION_COST = '''
 52 U.S.C. 30118 allows "communications by a corporation to its stockholders and
 executive or administrative personnel and their families or by a labor organization
@@ -815,6 +855,8 @@ to its members and their families on any subject," including the express advocac
 the election or defeat of any Federal candidate.  The costs of such communications
 must be reported to the Federal Election Commission under certain circumstances.
 '''
+
+COMMUNICATION_COST_AGGREGATE = 'Communication cost aggregated by candidate ID and committee ID.'
 
 FILER_RESOURCES = '''
 Useful tools for those who file with the FEC.
@@ -1091,6 +1133,9 @@ MIN_LAST_F1_DATE = 'Filter for committees whose latest Form 1 was received on or
 
 MAX_LAST_F1_DATE = 'Filter for committees whose latest Form 1 was received on or before this date.'
 
+CANDIDATE_MIN_FIRST_FILE_DATE = 'Selects all candidates whose first filing was received by the FEC after this date.'
+CANDIDATE_MAX_FIRST_FILE_DATE = 'Selects all candidates whose first filing was received by the FEC before this date.'
+
 # schedules
 MEMO_CODE = "'X' indicates that the amount is NOT to be included in the itemization total."
 
@@ -1107,25 +1152,34 @@ CONTRIBUTOR_ZIP = 'Zip code of contributor'
 IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo code is true. \
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'
+MISSING_STATE = 'Exclude values with missing state'
 
 # schedule B
-RECIPIENT_NAME = 'Name of the entity receiving the disbursement'
+DISBURSEMENT_DESCRIPTION = 'Description of disbursement'
+DISBURSEMENT_PURPOSE_CATEGORY = 'Disbursement purpose category'
+LAST_DISBURSEMENT_AMOUNT = 'When sorting by `disbursement_amount`, this is populated with the `disbursement_amount` of \
+the last result.  However, you will need to pass the index of that last result to `last_index` to get the next page.'
+LAST_DISBURSEMENT_DATE = 'When sorting by `disbursement_date`, this is populated with the `disbursement_date` of \
+the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'
+RECIPIENT_CITY = 'City of recipient'
+RECIPIENT_COMMITTEE_ID = 'The FEC identifier should be represented here if the contributor is registered with the FEC.'
 RECIPIENT_ID = 'The FEC identifier should be represented here if the entity receiving \
 the disbursement is registered with the FEC.'
+RECIPIENT_NAME = 'Name of the entity receiving the disbursement'
+RECIPIENT_STATE = 'State of recipient'
+
+PURPOSE = 'Purpose of the expenditure'
 
 # communication cost and electioneering
 SUPPORT_OPPOSE_INDICATOR = 'Explains if the money was spent in order to support or oppose a candidate or candidates. \
 (Coded S or O for support or oppose.) This indicator applies to independent expenditures and communication costs.'
-
-# schedule B
-PURPOSE = 'Purpose of the expenditure'
 
 # schedule E
 EXPENDITURE_MAX_DATE = 'Selects all items expended by this committee before this date'
 EXPENDITURE_MIN_DATE = 'Selects all items expended by this committee after this date'
 EXPENDITURE_MIN_AMOUNT = 'Selects all items expended by this committee greater than this amount'
 EXPENDITURE_MAX_AMOUNT = 'Selects all items expended by this committee less than this amount'
-
+SUPPORT_OPPOSE = 'Support or opposition'
 
 # dates
 DUE_DATE = 'Date the report is due'

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -116,7 +116,7 @@ class ScheduleAByStateView(AggregateResource):
         )
 
     def build_query(self, **kwargs):
-        query = super().build_query(self, **kwargs)
+        query = super().build_query(**kwargs)
         if kwargs['hide_null']:
             query = query.filter(self.model.state_full != None)  # noqa
         return query

--- a/webservices/resources/aggregates_by_committeeID.py
+++ b/webservices/resources/aggregates_by_committeeID.py
@@ -43,10 +43,9 @@ class AggregateResource(ApiResource):
             query = query.filter(self.model.committee_id == committee_id)
         return query
 
-
 @doc(
     tags=['receipts'],
-    description=docs.SCHEDULE_A_BY_SIZE_COMMITTEE_ID,
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_a/by_size/?committee_id=<committee_ID>',
 )
 class ScheduleABySizeByCommitteeIDView(AggregateResource):
 
@@ -62,12 +61,7 @@ class ScheduleABySizeByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['receipts'],
-    description=(
-        'Schedule A individual receipts aggregated by contributor state.'
-        'This is an aggregate of only individual contributions. To avoid double counting,memoed items are not included.'
-        'Transactions $200 and under do not have to beitemized, if those contributions are not itemized,'
-        'they will not be included in thestate totals.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_a/by_state/?committee_id=<committee_ID>'   
 )
 class ScheduleAByStateByCommitteeIDView(AggregateResource):
 
@@ -98,10 +92,7 @@ class ScheduleAByStateByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['receipts'],
-    description=(
-        'Schedule A receipts aggregated by contributor zip code.'
-        'To avoid double counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_a/by_zip/?committee_id=<committee_ID>',
 )
 class ScheduleAByZipByCommitteeIDView(AggregateResource):
 
@@ -117,10 +108,7 @@ class ScheduleAByZipByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['receipts'],
-    description=(
-        'Schedule A receipts aggregated by contributor zip code.'
-        'To avoid double counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_a/by_employer/?committee_id=<committee_ID>',
 )
 class ScheduleAByEmployerByCommitteeIDView(AggregateResource):
 
@@ -143,10 +131,7 @@ class ScheduleAByEmployerByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['receipts'],
-    description=(
-        'Schedule A receipts aggregated by contributor occupation.'
-        'To avoid double counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_a/by_occupation/?committee_id=<committee_ID>',
 )
 class ScheduleAByOccupationByCommitteeIDView(AggregateResource):
 
@@ -169,12 +154,7 @@ class ScheduleAByOccupationByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['disbursements'],
-    description=(
-        'Schedule B disbursements aggregated by disbursement purpose category.'
-        'To avoid double counting, memoed items are not included.Purpose is a combination of transaction codes,'
-        'category codes and disbursement description.'
-        'See the `disbursement_purpose` sql function within the migrations for more details.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_b/by_purpose/?committee_id=<committee_ID>',
 )
 class ScheduleBByPurposeByCommitteeIDView(AggregateResource):
 
@@ -191,10 +171,7 @@ class ScheduleBByPurposeByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['disbursements'],
-    description=(
-        'Schedule B disbursements aggregated by recipient name.'
-        'To avoid double counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_b/by_recipient/?committee_id=<committee_ID>',
 )
 class ScheduleBByRecipientByCommitteeIDView(AggregateResource):
 
@@ -212,10 +189,7 @@ class ScheduleBByRecipientByCommitteeIDView(AggregateResource):
 
 @doc(
     tags=['disbursements'],
-    description=(
-        'Schedule B disbursements aggregated by recipient committee ID, if applicable.'
-        'To avoid double counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_b/by_recipient_id/?committee_id=<committee_ID>',
 )
 class ScheduleBByRecipientIDByCommitteeIDView(AggregateResource):
 
@@ -323,10 +297,7 @@ class CandidateAggregateResource(AggregateResource):
 
 @doc(
     tags=['independent expenditures'],
-    description=(
-        'Schedule E receipts aggregated by recipient candidate. To avoid double '
-        'counting, memoed items are not included.'
-    )
+    description='This endpoint is `DEPRECATED`. Please use /schedules/schedule_e/by_candidate/?committee_id=<committee_ID>',
 )
 class ScheduleEByCandidateByCommitteeIDView(CandidateAggregateResource):
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -38,6 +38,7 @@ from webservices.resources import sched_e
 from webservices.resources import sched_f
 from webservices.resources import download
 from webservices.resources import aggregates
+from webservices.resources import aggregates_by_committeeID
 from webservices.resources import candidate_aggregates
 from webservices.resources import candidates
 from webservices.resources import committees
@@ -67,7 +68,7 @@ def sqla_conn_string():
     return sqla_conn_string
 
 
-# app.debug = True
+#app.debug = True
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
 app.config['APISPEC_FORMAT_RESPONSE'] = None
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
@@ -328,26 +329,35 @@ api.add_resource(audit.AuditCaseView, '/audit-case/')
 api.add_resource(audit.AuditCandidateNameSearch, '/names/audit_candidates/')
 api.add_resource(audit.AuditCommitteeNameSearch, '/names/audit_committees/')
 
+api.add_resource(aggregates.ScheduleABySizeView, '/schedules/schedule_a/by_size/')
+api.add_resource(aggregates.ScheduleAByStateView, '/schedules/schedule_a/by_state/')
+api.add_resource(aggregates.ScheduleAByZipView, '/schedules/schedule_a/by_zip/')
+api.add_resource(aggregates.ScheduleAByEmployerView, '/schedules/schedule_a/by_employer/')
+api.add_resource(aggregates.ScheduleAByOccupationView, '/schedules/schedule_a/by_occupation/')
+api.add_resource(aggregates.ScheduleBByRecipientView, '/schedules/schedule_b/by_recipient/')
+api.add_resource(aggregates.ScheduleBByRecipientIDView, '/schedules/schedule_b/by_recipient_id/')
+api.add_resource(aggregates.ScheduleBByPurposeView, '/schedules/schedule_b/by_purpose/')
+api.add_resource(aggregates.ScheduleEByCandidateView, '/schedules/schedule_e/by_candidate/')
 
-def add_aggregate_resource(api, view, schedule, label):
-    api.add_resource(
-        view,
-        '/schedules/schedule_{schedule}/by_{label}/'.format(**locals()),
-        '/committee/<committee_id>/schedules/schedule_{schedule}/by_{label}/'.format(**locals()),
-    )
-
-
-add_aggregate_resource(api, aggregates.ScheduleABySizeView, 'a', 'size')
-add_aggregate_resource(api, aggregates.ScheduleAByStateView, 'a', 'state')
-add_aggregate_resource(api, aggregates.ScheduleAByZipView, 'a', 'zip')
-add_aggregate_resource(api, aggregates.ScheduleAByEmployerView, 'a', 'employer')
-add_aggregate_resource(api, aggregates.ScheduleAByOccupationView, 'a', 'occupation')
-
-add_aggregate_resource(api, aggregates.ScheduleBByRecipientView, 'b', 'recipient')
-add_aggregate_resource(api, aggregates.ScheduleBByRecipientIDView, 'b', 'recipient_id')
-add_aggregate_resource(api, aggregates.ScheduleBByPurposeView, 'b', 'purpose')
-
-add_aggregate_resource(api, aggregates.ScheduleEByCandidateView, 'e', 'candidate')
+# These 9 endpoints will be DEPRECATED soon.
+api.add_resource(aggregates_by_committeeID.ScheduleABySizeByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_a/by_size/')
+api.add_resource(aggregates_by_committeeID.ScheduleAByStateByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_a/by_state/')
+api.add_resource(aggregates_by_committeeID.ScheduleAByZipByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_a/by_zip/')
+api.add_resource(aggregates_by_committeeID.ScheduleAByEmployerByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_a/by_employer/')
+api.add_resource(aggregates_by_committeeID.ScheduleAByOccupationByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_a/by_occupation/')
+api.add_resource(aggregates_by_committeeID.ScheduleBByRecipientByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_b/by_recipient/')
+api.add_resource(aggregates_by_committeeID.ScheduleBByRecipientIDByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_b/by_recipient_id/')
+api.add_resource(aggregates_by_committeeID.ScheduleBByPurposeByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_b/by_purpose/')
+api.add_resource(aggregates_by_committeeID.ScheduleEByCandidateByCommitteeIDView,
+    '/committee/<committee_id>/schedules/schedule_e/by_candidate/')
 
 api.add_resource(candidate_aggregates.ScheduleABySizeCandidateView, '/schedules/schedule_a/by_size/by_candidate/')
 api.add_resource(candidate_aggregates.ScheduleAByStateCandidateView, '/schedules/schedule_a/by_state/by_candidate/')
@@ -447,6 +457,18 @@ apidoc.register(aggregates.ScheduleBByRecipientView, blueprint='v1')
 apidoc.register(aggregates.ScheduleBByRecipientIDView, blueprint='v1')
 apidoc.register(aggregates.ScheduleBByPurposeView, blueprint='v1')
 apidoc.register(aggregates.ScheduleEByCandidateView, blueprint='v1')
+
+# These 9 endpoints will be DEPRECATED soon.
+apidoc.register(aggregates_by_committeeID.ScheduleABySizeByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleAByStateByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleAByZipByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleAByEmployerByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleAByOccupationByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleBByRecipientByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleBByRecipientIDByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleBByPurposeByCommitteeIDView, blueprint='v1')
+apidoc.register(aggregates_by_committeeID.ScheduleEByCandidateByCommitteeIDView, blueprint='v1')
+
 apidoc.register(aggregates.CommunicationCostByCandidateView, blueprint='v1')
 apidoc.register(aggregates.ElectioneeringByCandidateView, blueprint='v1')
 apidoc.register(candidate_aggregates.ScheduleABySizeCandidateView, blueprint='v1')


### PR DESCRIPTION
## Summary (required)
1. This ticket will add filter by one or more committee ID (the filer ID) on these 9 endpoints:
/schedules/schedule_a/by_size/
/schedules/schedule_a/by_state/
/schedules/schedule_a/by_zip/
/schedules/schedule_a/by_employer/
/schedules/schedule_a/by_occupation/
/schedules/schedule_b/by_recipient/
/schedules/schedule_b/by_recipient_id/
/schedules/schedule_b/by_purpose/
/schedules/schedule_e/by_candidate/

2. These 9 endpoints are deprecated: 
/committee/<committee_ID>/schedules/schedule_a/by_employer/
/committee/<committee_ID>/schedules/schedule_a/by_occupation/
/committee/<committee_ID>/schedules/schedule_a/by_size/
/committee/<committee_ID>/schedules/schedule_a/by_state/
/committee/<committee_ID>/schedules/schedule_a/by_zip/
/committee/<committee_ID>/schedules/schedule_b/by_purpose/
/committee/<committee_ID>/schedules/schedule_b/by_recipient/
/committee/<committee_ID>/schedules/schedule_b/by_recipient_id/
/committee/<committee_ID>/schedules/schedule_e/by_candidate/

3. /committee/<committee_ID>/schedules/schedule_x/by_xxxxxx/ will replace with
/schedules/schedule_x/by_xxxxxx/?committee_id=<committee_ID>


- Resolves #3995


## How to test the changes locally
1. checkout feature branch
2. db points to dev/stage/prod
3. pytest
4. ./manage.py runserver
5. Test endpoints and filter by one or more committee_id on /schedules/schedule_x/by_xxxxxx/
and compare with production api.

(1)/schedules/schedule_a/by_employer/
"count": 15859607
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 157342
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 240601 (two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false


(2)/schedules/schedule_a/by_occupation/
"count": 6670315
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 56216
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 91332 (two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false



(3)/schedules/schedule_a/by_size/
"count": 393414
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 11
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 30 (two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false


(4)/schedules/schedule_a/by_state/
"count": 1012850
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/?page=1&hide_null=false&sort=-total&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 104
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/?committee_id=C00575795&page=1&hide_null=false&sort=-total&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 705 (two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/?committee_id=C00401224&committee_id=C00431569&page=1&hide_null=false&sort=-total&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 1012850 (hide_null=true)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/?page=1&hide_null=true&sort=-total&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false



(5)/schedules/schedule_a/by_zip/
count": 11222472
http://127.0.0.1:5000/v1/schedules/schedule_a/by_zip/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 22389
http://127.0.0.1:5000/v1/schedules/schedule_a/by_zip/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 45706 (two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_a/by_zip/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false



(6)/schedules/schedule_b/by_purpose/
"count": 313156
http://127.0.0.1:5000/v1/schedules/schedule_b/by_purpose/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 14
http://127.0.0.1:5000/v1/schedules/schedule_b/by_purpose/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 42(two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_b/by_purpose/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false



(7)/schedules/schedule_b/by_recipient/
"count": 6931591
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?page=1&sort_nulls_last=false&per_page=100&sort_hide_null=false&sort_null_only=false

"count": 20435
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 44579(two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false



(8)/schedules/schedule_b/by_recipient_id/
"count": 3006827
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient_id/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

"count": 46
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient_id/?committee_id=C00575795&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

count": 116(two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient_id/?committee_id=C00575795&committee_id=C00431569&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false


(9)/schedules/schedule_e/by_candidate/
http://127.0.0.1:5000/v1/committee/C00002089/schedules/schedule_e/by_candidate/?candidate_id=P00003392&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false&election_full=true

"count": 279,
http://127.0.0.1:5000/v1/schedules/schedule_e/by_candidate/?candidate_id=P00003392&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false&election_full=true

count": 1,
http://127.0.0.1:5000/v1/schedules/schedule_e/by_candidate/?committee_id=C00002089&candidate_id=P00003392&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false&election_full=true

count": 2,(two committee_ids)
http://127.0.0.1:5000/v1/schedules/schedule_e/by_candidate/?committee_id=C00002089&committee_id=C00004036&candidate_id=P00003392&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false&election_full=true




6. Test 9 deprecated endpoints /committee/<committee_ID>/schedules/schedule_x/by_xxxxxx/
and compare with production api.
All deprecated endpoints description should like this:
<img width="849" alt="Screen Shot 2019-10-16 at 4 55 50 PM" src="https://user-images.githubusercontent.com/24395751/66958295-dd67a180-f035-11e9-9f58-11bc59711db2.png">



(1) /committee/<committee_ID>/schedules/schedule_a/by_employer/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_a/by_employer/?page=1&sort_nulls_last=false&per_page=100&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_a/by_employer/?employer=bill&page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(2) /committee/<committee_ID>/schedules/schedule_a/by_occupation/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_a/by_occupation/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_a/by_occupation/?page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(3) /committee/<committee_ID>/schedules/schedule_a/by_size/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_a/by_size/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_a/by_size/?size=500&page=1&sort_hide_null=false&sort_nulls_last=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(4) /committee/<committee_ID>/schedules/schedule_a/by_state/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_a/by_state/?page=1&hide_null=false&sort=-total&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_a/by_state/?page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&hide_null=false&sort=-total&api_key=DEMO_KEY


(5)/committee/<committee_ID>/schedules/schedule_a/by_zip/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_a/by_zip/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_a/by_zip/?page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(6) /committee/<committee_ID>/ schedules/schedule_b/by_purpose/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_b/by_purpose/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_b/by_purpose/?page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(7) /committee/<committee_ID>/schedules/schedule_b/by_recipient/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_b/by_recipient/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_b/by_recipient/?page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&api_key=DEMO_KEY


(8) /committee/<committee_ID>/schedules/schedule_b/by_recipient_id/
http://127.0.0.1:5000/v1/committee/C00575795/schedules/schedule_b/by_recipient_id/?page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false

https://api.open.fec.gov/v1/committee/C00575795/schedules/schedule_b/by_recipient_id/?api_key=DEMO_KEY&page=1&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20


(9) /committee/<committee_ID>/schedules/schedule_e/by_candidate/
http://127.0.0.1:5000/v1/committee/C00002089/schedules/schedule_e/by_candidate/?candidate_id=P00003392&page=1&sort_nulls_last=false&per_page=20&sort_hide_null=false&sort_null_only=false&election_full=true

https://api.open.fec.gov/v1/committee/C00002089/schedules/schedule_e/by_candidate/?page=1&cycle=2016&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20&office=president&election_full=true&api_key=DEMO_KEY




7. setup cms locally, point to local api. test web page using those endpoints.
(fortunately,  It seems that fec.gov don't use /committee/<committee_ID>/schedules/schedule_x/by_xxxxxxxx/ for now)

(1) Candidate Profile page
http://127.0.0.1:8000/data/candidate/P80001571/
https://www.fec.gov/data/candidate/P80001571/


(2) Committee Profile page
http://127.0.0.1:8000/data/committee/C00580100/?cycle=2020
https://www.fec.gov/data/committee/C00580100/?cycle=2020


(3) Raising by thenumber page (may take some time)
http://127.0.0.1:8000/data/raising-bythenumbers/
https://www.fec.gov/data/raising-bythenumbers/


(4) election page
http://127.0.0.1:8000/data/elections/house/AZ/02/2020/
http://127.0.0.1:8000/data/elections/president/2016/
http://127.0.0.1:8000/data/elections/senate/AZ/2020/

https://www.fec.gov/data/elections/house/AZ/02/2020/



## Impacted areas of the application
Candidate Profile page
Committee Profile page
Raising by the number page
election page


## Notes for remove DEPRECATED endpoints in the future:
/committee/<committee_ID>/schedules/schedule_x/by_xxxxxx/

1)rest.py
remove import aggregates_by_committeeID
remove api.add_resource() section
remove apidoc.register section

2)remove whole file: resources/aggregates_by_committeeID.py

3)args.py
remove line 583-569 for deprecated args

4)remove whole file tests/test_aggregates_by_committee_id.py

5)update Pingdom alert

