### PR TITLE
[HOTFIX - MERGE WITH GIT FLOW] Fix python runtime version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the 3.7.4 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.7 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 9.6 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.4
+python-3.7.x


### PR DESCRIPTION
## Summary (required)

- Resolves #4160

Fix python runtime version. Only specify major python version in runtime.txt  - python buildpacks available only seem to include the most recent two minor versions.

Example error message upon build:
```
-----> Supplying Python
       **ERROR** Could not install python: no match found for 3.7.4 in [2.7.16 2.7.17 3.5.7 3.5.9 3.6.9 3.6.10 3.7.5 3.7.6 3.8.0 3.8.1]
Failed to compile droplet: Failed to run all supply scripts: exit status 14
Exit status 223
```

## How to test the changes locally

- Can only test with a manual deploy - only test with a deploy to `develop` space please :) Just check out this branch, target the dev space, and do a manual deploy.
```
cf target -s dev
invoke deploy --space dev
```

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Deployments to cloud.gov

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
`feature/3951-update-python-version` | https://github.com/fecgov/openFEC/pull/3961

