### PR TITLE
Delete ofec_totals_candidate_committees_mv/vw

### DIFF
--- a/data/migrations/V0171__drop_ofec_totals_candidate_committees.sql
+++ b/data/migrations/V0171__drop_ofec_totals_candidate_committees.sql
@@ -1,0 +1,13 @@
+/*
+This migration file is to solve issue #3928
+
+The below two database objects are replaced by 
+ofec_candidate_totals_detail_mv
+ofec_candidate_totals_detail_vw
+
+and we can drop the unused ones
+*/
+
+DROP VIEW IF EXISTS public.ofec_totals_candidate_committees_vw;
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_candidate_committees_mv; 

--- a/manage.py
+++ b/manage.py
@@ -126,7 +126,6 @@ def refresh_materialized(concurrent=True):
         'sched_a_by_size_merged': ['ofec_sched_a_aggregate_size_merged_mv'],
         'sched_a_by_state_recipient_totals': ['ofec_sched_a_aggregate_state_recipient_totals_mv'],
         'sched_e_by_candidate': ['ofec_sched_e_aggregate_candidate_mv'],
-        'totals_candidate_committee': ['ofec_totals_candidate_committees_mv'],
         'totals_combined': ['ofec_totals_combined_mv'],
         'totals_house_senate': ['ofec_totals_house_senate_mv'],
         'totals_ie': ['ofec_totals_ie_only_mv'],

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -17,6 +17,7 @@ def get_graph():
         'candidate_fulltext',
         'candidate_history',
         'candidate_history_future',
+        'candidate_totals_detail',
         'committee_detail',
         'committee_fulltext',
         'committee_history',
@@ -40,7 +41,6 @@ def get_graph():
         'sched_a_by_size_merged',
         'sched_a_by_state_recipient_totals',
         'sched_e_by_candidate',
-        'totals_candidate_committee',
         'totals_combined',
         'totals_house_senate',
         'totals_ie',
@@ -110,12 +110,6 @@ def get_graph():
         ('filings', 'reports_pac_party'),
         ('filings', 'reports_presidential'),
         ('filings', 'reports_house_senate'),
-    ])
-
-    graph.add_edges_from([
-        ('candidate_election', 'totals_candidate_committee'),
-        ('filings', 'totals_candidate_committee'),
-        ('cand_cmte_linkage', 'totals_candidate_committee'),
     ])
 
     graph.add_edges_from([


### PR DESCRIPTION
## Summary (required)

- Resolves #[_3928_](https://github.com/fecgov/openfec/issues/3928)

_Delete ofec_totals_candidate_committees_mv and ofec_totals_candidate_committees_vw since they are not being used._

## How to test the changes locally

- run `flyway migrate` or `invoke create_sample_db`,  and ofec_totals_candidate_committees_mv is not on the list of refreshed mvs

- run `pytest`.


