### PR TITLE
Default statutes and regulations search to return all results

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -135,7 +135,10 @@ class UniversalSearch(utils.Resource):
         return results
 
 def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_), Q('query_string', query=q)]
+    must_query = [Q('term', _type=type_)]
+
+    if q:
+        must_query.append(Q('query_string', query=q))
 
     query = Search().using(es) \
         .query(Q('bool', must=must_query)) \

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -152,19 +152,7 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     return query
 
 def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_)]
-
-    if q:
-        must_query.append(Q('query_string', query=q))
-
-    query = Search().using(es) \
-        .query(Q('bool', must=must_query)) \
-        .highlight('text', 'name', 'no', 'summary', 'documents.text', 'documents.description') \
-        .highlight_options(require_field_match=False) \
-        .source(exclude=['text', 'documents.text', 'sort1', 'sort2']) \
-        .extra(size=hits_returned, from_=from_hit) \
-        .index('docs_search') \
-        .sort("sort1", "sort2")
+    query = generic_query_builder(q, type_, from_hit, hits_returned, **kwargs)
 
     must_clauses = []
     if kwargs.get('case_no'):
@@ -181,18 +169,13 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
 
 def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
-    must_query = [Q('term', _type=type_)]
+    # Only pass query string to document list below
+    query = generic_query_builder(None, type_, from_hit, hits_returned, **kwargs)
+
     should_query = [get_ao_document_query(q, **kwargs),
                 Q('query_string', query=q, fields=['no', 'name', 'summary'])]
 
-    query = Search().using(es) \
-        .query(Q('bool', must=must_query, should=should_query, minimum_should_match=1)) \
-        .highlight('text', 'name', 'no', 'summary', 'documents.text', 'documents.description') \
-        .highlight_options(require_field_match=False) \
-        .source(exclude=['text', 'documents.text', 'sort1', 'sort2']) \
-        .extra(size=hits_returned, from_=from_hit) \
-        .index('docs_search') \
-        .sort("sort1", "sort2")
+    query = query.query('bool', should=should_query, minimum_should_match=1)
 
     return apply_ao_specific_query_params(query, **kwargs)
 


### PR DESCRIPTION
## Summary (required)

Resolves https://github.com/fecgov/openFEC/issues/4028

- 8a46606b2941140e1dd9b18c7438bad72c46b407: Modify the `generic_query_builder` to use the logic in the other searches - only add the query string if it's provided. 
- a0bd35d49717b5b6ebae038c45b65089c1409418: Refactor the other query builders to use the shared  `generic_query_builder` as the base for queries

## How to test the changes locally

- Either manually deploy this branch to `dev` or:
- Load statutes and/or regulations into your local elasticsearch https://github.com/fecgov/openfec#create-index-for-current-legal-documents-excludes-archived-murs
- Do a default query with no parameters: https://fec-dev-api.app.cloud.gov/v1/legal/search or localhost:5000/v1/legal/search
- All statutes and regulations should be returned, like other legal docs

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Statute and regulations search should load all statutes/regs with no search terms, along with https://github.com/fecgov/fec-cms/pull/3282



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fec-cms: feature/4028-default-statutes-regs-to-all | https://github.com/fecgov/fec-cms/pull/3282

