### PR TITLE
Add columns to committee_history_mv and filings_all_mv to help filtering to display cycles with either financial reports or with activity.

### DIFF
--- a/data/migrations/V0168__add_filing_type_to_filings_all_mv.sql
+++ b/data/migrations/V0168__add_filing_type_to_filings_all_mv.sql
@@ -1,0 +1,256 @@
+/*
+This migration file is for #4034
+Add form_category column:
+    'REPORT': ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13'],
+    'NOTICE': ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
+    'STATEMENT': ['F1', 'F2'],
+    'OTHER': ['F1M', 'F8', 'F99', 'F12', 'FRQ']
+
+distinguish regular F5 and F5 notice by rpt_tp
+F2 added to the 'statements' list
+FRQ added to the 'other' list
+*/
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp AS
+SELECT row_number() OVER () AS idx,
+    cand.candidate_id,
+    cand.name AS candidate_name,
+    filing_history.cand_cmte_id AS committee_id,
+    com.name AS committee_name,
+    filing_history.sub_id,
+    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+    filing_history.election_yr AS election_year,
+    filing_history.form_tp AS form_type,
+    filing_history.rpt_yr AS report_year,
+    get_cycle(filing_history.rpt_yr) AS cycle,
+    filing_history.rpt_tp AS report_type,
+    filing_history.to_from_ind AS document_type,
+    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+    filing_history.begin_image_num::bigint AS beginning_image_number,
+    filing_history.end_image_num AS ending_image_number,
+    filing_history.pages,
+    filing_history.ttl_receipts AS total_receipts,
+    filing_history.ttl_indt_contb AS total_individual_contributions,
+    filing_history.net_dons AS net_donations,
+    filing_history.ttl_disb AS total_disbursements,
+    filing_history.ttl_indt_exp AS total_independent_expenditures,
+    filing_history.ttl_communication_cost AS total_communication_cost,
+    filing_history.coh_bop AS cash_on_hand_beginning_period,
+    filing_history.coh_cop AS cash_on_hand_end_period,
+    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+    filing_history.hse_pers_funds_amt AS house_personal_funds,
+    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+    filing_history.tres_nm AS treasurer_name,
+    filing_history.file_num AS file_number,
+    CASE
+        WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN 0
+        ELSE filing_history.prev_file_num
+    END AS previous_file_number,
+    report.rpt_tp_desc AS report_type_full,
+    filing_history.rpt_pgi AS primary_general_indicator,
+    filing_history.request_tp AS request_type,
+    filing_history.amndt_ind AS amendment_indicator,
+    filing_history.lst_updt_dt AS update_date,
+    report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.form_tp::text) AS pdf_url,
+    means_filed(filing_history.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+    report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    CASE
+        WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+        WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+        WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+        ELSE amendments.mst_rct_file_num
+    END AS most_recent_file_number,
+    is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+    CASE
+        WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+        WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) AND filing_history.file_num = v1.mst_rct_file_num THEN true
+        WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+        WHEN upper(filing_history.form_tp::text) IN ('F6'::text, 'F13'::text) THEN NULL
+        WHEN vs.orig_sub_id IS NOT NULL THEN true
+        WHEN vs.orig_sub_id IS NULL THEN false
+        ELSE NULL
+    END AS most_recent,
+    CASE
+        WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+        WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+        ELSE array_length(amendments.amendment_chain, 1) - 1
+    END AS amendment_version,
+    cand.state,
+    cand.office,
+    cand.district,
+    cand.party,
+    cmte_valid_fec_yr.cmte_tp,
+    get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+    CASE
+        WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+        WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+        WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+        WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+    END AS form_category
+  FROM disclosure.f_rpt_or_form_sub filing_history
+     LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+     LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+     LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+     LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+     LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+     LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+     LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+  WHERE filing_history.rpt_yr >= 1979::numeric AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+WITH DATA;
+
+ALTER TABLE public.ofec_filings_all_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (amendment_indicator)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (beginning_image_number)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (candidate_id )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (committee_id )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_end_date)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_start_date)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle, committee_id )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (district )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_type )
+    ;
+CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (idx)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office_cmte_tp )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (party )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (primary_general_indicator )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (receipt_date)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (request_type )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type_full )
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_year)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_disbursements)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_independent_expenditures)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_receipts)
+    ;
+CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (state )
+    ;
+
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_category)
+    ;
+   
+
+-- point view to the tmp mv
+CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+ SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+-- drop old MV
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;

