### PR TITLE
upgrade smart open related pkgs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ Flask-Cors==3.0.8
 Flask-Script==2.0.6
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.1
-python-dateutil==2.4.2
+python-dateutil==2.8.1
 sqlalchemy-postgres-copy==0.3.0
 networkx==1.11
 SQLAlchemy==1.3.1
-icalendar==4.0.4
+icalendar==4.0.2
 GitPython==1.0.1
 gunicorn==19.9.0
 gevent==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-dateutil==2.4.2
 sqlalchemy-postgres-copy==0.3.0
 networkx==1.11
 SQLAlchemy==1.3.1
-icalendar==3.9.1
+icalendar==4.0.4
 GitPython==1.0.1
 gunicorn==19.9.0
 gevent==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ marshmallow-sqlalchemy==0.15.0
 git+https://github.com/fecgov/marshmallow-pagination@master
 
 # Data export
-smart_open==1.7.1
+smart_open==1.8.0
 
 # Task queue
 celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above

--- a/tasks.py
+++ b/tasks.py
@@ -143,7 +143,8 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/4076-upgrade-smart-open-related-pkgs'),
+    # ('dev', lambda _, branch: branch == 'develop'),
 )
 
 


### PR DESCRIPTION
## Summary (required)
Update the pkg in requirements.txt file.

- Resolves #4076 

_Include a summary of proposed changes._
Update python-datautil to v2.8.1
Update icalendar to v4.0.2
Update smart_open to v1.8.0

## How to test the changes locally
- create a new python virtual env
- run `pip install -r requirements.txt` and `pip install -r requirememnts-dev.txt`
- run `pytest`
- test /dates/calendar-dates/export/  api endpoint:
Example 1 with `min_start_date`:
http://127.0.0.1:5000/v1/calendar-dates/export/?per_page=20&sort=-start_date&sort_null_only=false&renderer=csv&page=1&sort_nulls_last=false&sort_hide_null=false&min_start_date=12%2F26%2F2019
Example 2 with `min_end_date`:
http://127.0.0.1:5000/v1/calendar-dates/export/?per_page=20&sort=-start_date&sort_null_only=false&renderer=csv&page=1&sort_nulls_last=false&min_end_date=12%2F26%2F2019&sort_hide_null=false

-  test calendar exports from local cms :
test url : http://127.0.0.1:8000/calendar/
on the top right hand side corner, click on Download menu, select .csv option. 
Calendar events should be downloadable into a csv file. Screenshot attached below:

<img width="1273" alt="Screen Shot 2019-12-30 at 11 29 32 AM" src="https://user-images.githubusercontent.com/11650355/71683611-0825e400-2d61-11ea-9fe2-8a0d4dedbd3d.png">

- test downloads on your local (set up instructions #https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads)

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Calendar Exports
- Downloads
