### PR TITLE
[V0186] Add /presidential/coverage_end_date/

### DIFF
--- a/data/migrations/V0186__add_ofec_presidential_coverage_date_vw.sql
+++ b/data/migrations/V0186__add_ofec_presidential_coverage_date_vw.sql
@@ -1,0 +1,37 @@
+/*
+
+View for https://github.com/fecgov/openFEC/issues/4178
+Adds presidential coverage end date
+Endpoint: /presidential/coverage_end_date/
+
+*/
+
+-- View: public.ofec_presidential_coverage_date_vw
+
+CREATE OR REPLACE VIEW public.ofec_presidential_coverage_date_vw AS
+SELECT
+    row_number() OVER () AS idx, *
+FROM (
+    -- 2020 data
+    SELECT
+    cand_id AS candidate_id,
+    max(cand_nm) AS candidate_name,
+    to_char(max(cvg_end_dt), 'mm/dd/yyyy') as coverage_end_date,
+    2020 as election_year
+    FROM disclosure.pres_nml_form_3p_20d
+    GROUP BY candidate_id
+    UNION
+    -- 2016 data
+    SELECT
+    cand_id AS candidate_id,
+    max(cand_nm) AS candidate_name,
+    to_char(max(cvg_end_dt), 'mm/dd/yyyy') as coverage_end_date,
+    2016 as election_year
+    FROM disclosure.pres_nml_form_3p_16
+    GROUP BY candidate_id) AS combined
+ORDER BY election_year, candidate_id DESC;
+
+ALTER TABLE public.ofec_presidential_coverage_date_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_presidential_coverage_date_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_presidential_coverage_date_vw TO fec_read;

--- a/data/migrations/V0186__add_ofec_presidential_coverage_date_vw.sql
+++ b/data/migrations/V0186__add_ofec_presidential_coverage_date_vw.sql
@@ -16,7 +16,7 @@ FROM (
     SELECT
     cand_id AS candidate_id,
     max(cand_nm) AS candidate_name,
-    to_char(max(cvg_end_dt), 'mm/dd/yyyy') as coverage_end_date,
+    to_char(max(cvg_end_dt), 'mm/dd/yyyy'):: timestamp without time zone as coverage_end_date,
     2020 as election_year
     FROM disclosure.pres_nml_form_3p_20d
     GROUP BY candidate_id
@@ -25,7 +25,7 @@ FROM (
     SELECT
     cand_id AS candidate_id,
     max(cand_nm) AS candidate_name,
-    to_char(max(cvg_end_dt), 'mm/dd/yyyy') as coverage_end_date,
+    to_char(max(cvg_end_dt), 'mm/dd/yyyy'):: timestamp without time zone as coverage_end_date,
     2016 as election_year
     FROM disclosure.pres_nml_form_3p_16
     GROUP BY candidate_id) AS combined

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -504,3 +504,8 @@ class PresidentialSummaryFactory(BaseFactory):
     class Meta:
         model = models.PresidentialSummary
     idx = factory.Sequence(lambda n: n)
+
+class PresidentialCoverageFactory(BaseFactory):
+    class Meta:
+        model = models.PresidentialCoverage
+    idx = factory.Sequence(lambda n: n)

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -1,11 +1,13 @@
+import datetime
 from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices.rest import api
-from webservices.resources.presidential import(
+from webservices.resources.presidential import (
     PresidentialByCandidateView,
     PresidentialByStateView,
     PresidentialSummaryView,
+    PresidentialCoverageView,
 )
 
 
@@ -14,21 +16,41 @@ class PresidentialByCandidate(ApiBaseTest):
 
     def test_without_filter(self):
         """ Check results without filter"""
-        factories.PresidentialByCandidateFactory(candidate_id='C001', election_year=2016, contributor_state='US')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2016, contributor_state='NY')
-        factories.PresidentialByCandidateFactory(candidate_id='C001', election_year=2020, contributor_state='US')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2020, contributor_state='NY')
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C001', election_year=2016, contributor_state='US'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2016, contributor_state='NY'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C001', election_year=2020, contributor_state='US'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2020, contributor_state='NY'
+        )
 
         results = self._results(api.url_for(PresidentialByCandidateView))
         self.assertEqual(len(results), 4)
 
     def test_filters(self):
