### PR TITLE
[V0184] Make endpoint /presidential/financial_summary/

### DIFF
--- a/data/migrations/V0184__add_ofec_presidential_summary_vw.sql
+++ b/data/migrations/V0184__add_ofec_presidential_summary_vw.sql
@@ -1,0 +1,104 @@
+/*
+
+View for https://github.com/fecgov/openFEC/issues/4178
+Adds presidential financial summary
+Endpoint: /presidential/financial_summary/
+
+*/
+
+-- View: public.ofec_presidential_financial_summary_vw
+
+CREATE OR REPLACE VIEW public.ofec_presidential_financial_summary_vw AS
+SELECT
+    row_number() OVER () AS idx,
+    cmte_id                        AS committee_id,
+    cmte_nm                        AS committee_name,
+    filed_cmte_tp                  AS committee_type,
+    filed_cmte_dsgn                AS committee_designation,
+    active                         AS candidate_active,
+    cand_pty_affiliation           AS candidate_party_affiliation,
+    cand_id                        AS candidate_id,
+    UPPER(TRIM(TRAILING ',' FROM cand_nm))  AS candidate_name, --remove trailing commas
+    SUBSTR(cand_nm, 0, strpos(cand_nm,',')) AS candidate_last_name,
+    --Bringing this logic from ofec_presidential_by_candidate_vw
+    ((indv_contb_per - ref_indv_contb_per) +
+        (pol_pty_cmte_contb_per - ref_pol_pty_cmte_contb_per) +
+        (other_pol_cmte_contb_per - ref_other_pol_cmte_contb_per) +
+        cand_contb_per + tranf_from_affilated_cmte_per +
+        (loans_received_from_cand_per - repymts_loans_made_by_cand_per) +
+        (other_loans_received_per - repymts_other_loans_per) + other_receipts_per
+        + COALESCE(fed_funds_per,0)) AS net_receipts,
+    ROUND(((indv_contb_per - ref_indv_contb_per) +
+        (pol_pty_cmte_contb_per - ref_pol_pty_cmte_contb_per) +
+        (other_pol_cmte_contb_per - ref_other_pol_cmte_contb_per) +
+        cand_contb_per + tranf_from_affilated_cmte_per +
+        (loans_received_from_cand_per - repymts_loans_made_by_cand_per) +
+        (other_loans_received_per - repymts_other_loans_per) + other_receipts_per
+        + coalesce(fed_funds_per,0))/1000000,1) AS rounded_net_receipts,
+    election_yr                    AS election_year,
+    -- borrowed field names from ofec_report_pac_party_all_mv, removed `_period`
+    --from classic - summary
+    indv_contb_per - ref_indv_contb_per AS individual_contributions_less_refunds,
+    other_pol_cmte_contb_per - ref_other_pol_cmte_contb_per AS pac_contributions_less_refunds,
+    pol_pty_cmte_contb_per -ref_pol_pty_cmte_contb_per AS party_contributions_less_refunds,
+    cand_contb_per + loans_received_from_cand_per - repymts_loans_made_by_cand_per AS candidate_contributions_less_repayments,
+    (op_exp_per - offsets_to_op_exp_per) + (fndrsg_disb_per - offsets_to_fndrsg_exp_per) + (exempt_legal_acctg_disb_per - offsets_to_legal_acctg_per) + other_disb_per AS disbursements_less_offsets,
+    ttl_contb_per                  AS total_contributions,
+    indv_contb_per                 AS total_individual_contributions,
+    pol_pty_cmte_contb_per         AS political_party_committee_contributions,
+    other_pol_cmte_contb_per       AS other_political_committee_contributions,
+    cand_contb_per                 AS candidate_contributions,
+    ref_indv_contb_per             AS refunded_individual_contributions,
+    ref_pol_pty_cmte_contb_per     AS refunded_political_party_committee_contributions,
+    ref_other_pol_cmte_contb_per   AS refunded_other_political_committee_contributions,
+    tranf_from_affilated_cmte_per  AS transfers_from_affiliated_committees,
+    loans_received_from_cand_per   AS loans_received_from_candidate,
+    other_loans_received_per       AS other_loans_received,
+    repymts_loans_made_by_cand_per AS repayments_loans_made_by_candidate,
+    repymts_other_loans_per        AS repayments_other_loans,
+    op_exp_per                     AS operating_expenditures,
+    offsets_to_op_exp_per          AS offsets_to_operating_expenditures,
+    other_receipts_per             AS other_receipts,
+    debts_owed_by_cmte             AS debts_owed_by_committee,
+    coh_cop                        AS cash_on_hand_end,
+    fndrsg_disb_per                AS fundraising_disbursements,
+    offsets_to_fndrsg_exp_per      AS offsets_to_fundraising_expenditures,
+    exempt_legal_acctg_disb_per    AS exempt_legal_accounting_disbursement,
+    offsets_to_legal_acctg_per     AS offsets_to_legal_accounting,
+    other_disb_per                 AS other_disbursements,
+    mst_rct_rpt_yr                 AS most_recent_report_year,
+    mst_rct_rpt_tp                 AS most_recent_report_type,
+    coh_bop                        AS cash_on_hand_beginning,
+    ttl_receipts_sum_page_per      AS total_receipts_summary_page,
+    subttl_sum_page_per            AS subtotal_summary_page,
+    ttl_disb_sum_page_per          AS total_disbursements_summary_page,
+    debts_owed_to_cmte             AS debts_owed_to_committee,
+    exp_subject_limits             AS expenditure_subject_to_limits,
+    net_contb_sum_page_per         AS net_contributions,
+    net_op_exp_sum_page_per        AS net_operating_expenditures,
+    fed_funds_per                  AS federal_funds,
+    ttl_loans_received_per         AS total_loans_received,
+    ttl_offsets_to_op_exp_per      AS total_offsets_to_operating_expenditures,
+    ttl_receipts_per               AS total_receipts,
+    tranf_to_other_auth_cmte_per   AS transfers_to_other_authorized_committees,
+    ttl_loan_repymts_made_per      AS total_loan_repayments_made,
+    ttl_contb_ref_per              AS total_contribution_refunds,
+    ttl_disb_per                   AS total_disbursements,
+    items_on_hand_liquidated       AS items_on_hand_liquidated,
+    ttl_per                        AS total,
+    indv_item_contb_per            AS individual_itemized_contributions,
+    indv_unitem_contb_per          AS individual_unitemized_contributions,
+    load_dt                        AS load_date
+FROM (SELECT 2020 as election_year, *
+    --2020 data
+    FROM disclosure.pres_f3p_totals_ca_cm_link_20d
+    UNION
+    -- 2016 data
+    SELECT 2016 as election_year, *
+    FROM disclosure.pres_f3p_totals_ca_cm_link_16) AS combined
+ORDER BY election_year, net_receipts DESC;
+
+ALTER TABLE public.ofec_presidential_financial_summary_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_presidential_financial_summary_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_presidential_financial_summary_vw TO fec_read;

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -499,3 +499,8 @@ class PresidentialByStateFactory(BaseFactory):
     class Meta:
         model = models.PresidentialByState
     idx = factory.Sequence(lambda n: n)
