### PR TITLE
[V0185]Feature/4170 add endpoint presidential by size

### DIFF
--- a/data/migrations/V0185__add_ofec_presidential_by_size_vw.sql
+++ b/data/migrations/V0185__add_ofec_presidential_by_size_vw.sql
@@ -31,7 +31,7 @@ CREATE OR REPLACE VIEW public.ofec_presidential_by_size_vw AS
       cand_id as candidate_id,
       contb_range_id as size_range_id,
       size_range(contb_range_id) AS size,      
-      ROUND(contb_receipt_amt) AS contribution_receipt_amount,
+      contb_receipt_amt AS contribution_receipt_amount,
       2020 AS election_year
     FROM
       disclosure.pres_ca_cm_sched_link_sum_20d
@@ -40,7 +40,7 @@ CREATE OR REPLACE VIEW public.ofec_presidential_by_size_vw AS
       cand_id as candidate_id,
       contb_range_id as size_range_id,
       size_range(contb_range_id) AS size,      
-      ROUND(contb_receipt_amt) AS contribution_receipt_amount,
+      contb_receipt_amt AS contribution_receipt_amount,
       2016 AS election_year
     FROM
       disclosure.pres_ca_cm_sched_link_sum_16

--- a/data/migrations/V0185__add_ofec_presidential_by_size_vw.sql
+++ b/data/migrations/V0185__add_ofec_presidential_by_size_vw.sql
@@ -1,0 +1,54 @@
+/*
+used for Endpoint: /presidential/contributions/by_size/
+*/
+
+-- Function: public.size_range
+CREATE OR REPLACE FUNCTION public.size_range(size_range_id numeric) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+        RETURN CASE size_range_id
+            WHEN 1 THEN 0
+            WHEN 2 THEN 200
+            WHEN 3 THEN 500
+            WHEN 4 THEN 1000
+            WHEN 5 THEN 2000
+            ELSE 0
+        END;
+    END
+$$;
+
+ALTER FUNCTION public.size_range(size_range_id numeric) OWNER TO fec;
+
+
+-- DROP VIEW public.ofec_presidential_by_size_vw;
+-- View: public.ofec_presidential_by_size_vw
+
+CREATE OR REPLACE VIEW public.ofec_presidential_by_size_vw AS 
+  SELECT row_number() OVER () AS idx, *
+  FROM (
+    SELECT 
+      cand_id as candidate_id,
+      contb_range_id as size_range_id,
+      size_range(contb_range_id) AS size,      
+      ROUND(contb_receipt_amt) AS contribution_receipt_amount,
+      2020 AS election_year
+    FROM
+      disclosure.pres_ca_cm_sched_link_sum_20d
+    UNION
+    SELECT 
+      cand_id as candidate_id,
+      contb_range_id as size_range_id,
+      size_range(contb_range_id) AS size,      
+      ROUND(contb_receipt_amt) AS contribution_receipt_amount,
+      2016 AS election_year
+    FROM
+      disclosure.pres_ca_cm_sched_link_sum_16
+  )
+  AS multi_election_year_size
+  ORDER BY election_year,size_range_id;
+
+ALTER TABLE public.ofec_presidential_by_size_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_presidential_by_size_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_presidential_by_size_vw TO fec_read;

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -504,3 +504,8 @@ class PresidentialSummaryFactory(BaseFactory):
     class Meta:
         model = models.PresidentialSummary
     idx = factory.Sequence(lambda n: n)
+
+class PresidentialBySizeFactory(BaseFactory):
+    class Meta:
+        model = models.PresidentialBySize
+    idx = factory.Sequence(lambda n: n)

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -6,6 +6,7 @@ from webservices.resources.presidential import(
     PresidentialByCandidateView,
     PresidentialByStateView,
     PresidentialSummaryView,
+    PresidentialBySizeView,
 )
 
 
@@ -168,6 +169,39 @@ class PresidentialSummary(ApiBaseTest):
 
         for field, example in filter_fields:
             page = api.url_for(PresidentialSummaryView, **{field: example})
+
+
+class PresidentialBySize(ApiBaseTest):
+    """ Test /presidential/contributions/by_size/"""
+
+    def test_without_filter(self):
+        """ Check results without filter"""
+        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
+
+        results = self._results(api.url_for(PresidentialBySizeView))
+        self.assertEqual(len(results), 4)
+
+    def test_filters_election_year(self):
+        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2016, contribution_receipt_amount=100)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016, contribution_receipt_amount=200)
+        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020, contribution_receipt_amount=300)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=400)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=500)
+        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=600)
+
+        filter_fields = (
+            ('election_year', [2020]),
+        )
+
+        # checking one example from each field
+        orig_response = self._response(api.url_for(PresidentialBySizeView))
+        original_count = orig_response['pagination']['count']
+
+        for field, example in filter_fields:
+            page = api.url_for(PresidentialBySizeView, **{field: example})
             # returns at least one result
             results = self._results(page)
             self.assertGreater(len(results), 0)