--- a/data/migrations/V0168__add_filing_type_to_filings_all_mv.sql
+++ b/data/migrations/V0168__add_filing_type_to_filings_all_mv.sql
@@ -72,7 +72,7 @@ SELECT row_number() OVER () AS idx,
         WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
         WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) AND filing_history.file_num = v1.mst_rct_file_num THEN true
         WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
-        WHEN upper(filing_history.form_tp::text) IN ('F6'::text, 'F13'::text) THEN NULL
+        WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
         WHEN vs.orig_sub_id IS NOT NULL THEN true
         WHEN vs.orig_sub_id IS NULL THEN false
         ELSE NULL

--- a/data/migrations/V0169__add_cycles_has_reports_to_ofec_committee_history_mv.sql
+++ b/data/migrations/V0169__add_cycles_has_reports_to_ofec_committee_history_mv.sql
@@ -1,0 +1,194 @@
+/*
+This migration file is for #4034
+Add 4 columns to ofec_committee_history_mv to help filter committees activity to 
+only shows fec_elecrion_yr with financial report/notice 
+or only shows fec_elecrion_yr with filings
+
+last_cycle_has_financial
+cycles_has_financial
+
+last_cycle_has_activity
+cycles_has_activity
+*/
+
+-- ----------
+-- ofec_committee_history_mv
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_committee_history_mv_tmp AS
+WITH cycles AS (
+         SELECT cmte_valid_fec_yr.cmte_id,
+            (array_agg(cmte_valid_fec_yr.fec_election_yr))::integer[] AS cycles,
+            max(cmte_valid_fec_yr.fec_election_yr) AS max_cycle
+           FROM disclosure.cmte_valid_fec_yr
+          GROUP BY cmte_valid_fec_yr.cmte_id
+        ), dates AS (
+         SELECT f_rpt_or_form_sub.cand_cmte_id AS cmte_id,
+            min(f_rpt_or_form_sub.receipt_dt) AS first_file_date,
+            max(f_rpt_or_form_sub.receipt_dt) AS last_file_date,
+            max(f_rpt_or_form_sub.receipt_dt) FILTER (WHERE ((f_rpt_or_form_sub.form_tp)::text = 'F1'::text)) AS last_f1_date,
+            max(get_cycle(rpt_yr)) as last_cycle_has_activity,
+            array_agg(DISTINCT(get_cycle(rpt_yr)))::integer[] AS cycles_has_activity
+           FROM disclosure.f_rpt_or_form_sub
+          GROUP BY f_rpt_or_form_sub.cand_cmte_id
+        ), candidates AS (
+         SELECT cand_cmte_linkage.cmte_id,
+            (array_agg(DISTINCT cand_cmte_linkage.cand_id))::text[] AS candidate_ids
+           FROM disclosure.cand_cmte_linkage
+          GROUP BY cand_cmte_linkage.cmte_id
+        ), reports AS (
+        select cand_cmte_id as cmte_id,
+        max(get_cycle(rpt_yr)) as last_cycle_has_financial,
+        array_agg(DISTINCT(get_cycle(rpt_yr)))::integer[] AS cycles_has_financial
+        from disclosure.f_rpt_or_form_sub
+        where upper(form_tp) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13','F24', 'F6', 'F9', 'F10', 'F11')
+        group by cand_cmte_id
+        )
+ SELECT DISTINCT ON (fec_yr.cmte_id, fec_yr.fec_election_yr) row_number() OVER () AS idx,
+    fec_yr.fec_election_yr AS cycle,
+    fec_yr.cmte_id AS committee_id,
+    fec_yr.cmte_nm AS name,
+    fec_yr.tres_nm AS treasurer_name,
+    to_tsvector(parse_fulltext((fec_yr.tres_nm)::text)) AS treasurer_text,
+    f1.org_tp AS organization_type,
+    expand_organization_type((f1.org_tp)::text) AS organization_type_full,
+    fec_yr.cmte_st1 AS street_1,
+    fec_yr.cmte_st2 AS street_2,
+    fec_yr.cmte_city AS city,
+    fec_yr.cmte_st AS state,
+    expand_state((fec_yr.cmte_st)::text) AS state_full,
+    fec_yr.cmte_zip AS zip,
+    f1.tres_city AS treasurer_city,
+    f1.tres_f_nm AS treasurer_name_1,
+    f1.tres_l_nm AS treasurer_name_2,
+    f1.tres_m_nm AS treasurer_name_middle,
+    f1.tres_ph_num AS treasurer_phone,
+    f1.tres_prefix AS treasurer_name_prefix,
+    f1.tres_st AS treasurer_state,
+    f1.tres_st1 AS treasurer_street_1,
+    f1.tres_st2 AS treasurer_street_2,
+    f1.tres_suffix AS treasurer_name_suffix,
+    f1.tres_title AS treasurer_name_title,
+    f1.tres_zip AS treasurer_zip,
+    f1.cust_rec_city AS custodian_city,
+    f1.cust_rec_f_nm AS custodian_name_1,
+    f1.cust_rec_l_nm AS custodian_name_2,
+    f1.cust_rec_m_nm AS custodian_name_middle,
+    f1.cust_rec_nm AS custodian_name_full,
+    f1.cust_rec_ph_num AS custodian_phone,
+    f1.cust_rec_prefix AS custodian_name_prefix,
+    f1.cust_rec_st AS custodian_state,
+    f1.cust_rec_st1 AS custodian_street_1,
+    f1.cust_rec_st2 AS custodian_street_2,
+    f1.cust_rec_suffix AS custodian_name_suffix,
+    f1.cust_rec_title AS custodian_name_title,
+    f1.cust_rec_zip AS custodian_zip,
+    fec_yr.cmte_email AS email,
+    f1.cmte_fax AS fax,
+    fec_yr.cmte_url AS website,
+    f1.form_tp AS form_type,
+    f1.leadership_pac,
+    f1.lobbyist_registrant_pac,
+    f1.cand_pty_tp AS party_type,
+    f1.cand_pty_tp_desc AS party_type_full,
+    f1.qual_dt AS qualifying_date,
+    ((dates.first_file_date)::text)::date AS first_file_date,
+    ((dates.last_file_date)::text)::date AS last_file_date,
+    ((dates.last_f1_date)::text)::date AS last_f1_date,
+    fec_yr.cmte_dsgn AS designation,
+    expand_committee_designation((fec_yr.cmte_dsgn)::text) AS designation_full,
+    fec_yr.cmte_tp AS committee_type,
+    expand_committee_type((fec_yr.cmte_tp)::text) AS committee_type_full,
+    fec_yr.cmte_filing_freq AS filing_frequency,
+    fec_yr.cmte_pty_affiliation AS party,
+    fec_yr.cmte_pty_affiliation_desc AS party_full,
+    cycles.cycles,
+    COALESCE(candidates.candidate_ids, '{}'::text[]) AS candidate_ids,
+    f1.affiliated_cmte_nm AS affiliated_committee_name,
+    reports.last_cycle_has_financial,
+    reports.cycles_has_financial,
+    dates.last_cycle_has_activity,
+    dates.cycles_has_activity
+   FROM ((((disclosure.cmte_valid_fec_yr fec_yr
+     LEFT JOIN fec_vsum_f1_vw f1 ON ((((fec_yr.cmte_id)::text = (f1.cmte_id)::text) AND (fec_yr.fec_election_yr >= f1.rpt_yr))))
+     LEFT JOIN cycles ON (((fec_yr.cmte_id)::text = (cycles.cmte_id)::text)))
+     LEFT JOIN dates ON (((fec_yr.cmte_id)::text = (dates.cmte_id)::text)))
+     LEFT JOIN candidates ON (((fec_yr.cmte_id)::text = (candidates.cmte_id)::text)))
+     LEFT JOIN reports ON fec_yr.cmte_id = reports.cmte_id
+  WHERE ((cycles.max_cycle >= (1979)::numeric) AND (NOT ((fec_yr.cmte_id)::text IN 
+    ( SELECT DISTINCT unverified_filers_vw.cmte_id
+           FROM unverified_filers_vw
+          WHERE ((unverified_filers_vw.cmte_id)::text ~~ 'C%'::text)))))
+  ORDER BY fec_yr.cmte_id, fec_yr.fec_election_yr DESC, f1.rpt_yr DESC
+WITH DATA;
+
+--Permissions
+
+ALTER TABLE public.ofec_committee_history_mv_tmp
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_committee_history_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_committee_history_mv_tmp TO fec_read;
+
+--Indices
+
+CREATE UNIQUE INDEX idx_ofec_committee_history_mv_tmp_idx
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (idx);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_committee_id
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (committee_id);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_cycle_committee_id
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (cycle, committee_id);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_cycle
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (cycle);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_designation
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (designation);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_first_file_date
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (first_file_date);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_name
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (name);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_state
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (state);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_comid_state
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (committee_id, state);
+
+
+-- ----------
+CREATE OR REPLACE VIEW public.ofec_committee_history_vw AS
+SELECT * FROM public.ofec_committee_history_mv_tmp;
+
+ALTER TABLE public.ofec_committee_history_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_committee_history_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_committee_history_vw TO fec_read;
+
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv;
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv_tmp RENAME TO ofec_committee_history_mv;
+-- ----------
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_idx RENAME TO idx_ofec_committee_history_mv_idx;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_committee_id RENAME TO idx_ofec_committee_history_mv_committee_id;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_cycle_committee_id RENAME TO idx_ofec_committee_history_mv_cycle_committee_id;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_cycle RENAME TO idx_ofec_committee_history_mv_cycle;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_designation RENAME TO idx_ofec_committee_history_mv_designation;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_first_file_date RENAME TO idx_ofec_committee_history_mv_first_file_date;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_name RENAME TO idx_ofec_committee_history_mv_name;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_state RENAME TO idx_ofec_committee_history_mv_state;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_comid_state RENAME TO idx_ofec_committee_history_mv_comid_state;
+