+
+class PresidentialSummaryFactory(BaseFactory):
+    class Meta:
+        model = models.PresidentialSummary
+    idx = factory.Sequence(lambda n: n)

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -96,9 +96,6 @@ class PresidentialByState(ApiBaseTest):
             self.assertGreater(len(results), 0)
             # doesn't return all results
             response = self._response(page)
-            print("field=" + field)
-            print("original_count=" + str(original_count))
-            print("count=" + str(response['pagination']['count']))
             self.assertGreater(original_count, response['pagination']['count'])
 
     def test_filters_candidate_id(self):
@@ -176,9 +173,6 @@ class PresidentialSummary(ApiBaseTest):
             self.assertGreater(len(results), 0)
             # doesn't return all results
             response = self._response(page)
-            print("field=" + field)
-            print("original_count=" + str(original_count))
-            print("count=" + str(response['pagination']['count']))
             self.assertGreater(original_count, response['pagination']['count'])
 
     def test_sort(self):

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -5,6 +5,7 @@ from webservices.rest import api
 from webservices.resources.presidential import(
     PresidentialByCandidateView,
     PresidentialByStateView,
+    PresidentialSummaryView,
 )
 
 
@@ -133,6 +134,60 @@ class PresidentialByState(ApiBaseTest):
         factories.PresidentialByStateFactory(candidate_id='C002', contribution_receipt_amount=444)
 
         results = self._results(api.url_for(PresidentialByStateView))
