### PR TITLE
Install packages for pytest in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          - v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
           - v2-fec-api-dependencies-
 
@@ -66,13 +66,13 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements.txt  -r requirements-dev.txt
 
       - save_cache:
           paths:
             - ./venv
             - ./node_modules
-          key: v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+          key: v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in testing

Circle needs the `pytest`-related packages in `requirements-dev.txt` to run tests. It was relying on cached packages previously.

## How to test the changes locally

- Easiest to test in CircleCI. Rebuilding `develop` (or any branch) in Circle without cache will fail  because it can't find files for `pytest`:

https://circleci.com/gh/fecgov/openFEC/2212

```
Traceback (most recent call last):
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/_pytest/config/__init__.py", line 377, in _getconftestmodules
    return self._path2confmods[path]
KeyError: local('/home/circleci/repo/tests')

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/_pytest/config/__init__.py", line 408, in _importconftest
    return self._conftestpath2mod[conftestpath]
KeyError: local('/home/circleci/repo/tests/conftest.py')

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/_pytest/config/__init__.py", line 414, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/circleci/repo/venv/lib/python3.7/site-packages/py/_path/local.py", line 701, in pyimport
    __import__(modname)
  File "/home/circleci/repo/tests/__init__.py", line 1, in <module>
    import nplusone.ext.sqlalchemy  # noqa
ModuleNotFoundError: No module named 'nplusone'
ERROR: could not load /home/circleci/repo/tests/conftest.py
```
- Can also test locally by running `pip uninstall -r requirements-dev.txt` and running `pytest`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Pytest



## Related PRs
https://github.com/fecgov/openFEC/pull/4069