### PR TITLE
Add most_recent filter to sched_e endpoint

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -971,3 +971,13 @@ class TestItemized(ApiBaseTest):
         rest.db.session.flush()
         results = self._results(api.url_for(ScheduleEEfileView, candidate_search='Rob'))
         assert len(results) == 2
+
+    def test_filter_sched_e_most_recent(self):
+        [
+            factories.ScheduleEFactory(committee_id='C001', filing_form='F24', most_recent=True),
+            factories.ScheduleEFactory(committee_id='C002', filing_form='F5', most_recent=False),
+            factories.ScheduleEFactory(committee_id='C003', filing_form='F24', most_recent=True),
+            factories.ScheduleEFactory(committee_id='C004', filing_form='F3X', most_recent=True),
+        ]
+        results = self._results(api.url_for(ScheduleEView, most_recent=True, **self.kwargs))
+        self.assertEqual(len(results), 3)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -881,7 +881,9 @@ schedule_e = {
     'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
     'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
     'min_filing_date': fields.Date(description=docs.FILED_DATE),
-    'max_filing_date': fields.Date(description=docs.FILED_DATE)
+    'max_filing_date': fields.Date(description=docs.FILED_DATE),
+    'most_recent': fields.Bool(description=docs.MOST_RECENT),
+
 }
 
 schedule_e_efile = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -880,8 +880,8 @@ schedule_e = {
     'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
     'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),
     'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
-    'min_filing_date': fields.Date(description=docs.FILED_DATE),
-    'max_filing_date': fields.Date(description=docs.FILED_DATE),
+    'min_filing_date': fields.Date(description=docs.MIN_FILED_DATE),
+    'max_filing_date': fields.Date(description=docs.MAX_FILED_DATE),
     'most_recent': fields.Bool(description=docs.MOST_RECENT),
 
 }

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -590,6 +590,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     expenditure_description = db.Column('exp_desc', db.String)
     expenditure_date = db.Column('exp_dt', db.Date)
     dissemination_date = db.Column('dissem_dt', db.Date)
+    most_recent = db.Column('most_recent', db.Boolean, doc=docs.MOST_RECENT)
     filing_date = db.Column('filing_date', db.Date)
     expenditure_amount = db.Column('exp_amt', db.Float)
     office_total_ytd = db.Column('cal_ytd_ofc_sought', db.Float)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1306,6 +1306,14 @@ RECEIPT_DATE = 'Date the FEC received the electronic or paper record'
 
 FILED_DATE = 'Timestamp of electronic or paper record that FEC received'
 
+MIN_FILED_DATE = '''
+Selects all filings received after this date
+'''
+
+MAX_FILED_DATE = '''
+Selects all filings received before this date
+'''
+
 STATE_GENERIC = 'US state or territory'
 
 ZIP_CODE = 'Zip code'

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -54,6 +54,9 @@ class ScheduleEView(ItemizedResource):
         (('min_filing_date', 'max_filing_date'), models.ScheduleE.filing_date),
 
     ]
+    filter_match_fields = [
+        ('most_recent', models.ScheduleE.most_recent),
+    ]
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),
         sa.orm.joinedload(models.ScheduleE.committee),

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -428,7 +428,7 @@ def get_elasticsearch_connection():
     return es
 
 def print_literal_query_string(query):
-    print(str(query.statement.compile(dialect=postgresql.dialect())))
+    print(str(query.statement.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})))
 
 def create_eregs_link(part, section):
     url_part_section = part


### PR DESCRIPTION
## Summary (required) 
Add `most_recent` filter to the `schedules/schedule_e/` endpoint 

- Resolves #4058 

_Include a summary of proposed changes._

1. Map `most_recent` DB column in SE model, resource, args files
2. Add python test case to the `most_recent` filter 


## How to test the changes locally

- checkout branch feature/4058-sched_e_most-recent-filter
- export SQLA to dev db
- start server
-  test the `schedules/schedule_e` endpoint with most_recent filter
- examples:

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_null_only=false&sort=-expenditure_date&committee_id=C00483693&sort_nulls_last=false&per_page=20&most_recent=false&sort_hide_null=false

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_null_only=false&sort=-expenditure_date&committee_id=C00483693&sort_nulls_last=false&per_page=20&most_recent=true&sort_hide_null=false

## Impacted areas of the application
List general components of the application that this PR will affect:

-  api endpoint :  Under Independent Expenditure - `schedules/schedule_e` 