### PR TITLE
bump flask 1.0.2-->1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3
 psycopg2-binary==2.7.4
-Flask==1.0.2
+Flask==1.1.1
 Flask-Cors==3.0.6
 Flask-Script==2.0.6
 Flask-RESTful==0.3.6


### PR DESCRIPTION
## Summary (required)

- Resolves #4026 
- bumps version of Flask from 1.0.2 to 1.1.1 in requirements.txt
## How to test the changes locally

- check out this branch
- pip install -r requirements.txt
- pytest
- run local api and test endpoints

## Impacted areas of the application
Updates Flask with non-breaking changes.