### PR DESCRIPTION
## Summary (required)
- Resolves #4034 
Add cycles_has_financial and cycles_has_activity columns in ofec_committee_history_mv
Add form_category in ofec_filings_all_mv and updated most_recent for F13.
There changes will simplify API/front-end calculation.

## How to test the changes locally
Download the branch to local machine, execute invoke create_sample_db to make sure migration files executed successfully.
There are no changes in MV dependencies therefore no need to update manage.py and flow.py
 
## Impacted areas of the application
List general components of the application that this PR will affect:

-  These are new columns, the APIs that would utilize these new columns are implemented in issue #4016 
A tmp version of these two updated MVs are created in DEV for viewing.
ofec_committee_history_mv_tmp_jj  and ofec_filings_all_mv_tmp_jj 
two example committees are:
C00570978 (a committee that only filed statements, no financial reports/notices)
C00575795 (a committee that filed both statements and financial reports/notices)

select committee_id, cycle, cycles, cycles_has_financial, cycles_has_activity, * 
from ofec_committee_history_mv_tmp_jj 
where committee_id = 'C00570978' 
order by cycle;

select committee_id, cycle, form_category, form_type, most_recent, * 
from ofec_filings_all_mv_tmp_jj 
where committee_id = 'C00570978' 
order by cycle;

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