+        self.assertEqual(
+            [each['candidate_id'] for each in results],
+            ['C002', 'C003', 'C001', 'C004']
+        )
+
+class PresidentialSummary(ApiBaseTest):
+    """ Test /presidential/financial_summary/"""
+
+    def test_without_filter(self):
+        """ Check results without filter"""
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016)
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020)
+
+        results = self._results(api.url_for(PresidentialSummaryView))
+        self.assertEqual(len(results), 4)
+
+    def test_filters(self):
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
+        factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
+        factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
+
+        filter_fields = (
+            ('election_year', [2020]),
+            ('candidate_id', ['C001', 'C002']),
+        )
+
+        # checking one example from each field
+        orig_response = self._response(api.url_for(PresidentialSummaryView))
+        original_count = orig_response['pagination']['count']
+
+        for field, example in filter_fields:
+            page = api.url_for(PresidentialSummaryView, **{field: example})
+            # returns at least one result
+            results = self._results(page)
+            self.assertGreater(len(results), 0)
+            # doesn't return all results
+            response = self._response(page)
+            print("field=" + field)
+            print("original_count=" + str(original_count))
+            print("count=" + str(response['pagination']['count']))
+            self.assertGreater(original_count, response['pagination']['count'])
+
+    def test_sort(self):
+        factories.PresidentialSummaryFactory(candidate_id='C003', net_receipts=333),
+        factories.PresidentialSummaryFactory(candidate_id='C001', net_receipts=222)
+        factories.PresidentialSummaryFactory(candidate_id='C004', net_receipts=111)
+        factories.PresidentialSummaryFactory(candidate_id='C002', net_receipts=444)
+
+        results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(
             [each['candidate_id'] for each in results],
             ['C002', 'C003', 'C001', 'C004']

--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -9,7 +9,7 @@ class PresidentialByCandidate(db.Model):
     __tablename__ = 'ofec_presidential_by_candidate_vw'
 
     idx = db.Column(db.Integer, primary_key=True)
-    candidate_id = db.Column(db.String(0), doc=docs.CANDIDATE_ID)
+    candidate_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
     candidate_last_name = db.Column(db.String, doc='Candidate last name')
     candidate_party_affiliation = db.Column(db.String, doc=docs.PARTY)
     net_receipts = db.Column(db.Numeric(30, 2), doc='Net receipts: receipts minus refunds')
@@ -20,22 +20,40 @@ class PresidentialByCandidate(db.Model):
 
 class PresidentialSummary(db.Model):
 
-    __table_args__ = {'schema': 'public', 'extend_existing': True}
-    __tablename__ = 'ofec_rad_analyst_vw'
+    __table_args__ = {'schema': 'public'}
+    __tablename__ = 'ofec_presidential_financial_summary_vw'
 
     idx = db.Column(db.Integer, primary_key=True)
-    committee_id = db.Column(db.String, primary_key=True,  doc=docs.COMMITTEE_ID)
-    committee_name = db.Column(db.String(100),  doc=docs.COMMITTEE_NAME)
-    analyst_id = db.Column(db.Numeric(38, 0),  doc='ID of RAD analyst.')
-    analyst_short_id = db.Column(db.Numeric(4, 0), doc='Short ID of RAD analyst.')
-    first_name = db.Column(db.String(255),  doc='Fist name of RAD analyst')
-    last_name = db.Column(db.String(100),  doc='Last name of RAD analyst')
-    email = db.Column('analyst_email', db.String(100),  doc='Email of RAD analyst')
-    title = db.Column('analyst_title', db.String(100),  doc='Title of RAD analyst')
-    telephone_ext = db.Column(db.Numeric(4, 0),  doc='Telephone extension of RAD analyst')
-    rad_branch = db.Column(db.String(100),  doc='Branch of RAD analyst')
-    name_txt = db.Column(TSVECTOR)
-    assignment_update_date = db.Column(db.Date, doc="Date of most recent RAD analyst assignment change")
+    committee_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
+    committee_name = db.Column(db.String, doc=docs.COMMITTEE_NAME)
+    committee_type = db.Column(db.String, doc=docs.COMMITTEE_TYPE)
+    committee_designation = db.Column(db.String, doc=docs.DESIGNATION)
+    candidate_active = db.Column(db.String, doc='Candidate is actively seeking office')
+    candidate_party_affiliation = db.Column(db.String, doc=docs.PARTY)
+    candidate_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
+    candidate_name = db.Column(db.String, doc=docs.CANDIDATE_NAME)
+    candidate_last_name = db.Column(db.String, doc='Candidate last name')
+    election_year = db.Column(db.Integer, doc=docs.ELECTION_YEAR)
+
+    # Amounts
+    net_receipts = db.Column(db.Numeric(30, 2), doc='Net receipts: receipts minus refunds')
+    rounded_net_receipts = db.Column(db.Numeric(30, 2), doc='Net receipts, in millions')
+    individual_contributions_less_refunds = db.Column(db.Numeric(30, 2), doc='TODO')
+    pac_contributions_less_refunds = db.Column(db.Numeric(30, 2), doc='TODO')
+    party_contributions_less_refunds = db.Column(db.Numeric(30, 2), doc='TODO')
+    candidate_contributions_less_repayments = db.Column(db.Numeric(30, 2), doc='TODO')
+    disbursements_less_offsets = db.Column(db.Numeric(30, 2), doc='TODO')
+    operating_expenditures = db.Column(db.Numeric(30, 2), doc='TODO')
+    transfers_to_other_authorized_committees = db.Column(db.Numeric(30, 2), doc='TODO')
+    fundraising_disbursements = db.Column(db.Numeric(30, 2), doc='TODO')
+    exempt_legal_accounting_disbursement = db.Column(db.Numeric(30, 2), doc='TODO')
+    total_loan_repayments_made = db.Column(db.Numeric(30, 2), doc='TODO')
+    repayments_loans_made_by_candidate = db.Column(db.Numeric(30, 2), doc='TODO')
+    repayments_other_loans = db.Column(db.Numeric(30, 2), doc='TODO')
+    other_disbursements = db.Column(db.Numeric(30, 2), doc='TODO')
+    offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2), doc='TODO')
+    total_contribution_refunds = db.Column(db.Numeric(30, 2), doc='TODO')
+    debts_owed_by_committee = db.Column(db.Numeric(30, 2), doc='TODO')
 
 
 class PresidentialBySize(db.Model):

