### PR TITLE
Add missing fields to financial summary

### DIFF
--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -53,6 +53,8 @@ class PresidentialSummary(db.Model):
     offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2), doc='TODO')
     total_contribution_refunds = db.Column(db.Numeric(30, 2), doc='TODO')
     debts_owed_by_committee = db.Column(db.Numeric(30, 2), doc='TODO')
+    federal_funds = db.Column(db.Numeric(30, 2), doc='TODO')
+    cash_on_hand_end = db.Column(db.Numeric(30, 2), doc='TODO')
 
 
 class PresidentialBySize(db.Model):


### PR DESCRIPTION
## Summary (required)

- Resolves #4204

Add missing fields to financial summary: `cash_on_hand_end` and `federal_funds`

## How to test the changes locally

- Run this branch
- run: `export FEC_FEATURE_PRESIDENTIAL=true`
- Go to  http://localhost:5000/v1/presidential/financial_summary
- Check for `cash_on_hand_end` and `federal_funds`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Presidential map financial summary
