### PR TITLE
update elasticsearch and add pip-tools

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,5 @@ webtest==2.0.27
 pdbpp==0.9.1
 click==6.7
 
+# requirements.txt generation (pip-compile)
+pip-tools==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gevent==1.4.0
 webargs==5.3.1
 ujson==1.33
 requests==2.21.0
-elasticsearch==5.5.1
+elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 git+https://github.com/18F/slate.git
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4044

- change `elasticsearch==5.5.1` to `elasticsearch==5.5.3` in `requirements.txt`
- add `pip-tools==4.2.0` to `requirements-dev.txt` (for `pip-compile`)

## How to test the changes locally

- check out this branch
- `pytest`
- @jason-upchurch to deploy to `dev` for testing (e.g., https://dev.fec.gov/data/legal/advisory-opinions/)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  just dependency files, but work is needed to incorporate `pip-compile` into workflow