@@ -176,13 +210,13 @@ class PresidentialSummary(ApiBaseTest):
             self.assertGreater(original_count, response['pagination']['count'])
 
     def test_sort(self):
-        factories.PresidentialSummaryFactory(candidate_id='C003', net_receipts=333),
-        factories.PresidentialSummaryFactory(candidate_id='C001', net_receipts=222)
-        factories.PresidentialSummaryFactory(candidate_id='C004', net_receipts=111)
-        factories.PresidentialSummaryFactory(candidate_id='C002', net_receipts=444)
+        factories.PresidentialBySizeFactory(candidate_id='C003', size=100, contribution_receipt_amount=333),
+        factories.PresidentialBySizeFactory(candidate_id='C001', size=300, contribution_receipt_amount=222)
+        factories.PresidentialBySizeFactory(candidate_id='C004', size=500, contribution_receipt_amount=111)
+        factories.PresidentialBySizeFactory(candidate_id='C002', size=800, contribution_receipt_amount=444)
 
-        results = self._results(api.url_for(PresidentialSummaryView))
+        results = self._results(api.url_for(PresidentialBySizeView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['size'] for each in results],
+            [100, 300, 500, 800]
         )

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -208,7 +208,6 @@ class PresidentialBySize(ApiBaseTest):
             # doesn't return all results
             response = self._response(page)
             self.assertGreater(original_count, response['pagination']['count'])
-            self.assertGreater(original_count, response['pagination']['count'])
 
     def test_filters_candidate_id(self):
         """ always return 51 rows(51 states) for each candidate_id/"""

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -979,3 +979,9 @@ presidential_by_candidate = {
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
     'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
 }
+
+presidential_by_size = {
+    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
+}

--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -59,7 +59,7 @@ class PresidentialSummary(db.Model):
 class PresidentialBySize(db.Model):
 
     __table_args__ = {'schema': 'public'}
-    __tablename__ = 'ofec_presidential_by_size_vw_jl'
+    __tablename__ = 'ofec_presidential_by_size_vw'
 
     idx = db.Column(db.Integer, primary_key=True)
     candidate_id = db.Column(db.String(0), doc=docs.CANDIDATE_ID)

--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -58,22 +58,15 @@ class PresidentialSummary(db.Model):
 
 class PresidentialBySize(db.Model):
 
-    __table_args__ = {'schema': 'public', 'extend_existing': True}
-    __tablename__ = 'ofec_rad_analyst_vw'
+    __table_args__ = {'schema': 'public'}
+    __tablename__ = 'ofec_presidential_by_size_vw_jl'
 
     idx = db.Column(db.Integer, primary_key=True)
-    committee_id = db.Column(db.String, primary_key=True,  doc=docs.COMMITTEE_ID)
-    committee_name = db.Column(db.String(100),  doc=docs.COMMITTEE_NAME)
-    analyst_id = db.Column(db.Numeric(38, 0),  doc='ID of RAD analyst.')
-    analyst_short_id = db.Column(db.Numeric(4, 0), doc='Short ID of RAD analyst.')
-    first_name = db.Column(db.String(255),  doc='Fist name of RAD analyst')
-    last_name = db.Column(db.String(100),  doc='Last name of RAD analyst')
-    email = db.Column('analyst_email', db.String(100),  doc='Email of RAD analyst')
-    title = db.Column('analyst_title', db.String(100),  doc='Title of RAD analyst')
-    telephone_ext = db.Column(db.Numeric(4, 0),  doc='Telephone extension of RAD analyst')
-    rad_branch = db.Column(db.String(100),  doc='Branch of RAD analyst')
-    name_txt = db.Column(TSVECTOR)
-    assignment_update_date = db.Column(db.Date, doc="Date of most recent RAD analyst assignment change")
+    candidate_id = db.Column(db.String(0), doc=docs.CANDIDATE_ID)
+    contribution_receipt_amount = db.Column(db.Numeric(30, 2), doc=docs.CONTRIBUTION_RECEIPTS)
+    election_year = db.Column(db.Integer, doc=docs.ELECTION_YEAR)
+    size_range_id = db.Column(db.Integer, doc=docs.SIZE_RANGE_ID)
+    size = db.Column(db.Integer, doc=docs.SIZE)
 
 
 class PresidentialByState(db.Model):
