### PR TITLE
[HOTFIX][MERGE WITH GIT FLOW] Pin werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3
 psycopg2-binary==2.7.4
+werkzeug==0.16.1
 Flask==1.1.1
 Flask-Cors==3.0.8
 Flask-Script==2.0.6


### PR DESCRIPTION
## Summary (required)

- Resolves #4193 

Pin werkzeug version
We’re bringing in `Werkzeug>=0.15` from Flask==1.1.1, but `Werkzeug==1.0.0` went live today with breaking changes

## How to test the changes locally

- Manual deploy to `dev` or fresh `pip install -r requirements.txt` and run the app

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `werkzeug` is part of Flask's internals - see more info about `ProxyFix` here: https://github.com/pallets/werkzeug/blob/1a02200528b19bbca5d2597f77d50933bdb60294/src/werkzeug/middleware/proxy_fix.py#L27



## Related PRs
https://github.com/fecgov/openFEC/pull/1481
