### PR TITLE
add candidate_id filter to /schedules/schedule_e/efile/

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -877,6 +877,21 @@ class TestItemized(ApiBaseTest):
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
+    def test_candidate_id_filter_sched_e_efile(self):
+        filters = [
+            ('candidate_id', ScheduleEEfile.candidate_id, ['S01', 'S02']),
+        ]
+        factories.EFilingsFactory(file_number=123)
+        for label, column, values in filters:
+            [
+                factories.ScheduleEEfileFactory(**{column.key: value})
+                for value in values
+            ]
+            results = self._results(api.url_for(ScheduleEEfileView, **{label: values[0]}))
+            assert len(results) == 1
+            assert results[0][column.key] == values[0]
+        
+
     def test_schedule_e_sort_args_descending(self):
         [
             factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -882,6 +882,7 @@ schedule_e = {
 schedule_e_efile = {
     'candidate_search': fields.List(fields.Str, description=docs.CANDIDATE_FULL_SEARCH),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
     'image_number': fields.List(fields.Str, description=docs.IMAGE_NUMBER),
     'support_oppose_indicator': fields.List(

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -16,6 +16,8 @@ def _validate_natural(value):
             'Must be a natural number',
             status_code=422
         )
+
+
 Natural = functools.partial(fields.Int, validate=_validate_natural)
 
 per_page = Natural(
@@ -56,6 +58,7 @@ class District(fields.Str):
 
     def _deserialize(self, value, attr, data):
         return '{0:0>2}'.format(value)
+
 
 election_full = fields.Bool(missing=True, description=docs.ELECTION_FULL)
 
@@ -172,6 +175,7 @@ def make_seek_args(field=fields.Int, description=None):
             description=description or 'Index of last result from previous page',
         ),
     }
+
 
 names = {
     'q': fields.List(fields.Str, required=True, description='Name (candidate or committee) to search for'),

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -110,6 +110,7 @@ class ScheduleEEfileView(views.ApiResource):
     filter_multi_fields = [
         ('image_number', models.ScheduleEEfile.image_number),
         ('committee_id', models.ScheduleEEfile.committee_id),
+        ('candidate_id', models.ScheduleEEfile.candidate_id),
         ('support_oppose_indicator', models.ScheduleEEfile.support_oppose_indicator),
         ('candidate_party', models.ScheduleEEfile.candidate_party),
         ('candidate_office', models.ScheduleEEfile.candidate_office),


### PR DESCRIPTION
## Summary (required)

- Resolves #4005 
- adds `candidate_id` in `args.py` and `sched_e.py`
- fixes PEP8 style complaints for whitespaces

## How to test the changes locally

- check out branch
- pytest
- run local api/swagger-ui and check that /schedules/schedule_e/efile/ has candidate_id filter and that using the filter returns expected results

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /schedules/schedule_e/efile/ endpoint