@@ -81,12 +74,12 @@ class PresidentialByState(db.Model):
     __table_args__ = {'schema': 'public'}
     __tablename__ = 'ofec_presidential_by_state_vw'
 
-    # TODO: Update docstrings
     idx = db.Column(db.Integer, primary_key=True)
     candidate_id = db.Column(db.String(0), doc=docs.CANDIDATE_ID)
-    contribution_state = db.Column(db.String(2), doc='')
-    contribution_receipt_amount = db.Column(db.Numeric(30, 2), doc='')
-    election_year = db.Column(db.Integer, doc='')
+    contribution_state = db.Column(db.String(2), doc=docs.CONTRIBUTOR_STATE)
+    contribution_receipt_amount = db.Column(db.Numeric(30, 2), doc=docs.CONTRIBUTION_RECEIPTS)
+    election_year = db.Column(db.Integer, doc=docs.ELECTION_YEAR)
+
 
 class PresidentialCoverage(db.Model):
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -903,6 +903,14 @@ SCHEDULE_A_BY_OCCUPATION = '''
 This endpoint provides itemized individual contributions received by a committee, aggregated by the contributor’s occupation. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
 '''
 
+CONTRIBUTION_RECEIPTS = '''
+Contributions received
+'''
+
+SIZE_RANGE_ID = '''
+The total all contributions range id.
+'''
+
 SIZE = '''
 The total all contributions in the following ranges:
 ```

--- a/webservices/resources/presidential.py
+++ b/webservices/resources/presidential.py
@@ -78,29 +78,21 @@ class PresidentialBySizeView(ApiResource):
     schema = schemas.PresidentialBySizeSchema
     page_schema = schemas.PresidentialBySizePageSchema
 
-    filter_fulltext_fields = [
-        ('name', model.name_txt),
-        ('title', model.title),
-    ]
-
     filter_multi_fields = [
-        ('analyst_id', model.analyst_id),
-        ('analyst_short_id', model.analyst_short_id),
-        ('email', model.email),
-        ('telephone_ext', model.telephone_ext),
-        ('committee_id', model.committee_id),
-    ]
-
-    filter_range_fields = [
-        (('min_assignment_update_date', 'max_assignment_update_date'), model.assignment_update_date),
+        ('election_year', model.election_year),
+        ('candidate_id', model.candidate_id),
+        ('size', model.size),
     ]
 
     @property
     def args(self):
         return utils.extend(
             args.paging,
-            args.presidential,
-            args.make_sort_args(),
+            args.presidential_by_size,
+            args.make_sort_args(
+                default='size',
+                validator=args.OptionValidator(['size'])
+            ),
         )
 
     @property


### PR DESCRIPTION
## Summary (required)
(national map circle per candidate):
(view on DISCLOSURE.PRES_CA_CM_SCHED_A_JOIN_20D / _16
Filter: candidate_id, election_year


- Resolves part of [#4177](https://github.com/fecgov/openFEC/issues/4177)


## How to test the changes locally
- checkout branch
- run this cmd : `export FEC_FEATURE_PRESIDENTIAL=True`
- Change `PresidentialBySize` tablename to `'ofec_presidential_by_size_vw_jl'`
- Test a query with Swagger

(no filter)
http://127.0.0.1:5000/v1/presidential/contributions/by_size/?per_page=100&sort_hide_null=false&sort_nulls_last=false&sort=size&sort_null_only=false&page=1


(filter: candidate_id)
http://127.0.0.1:5000/v1/presidential/contributions/by_size/?per_page=20&sort_hide_null=false&sort_nulls_last=false&sort=size&candidate_id=P80001571&sort_null_only=false&page=1


(filter: candidate_id, election_year)
http://127.0.0.1:5000/v1/presidential/contributions/by_size/?per_page=20&sort_hide_null=false&sort_nulls_last=false&sort=size&candidate_id=P80001571&sort_null_only=false&election_year=2016&page=1

(filter: size)
http://127.0.0.1:5000/v1/presidential/contributions/by_size/?per_page=100&sort_hide_null=false&sort_nulls_last=false&sort=size&sort_null_only=false&page=1&size=2000

- Test migration with 
```
dropdb cfdm_test
createdb cfdm_test
invoke create_sample_db
flyway migrate
```