### PR TITLE
Update 'most_recent' filters to always include null values

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -919,7 +919,6 @@ class TestScheduleE(ApiBaseTest):
             ('image_number', ScheduleEEfile.image_number, ['456', '789']),
             ('committee_id', ScheduleEEfile.committee_id, ['C01', 'C02']),
             ('support_oppose_indicator', ScheduleEEfile.support_oppose_indicator, ['S', 'O']),
-            ('most_recent', ScheduleEEfile.most_recent, [True, False]),
             ('candidate_office', ScheduleEEfile.candidate_office, ['H', 'S', 'P']),
             ('candidate_party', ScheduleEEfile.candidate_party, ['DEM', 'REP']),
             ('candidate_office_state', ScheduleEEfile.candidate_office_state, ['AZ', 'AK']),
@@ -987,9 +986,27 @@ class TestScheduleE(ApiBaseTest):
             factories.ScheduleEFactory(committee_id='C002', filing_form='F5', most_recent=False),
             factories.ScheduleEFactory(committee_id='C003', filing_form='F24', most_recent=True),
             factories.ScheduleEFactory(committee_id='C004', filing_form='F3X', most_recent=True),
+            factories.ScheduleEFactory(committee_id='C005', filing_form='F3X'),
+            factories.ScheduleEFactory(committee_id='C006', filing_form='F3X'),
         ]
         results = self._results(api.url_for(ScheduleEView, most_recent=True, **self.kwargs))
-        self.assertEqual(len(results), 3)
+        # Most recent should include null values
+        self.assertEqual(len(results), 5)
+
+    def test_filter_sched_e_efile_most_recent(self):
+        [
+            factories.ScheduleEEfileFactory(committee_id='C001', filing_form='F24', most_recent=True),
+            factories.ScheduleEEfileFactory(committee_id='C002', filing_form='F5', most_recent=False),
+            factories.ScheduleEEfileFactory(committee_id='C003', filing_form='F24', most_recent=True),
+            factories.ScheduleEEfileFactory(committee_id='C004', filing_form='F3X', most_recent=True),
+            factories.ScheduleEEfileFactory(committee_id='C005', filing_form='F3X'),
+            factories.ScheduleEEfileFactory(committee_id='C006', filing_form='F3X'),
+        ]
+        factories.EFilingsFactory(file_number=123)
+        db.session.flush()
+        results = self._results(api.url_for(ScheduleEEfileView, most_recent=True, **self.kwargs))
+        # Most recent should include null values
+        self.assertEqual(len(results), 5)
 
 
 class TestScheduleH4(ApiBaseTest):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -830,7 +830,7 @@ schedule_e = {
     'max_dissemination_date': fields.Date(description=docs.DISSEMINATION_MAX_DATE),
     'min_filing_date': fields.Date(description=docs.MIN_FILED_DATE),
     'max_filing_date': fields.Date(description=docs.MAX_FILED_DATE),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT),
+    'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
 
 }
 
@@ -854,7 +854,7 @@ schedule_e_efile = {
     'candidate_office': fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P']), description=docs.OFFICE),
     'candidate_office_state': fields.List(IStr, description=docs.STATE),
     'candidate_office_district': fields.List(IStr, description=docs.DISTRICT),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT),
+    'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
     'min_filed_date': fields.Date(description=docs.FILED_DATE),
     'max_filed_date': fields.Date(description=docs.FILED_DATE),
     'filing_form': fields.List(IStr, description=docs.FORM_TYPE),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -654,6 +654,10 @@ MOST_RECENT = '''
 Report is either new or is the most-recently filed amendment
 '''
 
+MOST_RECENT_IE = '''
+The report associated with the transaction is either new or is the most-recently filed amendment. Undetermined version (`null`) is always included.
+'''
+
 HTML_URL = '''
 HTML link to the filing.
 '''

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -98,7 +98,7 @@ class ScheduleEView(ItemizedResource):
 
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
-        if kwargs.get('most_recent'):
+        if 'most_recent' in kwargs:
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
         return query
@@ -172,7 +172,7 @@ class ScheduleEEfileView(views.ApiResource):
             query = query.filter(filing_alias.filed_date >= kwargs['min_filed_date'])
         if kwargs.get('max_filed_date') is not None:
             query = query.filter(filing_alias.filed_date <= kwargs['max_filed_date'])
-        if kwargs.get('most_recent'):
+        if 'most_recent' in kwargs:
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
         return query


### PR DESCRIPTION
## Summary (required)

- Resolves #4208

Update `most_recent` filters to always include null values

## How to test the changes locally

- Checkout this branch, point to any database
- Schedule E and Schedule E efile should behave this way:
- When `most_recent` isn't specified, show all (matches current behavior)
http://localhost:5000/v1/schedules/schedule_e/
http://localhost:5000/v1/schedules/schedule_e/efile
- When `most_recent=true`, show `true` and `null` values:
http://localhost:5000/v1/schedules/schedule_e/?most_recent=true
http://localhost:5000/v1/schedules/schedule_e/efile/?most_recent=true
- When `most_recent=false`, show `false` and `null` values:
http://localhost:5000/v1/schedules/schedule_e/?most_recent=false
http://localhost:5000/v1/schedules/schedule_e/efile/?most_recent=false


## Impacted areas of the application
List general components of the application that this PR will affect:

-  IE datatables "Current Version" filter 