-        factories.PresidentialByCandidateFactory(candidate_id='C001', election_year=2016, contributor_state='US')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2016, contributor_state='NY')
-        factories.PresidentialByCandidateFactory(candidate_id='C001', election_year=2020, contributor_state='US')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2020, contributor_state='NY')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2020, contributor_state='VA')
-        factories.PresidentialByCandidateFactory(candidate_id='C002', election_year=2020, contributor_state='CA')
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C001', election_year=2016, contributor_state='US'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2016, contributor_state='NY'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C001', election_year=2020, contributor_state='US'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2020, contributor_state='NY'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2020, contributor_state='VA'
+        )
+        factories.PresidentialByCandidateFactory(
+            candidate_id='C002', election_year=2020, contributor_state='CA'
+        )
 
         filter_fields = (
             ('election_year', [2020]),
@@ -56,9 +78,9 @@ class PresidentialByCandidate(ApiBaseTest):
 
         results = self._results(api.url_for(PresidentialByCandidateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
+
 
 class PresidentialByState(ApiBaseTest):
     """ Test /presidential/contributions/by_state/"""
@@ -74,16 +96,26 @@ class PresidentialByState(ApiBaseTest):
         self.assertEqual(len(results), 4)
 
     def test_filters_election_year(self):
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2016, contribution_receipt_amount=100)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2016, contribution_receipt_amount=200)
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2020, contribution_receipt_amount=300)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=400)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=500)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=600)
-
-        filter_fields = (
-            ('election_year', [2020]),
+        factories.PresidentialByStateFactory(
+            candidate_id='C001', election_year=2016, contribution_receipt_amount=100
         )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', election_year=2016, contribution_receipt_amount=200
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C001', election_year=2020, contribution_receipt_amount=300
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=400
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=500
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=600
+        )
+
+        filter_fields = (('election_year', [2020]),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialByStateView))
@@ -107,9 +139,7 @@ class PresidentialByState(ApiBaseTest):
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
 
-        filter_fields = (
-            ('candidate_id', ['C001', 'C002']),
-        )
+        filter_fields = (('candidate_id', ['C001', 'C002']),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialByStateView))
@@ -125,16 +155,24 @@ class PresidentialByState(ApiBaseTest):
             self.assertEqual(original_count, response['pagination']['count'])
 
     def test_sort(self):
