### PR TITLE
Add endpoint communication_costs/aggregates/

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -696,6 +696,17 @@ communication_cost = {
     ),
 }
 
+CC_aggregates = {
+    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'support_oppose_indicator': IStr(
+        missing=None,
+        validate=validate.OneOf(['S', 'O']),
+        description=docs.SUPPORT_OPPOSE,
+    ),
+}
+
 electioneering = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -356,6 +356,11 @@ api.add_resource(
 )
 
 api.add_resource(
+    aggregates.CCAggregatesView,
+    '/communication_costs/aggregates/',
+)
+
+api.add_resource(
     aggregates.ElectioneeringByCandidateView,
     '/electioneering/by_candidate/',
     '/committee/<string:committee_id>/electioneering/by_candidate/',
@@ -454,6 +459,7 @@ apidoc.register(sched_d.ScheduleDViewBySubId, blueprint='v1')
 if bool(env.get_credential('FEC_FEATURE_SCHEDULE_H4', '')):
     apidoc.register(sched_h4.ScheduleH4View, blueprint='v1')
 apidoc.register(costs.CommunicationCostView, blueprint='v1')
+apidoc.register(aggregates.CCAggregatesView, blueprint='v1')
 apidoc.register(costs.ElectioneeringView, blueprint='v1')
 apidoc.register(aggregates.ECAggregatesView, blueprint='v1')
 apidoc.register(aggregates.ScheduleABySizeView, blueprint='v1')

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -750,6 +750,22 @@ CommunicationCostPageSchema = make_page_schema(CommunicationCostSchema, page_typ
 register_schema(CommunicationCostSchema)
 register_schema(CommunicationCostPageSchema)
 
+CCAggregatesSchema = make_schema(
+    models.CommunicationCostByCandidate,
+    fields={
+        'committee_id': ma.fields.Str(),
+        'candidate_id': ma.fields.Str(),
+        'committee_name': ma.fields.Str(),
+        'candidate_name': ma.fields.Str(),
+        'cycle': ma.fields.Int(),
+        'count': ma.fields.Int(),
+        'total': ma.fields.Decimal(places=2),
+    },
+)
+CCAggregatesPageSchema = make_page_schema(CCAggregatesSchema)
+register_schema(CCAggregatesSchema)
+register_schema(CCAggregatesPageSchema)
+
 ElectioneeringSchema = make_schema(
     models.Electioneering,
     fields={'election_type': ma.fields.Str()},


### PR DESCRIPTION
## Summary (required)
The current endpoint: /committee/{committee_id}/communication_costs/by_candidate/ filter by committee_id not work.

- Resolves [https://github.com/fecgov/openFEC/issues/4243](https://github.com/fecgov/openFEC/issues/4243)


_Include a summary of proposed changes._
Create a new endpoint: **/communication_costs/aggregates/**
based on same **ofec_communication_costs_aggregate_candidate_mv**
and make all filters work as expected.

## How to test the changes locally
1) checkout branch
2) dev db
3) pytest
4) ./manage.py runserver

Test 1: check filter by committee_id
on prod: **/committee/{committee_id}/communication_costs/by_candidate/**
return CC spending for all committee : 1265 rows (filter by committee_id not work)
https://api.open.fec.gov/v1/committee/C70000112/communication_costs/by_candidate/?cycle=2014&election_full=false&api_key=DEMO_KEY

on local: **/communication_costs/aggregates/**
return 161 rows (filter by C70000112 /2014 only)
http://127.0.0.1:5000/v1/communication_costs/aggregates/?committee_id=C70000112&cycle=2014


Test2: other filters for new endpoint: /communication_costs/aggregates/
ex1: H8NJ04014  (37 results) filter by candidate_id only
http://127.0.0.1:5000/v1/communication_costs/aggregates/?candidate_id=H8NJ04014

Test3L filter by support_oppose_indicator :  return 111. 
http://127.0.0.1:5000/v1/communication_costs/aggregates/?committee_id=C70000112&cycle=2014&support_oppose_indicator=S

Ref PR: [https://github.com/fecgov/openFEC/pull/4098](https://github.com/fecgov/openFEC/pull/4098)