--- a/webservices/resources/presidential.py
+++ b/webservices/resources/presidential.py
@@ -48,21 +48,9 @@ class PresidentialSummaryView(ApiResource):
     schema = schemas.PresidentialSummarySchema
     page_schema = schemas.PresidentialSummaryPageSchema
 
-    filter_fulltext_fields = [
-        ('name', model.name_txt),
-        ('title', model.title),
-    ]
-
     filter_multi_fields = [
-        ('analyst_id', model.analyst_id),
-        ('analyst_short_id', model.analyst_short_id),
-        ('email', model.email),
-        ('telephone_ext', model.telephone_ext),
-        ('committee_id', model.committee_id),
-    ]
-
-    filter_range_fields = [
-        (('min_assignment_update_date', 'max_assignment_update_date'), model.assignment_update_date),
+        ('election_year', model.election_year),
+        ('candidate_id', model.candidate_id),
     ]
 
     @property
@@ -70,7 +58,10 @@ class PresidentialSummaryView(ApiResource):
         return utils.extend(
             args.paging,
             args.presidential,
-            args.make_sort_args(),
+            args.make_sort_args(
+                default='-net_receipts',
+                validator=args.OptionValidator(['net_receipts'])
+            ),
         )
 
     @property

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1275,7 +1275,7 @@ register_schema(PresidentialByCandidatePageSchema)
 
 PresidentialSummarySchema = make_schema(
     models.PresidentialSummary,
-    options={'exclude': ('idx', 'name_txt')},
+    options={'exclude': ('idx',)},
 )
 PresidentialSummaryPageSchema = make_page_schema(PresidentialSummarySchema)
 register_schema(PresidentialSummarySchema)


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #4178 

 Make endpoint `/presidential/financial_summary/`

## How to test the changes locally

- `export FEC_FEATURE_PRESIDENTIAL=True`
- Change `PresidentialSummary` tablename to `'ofec_presidential_financial_summary_vw_lb'`
- Test a query with Swagger

**All:** 
- http://localhost:5000/v1/presidential/financial_summary

**Candidate ID:** 
- http://localhost:5000/v1/presidential/financial_summary/?candidate_id=P00000001
- http://localhost:5000/v1/presidential/financial_summary/?candidate_id=P00009621

**Election_year:**
- http://localhost:5000/v1/presidential/financial_summary/?election_year=2020
- Test migration with 
```
dropdb cfdm_test
createdb cfdm_test
invoke create_sample_db
flyway migrate
```
## Impacted areas of the application
List general components of the application that this PR will affect:

- Presidential map data, right-hand chart  "Summary" and "Expenditures"

<img width="206" alt="Screen Shot 2020-02-06 at 2 32 02 PM" src="https://user-images.githubusercontent.com/31420082/73971763-82600000-48ed-11ea-890c-f4beb8c254bc.png">

![Screen Shot 2020-02-06 at 2 31 44 PM](https://user-images.githubusercontent.com/31420082/73971764-82f89680-48ed-11ea-92bd-5455290ca306.png)



## Related PRs
https://github.com/fecgov/openFEC/pull/4190
https://github.com/fecgov/openFEC/pull/4181