### PR TITLE
add sche_e processed filters

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -824,9 +824,9 @@ class TestItemized(ApiBaseTest):
         self.assertEquals(len(results), 0)
 
     def test_filters_sched_e_dissemination_date_range(self):
-        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2020, 12, 30))
-        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2019, 8, 29))
-        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2018, 10, 25))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2023, 12, 30))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2021, 8, 29))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2019, 10, 25))
         factories.ScheduleEFactory(dissemination_date=datetime.datetime(2017, 6, 22))
         factories.ScheduleEFactory(dissemination_date=datetime.datetime(2015, 10, 15))
 
@@ -835,9 +835,23 @@ class TestItemized(ApiBaseTest):
         assert len(results) == 5
 
         results = self._results(api.url_for(ScheduleEView,
-            max_dissemination_date=datetime.date.fromisoformat('2018-10-25')))
-        assert len(results) == 3
+            max_dissemination_date=datetime.date.fromisoformat('2021-10-25')))
+        assert len(results) == 4
 
+    def test_filters_sched_e_filing_date_range(self):
+        factories.ScheduleEFactory(filing_date=datetime.datetime(2023, 12, 30))
+        factories.ScheduleEFactory(filing_date=datetime.datetime(2021, 8, 29))
+        factories.ScheduleEFactory(filing_date=datetime.datetime(2019, 10, 25))
+        factories.ScheduleEFactory(filing_date=datetime.datetime(2017, 6, 22))
+        factories.ScheduleEFactory(filing_date=datetime.datetime(2015, 10, 15))
+
+        results = self._results(api.url_for(ScheduleEView,
+            min_filing_date=datetime.date.fromisoformat('2015-01-01')))
+        assert len(results) == 5
+
+        results = self._results(api.url_for(ScheduleEView,
+            max_filing_date=datetime.date.fromisoformat('2021-10-25')))
+        assert len(results) == 4
 
     def test_filters_sched_a_efile(self):
         filters = [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -823,6 +823,22 @@ class TestItemized(ApiBaseTest):
         results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
         self.assertEquals(len(results), 0)
 
+    def test_filters_sched_e_dissemination_date_range(self):
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2020, 12, 30))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2019, 8, 29))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2018, 10, 25))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2017, 6, 22))
+        factories.ScheduleEFactory(dissemination_date=datetime.datetime(2015, 10, 15))
+
+        results = self._results(api.url_for(ScheduleEView,
+            min_dissemination_date=datetime.date.fromisoformat('2015-01-01')))
+        assert len(results) == 5
+
+        results = self._results(api.url_for(ScheduleEView,
+            max_dissemination_date=datetime.date.fromisoformat('2018-10-25')))
+        assert len(results) == 3
+
+
     def test_filters_sched_a_efile(self):
         filters = [
             ('image_number', ScheduleAEfile.image_number, ['123', '456']),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -878,6 +878,8 @@ schedule_e = {
     'last_support_oppose_indicator': fields.Str(missing=None,
         description=docs.LAST_SUPPOSE_OPPOSE_INDICATOR),
     'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
+    'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
+    'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
 }
 
 schedule_e_efile = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -880,6 +880,8 @@ schedule_e = {
     'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
     'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
     'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
+    'min_filing_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
+    'max_filing_date': fields.Date(description=docs.MAX_RECEIPT_DATE)
 }
 
 schedule_e_efile = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -880,8 +880,8 @@ schedule_e = {
     'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
     'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
     'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
-    'min_filing_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
-    'max_filing_date': fields.Date(description=docs.MAX_RECEIPT_DATE)
+    'min_filing_date': fields.Date(description=docs.FILED_DATE),
+    'max_filing_date': fields.Date(description=docs.FILED_DATE)
 }
 
 schedule_e_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -565,8 +565,8 @@ class ScheduleD(PdfMixin, BaseItemized):
 
 
 class ScheduleE(PdfMixin, BaseItemized):
-    __tablename__ = 'ofec_sched_e_mv'
-
+    # __tablename__ = 'ofec_sched_e_mv'
+    __tablename__ = 'ofec_sched_e_mv_tmp_jj'
     sub_id = db.Column(db.String, primary_key=True)
 
     # Payee info
@@ -596,6 +596,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     category_code = db.Column('catg_cd', db.String)
     category_code_full = db.Column('catg_cd_desc', db.String)
     support_oppose_indicator = db.Column('s_o_ind', db.String)
+    filing_date = db.Column('filing_date', db.Date)
 
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -565,10 +565,9 @@ class ScheduleD(PdfMixin, BaseItemized):
 
 
 class ScheduleE(PdfMixin, BaseItemized):
-    # __tablename__ = 'ofec_sched_e_mv'
-    __tablename__ = 'ofec_sched_e_mv_tmp_jj'
-    sub_id = db.Column(db.String, primary_key=True)
+    __tablename__ = 'ofec_sched_e_mv'
 
+    sub_id = db.Column(db.String, primary_key=True)
     # Payee info
     payee_prefix = db.Column(db.String)
     payee_name = db.Column('pye_nm', db.String)
@@ -591,12 +590,12 @@ class ScheduleE(PdfMixin, BaseItemized):
     expenditure_description = db.Column('exp_desc', db.String)
     expenditure_date = db.Column('exp_dt', db.Date)
     dissemination_date = db.Column('dissem_dt', db.Date)
+    filing_date = db.Column('filing_date', db.Date)
     expenditure_amount = db.Column('exp_amt', db.Float)
     office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)
     category_code = db.Column('catg_cd', db.String)
     category_code_full = db.Column('catg_cd_desc', db.String)
     support_oppose_indicator = db.Column('s_o_ind', db.String)
