### PR TITLE
Remove reference to swagger-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ npm install
 npm run build
 ```
 
-*Note: `swagger-tools` is required for testing the API documentation via the automated tests and must be installed globally as shown above.*
-
 ##### Git hooks
 This repo includes optional post-merge and post-checkout hooks to ensure that
 dependencies are up to date. If enabled, these hooks will update Python


### PR DESCRIPTION
## Summary (required)
`swagger-tools` removed from global install per #4109 and #4110. This PR cleans up the `openFEC` documentation.