-        factories.PresidentialByStateFactory(candidate_id='C003', contribution_receipt_amount=333),
-        factories.PresidentialByStateFactory(candidate_id='C001', contribution_receipt_amount=222)
-        factories.PresidentialByStateFactory(candidate_id='C004', contribution_receipt_amount=111)
-        factories.PresidentialByStateFactory(candidate_id='C002', contribution_receipt_amount=444)
+        factories.PresidentialByStateFactory(
+            candidate_id='C003', contribution_receipt_amount=333
+        ),
+        factories.PresidentialByStateFactory(
+            candidate_id='C001', contribution_receipt_amount=222
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C004', contribution_receipt_amount=111
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', contribution_receipt_amount=444
+        )
 
         results = self._results(api.url_for(PresidentialByStateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
+
 
 class PresidentialSummary(ApiBaseTest):
     """ Test /presidential/financial_summary/"""
@@ -150,12 +188,24 @@ class PresidentialSummary(ApiBaseTest):
         self.assertEqual(len(results), 4)
 
     def test_filters(self):
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
-        factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
-        factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
+        factories.PresidentialSummaryFactory(
+            candidate_id='C001', election_year=2016, net_receipts=100
+        )
+        factories.PresidentialSummaryFactory(
+            candidate_id='C002', election_year=2016, net_receipts=200
+        )
+        factories.PresidentialSummaryFactory(
+            candidate_id='C001', election_year=2020, net_receipts=300
+        )
+        factories.PresidentialSummaryFactory(
+            candidate_id='C002', election_year=2020, net_receipts=400
+        )
+        factories.PresidentialSummaryFactory(
+            candidate_id='C003', election_year=2020, net_receipts=500
+        )
+        factories.PresidentialSummaryFactory(
+            candidate_id='C004', election_year=2020, net_receipts=600
+        )
 
         filter_fields = (
             ('election_year', [2020]),
@@ -183,6 +233,85 @@ class PresidentialSummary(ApiBaseTest):
 
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
+
+
+class PresidentialCoverage(ApiBaseTest):
+    """ Test /presidential/coverage_end_date/"""
+
+    def test_without_filter(self):
+        """ Check results without filter"""
+        factories.PresidentialCoverageFactory(
+            candidate_id='C001',
+            election_year=2016,
+            coverage_end_date=datetime.date(2016, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C002',
+            election_year=2016,
+            coverage_end_date=datetime.date(2016, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C001',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C002',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+
+        results = self._results(api.url_for(PresidentialCoverageView))
+        self.assertEqual(len(results), 4)
+
+    def test_filters(self):
+        factories.PresidentialCoverageFactory(
+            candidate_id='C001',
+            election_year=2016,
+            coverage_end_date=datetime.date(2016, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C002',
+            election_year=2016,
+            coverage_end_date=datetime.date(2016, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C001',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C002',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C003',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+        factories.PresidentialCoverageFactory(
+            candidate_id='C004',
+            election_year=2020,
+            coverage_end_date=datetime.date(2018, 12, 31),
+        )
+
+        filter_fields = (
+            ('election_year', [2020]),
+            ('candidate_id', ['C001', 'C002']),
+        )
+
+        # checking one example from each field
+        orig_response = self._response(api.url_for(PresidentialCoverageView))
+        original_count = orig_response['pagination']['count']
+
+        for field, example in filter_fields:
+            page = api.url_for(PresidentialCoverageView, **{field: example})
+            # returns at least one result
+            results = self._results(page)
+            self.assertGreater(len(results), 0)
+            # doesn't return all results
+            response = self._response(page)
+            self.assertGreater(original_count, response['pagination']['count'])

--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -28,7 +28,6 @@ class PresidentialSummary(db.Model):
     committee_name = db.Column(db.String, doc=docs.COMMITTEE_NAME)
     committee_type = db.Column(db.String, doc=docs.COMMITTEE_TYPE)
     committee_designation = db.Column(db.String, doc=docs.DESIGNATION)
-    candidate_active = db.Column(db.String, doc='Candidate is actively seeking office')
     candidate_party_affiliation = db.Column(db.String, doc=docs.PARTY)
     candidate_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
     candidate_name = db.Column(db.String, doc=docs.CANDIDATE_NAME)

--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -90,19 +90,10 @@ class PresidentialByState(db.Model):
 
 class PresidentialCoverage(db.Model):
 
-    __table_args__ = {'schema': 'public', 'extend_existing': True}
-    __tablename__ = 'ofec_rad_analyst_vw'
+    __table_args__ = {'schema': 'public'}
+    __tablename__ = 'ofec_presidential_coverage_date_vw'
 
     idx = db.Column(db.Integer, primary_key=True)
-    committee_id = db.Column(db.String, primary_key=True,  doc=docs.COMMITTEE_ID)
-    committee_name = db.Column(db.String(100),  doc=docs.COMMITTEE_NAME)
-    analyst_id = db.Column(db.Numeric(38, 0),  doc='ID of RAD analyst.')
-    analyst_short_id = db.Column(db.Numeric(4, 0), doc='Short ID of RAD analyst.')
-    first_name = db.Column(db.String(255),  doc='Fist name of RAD analyst')
-    last_name = db.Column(db.String(100),  doc='Last name of RAD analyst')
-    email = db.Column('analyst_email', db.String(100),  doc='Email of RAD analyst')
-    title = db.Column('analyst_title', db.String(100),  doc='Title of RAD analyst')
-    telephone_ext = db.Column(db.Numeric(4, 0),  doc='Telephone extension of RAD analyst')
-    rad_branch = db.Column(db.String(100),  doc='Branch of RAD analyst')
-    name_txt = db.Column(TSVECTOR)
-    assignment_update_date = db.Column(db.Date, doc="Date of most recent RAD analyst assignment change")
+    candidate_id = db.Column(db.String, doc=docs.CANDIDATE_ID)
+    coverage_end_date = db.Column(db.DateTime, doc=docs.COVERAGE_END_DATE)
+    election_year = db.Column(db.Integer, doc=docs.ELECTION_YEAR)

--- a/webservices/resources/presidential.py
+++ b/webservices/resources/presidential.py
@@ -147,21 +147,9 @@ class PresidentialCoverageView(ApiResource):
     schema = schemas.PresidentialCoverageSchema
     page_schema = schemas.PresidentialCoveragePageSchema
 
-    filter_fulltext_fields = [
-        ('name', model.name_txt),
-        ('title', model.title),
-    ]
-
     filter_multi_fields = [
-        ('analyst_id', model.analyst_id),
-        ('analyst_short_id', model.analyst_short_id),
-        ('email', model.email),
-        ('telephone_ext', model.telephone_ext),
-        ('committee_id', model.committee_id),
-    ]
-
-    filter_range_fields = [
-        (('min_assignment_update_date', 'max_assignment_update_date'), model.assignment_update_date),
+        ('election_year', model.election_year),
+        ('candidate_id', model.candidate_id),
     ]
 
     @property
@@ -169,7 +157,10 @@ class PresidentialCoverageView(ApiResource):
         return utils.extend(
             args.paging,
             args.presidential,
-            args.make_sort_args(),
+            args.make_sort_args(
+                default='candidate_id',
+                validator=args.OptionValidator(['candidate_id'])
+            ),
         )
 
     @property

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1285,7 +1285,7 @@ register_schema(PresidentialSummaryPageSchema)
 
 PresidentialBySizeSchema = make_schema(
     models.PresidentialBySize,
-    options={'exclude': ('idx', 'name_txt')},
+    options={'exclude': ('idx',)},
 )
 PresidentialBySizePageSchema = make_page_schema(PresidentialBySizeSchema)
 register_schema(PresidentialBySizeSchema)
@@ -1305,7 +1305,7 @@ register_schema(PresidentialByStatePageSchema)
 
 PresidentialCoverageSchema = make_schema(
     models.PresidentialCoverage,
-    options={'exclude': ('idx', 'name_txt')},
+    options={'exclude': ('idx',)},
 )
 PresidentialCoveragePageSchema = make_page_schema(PresidentialCoverageSchema)
 register_schema(PresidentialCoverageSchema)


### PR DESCRIPTION
## Summary (required)

- Resolves #4178

Add `/presidential/coverage_end_date/`

## How to test the changes locally

- `export FEC_FEATURE_PRESIDENTIAL=True`
- Change `PresidentialCoverage` tablename to `'ofec_presidential_coverage_date_vw_lb'`
- Test a query with Swagger

**All:** 
- http://localhost:5000/v1/presidential/coverage_end_date

**Candidate ID:** 
- http://localhost:5000/v1/presidential/coverage_end_date/?candidate_id=P00009621

**Election_year:**
- http://localhost:5000/v1/presidential/coverage_end_date/?election_year=2020
- Test migration with 
```
dropdb cfdm_test
createdb cfdm_test
invoke create_sample_db
flyway migrate
```


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Presidential map data


## Related PRs
List related PRs against other branches:

#4185
#4181
#4189
#4190