### PR TITLE
Add new EC endpoint /electioneering/aggregates/.

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -780,6 +780,12 @@ electioneering_totals_by_candidate = {
     'election_full': election_full,
 }
 
+EC_aggregates = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+}
+
 elections_list = {
     'state': fields.List(IStr, description=docs.STATE),
     'district': fields.List(District, description=docs.DISTRICT),

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -85,9 +85,9 @@ class ScheduleBByPurpose(BaseDisbursementAggregate):
 class BaseSpendingAggregate(BaseAggregate):
     __abstract__ = True
     committee_id = db.Column('cmte_id', db.String, primary_key=True, doc=docs.COMMITTEE_ID)
-    committee = utils.related_committee('committee_id')
+    committee = utils.related_committee_history('committee_id', cycle_label='cycle')
     candidate_id = db.Column('cand_id', db.String, primary_key=True, doc=docs.CANDIDATE_ID)
-    candidate = utils.related_candidate('candidate_id')
+    candidate = utils.related_candidate_history('candidate_id', cycle_label='cycle')
 
 
 class ScheduleEByCandidate(BaseSpendingAggregate):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1171,7 +1171,9 @@ _The communication is distributed within 60 days prior to a general election or 
 to a primary election to federal office._
 '''
 
-ELECTIONEERING_AGGREGATE = 'Electioneering costs aggregated by candidate'
+ELECTIONEERING_AGGREGATE_BY_CANDIDATE = 'Electioneering costs aggregated by candidate'
+
+ELECTIONEERING_AGGREGATE = 'Electioneering costs aggregates'
 
 ELECTIONEERING_TOTAL_BY_CANDIDATE = '''
 Total electioneering communications by candidate by cycle

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -375,10 +375,16 @@ api.add_resource(
     '/communication_costs/by_candidate/',
     '/committee/<string:committee_id>/communication_costs/by_candidate/',
 )
+
 api.add_resource(
     aggregates.ElectioneeringByCandidateView,
     '/electioneering/by_candidate/',
     '/committee/<string:committee_id>/electioneering/by_candidate/',
+)
+
+api.add_resource(
+    aggregates.ECAggregatesView,
+    '/electioneering/aggregates/',
 )
 
 api.add_resource(
@@ -454,6 +460,7 @@ apidoc.register(sched_d.ScheduleDView, blueprint='v1')
 apidoc.register(sched_d.ScheduleDViewBySubId, blueprint='v1')
 apidoc.register(costs.CommunicationCostView, blueprint='v1')
 apidoc.register(costs.ElectioneeringView, blueprint='v1')
+apidoc.register(aggregates.ECAggregatesView, blueprint='v1')
 apidoc.register(aggregates.ScheduleABySizeView, blueprint='v1')
 apidoc.register(aggregates.ScheduleAByStateView, blueprint='v1')
 apidoc.register(aggregates.ScheduleAByZipView, blueprint='v1')

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -731,6 +731,22 @@ ElectioneeringPageSchema = make_page_schema(ElectioneeringSchema, page_type=pagi
 register_schema(ElectioneeringSchema)
 register_schema(ElectioneeringPageSchema)
 
+ECAggregatesSchema = make_schema(
+    models.ElectioneeringByCandidate,
+    fields={
+        'committee_id': ma.fields.Str(),
+        'candidate_id': ma.fields.Str(),
+        'committee_name': ma.fields.Str(),
+        'candidate_name': ma.fields.Str(),
+        'cycle': ma.fields.Int(),
+        'count': ma.fields.Int(),
+        'total': ma.fields.Decimal(places=2),
+    },
+)
+ECAggregatesPageSchema = make_page_schema(ECAggregatesSchema)
+register_schema(ECAggregatesSchema)
+register_schema(ECAggregatesPageSchema)
+
 BaseFilingsSchema = make_schema(
     models.Filings,
     fields={


### PR DESCRIPTION
## Summary (required)
The current endpoint:  /committee/{committee_id}/electioneering/by_candidate/ filter by committee_id not work.


- Resolves [#[_4066_]](https://github.com/fecgov/openFEC/issues/4066)

_Include a summary of proposed changes._
1. we create a new endpoint: **/electioneering/aggregates/**
based on same **ofec_electioneering_aggregate_candidate_mv**
and make all filters work as expected.

2. to do list: create a separated issue to remove (or deprecated ? don’t think any api user is using current one, because filter not work properly)current endpoint.
/committee/{committee_id}/electioneering/by_candidate/

3. change cms code to use /electioneering/aggregates/?committee_id={committee_id}


## How to test the changes locally
1) checkout branch
2) dev db
3) pytest
4) ./manage.py runserver

Test 1: compare current and new endpoint filter by committee_id
prod: **/committee/{committee_id}/electioneering/by_candidate/**
return all committee EC spending: 342 rows (filter by committee_id not work)
https://api.open.fec.gov/v1/committee/C30000533/electioneering/by_candidate/?api_key=DEMO_KEY&cycle=2008&election_full=false

local: **/electioneering/aggregates/**
return 4 rows (filter by C30000533 only)
http://127.0.0.1:5000/v1/electioneering/aggregates/?api_key=DEMO_KEY&cycle=2008&committee_id=C30000533


Test2: other filters for new endpoint: /electioneering/aggregates/
ex1: S8NC00239  (9 results) filter by candidate_id only
http://127.0.0.1:5000/v1/electioneering/aggregates/?api_key=DEMO_KEY&candidate_id=S8NC00239

ex2: S8NC00239 / 2014 (3 results) filter by candidate_id and cycle
http://127.0.0.1:5000/v1/electioneering/aggregates/?api_key=DEMO_KEY&candidate_id=S8NC00239&cycle=2014


