### PR TITLE
Add 'transfers_from_affiliated_committees' field to output

### DIFF
--- a/webservices/common/models/presidential.py
+++ b/webservices/common/models/presidential.py
@@ -44,6 +44,7 @@ class PresidentialSummary(db.Model):
     disbursements_less_offsets = db.Column(db.Numeric(30, 2), doc='TODO')
     operating_expenditures = db.Column(db.Numeric(30, 2), doc='TODO')
     transfers_to_other_authorized_committees = db.Column(db.Numeric(30, 2), doc='TODO')
+    transfers_from_affiliated_committees = db.Column(db.Numeric(30, 2), doc='TODO')
     fundraising_disbursements = db.Column(db.Numeric(30, 2), doc='TODO')
     exempt_legal_accounting_disbursement = db.Column(db.Numeric(30, 2), doc='TODO')
     total_loan_repayments_made = db.Column(db.Numeric(30, 2), doc='TODO')


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #4219

Add `transfers_from_affiliated_committees` to output for `/presidential/financial_summary/` endpoint 

## How to test the changes locally

- Make sure you have `FEC_FEATURE_PRESIDENTIAL` set to `True`
- Run this branch
- Confirm that http://localhost:5000/v1/presidential/financial_summary/?page=1&sort=-net_receipts&sort_nulls_last=false&sort_hide_null=false&sort_null_only=false&per_page=20 has `transfers_from_affiliated_committees`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Presidential map, transfers in 