-    filing_date = db.Column('filing_date', db.Date)
 
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1548,17 +1548,17 @@ The first value in the chain is the original filing.  The ordering in the chain 
 amendments were filed up to the amendment being viewed.
 '''
 
-AMENDMENT_INDICATOR = '''
+AMENDMENT_INDICATOR = 'Amendent types:\n\
     -N   new\n\
     -A   amendment\n\
     -T   terminated\n\
     -C   consolidated\n\
     -M   multi-candidate\n\
     -S   secondary\n\n\
-    Null might be new or amendment. If amendment indicator is null and the filings is the first or \
-    first in a chain treat it as if it was a new. If it is not the first or first in a chain then \
-    treat the filing as an amendment.\n\
-'''
+NULL might be new or amendment. If amendment indicator is null and the filings is the first or \
+first in a chain treat it as if it was a new. If it is not the first or first in a chain then \
+treat the filing as an amendment.\n\
+'
 
 AMENDED_BY = '''
 If this report has been amended, this field gives the file_number of the report that should be used. For example,

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -56,6 +56,8 @@ class ScheduleEView(ItemizedResource):
         (('min_date', 'max_date'), models.ScheduleE.expenditure_date),
         (('min_amount', 'max_amount'), models.ScheduleE.expenditure_amount),
         (('min_image_number', 'max_image_number'), models.ScheduleE.image_number),
+        (('min_dissemination_date', 'max_dissemination_date'), models.ScheduleE.dissemination_date),
+
     ]
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -8,13 +8,7 @@ from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager
 from webservices.common import models
 from webservices.common import views
-from webservices.common import counts
 from webservices.common.views import ItemizedResource
-from webservices.common.models import (
-    EFilings,
-    db
-)
-
 
 @doc(
     tags=['independent expenditures'],

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -57,6 +57,7 @@ class ScheduleEView(ItemizedResource):
         (('min_amount', 'max_amount'), models.ScheduleE.expenditure_amount),
         (('min_image_number', 'max_image_number'), models.ScheduleE.image_number),
         (('min_dissemination_date', 'max_dissemination_date'), models.ScheduleE.dissemination_date),
+        (('min_filing_date', 'max_filing_date'), models.ScheduleE.filing_date),
 
     ]
     query_options = [


### PR DESCRIPTION
 Make `/schedules/schedule_e/` api endpoint filter on`filing_date` and `dissemination_date`.

- Resolves https://github.com/fecgov/openFEC/issues/3817

_Include a summary of proposed changes._

 - In models/itemized.py :  map the new`filing_date`column  
 - In resources/sched_e.py, ScheudleE class : add `filing_date` and `dissemination_date` as range filters (min/max) 
-  In test_itemized.py : add python tests to the date range filters
## How to test the changes locally

- checkout branch
- run `pytest` make sure all tests PASS
- export `SQLA_CONN` to  point `dev` DB
- start server
- test`filing_date` and `dissemenation_date` filters in `schedules/schedule_e` endpoint
- example:
 Dissemination Date: 
http://localhost:5000/v1/schedules/schedule_e/?max_dissemination_date=2019-10-29&sort_null_only=false&sort=-expenditure_date&sort_hide_null=false&per_page=20&sort_nulls_last=false
- Filing Date: 
http://127.0.0.1:5000/v1/schedules/schedule_e/?per_page=20&sort_hide_null=false&max_filing_date=2019-10-29&sort=-expenditure_date&sort_null_only=false&sort_nulls_last=false

## Impacted areas of the application
List general components of the application that this PR will affect:
API Endpoint : `schedules/schedule_e`
