### PR TITLE
Add flake8 to pytest for automated pep8 testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,18 @@ Running the tests:
 pytest
 ```
 
+Running only the pep8 linting:
+
+```
+pytest --linting
+```
+
+Running the tests without pep8 linting:
+
+```
+pytest --no-linting
+```
+
 #### The test data subset
 If you add new tables to the data, you'll need to generate a new subset for testing.
 

--- a/endpoints_walk.py
+++ b/endpoints_walk.py
@@ -124,7 +124,7 @@ def check_endpoints(server, api_key):
         if r.status_code == 200:
             print("{}: ok".format(endp))
         else:
-            print("******{}: not working. Status: {}".format(endp,r.status_code))
+            print("******{}: not working. Status: {}".format(endp, r.status_code))
 
 
 if __name__ == "__main__":

--- a/jdbc_utils.py
+++ b/jdbc_utils.py
@@ -1,16 +1,19 @@
 import re
 
+
 def get_jdbc_credentials(dbi_url):
     """Extract username and password from connection string"""
-    DB_URL_REGEX = re.compile(r'postgresql://(?P<username>[^:]*):?(?P<password>\S*)@(?P<host_port>\S*)$')
+    DB_URL_REGEX = re.compile(
+        r'postgresql://(?P<username>[^:]*):?(?P<password>\S*)@(?P<host_port>\S*)$'
+    )
     match = DB_URL_REGEX.match(dbi_url)
     if match:
-        jdbc_url = 'jdbc:postgresql://{}'.format(
-            match.group('host_port'))
+        jdbc_url = 'jdbc:postgresql://{}'.format(match.group('host_port'))
         username = match.group('username')
         password = match.group('password')
         return jdbc_url, username, password
     return None, None, None
+
 
 def to_jdbc_url(dbi_url):
     """Reformat PostgreSQL uri to JDBC uri"""
@@ -42,12 +45,13 @@ def remove_credentials(error):
         '3D000': 'invalid_catalog_name',
         '42000': 'syntax_error_or_access_rule_violation',
         '42501': 'insufficient_privilege',
-        '42601': 'syntax_error'
+        '42601': 'syntax_error',
     }
     match = re.search(r'.*(SQL State  : )+(?P<error>[a-zA-Z0-9]{0,5})', error)
     if match:
         error_code = match.group('error')
         return 'PostgreSQL error code {}: {}'.format(
-            error_code, login_related_error_codes.get(error_code, error))
+            error_code, login_related_error_codes.get(error_code, error)
+        )
     else:
         return error

--- a/locustfile.py
+++ b/locustfile.py
@@ -119,7 +119,6 @@ poor_performance_a = [
     {
         "sort_nulls_large": True,
         "contributor_name": "tom+lewis",
-        "contributor_name": "thomas+lewis",
         "two_year_transaction_period": 2016,
         "min_date": "01%2F01%2F2015",
         "max_date": "12%2F31%2F2016",

--- a/manage.py
+++ b/manage.py
@@ -56,11 +56,11 @@ def execute_sql_file(path):
     db.engine.dispose()
     logger.info(('Running {}'.format(path)))
     with open(path) as fp:
-        cmd = '\n'.join([
-            line for line in fp.readlines()
-            if not line.strip().startswith('--')
-        ])
+        cmd = '\n'.join(
+            [line for line in fp.readlines() if not line.strip().startswith('--')]
+        )
         db.engine.execute(sa.text(cmd), **SQL_CONFIG)
+
 
 def execute_sql_folder(path, processes):
     sql_dir = get_full_path(path)
@@ -74,6 +74,7 @@ def execute_sql_folder(path, processes):
         for path in paths:
             execute_sql_file(path)
 
+
 @manager.command
 def refresh_materialized(concurrent=True):
     """Refresh materialized views in dependency order
@@ -84,11 +85,13 @@ def refresh_materialized(concurrent=True):
     logger.info('Refreshing materialized views...')
 
     materialized_view_names = {
-        'audit_case': ['ofec_audit_case_mv',
-                       'ofec_audit_case_category_rel_mv',
-                       'ofec_audit_case_sub_category_rel_mv',
-                       'ofec_committee_fulltext_audit_mv',
-                       'ofec_candidate_fulltext_audit_mv'],
+        'audit_case': [
+            'ofec_audit_case_mv',
+            'ofec_audit_case_category_rel_mv',
+            'ofec_audit_case_sub_category_rel_mv',
+            'ofec_committee_fulltext_audit_mv',
+            'ofec_candidate_fulltext_audit_mv',
+        ],
         'cand_cmte_linkage': ['ofec_cand_cmte_linkage_mv'],
         'candidate_aggregates': ['ofec_candidate_totals_mv'],
         'candidate_detail': ['ofec_candidate_detail_mv'],
@@ -102,20 +105,30 @@ def refresh_materialized(concurrent=True):
         'committee_fulltext': ['ofec_committee_fulltext_mv'],
         'committee_history': ['ofec_committee_history_mv'],
         'communication_cost': ['ofec_communication_cost_mv'],
-        'communication_cost_by_candidate': ['ofec_communication_cost_aggregate_candidate_mv'],
+        'communication_cost_by_candidate': [
+            'ofec_communication_cost_aggregate_candidate_mv'
+        ],
         'electioneering': ['ofec_electioneering_mv'],
         'electioneering_by_candidate': ['ofec_electioneering_aggregate_candidate_mv'],
         'elections_list': ['ofec_elections_list_mv'],
         'filing_amendments_all': ['ofec_amendments_mv'],
-        'filing_amendments_house_senate': ['ofec_house_senate_electronic_amendments_mv',
-                                           'ofec_house_senate_paper_amendments_mv'],
-        'filing_amendments_pac_party': ['ofec_pac_party_electronic_amendments_mv',
-                                        'ofec_pac_party_paper_amendments_mv'],
-        'filing_amendments_presidential': ['ofec_presidential_electronic_amendments_mv',
-                                           'ofec_presidential_paper_amendments_mv'],
-        'filings': ['ofec_filings_amendments_all_mv',
-                    'ofec_filings_mv',
-                    'ofec_filings_all_mv'],
+        'filing_amendments_house_senate': [
+            'ofec_house_senate_electronic_amendments_mv',
+            'ofec_house_senate_paper_amendments_mv',
+        ],
+        'filing_amendments_pac_party': [
+            'ofec_pac_party_electronic_amendments_mv',
+            'ofec_pac_party_paper_amendments_mv',
+        ],
+        'filing_amendments_presidential': [
+            'ofec_presidential_electronic_amendments_mv',
+            'ofec_presidential_paper_amendments_mv',
+        ],
+        'filings': [
+            'ofec_filings_amendments_all_mv',
+            'ofec_filings_mv',
+            'ofec_filings_all_mv',
+        ],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],
         'ofec_sched_a_agg_state': ['ofec_sched_a_agg_state_mv'],
         'ofec_sched_e_mv': ['ofec_sched_e_mv'],
@@ -124,7 +137,9 @@ def refresh_materialized(concurrent=True):
         'reports_pac_party': ['ofec_reports_pac_party_mv'],
         'reports_presidential': ['ofec_reports_presidential_mv'],
         'sched_a_by_size_merged': ['ofec_sched_a_aggregate_size_merged_mv'],
-        'sched_a_by_state_recipient_totals': ['ofec_sched_a_aggregate_state_recipient_totals_mv'],
+        'sched_a_by_state_recipient_totals': [
+            'ofec_sched_a_aggregate_state_recipient_totals_mv'
+        ],
         'sched_e_by_candidate': ['ofec_sched_e_aggregate_candidate_mv'],
         'totals_combined': ['ofec_totals_combined_mv'],
         'totals_house_senate': ['ofec_totals_house_senate_mv'],
@@ -143,19 +158,20 @@ def refresh_materialized(concurrent=True):
                     logger.info('Refreshing %s', mv)
 
                     if concurrent:
-                        refresh_command = 'REFRESH MATERIALIZED VIEW CONCURRENTLY {}'.format(mv)
+                        refresh_command = 'REFRESH MATERIALIZED VIEW CONCURRENTLY {}'.format(
+                            mv
+                        )
                     else:
                         refresh_command = 'REFRESH MATERIALIZED VIEW {}'.format(mv)
 
                     connection.execute(
-                        sa.text(refresh_command).execution_options(
-                            autocommit=True
-                        )
+                        sa.text(refresh_command).execution_options(autocommit=True)
                     )
             else:
                 logger.error('Error refreshing node %s: not found.'.format(node))
 
     logger.info('Finished refreshing materialized views.')
+
 
 @manager.command
 def cf_startup():
@@ -171,6 +187,7 @@ def slack_message(message):
     run ./manage.py slack_message 'The message you want to post'
     """
     post_to_slack(message, '#bots')
+
 
 @manager.shell
 def make_shell_context():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ git+https://github.com/18F/rdbms-subsetter
 # Testing
 factory_boy==2.8.1
 nplusone==0.8.0
-webtest==2.0.27
+webtest==2.0.34
 pdbpp==0.9.1
 click==6.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ celery-once==3.0.0
 redis==3.2.0
 
 # testing and build in circle
-pytest==3.7.4
+pytest==5.2.0
 pytest-cov==2.5.1
 codecov==2.0.9
 pytest-flake8==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ redis==3.2.0
 pytest==3.7.4
 pytest-cov==2.5.1
 codecov==2.0.9
+pytest-flake8==1.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=--cov webservices --cov-report term-missing
+addopts=--cov webservices --cov-report term-missing --flake8 -s
 
 [flake8]
 ignore = E127,E128,E265,E301,E302

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 addopts=--cov webservices --cov-report term-missing --flake8
+testpaths=tests
 
 [flake8]
 ignore = E127,E128,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
-addopts=--cov webservices --cov-report term-missing --flake8 -s
+addopts=--cov webservices --cov-report term-missing --flake8
 
 [flake8]
-ignore = E127,E128,E265,E301,E302
+ignore = E127,E128,E265,E301,E302,W503
 max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 addopts=--cov webservices --cov-report term-missing --flake8
 
 [flake8]
-ignore = E127,E128,E265,E301,E302,W503
+ignore = E127,E128,W503
 max-line-length = 120

--- a/tasks.py
+++ b/tasks.py
@@ -4,7 +4,6 @@ import subprocess
 import git
 
 from invoke import task, exceptions
-from webservices.env import env
 from jdbc_utils import get_jdbc_credentials, to_jdbc_url, remove_credentials
 
 
@@ -25,11 +24,11 @@ EXCLUDE_TABLES = [
 ]
 
 # Include records used in integration tests
-# FORCE_INCLUDE = [
-#     ('dimcand', 10025229),  # Nancy Pelosi
-#     ('dimcand', 10012694),  # John Boehner
-#     ('dimcmte', 10031117),  # Raul Grijalva (committee)
-# ]
+FORCE_INCLUDE = [
+    ('dimcand', 10025229),  # Nancy Pelosi
+    ('dimcand', 10012694),  # John Boehner
+    ('dimcmte', 10031117),  # Raul Grijalva (committee)
+]
 
 
 @task
@@ -175,7 +174,9 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
 
     # Log in if necessary
     if login == 'True':
-        login_command = 'cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(space.upper())
+        login_command = 'cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(
+            space.upper()
+        )
         ctx.run(login_command, echo=True)
 
     # Target space
@@ -192,7 +193,9 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
 
         if not all((jdbc_url, migration_user, migration_password)):
             print(
-                "\nUnable to retrieve or parse {0}. Make sure the environmental variable is set and properly formatted.\n".format(
+                "\nUnable to retrieve or parse {0}. \
+                Make sure the environmental variable is set and properly \
+                formatted.\n".format(
                     migration_env_var
                 )
             )
@@ -219,7 +222,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
         ctx.run('cf {cmd} {app} -f manifests/manifest_{file}_{space}.yml'.format(
             cmd=cmd,
             app=app,
-            file=app.replace('-','_'),
+            file=app.replace('-', '_'),
             space=space
         ), echo=True)
 
@@ -253,7 +256,9 @@ def create_sample_db(ctx):
 
 @task
 def run_migrations(ctx, jdbc_url, migration_user=None, migration_password=None):
-    command = 'flyway migrate -q -url="{0}" -locations=filesystem:data/migrations'.format(jdbc_url)
+    command = 'flyway migrate -q -url="{0}" -locations=filesystem:data/migrations'.format(
+        jdbc_url
+    )
     if migration_user:
         command += ' -user="{}"'.format(migration_user)
     if migration_password:

--- a/tasks.py
+++ b/tasks.py
@@ -193,9 +193,9 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
 
         if not all((jdbc_url, migration_user, migration_password)):
             print(
-                "\nUnable to retrieve or parse {0}. \
-                Make sure the environmental variable is set and properly \
-                formatted.\n".format(
+                "\nUnable to retrieve or parse {0}. "
+                "Make sure the environmental variable is set and properly "
+                "formatted.\n".format(
                     migration_env_var
                 )
             )

--- a/tasks.py
+++ b/tasks.py
@@ -226,6 +226,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
             space=space
         ), echo=True)
 
+
 @task
 def create_sample_db(ctx):
     """

--- a/tests/common.py
+++ b/tests/common.py
@@ -104,7 +104,7 @@ class ApiBaseTest(BaseTestCase):
 
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)

--- a/tests/common.py
+++ b/tests/common.py
@@ -16,8 +16,10 @@ TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
 rest.app.config['NPLUSONE_RAISE'] = True
 NPlusOne(rest.app)
 
+
 def _setup_extensions():
     rest.db.engine.execute('create extension if not exists btree_gin;')
+
 
 def _reset_schema():
     rest.db.engine.execute('drop schema if exists public cascade;')
@@ -35,7 +37,6 @@ def _reset_schema():
 
 
 class BaseTestCase(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         rest.app.config['TESTING'] = True
@@ -62,25 +63,32 @@ class BaseTestCase(unittest.TestCase):
 
 
 class ApiBaseTest(BaseTestCase):
-
     @classmethod
     def setUpClass(cls):
         super(ApiBaseTest, cls).setUpClass()
         _reset_schema()
         with open(os.devnull, 'w') as null:
             subprocess.check_call(
-                ['psql', '-f', 'data/migrations/V0039__states_and_zips_data.sql', TEST_CONN],
-                stdout=null
+                [
+                    'psql',
+                    '-f',
+                    'data/migrations/V0039__states_and_zips_data.sql',
+                    TEST_CONN,
+                ],
+                stdout=null,
             )
 
-        whitelist = [models.CandidateCommitteeTotalsPresidential, models.CandidateCommitteeTotalsHouseSenate]
+        whitelist = [
+            models.CandidateCommitteeTotalsPresidential,
+            models.CandidateCommitteeTotalsHouseSenate,
+        ]
         rest.db.metadata.create_all(
             rest.db.engine,
             tables=[
-                each.__table__ for each in rest.db.Model._decl_class_registry.values()
+                each.__table__
+                for each in rest.db.Model._decl_class_registry.values()
                 if hasattr(each, '__table__') and each not in whitelist
-            ]
-
+            ],
         )
 
     def setUp(self):
@@ -106,9 +114,11 @@ class ApiBaseTest(BaseTestCase):
         response = self._response(qry)
         return response['results']
 
+
 def assert_dicts_subset(first, second):
     expected = {key: first.get(key) for key in second}
     assert expected == second
+
 
 def get_test_jdbc_url():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import manage
-from tests.common import get_test_jdbc_url
+from tests import common
 from webservices import rest
 
 import pytest
@@ -9,9 +9,12 @@ import logging
 
 @pytest.fixture(scope="session")
 def migrate_db(request):
-    reset_schema()
-    run_migrations()
-    manage.refresh_materialized(concurrent=False)
+    with rest.app.app_context():
+        rest.app.config['TESTING'] = True
+        rest.app.config['SQLALCHEMY_DATABASE_URI'] = common.TEST_CONN
+        reset_schema()
+        run_migrations()
+        manage.refresh_materialized(concurrent=False)
 
 
 def run_migrations():
@@ -20,7 +23,7 @@ def run_migrations():
             'flyway',
             'migrate',
             '-n',
-            '-url={0}'.format(get_test_jdbc_url()),
+            '-url={0}'.format(common.get_test_jdbc_url()),
             '-locations=filesystem:data/migrations',
         ],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,18 @@ def migrate_db(request):
     run_migrations()
     manage.refresh_materialized(concurrent=False)
 
+
 def run_migrations():
     subprocess.check_call(
-        ['flyway', 'migrate', '-n', '-url={0}'.format(get_test_jdbc_url()), '-locations=filesystem:data/migrations'],)
+        [
+            'flyway',
+            'migrate',
+            '-n',
+            '-url={0}'.format(get_test_jdbc_url()),
+            '-locations=filesystem:data/migrations',
+        ],
+    )
+
 
 def reset_schema():
     for schema in [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,13 +49,13 @@ def reset_schema():
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--skip-linting",
+        "--no-linting",
         action="store_true",
         default=False,
         help="Skip linting checks",
     )
     parser.addoption(
-        "--only-linting",
+        "--linting",
         action="store_true",
         default=False,
         help="Only run linting checks",
@@ -63,9 +63,9 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(session, config, items):
-    if config.getoption("--skip-linting"):
+    if config.getoption("--no-linting"):
         items[:] = [item for item in items if not item.get_closest_marker('flake8')]
-    if config.getoption("--only-linting"):
+    if config.getoption("--linting"):
         items[:] = [item for item in items if item.get_closest_marker('flake8')]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from webservices import rest
 
 import pytest
 import subprocess
+import logging
 
 
 @pytest.fixture(scope="session")
@@ -32,3 +33,30 @@ def reset_schema():
     ]:
         rest.db.engine.execute('drop schema if exists %s cascade;' % schema)
     rest.db.engine.execute('create schema public;')
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-linting",
+        action="store_true",
+        default=False,
+        help="Skip linting checks",
+    )
+    parser.addoption(
+        "--only-linting",
+        action="store_true",
+        default=False,
+        help="Only run linting checks",
+    )
+
+
+def pytest_collection_modifyitems(session, config, items):
+    if config.getoption("--skip-linting"):
+        items[:] = [item for item in items if not item.get_closest_marker('flake8')]
+    if config.getoption("--only-linting"):
+        items[:] = [item for item in items if item.get_closest_marker('flake8')]
+
+
+def pytest_configure(config):
+    """Flake8 is very verbose by default. Silence it."""
+    logging.getLogger("flake8").setLevel(logging.WARNING)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,12 +15,14 @@ class BaseFactory(SQLAlchemyModelFactory):
 class CandidateSearchFactory(BaseFactory):
     class Meta:
         model = models.CandidateSearch
+
     id = factory.Sequence(lambda n: n)
 
 
 class CommitteeSearchFactory(BaseFactory):
     class Meta:
         model = models.CommitteeSearch
+
     id = factory.Sequence(lambda n: n)
 
 
@@ -31,6 +33,7 @@ class BaseCandidateFactory(BaseFactory):
 class CandidateFactory(BaseCandidateFactory):
     class Meta:
         model = models.Candidate
+
     election_years = [2012, 2014]
 
 
@@ -42,26 +45,32 @@ class CandidateDetailFactory(BaseCandidateFactory):
 class CandidateCommitteeTotalsPresidentialFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateCommitteeTotalsPresidential
+
     cycle = 2016
 
 
 class CandidateCommitteeTotalsHouseSenateFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateCommitteeTotalsHouseSenate
+
     cycle = 2016
 
 
 class CandidateHistoryFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateHistory
+
     two_year_period = 2016
     candidate_inactive = False
+
 
 class CandidateHistoryFutureFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateHistoryWithFuture
+
     two_year_period = 2016
     candidate_inactive = False
+
 
 class CandidateElectionFactory(BaseCandidateFactory):
     class Meta:
@@ -71,6 +80,7 @@ class CandidateElectionFactory(BaseCandidateFactory):
 class CandidateTotalFactory(BaseCandidateFactory):
     class Meta:
         model = models.CandidateTotal
+
     cycle = 2016
 
 
@@ -99,13 +109,16 @@ class CommitteeDetailFactory(BaseCommitteeFactory):
 class CommitteeHistoryFactory(BaseCommitteeFactory):
     class Meta:
         model = models.CommitteeHistory
+
     cycle = 2016
 
 
 class CommitteeTotalsHouseSenateFactory(BaseCommitteeFactory):
     class Meta:
         model = models.CommitteeTotalsHouseSenate
+
     cycle = 2016
+
 
 # Force linked factories to share sequence counters
 for each in BaseCandidateFactory.__subclasses__():
@@ -118,6 +131,7 @@ for each in BaseCommitteeFactory.__subclasses__():
 class CandidateCommitteeLinkFactory(BaseFactory):
     class Meta:
         model = models.CandidateCommitteeLink
+
     linkage_id = factory.Sequence(lambda n: n)
 
 
@@ -140,13 +154,16 @@ class TotalsPacPartyFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPacParty
 
+
 class TotalsPacFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPacParty
 
+
 class TotalsPartyFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPacParty
+
 
 class TotalsIEOnlyFactory(BaseFactory):
     class Meta:
@@ -195,6 +212,7 @@ class ReportsIEOnlyFactory(BaseFactory):
 class ScheduleAFactory(BaseFactory):
     class Meta:
         model = models.ScheduleA
+
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
     two_year_transaction_period = 2016
@@ -203,24 +221,30 @@ class ScheduleAFactory(BaseFactory):
     def update_fulltext(obj, create, extracted, **kwargs):
         obj.contributor_name_text = sa.func.to_tsvector(obj.contributor_name)
         obj.contributor_employer_text = sa.func.to_tsvector(obj.contributor_employer)
-        obj.contributor_occupation_text = sa.func.to_tsvector(obj.contributor_occupation)
+        obj.contributor_occupation_text = sa.func.to_tsvector(
+            obj.contributor_occupation
+        )
 
 
 class ScheduleBFactory(BaseFactory):
     class Meta:
         model = models.ScheduleB
+
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
     two_year_transaction_period = 2016
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):
-        obj.disbursement_description_text = sa.func.to_tsvector(obj.disbursement_description)
+        obj.disbursement_description_text = sa.func.to_tsvector(
+            obj.disbursement_description
+        )
 
 
 class ScheduleCFactory(BaseFactory):
     class Meta:
         model = models.ScheduleC
+
     sub_id = factory.Sequence(lambda n: n)
 
     @factory.post_generation
@@ -228,15 +252,18 @@ class ScheduleCFactory(BaseFactory):
         obj.candidate_name_text = sa.func.to_tsvector(obj.candidate_name)
         obj.loan_source_name_text = sa.func.to_tsvector(obj.loan_source_name)
 
+
 class ScheduleCViewBySubIdFactory(BaseFactory):
     class Meta:
         model = models.ScheduleC
+
     sub_id = factory.Sequence(lambda n: n)
 
 
 class ScheduleEFactory(BaseFactory):
     class Meta:
         model = models.ScheduleE
+
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
 
@@ -248,14 +275,16 @@ class ScheduleEFactory(BaseFactory):
 class ScheduleBEfileFactory(BaseFactory):
     class Meta:
         model = models.ScheduleBEfile
+
     file_number = factory.Sequence(lambda n: n)
     related_line_number = factory.Sequence(lambda n: n)
-    #report_year = 2016
+    # report_year = 2016
 
 
 class ScheduleEEfileFactory(BaseFactory):
     class Meta:
         model = models.ScheduleEEfile
+
     file_number = 123
     related_line_number = factory.Sequence(lambda n: n)
 
@@ -263,17 +292,19 @@ class ScheduleEEfileFactory(BaseFactory):
 class ScheduleAEfileFactory(BaseFactory):
     class Meta:
         model = models.ScheduleAEfile
+
     file_number = factory.Sequence(lambda n: n)
     related_line_number = factory.Sequence(lambda n: n)
 
-    
+
 class ScheduleH4Factory(BaseFactory):
     class Meta:
         model = models.ScheduleH4
+
     sub_id = factory.Sequence(lambda n: n)
     report_year = 2016
     cycle = 2016
-    
+
 
 class FilingsFactory(BaseFactory):
     sub_id = factory.Sequence(lambda n: n)
@@ -287,6 +318,7 @@ class EFilingsFactory(BaseFactory):
 
     class Meta:
         model = models.EFilings
+
 
 class BaseFilingFactory(BaseFactory):
     file_number = factory.Sequence(lambda n: n)
@@ -321,17 +353,21 @@ class ScheduleBByPurposeFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleBByPurpose
 
+
 class ScheduleBByRecipientFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleBByRecipient
+
 
 class ScheduleBByRecipientIDFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleBByRecipientID
 
+
 class ScheduleEByCandidateFactory(BaseAggregateFactory):
     class Meta:
         model = models.ScheduleEByCandidate
+
     candidate_id = factory.Sequence(lambda n: str(n))
     support_oppose_indicator = 'S'
 
@@ -339,6 +375,7 @@ class ScheduleEByCandidateFactory(BaseAggregateFactory):
 class CommunicationCostByCandidateFactory(BaseAggregateFactory):
     class Meta:
         model = models.CommunicationCostByCandidate
+
     candidate_id = factory.Sequence(lambda n: str(n))
     support_oppose_indicator = 'S'
 
@@ -346,6 +383,7 @@ class CommunicationCostByCandidateFactory(BaseAggregateFactory):
 class ElectioneeringByCandidateFactory(BaseAggregateFactory):
     class Meta:
         model = models.ElectioneeringByCandidate
+
     candidate_id = factory.Sequence(lambda n: str(n))
 
 
@@ -377,38 +415,46 @@ class ElectionDateFactory(BaseFactory):
 class ElectionsListFactory(BaseFactory):
     class Meta:
         model = models.ElectionsList
+
     cycle = 2012
 
 
 class ZipsDistrictsFactory(BaseFactory):
     class Meta:
         model = models.ZipsDistricts
+
     active = 'Y'
 
 
 class CommunicationCostFactory(BaseFactory):
     class Meta:
         model = models.CommunicationCost
+
     sub_id = factory.Sequence(lambda n: n)
+
 
 class ScheduleDViewFactory(BaseFactory):
     class Meta:
         model = models.ScheduleD
+
     sub_id = factory.Sequence(lambda n: n)
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):
         obj.creditor_debtor_name_text = sa.func.to_tsvector(obj.creditor_debtor_name)
 
+
 class ScheduleDViewBySubIdFactory(BaseFactory):
     class Meta:
         model = models.ScheduleD
+
     sub_id = factory.Sequence(lambda n: n)
 
 
 class ElectioneeringFactory(BaseFactory):
     class Meta:
         model = models.Electioneering
+
     idx = factory.Sequence(lambda n: n)
     election_type_raw = 'G'
 
@@ -420,24 +466,28 @@ class ElectioneeringFactory(BaseFactory):
 class RadAnalystFactory(BaseFactory):
     class Meta:
         model = models.RadAnalyst
+
     idx = factory.Sequence(lambda n: n)
 
 
 class EntityReceiptDisbursementTotalsFactory(BaseFactory):
     class Meta:
         model = models.EntityReceiptDisbursementTotals
+
     idx = factory.Sequence(lambda n: n)
 
 
 class ScheduleAByStateRecipientTotalsFactory(BaseFactory):
     class Meta:
         model = models.ScheduleAByStateRecipientTotals
+
     idx = factory.Sequence(lambda n: n)
 
 
 class AuditCaseFactory(BaseFactory):
     class Meta:
         model = models.AuditCase
+
     audit_case_id = '2219'
     primary_category_id = '3'
     sub_category_id = '227'
@@ -446,71 +496,91 @@ class AuditCaseFactory(BaseFactory):
 class AuditCategoryFactory(BaseFactory):
     class Meta:
         model = models.AuditCategory
+
     primary_category_id = '3'
 
 
 class AuditPrimaryCategoryFactory(BaseFactory):
     class Meta:
         model = models.AuditPrimaryCategory
+
     primary_category_id = '3'
 
 
 class AuditCandidateSearchFactory(BaseFactory):
     class Meta:
         model = models.AuditCandidateSearch
+
     idx = factory.Sequence(lambda n: n)
 
 
 class AuditCommitteeSearchFactory(BaseFactory):
     class Meta:
         model = models.AuditCommitteeSearch
+
     idx = factory.Sequence(lambda n: n)
 
 
 class StateElectionOfficesFactory(BaseFactory):
     class Meta:
         model = models.StateElectionOfficeInfo
+
     state = 'VA'
     office_type = 'STATE CAMPAIGN FINANCE'
+
 
 class OperationsLogFactory(BaseFactory):
     class Meta:
         model = models.OperationsLog
 
+
 class TransactionCoverageFactory(BaseFactory):
     class Meta:
         model = models.TransactionCoverage
+
 
 class TotalsCombinedFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsCombined
 
+
 class CommitteeTotalsPerCycleFactory(BaseTotalsFactory):
     class Meta:
         model = models.CommitteeTotalsPerCycle
+
     idx = factory.Sequence(lambda n: n)
+
 
 class PresidentialByCandidateFactory(BaseFactory):
     class Meta:
         model = models.PresidentialByCandidate
+
     idx = factory.Sequence(lambda n: n)
+
 
 class PresidentialByStateFactory(BaseFactory):
     class Meta:
         model = models.PresidentialByState
+
     idx = factory.Sequence(lambda n: n)
+
 
 class PresidentialSummaryFactory(BaseFactory):
     class Meta:
         model = models.PresidentialSummary
+
     idx = factory.Sequence(lambda n: n)
+
 
 class PresidentialCoverageFactory(BaseFactory):
     class Meta:
         model = models.PresidentialCoverage
+
     idx = factory.Sequence(lambda n: n)
+
 
 class PresidentialBySizeFactory(BaseFactory):
     class Meta:
         model = models.PresidentialBySize
+
     idx = factory.Sequence(lambda n: n)

--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -16,7 +16,8 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
     def setUp(self):
         self.connection = rest.db.engine.connect()
         subprocess.check_call(
-            ["psql", TEST_CONN, "-f", "data/load_base_advisory_opinion_data.sql"])
+            ["psql", TEST_CONN, "-f", "data/load_base_advisory_opinion_data.sql"]
+        )
 
     def tearDown(self):
         self.clear_test_data()
@@ -44,7 +45,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "representative_names": [],
             "sort1": -2017,
             "sort2": -1,
-            "entities": []
+            "entities": [],
         }
         self.create_ao(1, expected_ao)
         actual_ao = next(get_advisory_opinions(None))
@@ -53,8 +54,14 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     def test_ao_with_entities(self, get_bucket):
-        expected_requestor_names = ["The Manchurian Candidate", "Federation of Interstate Truckers"]
-        expected_requestor_types = ["Federal candidate/candidate committee/officeholder", "Labor Organization"]
+        expected_requestor_names = [
+            "The Manchurian Candidate",
+            "Federation of Interstate Truckers",
+        ]
+        expected_requestor_types = [
+            "Federal candidate/candidate committee/officeholder",
+            "Labor Organization",
+        ]
         expected_commenter_names = ["Tom Troll", "Harry Troll"]
         expected_representative_names = ["Dewey Cheetham and Howe LLC"]
         expected_ao = {
@@ -70,20 +77,26 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
 
         self.create_ao(1, expected_ao)
         for i, _ in enumerate(expected_requestor_names):
-            self.create_requestor(1, i + 1, expected_requestor_names[i], expected_requestor_types[i])
+            self.create_requestor(
+                1, i + 1, expected_requestor_names[i], expected_requestor_types[i]
+            )
         offset = len(expected_requestor_names)
         for i, _ in enumerate(expected_commenter_names):
             self.create_commenter(1, i + offset + 1, expected_commenter_names[i])
         offset += len(expected_commenter_names)
         for i, _ in enumerate(expected_representative_names):
-            self.create_representative(1, i + offset + 1, expected_representative_names[i])
+            self.create_representative(
+                1, i + offset + 1, expected_representative_names[i]
+            )
 
         actual_ao = next(get_advisory_opinions(None))
 
         assert set(actual_ao["requestor_names"]) == set(expected_requestor_names)
         assert set(actual_ao["requestor_types"]) == set(expected_requestor_types)
         assert set(actual_ao["commenter_names"]) == set(expected_commenter_names)
-        assert set(actual_ao["representative_names"]) == set(expected_representative_names)
+        assert set(actual_ao["representative_names"]) == set(
+            expected_representative_names
+        )
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     def test_completed_ao_with_docs(self, get_bucket):
@@ -95,7 +108,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "text": "Some Text",
             "description": "Some Description",
             "date": datetime.datetime(2017, 2, 9, 0, 0),
-            "url": "/files/legal/aos/{0}/{1}".format(ao_no, filename.replace(' ', '-'))
+            "url": "/files/legal/aos/{0}/{1}".format(ao_no, filename.replace(' ', '-')),
         }
         expected_ao = {
             "no": ao_no,
@@ -126,7 +139,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "category": "Final Opinion",
             "text": "Not an AO reference 1776-01",
             "description": "Some Description",
-            "date": datetime.datetime(2017, 2, 9, 0, 0)
+            "date": datetime.datetime(2017, 2, 9, 0, 0),
         }
         ao1 = {
             "no": "2017-01",
@@ -143,7 +156,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "category": "Final Opinion",
             "text": "Reference to AO 2017-01",
             "description": "Some Description",
-            "date": datetime.datetime(2017, 2, 9, 0, 0)
+            "date": datetime.datetime(2017, 2, 9, 0, 0),
         }
         ao2 = {
             "no": "2017-02",
@@ -180,7 +193,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "category": "Final Opinion",
             "text": "A statutory citation 2 U.S.C. 431 and some text",
             "description": "Some Description",
-            "date": datetime.datetime(2017, 2, 9, 0, 0)
+            "date": datetime.datetime(2017, 2, 9, 0, 0),
         }
         ao = {
             "no": "2017-01",
@@ -207,7 +220,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "category": "Final Opinion",
             "text": "A regulatory citation 11 CFR §9034.4(b)(4) and some text",
             "description": "Some Description",
-            "date": datetime.datetime(2017, 2, 9, 0, 0)
+            "date": datetime.datetime(2017, 2, 9, 0, 0),
         }
         ao = {
             "no": "2017-01",
@@ -224,7 +237,9 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
 
         actual_ao = next(get_advisory_opinions(None))
 
-        assert actual_ao["regulatory_citations"] == [{"title": 11, "part": 9034, "section": 4}]
+        assert actual_ao["regulatory_citations"] == [
+            {"title": 11, "part": 9034, "section": 4}
+        ]
 
     def create_ao(self, ao_id, ao):
 
@@ -234,8 +249,14 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         self.connection.execute(
             "INSERT INTO aouser.ao (ao_id, ao_no, name, summary, req_date, issue_date, stage)"
             "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-            ao_id, ao["no"], ao["name"], ao["summary"], ao["request_date"],
-            ao["issue_date"], ao_status_to_stage(ao["status"]))
+            ao_id,
+            ao["no"],
+            ao["name"],
+            ao["summary"],
+            ao["request_date"],
+            ao["issue_date"],
+            ao_status_to_stage(ao["status"]),
+        )
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     def test_ao_offsets(self, get_bucket):
@@ -258,7 +279,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "representative_names": [],
             "sort1": -2015,
             "sort2": -1,
-            "entities": []
+            "entities": [],
         }
         expected_ao2 = {
             "no": "2015-02",
@@ -279,7 +300,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "representative_names": [],
             "sort1": -2015,
             "sort2": -2,
-            "entities": []
+            "entities": [],
         }
         expected_ao3 = {
             "no": "2016-01",
@@ -300,20 +321,20 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "representative_names": [],
             "sort1": -2016,
             "sort2": -1,
-            "entities": []
+            "entities": [],
         }
         self.create_ao(1, expected_ao1)
         self.create_ao(2, expected_ao2)
         self.create_ao(3, expected_ao3)
 
         gen = get_advisory_opinions(None)
-        assert(next(gen)) == expected_ao1
-        assert(next(gen)) == expected_ao2
-        assert(next(gen)) == expected_ao3
+        assert (next(gen)) == expected_ao1
+        assert (next(gen)) == expected_ao2
+        assert (next(gen)) == expected_ao3
 
         gen = get_advisory_opinions('2015-02')
-        assert(next(gen)) == expected_ao2
-        assert(next(gen)) == expected_ao3
+        assert (next(gen)) == expected_ao2
+        assert (next(gen)) == expected_ao3
 
     def create_document(self, ao_id, document, filename='201801_C.pdf'):
         self.connection.execute(
@@ -328,13 +349,14 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             document["text"],
             document["description"],
             document["date"],
-            filename
+            filename,
         )
 
     def create_requestor(self, ao_id, entity_id, requestor_name, requestor_type):
         entity_type_id = self.connection.execute(
-            "SELECT entity_type_id FROM aouser.entity_type "
-            " WHERE description = %s ", requestor_type).scalar()
+            "SELECT entity_type_id FROM aouser.entity_type " " WHERE description = %s ",
+            requestor_type,
+        ).scalar()
 
         self.create_entity(ao_id, entity_id, requestor_name, entity_type_id, 1)
 
@@ -352,7 +374,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             VALUES (%s, %s, %s)""",
             entity_id,
             requestor_name,
-            entity_type_id
+            entity_type_id,
         )
         self.connection.execute(
             """
@@ -362,18 +384,11 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             entity_id,
             ao_id,
             entity_id,
-            role_id
+            role_id,
         )
 
     def clear_test_data(self):
-        tables = [
-            "ao",
-            "document",
-            "players",
-            "entity",
-            "entity_type",
-            "role"
-        ]
+        tables = ["ao", "document", "players", "entity", "entity_type", "role"]
         for table in tables:
             self.connection.execute("DELETE FROM aouser.{}".format(table))
 

--- a/tests/integration/test_amendment_chain.py
+++ b/tests/integration/test_amendment_chain.py
@@ -7,7 +7,7 @@ import copy
 import manage
 from tests.common import BaseTestCase
 from webservices import rest, __API_VERSION__
-from webservices.resources.filings import FilingsView, FilingsList, EFilingsView
+from webservices.resources.filings import FilingsView, FilingsList
 
 
 @pytest.mark.usefixtures("migrate_db")
@@ -25,7 +25,7 @@ class TestAmendmentChain(BaseTestCase):
         'most_recent': True,
         'report_type': None,
         'form_type': 'F1',
-        'begin_image_num': '20180131001'
+        'begin_image_num': '20180131001',
     }
     STOCK_SECOND_F1 = {
         'committee_id': 'C006',
@@ -39,7 +39,7 @@ class TestAmendmentChain(BaseTestCase):
         'most_recent': True,
         'report_type': None,
         'form_type': 'F1',
-        'begin_image_num': '20180228002'
+        'begin_image_num': '20180228002',
     }
 
     def setUp(self):
@@ -79,7 +79,9 @@ class TestAmendmentChain(BaseTestCase):
         # FilingsList view
         # /filings/ endpoint
 
-        results = self._results(rest.api.url_for(FilingsList, committee_id=expected_filing['committee_id']))
+        results = self._results(
+            rest.api.url_for(FilingsList, committee_id=expected_filing['committee_id'])
+        )
         assert len(results) == 1
         list_result = results[0]
 
@@ -88,7 +90,9 @@ class TestAmendmentChain(BaseTestCase):
         # FilingsView view
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
 
-        results = self._results(rest.api.url_for(FilingsView, committee_id=expected_filing['committee_id']))
+        results = self._results(
+            rest.api.url_for(FilingsView, committee_id=expected_filing['committee_id'])
+        )
         assert len(results) == 1
         view_result = results[0]
 
@@ -105,7 +109,13 @@ class TestAmendmentChain(BaseTestCase):
 
         # /filings/ endpoint
 
-        results = self._results(rest.api.url_for(FilingsList, committee_id=expected_filing['committee_id'], most_recent=True))
+        results = self._results(
+            rest.api.url_for(
+                FilingsList,
+                committee_id=expected_filing['committee_id'],
+                most_recent=True,
+            )
+        )
         assert len(results) == 1
         list_result = results[0]
 
@@ -114,7 +124,13 @@ class TestAmendmentChain(BaseTestCase):
         # FilingsView view
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
 
-        results = self._results(rest.api.url_for(FilingsView, committee_id=expected_filing['committee_id'], most_recent=True))
+        results = self._results(
+            rest.api.url_for(
+                FilingsView,
+                committee_id=expected_filing['committee_id'],
+                most_recent=True,
+            )
+        )
         assert len(results) == 1
         view_result = results[0]
 
@@ -133,7 +149,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': False,
             'report_type': 'Q2',
             'form_type': 'F3',
-            'begin_image_num': '20180715001'
+            'begin_image_num': '20180715001',
         }
         form_3_q2_amend_1 = {
             'committee_id': 'C006',
@@ -147,7 +163,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': False,
             'report_type': 'Q2',
             'form_type': 'F3',
-            'begin_image_num': '20180815001'
+            'begin_image_num': '20180815001',
         }
         form_3_q3_new = {
             'committee_id': 'C006',
@@ -161,7 +177,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': False,
             'report_type': 'Q3',
             'form_type': 'F3',
-            'begin_image_num': '20181015001'
+            'begin_image_num': '20181015001',
         }
         form_3_q3_amend_1 = {
             'committee_id': 'C006',
@@ -175,7 +191,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': True,
             'report_type': 'Q3',
             'form_type': 'F3',
-            'begin_image_num': '20181115001'
+            'begin_image_num': '20181115001',
         }
         form_3_q2_amend_2 = {
             'committee_id': 'C006',
@@ -189,7 +205,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': True,
             'report_type': 'Q2',
             'form_type': 'F3',
-            'begin_image_num': '20181215001'
+            'begin_image_num': '20181215001',
         }
         self.create_filing(1, form_3_q2_new)
         self.create_filing(2, form_3_q2_amend_1)
@@ -203,14 +219,26 @@ class TestAmendmentChain(BaseTestCase):
         # Refresh downstream `ofec_amendments_mv` and `ofec_filings_all_mv`
         manage.refresh_materialized(concurrent=False)
 
-        q2_results = self._results(rest.api.url_for(FilingsList, committee_id=form_3_q2_new['committee_id'], report_type='Q2'))
+        q2_results = self._results(
+            rest.api.url_for(
+                FilingsList,
+                committee_id=form_3_q2_new['committee_id'],
+                report_type='Q2',
+            )
+        )
 
         for result in q2_results:
             for filing in (form_3_q2_new, form_3_q2_amend_1, form_3_q2_amend_2):
                 if result['file_number'] == filing['file_number']:
                     self.assert_filings_equal(result, filing)
 
-        q3_results = self._results(rest.api.url_for(FilingsList, committee_id=form_3_q3_new['committee_id'], report_type='Q3'))
+        q3_results = self._results(
+            rest.api.url_for(
+                FilingsList,
+                committee_id=form_3_q3_new['committee_id'],
+                report_type='Q3',
+            )
+        )
 
         for result in q3_results:
             for filing in (form_3_q3_new, form_3_q3_amend_1):
@@ -230,7 +258,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': False,
             'report_type': None,
             'form_type': 'F1',
-            'begin_image_num': '20180131004'
+            'begin_image_num': '20180131004',
         }
         second_f1 = {
             'committee_id': 'C006',
@@ -244,7 +272,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': False,
             'report_type': None,
             'form_type': 'F1',
-            'begin_image_num': '20180228001'
+            'begin_image_num': '20180228001',
         }
         third_f1 = {
             'committee_id': 'C006',
@@ -258,10 +286,12 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': True,
             'report_type': None,
             'form_type': 'F1',
-            'begin_image_num': '20180328001'
+            'begin_image_num': '20180328001',
         }
         unusual_entry_for_second_f1 = copy.deepcopy(second_f1)
-        unusual_entry_for_second_f1['previous_file_number'] = unusual_entry_for_second_f1['file_number']
+        unusual_entry_for_second_f1[
+            'previous_file_number'
+        ] = unusual_entry_for_second_f1['file_number']
 
         self.create_filing(1, first_f1)
         self.create_filing(2, unusual_entry_for_second_f1)
@@ -270,14 +300,18 @@ class TestAmendmentChain(BaseTestCase):
         # Refresh downstream `ofec_amendments_mv` and `ofec_filings_all_mv`
         manage.refresh_materialized(concurrent=False)
 
-        results = self._results(rest.api.url_for(FilingsList, committee_id=first_f1['committee_id']))
+        results = self._results(
+            rest.api.url_for(FilingsList, committee_id=first_f1['committee_id'])
+        )
 
         for result in sorted(results, key=lambda x: x['file_number']):
             for filing in (first_f1, unusual_entry_for_second_f1, third_f1):
                 if result['file_number'] == filing['file_number']:
                     self.assert_filings_equal(result, filing)
                     # Note: we're leaving data-entered previous_file_number alone
-                    assert result['previous_file_number'] == filing['previous_file_number']
+                    assert (
+                        result['previous_file_number'] == filing['previous_file_number']
+                    )
 
     def test_negative_filing_chain(self):
         # Make sure no negative numbers appear in amendment chain
@@ -293,7 +327,7 @@ class TestAmendmentChain(BaseTestCase):
             'most_recent': True,
             'report_type': None,
             'form_type': 'F1',
-            'begin_image_num': '20180131005'
+            'begin_image_num': '20180131005',
         }
 
         non_negative_f1 = copy.deepcopy(self.STOCK_FIRST_F1)
@@ -304,40 +338,68 @@ class TestAmendmentChain(BaseTestCase):
         # Refresh downstream `ofec_amendments_mv` and `ofec_filings_all_mv`
         manage.refresh_materialized(concurrent=False)
 
-        results = self._results(rest.api.url_for(FilingsList, committee_id=non_negative_f1['committee_id'], most_recent=True))
+        results = self._results(
+            rest.api.url_for(
+                FilingsList,
+                committee_id=non_negative_f1['committee_id'],
+                most_recent=True,
+            )
+        )
         assert len(results) == 1
 
         result = results[0]
         self.assert_filings_equal(result, negative_f1)
 
-
     def insert_vsum(self, sub_id, expected_filing):
         self.connection.execute(
-            "INSERT INTO disclosure.v_sum_and_det_sum_report (orig_sub_id, form_tp_cd,cmte_id, file_num) "
-            "VALUES (%s, %s, %s, %s)", sub_id, expected_filing['form_type'], expected_filing['committee_id'], expected_filing['file_number']
+            "INSERT INTO disclosure.v_sum_and_det_sum_report \
+            (orig_sub_id, form_tp_cd,cmte_id, file_num) "
+            "VALUES (%s, %s, %s, %s)",
+            sub_id,
+            expected_filing['form_type'],
+            expected_filing['committee_id'],
+            expected_filing['file_number'],
         )
 
     def create_filing(self, sub_id, expected_filing):
         self.connection.execute(
-            "INSERT INTO disclosure.f_rpt_or_form_sub (sub_id, cand_cmte_id, form_tp, rpt_yr, rpt_tp, amndt_ind, receipt_dt, file_num, prev_file_num, begin_image_num) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)", sub_id, expected_filing['committee_id'], expected_filing['form_type'], expected_filing['report_year'], expected_filing['report_type'], expected_filing['amendment_indicator'], int(expected_filing['receipt_date'].strftime("%Y%m%d")), expected_filing['file_number'], expected_filing['previous_file_number'], expected_filing['begin_image_num']
+            "INSERT INTO disclosure.f_rpt_or_form_sub \
+            (sub_id, cand_cmte_id, form_tp, rpt_yr, rpt_tp, amndt_ind, \
+            receipt_dt, file_num, prev_file_num, begin_image_num) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            sub_id,
+            expected_filing['committee_id'],
+            expected_filing['form_type'],
+            expected_filing['report_year'],
+            expected_filing['report_type'],
+            expected_filing['amendment_indicator'],
+            int(expected_filing['receipt_date'].strftime("%Y%m%d")),
+            expected_filing['file_number'],
+            expected_filing['previous_file_number'],
+            expected_filing['begin_image_num'],
         )
 
     def assert_filings_equal(self, api_result, expected_filing):
         assert api_result['committee_id'] == expected_filing['committee_id']
         assert api_result['report_year'] == expected_filing['report_year']
-        assert api_result['amendment_indicator'] == expected_filing['amendment_indicator']
-        assert api_result['receipt_date'][:10] == expected_filing['receipt_date']. isoformat()
+        assert (
+            api_result['amendment_indicator'] == expected_filing['amendment_indicator']
+        )
+        assert (
+            api_result['receipt_date'][:10]
+            == expected_filing['receipt_date'].isoformat()
+        )
         assert api_result['file_number'] == expected_filing['file_number']
         assert api_result['amendment_chain'] == expected_filing['amendment_chain']
-        assert api_result['most_recent_file_number'] == expected_filing['most_recent_file_number']
+        assert (
+            api_result['most_recent_file_number']
+            == expected_filing['most_recent_file_number']
+        )
         assert api_result['most_recent'] == expected_filing['most_recent']
         assert api_result['report_type'] == expected_filing['report_type']
         assert api_result['form_type'] == expected_filing['form_type']
 
     def clear_test_data(self):
-        tables = [
-            ('disclosure', 'f_rpt_or_form_sub')
-        ]
+        tables = [('disclosure', 'f_rpt_or_form_sub')]
         for table in tables:
             self.connection.execute("DELETE FROM {0}.{1}".format(table[0], table[1]))

--- a/tests/integration/test_amendment_chain.py
+++ b/tests/integration/test_amendment_chain.py
@@ -59,7 +59,7 @@ class TestAmendmentChain(BaseTestCase):
     # _response and _results from APIBaseCase
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -22,7 +22,7 @@ class TotalTestCase(common.BaseTestCase):
 
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -9,6 +9,7 @@ from webservices import rest, __API_VERSION__
 from webservices.rest import db
 from webservices.resources.totals import CandidateTotalsView, TotalsCommitteeView
 
+
 @pytest.mark.usefixtures("migrate_db")
 class TotalTestCase(common.BaseTestCase):
     def setUp(self):
@@ -105,7 +106,7 @@ class TotalTestCase(common.BaseTestCase):
         'ttl_disb': 30,
         'form_type': 'F3P',
         'sub_id': 1,
-        'rpt_year': 2019
+        'rpt_year': 2019,
     }
     STOCK_FILING_F3X_Q2 = {
         'committee_id': 'C001',
@@ -115,7 +116,7 @@ class TotalTestCase(common.BaseTestCase):
         'ttl_disb': 50,
         'form_type': 'F3X',
         'sub_id': 2,
-        'rpt_year': 2019
+        'rpt_year': 2019,
     }
     STOCK_FILING_F3_Q1 = {
         'committee_id': 'C002',
@@ -125,7 +126,7 @@ class TotalTestCase(common.BaseTestCase):
         'ttl_disb': 5,
         'form_type': 'F3',
         'sub_id': 3,
-        'rpt_year': 2019
+        'rpt_year': 2019,
     }
 
     def test_candidate_committee_wrong_form_totals(self):
@@ -146,7 +147,7 @@ class TotalTestCase(common.BaseTestCase):
         committee_totals_api = self._results(
             rest.api.url_for(TotalsCommitteeView, **params_cmte)
         )
-        assert (len(committee_totals_api) == 1)
+        assert len(committee_totals_api) == 1
         assert committee_totals_api[0]['receipts'] == 300
         assert committee_totals_api[0]['disbursements'] == 80
 
@@ -157,7 +158,7 @@ class TotalTestCase(common.BaseTestCase):
         candidate_totals_api = self._results(
             rest.api.url_for(CandidateTotalsView, **params_cand)
         )
-        assert (len(candidate_totals_api) == 1)
+        assert len(candidate_totals_api) == 1
         assert candidate_totals_api[0]['receipts'] == 311
         assert candidate_totals_api[0]['disbursements'] == 85
 
@@ -173,7 +174,7 @@ class TotalTestCase(common.BaseTestCase):
         candidate_totals_api = self._results(
             rest.api.url_for(CandidateTotalsView, **params_cand)
         )
-        assert (len(candidate_totals_api) == 0)
+        assert len(candidate_totals_api) == 0
 
     def create_cmte_valid(self, committee_data):
         sql_insert = (
@@ -196,7 +197,7 @@ class TotalTestCase(common.BaseTestCase):
             filing['file_number'],
             filing['ttl_receipts'],
             filing['ttl_disb'],
-            filing['rpt_year']
+            filing['rpt_year'],
         )
 
     def create_cand_cmte_linkage(self, linkage_data):

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -24,7 +24,7 @@ class CandidatesTestCase(common.BaseTestCase):
 
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -148,20 +148,22 @@ class CandidatesTestCase(common.BaseTestCase):
 
     def create_cand_valid(self, candidate_data):
         sql_insert = (
-            "INSERT INTO disclosure.cand_valid_fec_yr "
-            + "(cand_valid_yr_id, cand_id, fec_election_yr, cand_election_yr, "
-            + "cand_status, cand_office, cand_office_st, cand_office_district, date_entered) VALUES (%(cand_valid_yr_id)s, %(cand_id)s, "
-            + "%(fec_election_yr)s, %(cand_election_yr)s, %(cand_status)s, %(cand_office)s, %(cand_office_st)s, %(cand_office_district)s, %(date_entered)s)"
+            "INSERT INTO disclosure.cand_valid_fec_yr \
+            (cand_valid_yr_id, cand_id, fec_election_yr, cand_election_yr, \
+            cand_status, cand_office, cand_office_st, cand_office_district, date_entered) \
+            VALUES (%(cand_valid_yr_id)s, %(cand_id)s, \
+            %(fec_election_yr)s, %(cand_election_yr)s, %(cand_status)s, %(cand_office)s, \
+            %(cand_office_st)s, %(cand_office_district)s, %(date_entered)s)"
         )
         self.connection.execute(sql_insert, candidate_data)
 
     def create_cand_cmte_linkage(self, linkage_data):
         sql_insert = (
-            "INSERT INTO disclosure.cand_cmte_linkage "
-            + "(linkage_id, cand_id, fec_election_yr, cand_election_yr, "
-            + "cmte_id, cmte_count_cand_yr, cmte_tp, cmte_dsgn, linkage_type, date_entered) "
-            + "VALUES (%(linkage_id)s, %(cand_id)s, "
-            + "%(fec_election_yr)s, %(cand_election_yr)s, %(cmte_id)s, %(cmte_count_cand_yr)s, "
-            + "%(cmte_tp)s, %(cmte_dsgn)s, %(linkage_type)s, %(date_entered)s)"
+            "INSERT INTO disclosure.cand_cmte_linkage \
+            (linkage_id, cand_id, fec_election_yr, cand_election_yr, \
+            cmte_id, cmte_count_cand_yr, cmte_tp, cmte_dsgn, linkage_type, date_entered) \
+            VALUES (%(linkage_id)s, %(cand_id)s, \
+            %(fec_election_yr)s, %(cand_election_yr)s, %(cmte_id)s, %(cmte_count_cand_yr)s, \
+            %(cmte_tp)s, %(cmte_dsgn)s, %(linkage_type)s, %(date_entered)s)"
         )
         self.connection.execute(sql_insert, linkage_data)

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -68,28 +68,28 @@ class CommitteeTestCase(BaseTestCase):
             'receipt_dt': 20160610,
             'form_tp': 'F1',
             'rpt_yr': 2015,
-            'sub_id': 1001
+            'sub_id': 1001,
         },
         {
             'cand_cmte_id': 'C001',
             'receipt_dt': 20170310,
             'form_tp': 'F3',
             'rpt_yr': 2017,
-            'sub_id': 1002
+            'sub_id': 1002,
         },
         {
             'cand_cmte_id': 'C001',
             'receipt_dt': 20170510,
             'form_tp': 'F3',
             'rpt_yr': None,
-            'sub_id': 1003
+            'sub_id': 1003,
         },
         {
             'cand_cmte_id': 'C001',
             'receipt_dt': 20190310,
             'form_tp': 'F3',
             'rpt_yr': 2019,
-            'sub_id': 1004
+            'sub_id': 1004,
         },
     ]
 
@@ -103,10 +103,16 @@ class CommitteeTestCase(BaseTestCase):
             'committee_id': 'C001',
         }
 
-        committee_api = self._results(rest.api.url_for(CommitteeHistoryView, **params_cmte))
+        committee_api = self._results(
+            rest.api.url_for(CommitteeHistoryView, **params_cmte)
+        )
         self.check_nulls_in_array_column(committee_api, array_column='cycles')
-        self.check_nulls_in_array_column(committee_api, array_column='cycles_has_activity')
-        self.check_nulls_in_array_column(committee_api, array_column='cycles_has_financial')
+        self.check_nulls_in_array_column(
+            committee_api, array_column='cycles_has_activity'
+        )
+        self.check_nulls_in_array_column(
+            committee_api, array_column='cycles_has_financial'
+        )
 
     def check_nulls_in_array_column(self, api_result, array_column):
         self.assertEqual(len(api_result), 1)
@@ -146,10 +152,6 @@ class CommitteeTestCase(BaseTestCase):
         self.connection.execute(sql_insert, f_rpt_or_form_sub_data)
 
     def clear_test_data(self):
-        tables = [
-            "cmte_valid_fec_yr",
-            "cand_cmte_linkage",
-            "f_rpt_or_form_sub"
-        ]
+        tables = ["cmte_valid_fec_yr", "cand_cmte_linkage", "f_rpt_or_form_sub"]
         for table in tables:
             self.connection.execute("DELETE FROM disclosure.{}".format(table))

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -21,7 +21,7 @@ class CommitteeTestCase(BaseTestCase):
 
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)

--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -10,13 +10,12 @@ from webservices.legal_docs.current_cases import get_cases
 
 from tests.common import TEST_CONN, BaseTestCase
 
+
 @pytest.mark.usefixtures("migrate_db")
 class TestLoadCurrentCases(BaseTestCase):
-
     def setUp(self):
         self.connection = rest.db.engine.connect()
-        subprocess.check_call(
-            ['psql', TEST_CONN, '-f', 'data/load_base_mur_data.sql'])
+        subprocess.check_call(['psql', TEST_CONN, '-f', 'data/load_base_mur_data.sql'])
 
     def tearDown(self):
         self.clear_test_data()
@@ -43,9 +42,15 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/1/',
             'sort1': -1,
-            'sort2': None
+            'sort2': None,
         }
-        self.create_case(1, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
+        self.create_case(
+            1,
+            expected_mur['no'],
+            expected_mur['name'],
+            mur_subject,
+            expected_mur['published_flg'],
+        )
         actual_mur = next(get_cases('MUR'))
 
         assert actual_mur == expected_mur
@@ -70,9 +75,15 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/101/',
             'sort1': -101,
-            'sort2': None
+            'sort2': None,
         }
-        self.create_case(101, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
+        self.create_case(
+            101,
+            expected_mur['no'],
+            expected_mur['name'],
+            mur_subject,
+            expected_mur['published_flg'],
+        )
         actual_mur = next(get_cases('MUR'))
 
         assert actual_mur == expected_mur
@@ -96,9 +107,16 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/alternative-dispute-resolution/1/',
             'sort1': -1,
-            'sort2': None
+            'sort2': None,
         }
-        self.create_case(1, expected_adr['no'], expected_adr['name'], adr_subject, expected_adr['published_flg'], 'ADR')
+        self.create_case(
+            1,
+            expected_adr['no'],
+            expected_adr['name'],
+            adr_subject,
+            expected_adr['published_flg'],
+            'ADR',
+        )
         actual_adr = next(get_cases('ADR'))
 
         assert actual_adr == expected_adr
@@ -129,11 +147,18 @@ class TestLoadCurrentCases(BaseTestCase):
             'petition_court_decision_date': None,
             'url': '/legal/administrative-fine/1/',
             'sort1': -1,
-            'sort2': None
+            'sort2': None,
         }
-        self.create_case(1, expected_admin_fine['no'], expected_admin_fine['name'],
-            dummy_subject, expected_admin_fine['published_flg'], 'AF')
-        self.create_admin_fine(1,
+        self.create_case(
+            1,
+            expected_admin_fine['no'],
+            expected_admin_fine['name'],
+            dummy_subject,
+            expected_admin_fine['published_flg'],
+            'AF',
+        )
+        self.create_admin_fine(
+            1,
             expected_admin_fine['committee_id'],
             expected_admin_fine['report_year'],
             expected_admin_fine['report_type'],
@@ -147,7 +172,8 @@ class TestLoadCurrentCases(BaseTestCase):
             expected_admin_fine['treasury_referral_date'],
             expected_admin_fine['treasury_referral_amount'],
             expected_admin_fine['petition_court_filing_date'],
-            expected_admin_fine['petition_court_decision_date'])
+            expected_admin_fine['petition_court_decision_date'],
+        )
         actual_admin_fine = next(get_cases('AF'))
 
         assert actual_admin_fine == expected_admin_fine
@@ -165,22 +191,34 @@ class TestLoadCurrentCases(BaseTestCase):
             'election_cycles': [2016],
             'doc_id': 'mur_1',
             'subjects': [mur_subject],
-            'respondents': ["Bilbo Baggins", "Thorin Oakenshield"]
+            'respondents': ["Bilbo Baggins", "Thorin Oakenshield"],
         }
         participants = [
             ("Complainant", "Gollum"),
             ("Respondent", "Bilbo Baggins"),
-            ("Respondent", "Thorin Oakenshield")
+            ("Respondent", "Thorin Oakenshield"),
         ]
         filename = "Some File.pdf"
         documents = [
-            ('A Category', 'Some text', 'legal/murs/{0}/{1}'.format('1',
-                    filename.replace(' ', '-'))),
-            ('Another Category', 'Different text', 'legal/murs/{0}/{1}'.format('1',
-                    filename.replace(' ', '-'))),
+            (
+                'A Category',
+                'Some text',
+                'legal/murs/{0}/{1}'.format('1', filename.replace(' ', '-')),
+            ),
+            (
+                'Another Category',
+                'Different text',
+                'legal/murs/{0}/{1}'.format('1', filename.replace(' ', '-')),
+            ),
         ]
 
-        self.create_case(case_id, expected_mur['no'], expected_mur['name'], mur_subject, expected_mur['published_flg'])
+        self.create_case(
+            case_id,
+            expected_mur['no'],
+            expected_mur['name'],
+            mur_subject,
+            expected_mur['published_flg'],
+        )
         for entity_id, participant in enumerate(participants):
             role, name = participant
             self.create_participant(case_id, entity_id, role, name)
@@ -193,11 +231,13 @@ class TestLoadCurrentCases(BaseTestCase):
         for key in expected_mur:
             assert actual_mur[key] == expected_mur[key]
 
-        assert participants == [(p['role'], p['name'])
-                                for p in actual_mur['participants']]
+        assert participants == [
+            (p['role'], p['name']) for p in actual_mur['participants']
+        ]
 
         assert [(d[0], d[1], len(d[1])) for d in documents] == [
-            (d['category'], d['text'], d['length']) for d in actual_mur['documents']]
+            (d['category'], d['text'], d['length']) for d in actual_mur['documents']
+        ]
 
     @patch('webservices.env.env.get_credential', return_value='BUCKET_NAME')
     @patch('webservices.legal_docs.current_cases.get_bucket')
@@ -226,13 +266,30 @@ class TestLoadCurrentCases(BaseTestCase):
         is_key_date = 0
         check_primary_respondent = 0
         pg_date = '2016-01-01'
-        self.create_event(event_id, parent_event, event_name, path, is_key_date,
-        check_primary_respondent, pg_date)
+        self.create_event(
+            event_id,
+            parent_event,
+            event_name,
+            path,
+            is_key_date,
+            check_primary_respondent,
+            pg_date,
+        )
 
         first_name = "Commander"
         last_name = "Data"
         middle_name, prefix, suffix, type = ('', '', '', '')
-        self.create_entity(entity_id, first_name, last_name, middle_name, prefix, suffix, type, name, pg_date)
+        self.create_entity(
+            entity_id,
+            first_name,
+            last_name,
+            middle_name,
+            prefix,
+            suffix,
+            type,
+            name,
+            pg_date,
+        )
 
         master_key = 1
         detail_key = 1
@@ -243,48 +300,76 @@ class TestLoadCurrentCases(BaseTestCase):
         initial_amount = 0
         final_amount = 50000
         amount_received, settlement_type = (0, '')
-        self.create_settlement(settlement_id, case_id, initial_amount, final_amount,
-        amount_received, settlement_type, pg_date)
+        self.create_settlement(
+            settlement_id,
+            case_id,
+            initial_amount,
+            final_amount,
+            amount_received,
+            settlement_type,
+            pg_date,
+        )
 
         stage = 'Closed'
         statutory_citation = '431'
         regulatory_citation = '456'
-        self.create_violation(case_id, entity_id, stage, statutory_citation, regulatory_citation)
+        self.create_violation(
+            case_id, entity_id, stage, statutory_citation, regulatory_citation
+        )
 
         commission_id = 1
         agenda_date = event_date
         vote_date = event_date
         action = 'Conciliation Reached.'
-        self.create_commission(commission_id, agenda_date, vote_date, action, case_id, pg_date)
+        self.create_commission(
+            commission_id, agenda_date, vote_date, action, case_id, pg_date
+        )
 
         actual_mur = next(get_cases('MUR'))
 
         expected_mur = {
-            'commission_votes': [{'action': 'Conciliation Reached.', 'vote_date': datetime(2008, 1, 1, 0, 0)}],
-            'dispositions': [{
-                'disposition': 'Conciliation-PPC',
-                'respondent': 'Open Elections LLC', 'penalty': Decimal('50000.00'),
-                'citations': [
-                    {'text': '431',
-                    'title': '2',
-                    'type': 'statute',
-                    'url': 'https://www.govinfo.gov/link/uscode/52/30101'},
-                    {'text': '456',
-                    'title': '11',
-                    'type': 'regulation',
-                    'url': '/regulations/456/CURRENT'}
-                ]
-            }],
+            'commission_votes': [
+                {
+                    'action': 'Conciliation Reached.',
+                    'vote_date': datetime(2008, 1, 1, 0, 0),
+                }
+            ],
+            'dispositions': [
+                {
+                    'disposition': 'Conciliation-PPC',
+                    'respondent': 'Open Elections LLC',
+                    'penalty': Decimal('50000.00'),
+                    'citations': [
+                        {
+                            'text': '431',
+                            'title': '2',
+                            'type': 'statute',
+                            'url': 'https://www.govinfo.gov/link/uscode/52/30101',
+                        },
+                        {
+                            'text': '456',
+                            'title': '11',
+                            'type': 'regulation',
+                            'url': '/regulations/456/CURRENT',
+                        },
+                    ],
+                }
+            ],
             'subjects': ['Fraudulent misrepresentation'],
             'respondents': [],
-            'documents': [], 'participants': [], 'no': '1', 'doc_id': 'mur_1',
+            'documents': [],
+            'participants': [],
+            'no': '1',
+            'doc_id': 'mur_1',
             'published_flg': True,
-            'mur_type': 'current', 'name': 'Open Elections LLC', 'open_date': datetime(2005, 1, 1, 0, 0),
+            'mur_type': 'current',
+            'name': 'Open Elections LLC',
+            'open_date': datetime(2005, 1, 1, 0, 0),
             'election_cycles': [2016],
             'close_date': datetime(2008, 1, 1, 0, 0),
             'url': '/legal/matter-under-review/1/',
             'sort1': -1,
-            'sort2': None
+            'sort2': None,
         }
         assert actual_mur == expected_mur
 
@@ -308,7 +393,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/1/',
             'sort1': -1,
-            'sort2': None
+            'sort2': None,
         }
         expected_mur2 = {
             'no': '2',
@@ -327,7 +412,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/2/',
             'sort1': -2,
-            'sort2': None
+            'sort2': None,
         }
         expected_mur3 = {
             'no': '3',
@@ -346,108 +431,279 @@ class TestLoadCurrentCases(BaseTestCase):
             'open_date': None,
             'url': '/legal/matter-under-review/3/',
             'sort1': -3,
-            'sort2': None
+            'sort2': None,
         }
-        self.create_case(1, expected_mur1['no'], expected_mur1['name'], mur_subject, expected_mur1['published_flg'])
-        self.create_case(2, expected_mur2['no'], expected_mur2['name'], mur_subject, expected_mur2['published_flg'])
-        self.create_case(3, expected_mur3['no'], expected_mur3['name'], mur_subject, expected_mur3['published_flg'])
+        self.create_case(
+            1,
+            expected_mur1['no'],
+            expected_mur1['name'],
+            mur_subject,
+            expected_mur1['published_flg'],
+        )
+        self.create_case(
+            2,
+            expected_mur2['no'],
+            expected_mur2['name'],
+            mur_subject,
+            expected_mur2['published_flg'],
+        )
+        self.create_case(
+            3,
+            expected_mur3['no'],
+            expected_mur3['name'],
+            mur_subject,
+            expected_mur3['published_flg'],
+        )
 
         gen = get_cases('MUR')
-        assert(next(gen)) == expected_mur1
-        assert(next(gen)) == expected_mur2
-        assert(next(gen)) == expected_mur3
+        assert (next(gen)) == expected_mur1
+        assert (next(gen)) == expected_mur2
+        assert (next(gen)) == expected_mur3
 
         actual_murs = [mur for mur in get_cases('MUR', '2')]
         assert actual_murs == [expected_mur2]
 
-    def create_case(self, case_id, case_no, name, subject_description, published_flg, case_type='MUR'):
+    def create_case(
+        self,
+        case_id,
+        case_no,
+        name,
+        subject_description,
+        published_flg,
+        case_type='MUR',
+    ):
         subject_id = self.connection.execute(
-            "SELECT subject_id FROM fecmur.subject "
-            " WHERE description = %s ", subject_description).scalar()
+            "SELECT subject_id FROM fecmur.subject " " WHERE description = %s ",
+            subject_description,
+        ).scalar()
         self.connection.execute(
             "INSERT INTO fecmur.case (case_id, case_no, name, published_flg, case_type) "
-            "VALUES (%s, %s, %s, %s, %s)", case_id, case_no, name, published_flg, case_type)
+            "VALUES (%s, %s, %s, %s, %s)",
+            case_id,
+            case_no,
+            name,
+            published_flg,
+            case_type,
+        )
         if case_type != 'AF':
             self.connection.execute(
                 "INSERT INTO fecmur.case_subject (case_id, subject_id, relatedsubject_id) "
-                "VALUES (%s, %s, -1)", case_id, subject_id)
+                "VALUES (%s, %s, -1)",
+                case_id,
+                subject_id,
+            )
             self.connection.execute(
                 "INSERT INTO fecmur.electioncycle (case_id, election_cycle) "
-                "VALUES (%s, 2016)", case_id)
+                "VALUES (%s, 2016)",
+                case_id,
+            )
 
     def create_admin_fine(
-            self, case_id, committee_id, report_year, report_type,
-            reason_to_believe_action_date, reason_to_believe_fine_amount,
-            challenge_receipt_date, challenge_outcome, final_determination_date,
-            final_determination_amount, check_amount, treasury_referral_date,
-            treasury_referral_amount, petition_court_filing_date,
-            petition_court_decision_date):
+        self,
+        case_id,
+        committee_id,
+        report_year,
+        report_type,
+        reason_to_believe_action_date,
+        reason_to_believe_fine_amount,
+        challenge_receipt_date,
+        challenge_outcome,
+        final_determination_date,
+        final_determination_amount,
+        check_amount,
+        treasury_referral_date,
+        treasury_referral_amount,
+        petition_court_filing_date,
+        petition_court_decision_date,
+    ):
 
         self.connection.execute(
-            "INSERT INTO fecmur.af_case (case_id, committee_id, report_year, report_type, rtb_action_date, rtb_fine_amount, chal_receipt_date, chal_outcome_code_desc, fd_date, fd_final_fine_amount, check_amount, treasury_date, treasury_amount, petition_court_filing_date, petition_court_decision_date) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)", case_id, committee_id, report_year, report_type, reason_to_believe_action_date, reason_to_believe_fine_amount,  challenge_receipt_date, challenge_outcome, final_determination_date, final_determination_amount, check_amount, treasury_referral_date, treasury_referral_amount, petition_court_filing_date, petition_court_decision_date)
+            "INSERT INTO fecmur.af_case (case_id, committee_id, report_year, report_type, \
+            rtb_action_date, rtb_fine_amount, chal_receipt_date, chal_outcome_code_desc, \
+            fd_date, fd_final_fine_amount, check_amount, treasury_date, treasury_amount, \
+            petition_court_filing_date, petition_court_decision_date) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            case_id,
+            committee_id,
+            report_year,
+            report_type,
+            reason_to_believe_action_date,
+            reason_to_believe_fine_amount,
+            challenge_receipt_date,
+            challenge_outcome,
+            final_determination_date,
+            final_determination_amount,
+            check_amount,
+            treasury_referral_date,
+            treasury_referral_amount,
+            petition_court_filing_date,
+            petition_court_decision_date,
+        )
 
-    def create_participant(self, case_id, entity_id, role, name,
-            stage=None, statutory_citation=None, regulatory_citation=None):
+    def create_participant(
+        self,
+        case_id,
+        entity_id,
+        role,
+        name,
+        stage=None,
+        statutory_citation=None,
+        regulatory_citation=None,
+    ):
         role_id = self.connection.execute(
-            "SELECT role_id FROM fecmur.role "
-            " WHERE description = %s ", role).scalar()
+            "SELECT role_id FROM fecmur.role " " WHERE description = %s ", role
+        ).scalar()
         self.connection.execute(
-            "INSERT INTO fecmur.entity (entity_id, name) "
-            "VALUES (%s, %s)", entity_id, name)
+            "INSERT INTO fecmur.entity (entity_id, name) " "VALUES (%s, %s)",
+            entity_id,
+            name,
+        )
         self.connection.execute(
             "INSERT INTO fecmur.players (player_id, entity_id, case_id, role_id) "
-            "VALUES (%s, %s, %s, %s)", entity_id, entity_id, case_id, role_id)
+            "VALUES (%s, %s, %s, %s)",
+            entity_id,
+            entity_id,
+            case_id,
+            role_id,
+        )
         if stage:
-            self.create_violation(case_id, entity_id, stage, statutory_citation, regulatory_citation)
+            self.create_violation(
+                case_id, entity_id, stage, statutory_citation, regulatory_citation
+            )
 
-    def create_violation(self, case_id, entity_id, stage, statutory_citation, regulatory_citation):
+    def create_violation(
+        self, case_id, entity_id, stage, statutory_citation, regulatory_citation
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.violations (case_id, entity_id, stage, statutory_citation, regulatory_citation) "
-            "VALUES (%s, %s, %s, %s, %s)", case_id, entity_id, stage, statutory_citation, regulatory_citation)
+            "VALUES (%s, %s, %s, %s, %s)",
+            case_id,
+            entity_id,
+            stage,
+            statutory_citation,
+            regulatory_citation,
+        )
 
-    def create_document(self, case_id, document_id, category, ocrtext, filename='129812.pdf'):
+    def create_document(
+        self, case_id, document_id, category, ocrtext, filename='129812.pdf'
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.document (document_id, doc_order_id, case_id, category, ocrtext, fileimage, filename) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-            document_id, document_id, case_id, category, ocrtext, ocrtext, filename)
+            document_id,
+            document_id,
+            case_id,
+            category,
+            ocrtext,
+            ocrtext,
+            filename,
+        )
 
     def create_calendar_event(self, entity_id, event_date, event_id, case_id):
         self.connection.execute(
             "INSERT INTO fecmur.calendar (entity_id, event_date, event_id, case_id) "
-            "VALUES (%s, %s, %s, %s)", entity_id, event_date, event_id, case_id)
+            "VALUES (%s, %s, %s, %s)",
+            entity_id,
+            event_date,
+            event_id,
+            case_id,
+        )
 
-    def create_entity(self, entity_id, first_name, last_name, middle_name, prefix, suffix, type, name, pg_date):
+    def create_entity(
+        self,
+        entity_id,
+        first_name,
+        last_name,
+        middle_name,
+        prefix,
+        suffix,
+        type,
+        name,
+        pg_date,
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.entity (entity_id, first_name, last_name, middle_name, "
             "prefix, suffix, type, name, pg_date) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)", entity_id, first_name,
-            last_name, middle_name, prefix, suffix, type, name, pg_date)
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            entity_id,
+            first_name,
+            last_name,
+            middle_name,
+            prefix,
+            suffix,
+            type,
+            name,
+            pg_date,
+        )
 
-    def create_event(self, event_id, parent_event, event_name, path, is_key_date, check_primary_respondent, pg_date):
+    def create_event(
+        self,
+        event_id,
+        parent_event,
+        event_name,
+        path,
+        is_key_date,
+        check_primary_respondent,
+        pg_date,
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.event (event_id, parent_event, event_name, path, is_key_date, "
             "check_primary_respondent, pg_date) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s)", event_id, parent_event,
-            event_name, path, is_key_date, check_primary_respondent, pg_date)
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            event_id,
+            parent_event,
+            event_name,
+            path,
+            is_key_date,
+            check_primary_respondent,
+            pg_date,
+        )
 
     def create_relatedobjects(self, master_key, detail_key, relation_id):
         self.connection.execute(
             "INSERT INTO fecmur.relatedobjects (master_key, detail_key, relation_id) "
-            "VALUES (%s, %s, %s)", master_key, detail_key, relation_id)
+            "VALUES (%s, %s, %s)",
+            master_key,
+            detail_key,
+            relation_id,
+        )
 
-    def create_settlement(self, settlement_id, case_id, initial_amount, final_amount,
-      amount_received, settlement_type, pg_date):
+    def create_settlement(
+        self,
+        settlement_id,
+        case_id,
+        initial_amount,
+        final_amount,
+        amount_received,
+        settlement_type,
+        pg_date,
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.settlement (settlement_id, case_id, initial_amount, "
             "final_amount, amount_received, settlement_type, pg_date) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s)", settlement_id, case_id, initial_amount, final_amount,
-            amount_received, settlement_type, pg_date)
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            settlement_id,
+            case_id,
+            initial_amount,
+            final_amount,
+            amount_received,
+            settlement_type,
+            pg_date,
+        )
 
-    def create_commission(self, commission_id, agenda_date, vote_date, action, case_id, pg_date):
+    def create_commission(
+        self, commission_id, agenda_date, vote_date, action, case_id, pg_date
+    ):
         self.connection.execute(
             "INSERT INTO fecmur.commission (commission_id, agenda_date, vote_date, action, case_id, pg_date) "
-            "VALUES (%s, %s, %s, %s, %s, %s)", commission_id, agenda_date, vote_date, action, case_id, pg_date)
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            commission_id,
+            agenda_date,
+            vote_date,
+            action,
+            case_id,
+            pg_date,
+        )
 
     def clear_test_data(self):
         tables = [
@@ -463,7 +719,7 @@ class TestLoadCurrentCases(BaseTestCase):
             "event",
             "commission",
             "subject",
-            "role"
+            "role",
         ]
         for table in tables:
             self.connection.execute("DELETE FROM fecmur.{}".format(table))

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -26,7 +26,7 @@ class TriggerTestCase(common.BaseTestCase):
 
     def _response(self, qry):
         response = self.app.get(qry)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
         self.assertNotEqual(result, [], "Empty response!")
         self.assertEqual(result['api_version'], __API_VERSION__)
@@ -77,7 +77,7 @@ class TriggerTestCase(common.BaseTestCase):
             results = connection.execute(select).fetchall()
             recipient_nm_list = [name[2] for name in results]
             # the only result not returned is the "bad" last element
-            self.assertEquals(
+            self.assertEqual(
                 set(names[key]) - set(recipient_nm_list), {names[key][-1]}
             )
         connection.close()
@@ -123,7 +123,7 @@ class TriggerTestCase(common.BaseTestCase):
             results = connection.execute(select).fetchall()
             contbr_nm_list = [name[3] for name in results]
             # the only result not returned is the "bad" last element
-            self.assertEquals(set(names[key]) - set(contbr_nm_list), {names[key][-1]})
+            self.assertEqual(set(names[key]) - set(contbr_nm_list), {names[key][-1]})
         connection.close()
 
     def test_schedule_a_contributor_employer_text(self):
@@ -167,7 +167,7 @@ class TriggerTestCase(common.BaseTestCase):
             results = connection.execute(select).fetchall()
             contbr_employer_list = [name[16] for name in results]
             # the only result not returned is the "bad" last element
-            self.assertEquals(
+            self.assertEqual(
                 set(names[key]) - set(contbr_employer_list), {names[key][-1]}
             )
         connection.close()
@@ -213,7 +213,7 @@ class TriggerTestCase(common.BaseTestCase):
             results = connection.execute(select).fetchall()
             contbr_occupation_list = [name[17] for name in results]
             # the only result not returned is the "bad" last element
-            self.assertEquals(
+            self.assertEqual(
                 set(names[key]) - set(contbr_occupation_list), {names[key][-1]}
             )
         connection.close()

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -1,9 +1,6 @@
 import codecs
 import pytest
 import json
-import random
-import string
-import re
 
 import manage
 
@@ -16,9 +13,9 @@ from webservices import rest, __API_VERSION__
 from webservices.rest import db
 from webservices.utils import parse_fulltext
 
+
 @pytest.mark.usefixtures("migrate_db")
 class TriggerTestCase(common.BaseTestCase):
-
     def setUp(self):
         super().setUp()
         self.longMessage = True
@@ -38,7 +35,7 @@ class TriggerTestCase(common.BaseTestCase):
     def _results(self, qry):
         response = self._response(qry)
         return response['results']
-    
+
     def test_schedule_b_exclude(self):
         '''
         Test that for each set of names, searching by the parsed key returns all but the last result.
@@ -48,7 +45,12 @@ class TriggerTestCase(common.BaseTestCase):
         # each list value in the dict below has 3 "good" names, one "bad" name
         names = {
             "Test.com": ['Test.com', 'Test com', 'Test .com', 'Test'],
-            "Steven O'Reilly": ["Steven O'Reilly", "Steven O' Reilly", "Steven O Reilly", "O'Reilly"]
+            "Steven O'Reilly": [
+                "Steven O'Reilly",
+                "Steven O' Reilly",
+                "Steven O Reilly",
+                "O'Reilly",
+            ],
         }
         i = 0
         for key in names:
@@ -57,19 +59,27 @@ class TriggerTestCase(common.BaseTestCase):
                 data = {
                     'recipient_nm': n,
                     'sub_id': 9999999999999999990 + i,
-                    'filing_form': 'F3'
+                    'filing_form': 'F3',
                 }
-                insert = "INSERT INTO disclosure.fec_fitem_sched_b " + \
-                    "(recipient_nm, sub_id, filing_form) " + \
-                    " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                insert = (
+                    "INSERT INTO disclosure.fec_fitem_sched_b "
+                    + "(recipient_nm, sub_id, filing_form) "
+                    + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
-            select = "SELECT * from disclosure.fec_fitem_sched_b " + \
-                "WHERE recipient_name_text @@ to_tsquery('" + parse_fulltext(key) + "');"
+            select = (
+                "SELECT * from disclosure.fec_fitem_sched_b "
+                + "WHERE recipient_name_text @@ to_tsquery('"
+                + parse_fulltext(key)
+                + "');"
+            )
             results = connection.execute(select).fetchall()
             recipient_nm_list = [name[2] for name in results]
-            #the only result not returned is the "bad" last element
-            self.assertEquals(set(names[key]) - set(recipient_nm_list), {names[key][-1]})
+            # the only result not returned is the "bad" last element
+            self.assertEquals(
+                set(names[key]) - set(recipient_nm_list), {names[key][-1]}
+            )
         connection.close()
 
     def test_schedule_a_contributor_name_text(self):
@@ -81,7 +91,12 @@ class TriggerTestCase(common.BaseTestCase):
         # each list value in the dict below has 3 "good" names, one "bad" name
         names = {
             "Test.com": ['Test.com', 'Test com', 'Test .com', 'Test'],
-            "Steven O'Reilly": ["Steven O'Reilly", "Steven O' Reilly", "Steven O Reilly", "O'Reilly"]
+            "Steven O'Reilly": [
+                "Steven O'Reilly",
+                "Steven O' Reilly",
+                "Steven O Reilly",
+                "O'Reilly",
+            ],
         }
         i = 0
         for key in names:
@@ -90,18 +105,24 @@ class TriggerTestCase(common.BaseTestCase):
                 data = {
                     'contbr_nm': n,
                     'sub_id': 9999999999999999990 + i,
-                    'filing_form': 'F3'
+                    'filing_form': 'F3',
                 }
-                insert = "INSERT INTO disclosure.fec_fitem_sched_a " + \
-                    "(contbr_nm, sub_id, filing_form) " + \
-                    " VALUES (%(contbr_nm)s, %(sub_id)s, %(filing_form)s)"
+                insert = (
+                    "INSERT INTO disclosure.fec_fitem_sched_a "
+                    + "(contbr_nm, sub_id, filing_form) "
+                    + " VALUES (%(contbr_nm)s, %(sub_id)s, %(filing_form)s)"
+                )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
-            select = "SELECT * from disclosure.fec_fitem_sched_a " + \
-                "WHERE contributor_name_text @@ to_tsquery('" + parse_fulltext(key) + "');"
+            select = (
+                "SELECT * from disclosure.fec_fitem_sched_a "
+                + "WHERE contributor_name_text @@ to_tsquery('"
+                + parse_fulltext(key)
+                + "');"
+            )
             results = connection.execute(select).fetchall()
             contbr_nm_list = [name[3] for name in results]
-            #the only result not returned is the "bad" last element
+            # the only result not returned is the "bad" last element
             self.assertEquals(set(names[key]) - set(contbr_nm_list), {names[key][-1]})
         connection.close()
 
@@ -114,7 +135,12 @@ class TriggerTestCase(common.BaseTestCase):
         # each list value in the dict below has 3 "good" names, one "bad" name
         names = {
             "Test.com": ['Test.com', 'Test com', 'Test .com', 'Test'],
-            "Steven O'Reilly": ["Steven O'Reilly", "Steven O' Reilly", "Steven O Reilly", "O'Reilly"]
+            "Steven O'Reilly": [
+                "Steven O'Reilly",
+                "Steven O' Reilly",
+                "Steven O Reilly",
+                "O'Reilly",
+            ],
         }
         i = 0
         for key in names:
@@ -123,19 +149,27 @@ class TriggerTestCase(common.BaseTestCase):
                 data = {
                     'contbr_employer': n,
                     'sub_id': 9999999999999999980 + i,
-                    'filing_form': 'F3'
+                    'filing_form': 'F3',
                 }
-                insert = "INSERT INTO disclosure.fec_fitem_sched_a " + \
-                    "(contbr_employer, sub_id, filing_form) " + \
-                    " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                insert = (
+                    "INSERT INTO disclosure.fec_fitem_sched_a "
+                    + "(contbr_employer, sub_id, filing_form) "
+                    + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
-            select = "SELECT * from disclosure.fec_fitem_sched_a " + \
-                "WHERE contributor_employer_text @@ to_tsquery('" + parse_fulltext(key) + "');"
+            select = (
+                "SELECT * from disclosure.fec_fitem_sched_a "
+                + "WHERE contributor_employer_text @@ to_tsquery('"
+                + parse_fulltext(key)
+                + "');"
+            )
             results = connection.execute(select).fetchall()
             contbr_employer_list = [name[16] for name in results]
-            #the only result not returned is the "bad" last element
-            self.assertEquals(set(names[key]) - set(contbr_employer_list), {names[key][-1]})
+            # the only result not returned is the "bad" last element
+            self.assertEquals(
+                set(names[key]) - set(contbr_employer_list), {names[key][-1]}
+            )
         connection.close()
 
     def test_schedule_a_contributor_occupation_text(self):
@@ -147,7 +181,12 @@ class TriggerTestCase(common.BaseTestCase):
         # each list value in the dict below has 3 "good" names, one "bad" name
         names = {
             "Test.com": ['Test.com', 'Test com', 'Test .com', 'Test'],
-            "Steven O'Reilly": ["Steven O'Reilly", "Steven O' Reilly", "Steven O Reilly", "O'Reilly"]
+            "Steven O'Reilly": [
+                "Steven O'Reilly",
+                "Steven O' Reilly",
+                "Steven O Reilly",
+                "O'Reilly",
+            ],
         }
         i = 0
         for key in names:
@@ -156,19 +195,27 @@ class TriggerTestCase(common.BaseTestCase):
                 data = {
                     'contbr_occupation': n,
                     'sub_id': 9999999999999999970 + i,
-                    'filing_form': 'F3'
+                    'filing_form': 'F3',
                 }
-                insert = "INSERT INTO disclosure.fec_fitem_sched_a " + \
-                    "(contbr_occupation, sub_id, filing_form) " + \
-                    " VALUES (%(contbr_occupation)s, %(sub_id)s, %(filing_form)s)"
+                insert = (
+                    "INSERT INTO disclosure.fec_fitem_sched_a "
+                    + "(contbr_occupation, sub_id, filing_form) "
+                    + " VALUES (%(contbr_occupation)s, %(sub_id)s, %(filing_form)s)"
+                )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
-            select = "SELECT * from disclosure.fec_fitem_sched_a " + \
-                "WHERE contributor_occupation_text @@ to_tsquery('" + parse_fulltext(key) + "');"
+            select = (
+                "SELECT * from disclosure.fec_fitem_sched_a "
+                + "WHERE contributor_occupation_text @@ to_tsquery('"
+                + parse_fulltext(key)
+                + "');"
+            )
             results = connection.execute(select).fetchall()
             contbr_occupation_list = [name[17] for name in results]
-            #the only result not returned is the "bad" last element
-            self.assertEquals(set(names[key]) - set(contbr_occupation_list), {names[key][-1]})
+            # the only result not returned is the "bad" last element
+            self.assertEquals(
+                set(names[key]) - set(contbr_occupation_list), {names[key][-1]}
+            )
         connection.close()
 
     def test_schedule_c_loan_source_name_text(self):
@@ -186,21 +233,27 @@ class TriggerTestCase(common.BaseTestCase):
             data = {
                 'loan_src_nm': n,
                 'sub_id': 9999999999999999970 + i,
-                'filing_form': 'F3'
+                'filing_form': 'F3',
             }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_c " + \
-                "(loan_src_nm, sub_id, filing_form) " + \
-                   " VALUES (%(loan_src_nm)s, %(sub_id)s, %(filing_form)s)"
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_c "
+                + "(loan_src_nm, sub_id, filing_form) "
+                + " VALUES (%(loan_src_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        select = "SELECT * from disclosure.fec_fitem_sched_c " + \
-            "WHERE loan_source_name_text @@ to_tsquery('" + parse_fulltext(name) + "');"
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_c "
+            + "WHERE loan_source_name_text @@ to_tsquery('"
+            + parse_fulltext(name)
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         loan_src_nm_list = {na[7] for na in results}
-        #assert all good names in result set
-        assert(names_good.issubset(loan_src_nm_list))
-        #assert no bad names in result set
-        assert(names_bad.isdisjoint(loan_src_nm_list))
+        # assert all good names in result set
+        assert names_good.issubset(loan_src_nm_list)
+        # assert no bad names in result set
+        assert names_bad.isdisjoint(loan_src_nm_list)
         connection.close()
 
     def test_schedule_c_candidate_name_text(self):
@@ -218,21 +271,27 @@ class TriggerTestCase(common.BaseTestCase):
             data = {
                 'cand_nm': n,
                 'sub_id': 9999999999999999960 + i,
-                'filing_form': 'F3'
+                'filing_form': 'F3',
             }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_c " + \
-                "(cand_nm, sub_id, filing_form) " + \
-                   " VALUES (%(cand_nm)s, %(sub_id)s, %(filing_form)s)"
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_c "
+                + "(cand_nm, sub_id, filing_form) "
+                + " VALUES (%(cand_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        select = "SELECT * from disclosure.fec_fitem_sched_c " + \
-            "WHERE candidate_name_text @@ to_tsquery('" + parse_fulltext(name) + "');"
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_c "
+            + "WHERE candidate_name_text @@ to_tsquery('"
+            + parse_fulltext(name)
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         cand_nm_list = {na[32] for na in results}
-        #assert all good names in result set
-        assert(names_good.issubset(cand_nm_list))
-        #assert no bad names in result set
-        assert(names_bad.isdisjoint(cand_nm_list))
+        # assert all good names in result set
+        assert names_good.issubset(cand_nm_list)
+        # assert no bad names in result set
+        assert names_bad.isdisjoint(cand_nm_list)
         connection.close()
 
     def test_schedule_d_creditor_debtor_name_text(self):
@@ -250,23 +309,29 @@ class TriggerTestCase(common.BaseTestCase):
             data = {
                 'cred_dbtr_nm': n,
                 'sub_id': 9999999999999999970 + i,
-                'filing_form': 'F3'
+                'filing_form': 'F3',
             }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_d " + \
-                "(cred_dbtr_nm, sub_id, filing_form) " + \
-                   " VALUES (%(cred_dbtr_nm)s, %(sub_id)s, %(filing_form)s)"
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_d "
+                + "(cred_dbtr_nm, sub_id, filing_form) "
+                + " VALUES (%(cred_dbtr_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        select = "SELECT * from disclosure.fec_fitem_sched_d " + \
-            "WHERE creditor_debtor_name_text @@ to_tsquery('" + parse_fulltext(name) + "');"
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_d "
+            + "WHERE creditor_debtor_name_text @@ to_tsquery('"
+            + parse_fulltext(name)
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         cred_dbtr_nm_list = {na[3] for na in results}
-        #assert all good names in result set
-        assert(names_good.issubset(cred_dbtr_nm_list))
-        #assert no bad names in result set
-        assert(names_bad.isdisjoint(cred_dbtr_nm_list))
+        # assert all good names in result set
+        assert names_good.issubset(cred_dbtr_nm_list)
+        # assert no bad names in result set
+        assert names_bad.isdisjoint(cred_dbtr_nm_list)
         connection.close()
-        
+
     def test_schedule_f_payee_name_text(self):
         '''
         Test to see that pye_nm is parsed correctly and retrieved as
@@ -279,24 +344,26 @@ class TriggerTestCase(common.BaseTestCase):
         i = 0
         for n in names_good.union(names_bad):
             i += 1
-            data = {
-                'pye_nm': n,
-                'sub_id': 9999999999999999970 + i,
-                'filing_form': 'F3'
-            }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_f " + \
-                "(pye_nm, sub_id, filing_form) " + \
-                   " VALUES (%(pye_nm)s, %(sub_id)s, %(filing_form)s)"
+            data = {'pye_nm': n, 'sub_id': 9999999999999999970 + i, 'filing_form': 'F3'}
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_f "
+                + "(pye_nm, sub_id, filing_form) "
+                + " VALUES (%(pye_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        select = "SELECT * from disclosure.fec_fitem_sched_f " + \
-            "WHERE payee_name_text @@ to_tsquery('" + parse_fulltext(name) + "');"
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_f "
+            + "WHERE payee_name_text @@ to_tsquery('"
+            + parse_fulltext(name)
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         pye_nm_list = {na[14] for na in results}
-        #assert all good names in result set
-        assert(names_good.issubset(pye_nm_list))
-        #assert no bad names in result set
-        assert(names_bad.isdisjoint(pye_nm_list))
+        # assert all good names in result set
+        assert names_good.issubset(pye_nm_list)
+        # assert no bad names in result set
+        assert names_bad.isdisjoint(pye_nm_list)
         connection.close()
 
     def test_schedule_f_payee_name_text_accent(self):
@@ -309,26 +376,32 @@ class TriggerTestCase(common.BaseTestCase):
         i = 0
         for n in names:
             i += 1
-            data = {
-                'pye_nm': n,
-                'sub_id': 9999999998999999970 + i,
-                'filing_form': 'F3'
-            }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_f " + \
-                "(pye_nm, sub_id, filing_form) " + \
-                   " VALUES (%(pye_nm)s, %(sub_id)s, %(filing_form)s)"
+            data = {'pye_nm': n, 'sub_id': 9999999998999999970 + i, 'filing_form': 'F3'}
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_f "
+                + "(pye_nm, sub_id, filing_form) "
+                + " VALUES (%(pye_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        select = "SELECT * from disclosure.fec_fitem_sched_f " + \
-            "WHERE payee_name_text @@ to_tsquery('" + parse_fulltext('ÁCCENTED NAME') + "');"
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_f "
+            + "WHERE payee_name_text @@ to_tsquery('"
+            + parse_fulltext('ÁCCENTED NAME')
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         pye_nm_list = {na[14] for na in results}
-        assert(names.issubset(pye_nm_list))
-        select = "SELECT * from disclosure.fec_fitem_sched_f " + \
-            "WHERE payee_name_text @@ to_tsquery('" + parse_fulltext('ACCENTED NAME') + "');"
+        assert names.issubset(pye_nm_list)
+        select = (
+            "SELECT * from disclosure.fec_fitem_sched_f "
+            + "WHERE payee_name_text @@ to_tsquery('"
+            + parse_fulltext('ACCENTED NAME')
+            + "');"
+        )
         results = connection.execute(select).fetchall()
         pye_nm_list = {na[14] for na in results}
-        assert(names.issubset(pye_nm_list))
+        assert names.issubset(pye_nm_list)
         connection.close()
 
     def test_accent_insensitive_sched_a(self):
@@ -337,26 +410,39 @@ class TriggerTestCase(common.BaseTestCase):
         '''
         connection = db.engine.connect()
         # each list value in the dict below has 3 "good" names, one "bad" name
-        names = {'Tést.com', 'Test com', 'Test .com', 'test.com', 'TEST.COM', 'Test.com'}
+        names = {
+            'Tést.com',
+            'Test com',
+            'Test .com',
+            'test.com',
+            'TEST.COM',
+            'Test.com',
+        }
         i = 0
         for n in names:
             i += 1
             data = {
                 'contbr_employer': n,
                 'sub_id': 9999999959999999980 + i,
-                'filing_form': 'F3'
+                'filing_form': 'F3',
             }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_a " + \
-                "(contbr_employer, sub_id, filing_form) " + \
-                " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_a "
+                + "(contbr_employer, sub_id, filing_form) "
+                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test.com'))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='Test.com')
+        )
         contbr_employer_list = {r['contributor_employer'] for r in results}
-        assert(names.issubset(contbr_employer_list))
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Tést.com'))
+        assert names.issubset(contbr_employer_list)
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='Tést.com')
+        )
         contbr_employer_list = {r['contributor_employer'] for r in results}
-        assert(names.issubset(contbr_employer_list))
+        assert names.issubset(contbr_employer_list)
         connection.close()
 
     def test_accent_insensitive_sched_b(self):
@@ -365,27 +451,40 @@ class TriggerTestCase(common.BaseTestCase):
         '''
         connection = db.engine.connect()
         # each list value in the dict below has 3 "good" names, one "bad" name
-        names = {'ést-lou', 'Est lou', 'ést lóu', 'EST LOU', 'est lou', '@@@est      lou---@'}
+        names = {
+            'ést-lou',
+            'Est lou',
+            'ést lóu',
+            'EST LOU',
+            'est lou',
+            '@@@est      lou---@',
+        }
         i = 0
         for n in names:
             i += 1
             data = {
                 'recipient_nm': n,
                 'sub_id': 9999999999995699990 + i,
-                'filing_form': 'F3'
+                'filing_form': 'F3',
             }
-            insert = "INSERT INTO disclosure.fec_fitem_sched_b " + \
-                "(recipient_nm, sub_id, filing_form) " + \
-                " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+            insert = (
+                "INSERT INTO disclosure.fec_fitem_sched_b "
+                + "(recipient_nm, sub_id, filing_form) "
+                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+            )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
-        results = self._results(api.url_for(ScheduleBView, contributor_employer='ést-lou'))
+        results = self._results(
+            api.url_for(ScheduleBView, contributor_employer='ést-lou')
+        )
         print('results = ', results)
         contbr_employer_list = {r['recipient_name'] for r in results}
-        assert(names.issubset(contbr_employer_list))
-        results = self._results(api.url_for(ScheduleBView, contributor_employer='est lou'))
+        assert names.issubset(contbr_employer_list)
+        results = self._results(
+            api.url_for(ScheduleBView, contributor_employer='est lou')
+        )
         contbr_employer_list = {r['recipient_name'] for r in results}
-        assert(names.issubset(contbr_employer_list))
+        assert names.issubset(contbr_employer_list)
         connection.close()
 
     def real_efile_sa7(self):
@@ -403,18 +502,22 @@ class TriggerTestCase(common.BaseTestCase):
             'mname': {'The', '', ''},
             'name': {'Grouch', 'Count', 'Rogers'},
             'indemp': {'The Street', 'The Street', 'The Neighborhood'},
-            'indocc': {'Lead Grouch', 'Vampire/Educator', 'Neighbor'}
+            'indocc': {'Lead Grouch', 'Vampire/Educator', 'Neighbor'},
         }
-        insert = "INSERT INTO real_efile_sa7 " + \
-            "(repid, tran_id, fname, mname, name, indemp, indocc) " + \
-            "VALUES (%(repid)s, %(tran_id)s, %(fname)s, %(mname)s, %(name)s, %(indemp)s, %(indocc)s)"
+        insert = (
+            "INSERT INTO real_efile_sa7 "
+            + "(repid, tran_id, fname, mname, name, indemp, indocc) "
+            + "VALUES (%(repid)s, %(tran_id)s, %(fname)s, %(mname)s, %(name)s, %(indemp)s, %(indocc)s)"
+        )
         connection.executemany(insert, data)
         manage.refresh_materialized(concurrent=False)
-        results = self._results(api.url_for(ScheduleAEfileView, contributor_employer='Neighborhood'))
+        results = self._results(
+            api.url_for(ScheduleAEfileView, contributor_employer='Neighborhood')
+        )
         employer_set = {r['contributor_employer'] for r in results}
-        assert({'The Neighborhood'}.issubset(employer_set))
+        assert {'The Neighborhood'}.issubset(employer_set)
         name_set = {r['contributor_name'] for r in results}
-        assert({'Mr.'}.issubset(name_set))
+        assert {'Mr.'}.issubset(name_set)
         occupation_set = {r['contributor_occupation'] for r in results}
-        assert({'Educator'}.issubset(occupation_set))
+        assert {'Educator'}.issubset(occupation_set)
         connection.close()

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -24,19 +24,22 @@ from webservices.resources.candidate_aggregates import (
     AggregateByOfficeByPartyView,
 )
 
+
 class TestCommitteeAggregates(ApiBaseTest):
     def test_stable_sort(self):
         rows = [
             factories.ScheduleAByEmployerFactory(
-                committee_id='C001',
-                employer='omnicorp-{}'.format(idx),
-                total=538,
+                committee_id='C001', employer='omnicorp-{}'.format(idx), total=538,
             )
             for idx in range(100)
         ]
         employers = []
         for page in range(2):
-            results = self._results(api.url_for(ScheduleAByEmployerView, sort='-total', per_page=50, page=page + 1))
+            results = self._results(
+                api.url_for(
+                    ScheduleAByEmployerView, sort='-total', per_page=50, page=page + 1
+                )
+            )
             employers.extend(result['employer'] for result in results)
         assert len(set(employers)) == len(rows)
 
@@ -75,36 +78,20 @@ class TestCommitteeAggregates(ApiBaseTest):
             ),
         ]
         results = self._results(
-            api.url_for(
-                ScheduleAByStateView,
-                committee_id='C0001',
-                cycle=2012
-            )
+            api.url_for(ScheduleAByStateView, committee_id='C0001', cycle=2012)
         )
         assert len(results) == 1
 
-        results = self._results(
-            api.url_for(
-                ScheduleAByStateView,
-                state='NY',
-            )
-        )
+        results = self._results(api.url_for(ScheduleAByStateView, state='NY',))
         assert len(results) == 2
 
         results = self._results(
-            api.url_for(
-                ScheduleAByStateView,
-                cycle=2018,
-                state='OT',
-            )
+            api.url_for(ScheduleAByStateView, cycle=2018, state='OT',)
         )
         assert len(results) == 1
 
         results = self._results(
-            api.url_for(
-                ScheduleAByStateView,
-                committee_id='C0001',
-            )
+            api.url_for(ScheduleAByStateView, committee_id='C0001',)
         )
         assert len(results) == 2
 
@@ -114,14 +101,14 @@ class TestCommitteeAggregates(ApiBaseTest):
         aggregate = factories.ScheduleBByPurposeFactory(
             committee_id=committee.committee_id,
             cycle=committee.cycle,
-            purpose='ADMINISTRATIVE EXPENSES'
+            purpose='ADMINISTRATIVE EXPENSES',
         )
         results = self._results(
             api.url_for(
                 ScheduleBByPurposeView,
                 committee_id=committee.committee_id,
                 cycle=2012,
-                purpose='Administrative'
+                purpose='Administrative',
             )
         )
         self.assertEqual(len(results), 1)
@@ -142,14 +129,14 @@ class TestCommitteeAggregates(ApiBaseTest):
         aggregate = factories.ScheduleBByRecipientFactory(
             committee_id=committee.committee_id,
             cycle=committee.cycle,
-            recipient_name='STARBOARD STRATEGIES, INC.'
+            recipient_name='STARBOARD STRATEGIES, INC.',
         )
         results = self._results(
             api.url_for(
                 ScheduleBByRecipientView,
                 committee_id=committee.committee_id,
                 cycle=2012,
-                recipient_name='Starboard Strategies'
+                recipient_name='Starboard Strategies',
             )
         )
         self.assertEqual(len(results), 1)
@@ -174,14 +161,14 @@ class TestCommitteeAggregates(ApiBaseTest):
             total=4000,
             count=2,
             memo_total=10,
-            memo_count=1
+            memo_count=1,
         )
         results = self._results(
             api.url_for(
                 ScheduleBByRecipientIDView,
                 committee_id=committee.committee_id,
                 cycle=2012,
-                recipient_id='C00507368'
+                recipient_id='C00507368',
             )
         )
         self.assertEqual(len(results), 1)
@@ -219,8 +206,7 @@ class TestAggregates(ApiBaseTest):
     def setUp(self):
         super(TestAggregates, self).setUp()
         self.committee = factories.CommitteeHistoryFactory(
-            name='Ritchie for America',
-            cycle=2012,
+            name='Ritchie for America', cycle=2012,
         )
         self.candidate = factories.CandidateDetailFactory(
             candidate_id='P123',
@@ -236,8 +222,7 @@ class TestAggregates(ApiBaseTest):
             office='P',
         )
         factories.CandidateElectionFactory(
-            candidate_id='P123',
-            cand_election_year=2012,
+            candidate_id='P123', cand_election_year=2012,
         )
 
     def make_aggregates(self, factory):
@@ -272,10 +257,12 @@ class TestAggregates(ApiBaseTest):
             )
             assert len(results) == 1
             serialized = schema().dump(aggregates[0]).data
-            serialized.update({
-                'committee_name': self.committee.name,
-                'candidate_name': self.candidate.name,
-            })
+            serialized.update(
+                {
+                    'committee_name': self.committee.name,
+                    'candidate_name': self.candidate.name,
+                }
+            )
             assert results[0] == serialized
 
     def test_candidate_aggregates_by_committee_full(self):
@@ -298,12 +285,14 @@ class TestAggregates(ApiBaseTest):
             )
             assert len(results) == 1
             serialized = schema().dump(aggregates[0]).data
-            serialized.update({
-                'committee_name': self.committee.name,
-                'candidate_name': self.candidate.name,
-                'total': sum(each.total for each in aggregates),
-                'count': sum(each.count for each in aggregates),
-            })
+            serialized.update(
+                {
+                    'committee_name': self.committee.name,
+                    'candidate_name': self.candidate.name,
+                    'total': sum(each.total for each in aggregates),
+                    'count': sum(each.count for each in aggregates),
+                }
+            )
             assert results[0] == serialized
 
     def test_candidate_aggregates_by_election(self):
@@ -314,19 +303,14 @@ class TestAggregates(ApiBaseTest):
                     candidate_id=self.candidate.candidate_id,
                     cycle=self.committee.cycle,
                 ),
-                factory(
-                    cycle=self.committee.cycle,
-                ),
+                factory(cycle=self.committee.cycle,),
             ]
             results = self._results(
-                api.url_for(
-                    resource,
-                    office='president',
-                    cycle=2012,
-                )
+                api.url_for(resource, office='president', cycle=2012,)
             )
             assert len(results) == 1
             assert results[0]['candidate_id'] == self.candidate.candidate_id
+
 
 class TestCandidateAggregates(ApiBaseTest):
     current_cycle = get_current_cycle()
@@ -335,22 +319,19 @@ class TestCandidateAggregates(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateHistoryFutureFactory(
-            candidate_id='S123',
-            two_year_period=2012,
-            candidate_election_year=2012,
+            candidate_id='S123', two_year_period=2012, candidate_election_year=2012,
         )
         self.committees = [
             factories.CommitteeHistoryFactory(cycle=2012, designation='P'),
             factories.CommitteeHistoryFactory(cycle=2012, designation='A'),
         ]
         factories.CandidateDetailFactory(
-            candidate_id=self.candidate.candidate_id,
-            election_years=[2008, 2012],
+            candidate_id=self.candidate.candidate_id, election_years=[2008, 2012],
         )
         [
             factories.CandidateElectionFactory(
                 candidate_id=self.candidate.candidate_id,
-                cand_election_year=election_year
+                cand_election_year=election_year,
             )
             for election_year in [2008, 2012]
         ]
@@ -370,9 +351,7 @@ class TestCandidateAggregates(ApiBaseTest):
             is_election=False,
             receipts=75,
         )
-        factories.CandidateFlagsFactory(
-            candidate_id=self.candidate.candidate_id
-        )
+        factories.CandidateFlagsFactory(candidate_id=self.candidate.candidate_id)
         db.session.flush()
         # Create two-year totals for both the target period (2011-2012) and the
         # previous period (2009-2010) for testing the `election_full` flag
@@ -406,11 +385,9 @@ class TestCandidateAggregates(ApiBaseTest):
             two_year_period=2018,
             candidate_election_year=2018,
             candidate_inactive=True,
-
         )
         factories.CandidateDetailFactory(
-            candidate_id=self.candidate_zero.candidate_id,
-            election_years=[2018],
+            candidate_id=self.candidate_zero.candidate_id, election_years=[2018],
         )
         factories.CandidateTotalFactory(
             candidate_id=self.candidate_zero.candidate_id,
@@ -431,19 +408,17 @@ class TestCandidateAggregates(ApiBaseTest):
             two_year_period=2018,
             candidate_election_year=2018,
             candidate_inactive=False,
-
         )
         self.committees_17_18 = [
             factories.CommitteeHistoryFactory(cycle=2018, designation='P'),
         ]
         factories.CandidateDetailFactory(
-            candidate_id=self.candidate_17_18.candidate_id,
-            election_years=[2018],
+            candidate_id=self.candidate_17_18.candidate_id, election_years=[2018],
         )
         [
             factories.CandidateElectionFactory(
                 candidate_id=self.candidate_17_18.candidate_id,
-                cand_election_year=election_year
+                cand_election_year=election_year,
             )
             for election_year in [2017, 2018]
         ]
@@ -463,9 +438,7 @@ class TestCandidateAggregates(ApiBaseTest):
             is_election=False,
             receipts=100,
         )
-        factories.CandidateFlagsFactory(
-            candidate_id=self.candidate_17_18.candidate_id
-        )
+        factories.CandidateFlagsFactory(candidate_id=self.candidate_17_18.candidate_id)
         db.session.flush()
 
         factories.CandidateCommitteeLinkFactory(
@@ -486,21 +459,18 @@ class TestCandidateAggregates(ApiBaseTest):
         )
         # Create data for a candidate who ran just in 2017
         self.candidate_17_only = factories.CandidateHistoryFutureFactory(
-            candidate_id='H456',
-            two_year_period=2018,
-            candidate_election_year=2017,
+            candidate_id='H456', two_year_period=2018, candidate_election_year=2017,
         )
         self.committees_17_only = [
             factories.CommitteeHistoryFactory(cycle=2018, designation='P'),
         ]
         factories.CandidateDetailFactory(
-            candidate_id=self.candidate_17_only.candidate_id,
-            election_years=[2017],
+            candidate_id=self.candidate_17_only.candidate_id, election_years=[2017],
         )
         [
             factories.CandidateElectionFactory(
                 candidate_id=self.candidate_17_only.candidate_id,
-                cand_election_year=election_year
+                cand_election_year=election_year,
             )
             for election_year in [2017]
         ]
@@ -548,9 +518,11 @@ class TestCandidateAggregates(ApiBaseTest):
             two_year_period=self.next_cycle,
             candidate_election_year=self.next_cycle,
         )
-        #Candidate history won't have next_cycle yet
+        # Candidate history won't have next_cycle yet
         self.committees_20 = [
-            factories.CommitteeHistoryFactory(cycle=self.current_cycle, designation='P'),
+            factories.CommitteeHistoryFactory(
+                cycle=self.current_cycle, designation='P'
+            ),
         ]
         factories.CandidateDetailFactory(
             candidate_id=self.candidate_20.candidate_id,
@@ -559,7 +531,7 @@ class TestCandidateAggregates(ApiBaseTest):
         [
             factories.CandidateElectionFactory(
                 candidate_id=self.candidate_20.candidate_id,
-                cand_election_year=election_year
+                cand_election_year=election_year,
             )
             for election_year in [self.next_cycle - 4, self.next_cycle]
         ]
@@ -567,23 +539,21 @@ class TestCandidateAggregates(ApiBaseTest):
             factories.CommitteeDetailFactory(committee_id=each.committee_id)
             for each in self.committees_20
         ]
-        #Full next_cycle
+        # Full next_cycle
         factories.CandidateTotalFactory(
             candidate_id=self.candidate_20.candidate_id,
             cycle=self.next_cycle,
             is_election=True,
             receipts=55000,
         )
-        #current_cycle 2-year
+        # current_cycle 2-year
         factories.CandidateTotalFactory(
             candidate_id=self.candidate_20.candidate_id,
             cycle=self.current_cycle,
             is_election=False,
             receipts=25000,
         )
-        factories.CandidateFlagsFactory(
-            candidate_id=self.candidate_20.candidate_id
-        )
+        factories.CandidateFlagsFactory(candidate_id=self.candidate_20.candidate_id)
         db.session.flush()
 
         factories.CandidateCommitteeLinkFactory(
@@ -777,7 +747,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2012,
-                election_full=False
+                election_full=False,
             )
         )
         assert len(results) == 1
@@ -806,18 +776,18 @@ class TestCandidateAggregates(ApiBaseTest):
         assert len(results) == 1
         assert_dicts_subset(results[0], {'cycle': 2018, 'receipts': 0})
 
-        #active candidate test: loading active candidates result nothing
+        # active candidate test: loading active candidates result nothing
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
                 candidate_id=self.candidate_zero.candidate_id,
                 cycle=2018,
-                is_active_candidate=True
+                is_active_candidate=True,
             )
         )
         assert len(results) == 0
 
-        #active candidate test: loading inactive candidates result current one
+        # active candidate test: loading inactive candidates result current one
         results = self._results(
             api.url_for(
                 TotalsCandidateView,
@@ -846,7 +816,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_17_18.candidate_id,
                 cycle=2018,
-                is_active_candidate=False
+                is_active_candidate=False,
             )
         )
         assert len(results) == 0
@@ -857,7 +827,7 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_17_18.candidate_id,
                 cycle=2018,
-                is_active_candidate=True
+                is_active_candidate=True,
             )
         )
         assert len(results) == 1
@@ -879,11 +849,13 @@ class TestCandidateAggregates(ApiBaseTest):
                 TotalsCandidateView,
                 candidate_id=self.candidate_20.candidate_id,
                 cycle=self.current_cycle,
-                election_full=False
+                election_full=False,
             )
         )
         assert len(results) == 1
-        assert_dicts_subset(results[0], {'cycle': self.current_cycle, 'receipts': 25000})
+        assert_dicts_subset(
+            results[0], {'cycle': self.current_cycle, 'receipts': 25000}
+        )
 
     def test_totals_full(self):
         results = self._results(
@@ -911,16 +883,13 @@ class TestCandidateAggregates(ApiBaseTest):
 
 
 class TestCandidateTotalsByOffice(ApiBaseTest):
-
     def setUp(self):
         super().setUp()
         self.candidate_1 = factories.CandidateHistoryFutureFactory(
-            candidate_id='S123',
-            candidate_election_year=2016,
+            candidate_id='S123', candidate_election_year=2016,
         )
         self.candidate_2 = factories.CandidateHistoryFutureFactory(
-            candidate_id='S456',
-            candidate_election_year=2016,
+            candidate_id='S456', candidate_election_year=2016,
         )
         self.candidate_3 = factories.CandidateHistoryFutureFactory(
             candidate_id='S789',
@@ -929,9 +898,7 @@ class TestCandidateTotalsByOffice(ApiBaseTest):
             candidate_inactive=True,
         )
         self.candidate_4 = factories.CandidateHistoryFutureFactory(
-            candidate_id='P123',
-            two_year_period=2018,
-            candidate_election_year=2020,
+            candidate_id='P123', two_year_period=2018, candidate_election_year=2020,
         )
         factories.CandidateTotalFactory(
             candidate_id=self.candidate_1.candidate_id,
@@ -970,44 +937,27 @@ class TestCandidateTotalsByOffice(ApiBaseTest):
         )
 
     def test_candidate_totals_by_office(self):
-        results = self._results(
-            api.url_for(
-                AggregateByOfficeView,
-            )
-        )
+        results = self._results(api.url_for(AggregateByOfficeView,))
         assert len(results) == 2
 
-        results = self._results(
-            api.url_for(
-                AggregateByOfficeView,
-                office='S'
-            )
-        )
+        results = self._results(api.url_for(AggregateByOfficeView, office='S'))
         assert len(results) == 1
         assert_dicts_subset(results[0], {'election_year': 2016, 'total_receipts': 5121})
 
         results = self._results(
-            api.url_for(
-                AggregateByOfficeView,
-                office='S',
-                is_active_candidate=True,
-            )
+            api.url_for(AggregateByOfficeView, office='S', is_active_candidate=True,)
         )
         assert len(results) == 1
         assert_dicts_subset(results[0], {'election_year': 2016, 'total_receipts': 121})
 
         results = self._results(
-            api.url_for(
-                AggregateByOfficeView,
-                office='S',
-                is_active_candidate=False,
-            )
+            api.url_for(AggregateByOfficeView, office='S', is_active_candidate=False,)
         )
         assert len(results) == 1
         assert_dicts_subset(results[0], {'election_year': 2016, 'total_receipts': 5000})
 
-class TestCandidateTotalsByOfficeByParty(ApiBaseTest):
 
+class TestCandidateTotalsByOfficeByParty(ApiBaseTest):
     def setUp(self):
         super().setUp()
         factories.CandidateTotalFactory(
@@ -1082,38 +1032,51 @@ class TestCandidateTotalsByOfficeByParty(ApiBaseTest):
         )
 
     def test_candidate_totals_by_office_by_party(self):
-        results = self._results(
-            api.url_for(
-                AggregateByOfficeByPartyView,
-            )
-        )
+        results = self._results(api.url_for(AggregateByOfficeByPartyView,))
         assert len(results) == 6
 
-        results = self._results(
-            api.url_for(
-                AggregateByOfficeByPartyView,
-                office='S'
-            )
-        )
+        results = self._results(api.url_for(AggregateByOfficeByPartyView, office='S'))
         assert len(results) == 2
         assert_dicts_subset(
-            results[0], {'election_year': 2016, 'party': 'DEM', 'total_receipts': 100, 'total_disbursements': 100}
+            results[0],
+            {
+                'election_year': 2016,
+                'party': 'DEM',
+                'total_receipts': 100,
+                'total_disbursements': 100,
+            },
         )
         assert_dicts_subset(
-            results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 10000, 'total_disbursements': 10000}
+            results[1],
+            {
+                'election_year': 2016,
+                'party': 'REP',
+                'total_receipts': 10000,
+                'total_disbursements': 10000,
+            },
         )
 
         results = self._results(
             api.url_for(
-                AggregateByOfficeByPartyView,
-                office='H',
-                is_active_candidate=True,
+                AggregateByOfficeByPartyView, office='H', is_active_candidate=True,
             )
         )
         assert len(results) == 2
         assert_dicts_subset(
-            results[0], {'election_year': 2016, 'party': 'Other', 'total_receipts': 300, 'total_disbursements': 300}
+            results[0],
+            {
+                'election_year': 2016,
+                'party': 'Other',
+                'total_receipts': 300,
+                'total_disbursements': 300,
+            },
         )
         assert_dicts_subset(
-            results[1], {'election_year': 2016, 'party': 'REP', 'total_receipts': 200, 'total_disbursements': 200}
+            results[1],
+            {
+                'election_year': 2016,
+                'party': 'REP',
+                'total_receipts': 200,
+                'total_disbursements': 200,
+            },
         )

--- a/tests/test_ao_citations.py
+++ b/tests/test_ao_citations.py
@@ -13,122 +13,235 @@ from webservices.legal_docs.advisory_opinions import (
 EMPTY_SET = set()
 
 
-@pytest.mark.parametrize("text,ao_nos,expected", [
-    ("1994-01", {"1994-01"}, {"1994-01"}),
-    ("Nothing here", {"1994-01"}, EMPTY_SET),
-    ("1994-01 not in filter set", {"1994-02"}, EMPTY_SET),
-    ("1994-01 remove duplicates 1994-01", {"1994-01"}, {"1994-01"}),
-    ("1994-01 find multiple 1994-02", {"1994-01", "1994-02"}, {"1994-01", "1994-02"}),
-    ("1994-01not a word boundary", {"1994-01"}, EMPTY_SET),
-    ("1994-doesn't match pattern", {"1994-01"}, EMPTY_SET),
-    ("1994-123 works if the serial number has 3 digits", {"1994-123"}, {"1994-123"}),
-    ("1994-1 works if the citation drops leading 0 in serial number", {"1994-01"}, {"1994-01"}),
-    ("1994-01 also works if the actual AO drops leading 0 in serial number", {"1994-1"}, {"1994-1"}),
-])
+@pytest.mark.parametrize(
+    "text,ao_nos,expected",
+    [
+        ("1994-01", {"1994-01"}, {"1994-01"}),
+        ("Nothing here", {"1994-01"}, EMPTY_SET),
+        ("1994-01 not in filter set", {"1994-02"}, EMPTY_SET),
+        ("1994-01 remove duplicates 1994-01", {"1994-01"}, {"1994-01"}),
+        (
+            "1994-01 find multiple 1994-02",
+            {"1994-01", "1994-02"},
+            {"1994-01", "1994-02"},
+        ),
+        ("1994-01not a word boundary", {"1994-01"}, EMPTY_SET),
+        ("1994-doesn't match pattern", {"1994-01"}, EMPTY_SET),
+        (
+            "1994-123 works if the serial number has 3 digits",
+            {"1994-123"},
+            {"1994-123"},
+        ),
+        (
+            "1994-1 works if the citation drops leading 0 in serial number",
+            {"1994-01"},
+            {"1994-01"},
+        ),
+        (
+            "1994-01 also works if the actual AO drops leading 0 in serial number",
+            {"1994-1"},
+            {"1994-1"},
+        ),
+    ],
+)
 def test_parse_ao_citations(text, ao_nos, expected):
     ao_component_to_name_map = {tuple(map(int, a.split('-'))): a for a in ao_nos}
     assert parse_ao_citations(text, ao_component_to_name_map) == expected
 
-@pytest.mark.parametrize("title,section,expected", [
-    ("52", "10-Day", False),
-    ("2", "431", True),
-    ("2", "590", False),
-    ("18", "590", True),
-    ("18", "100", True),
-    ("18", "620", False),
-    ("26", "9001", True),
-    ("26", "9050", False),
-    ("26", "501", True),
-    ("26", "525", False),
-    ("52", "30101", True),
-    ("26", "30201", False),
-    ("123", "123456", True),
-])
+
+@pytest.mark.parametrize(
+    "title,section,expected",
+    [
+        ("52", "10-Day", False),
+        ("2", "431", True),
+        ("2", "590", False),
+        ("18", "590", True),
+        ("18", "100", True),
+        ("18", "620", False),
+        ("26", "9001", True),
+        ("26", "9050", False),
+        ("26", "501", True),
+        ("26", "525", False),
+        ("52", "30101", True),
+        ("26", "30201", False),
+        ("123", "123456", True),
+    ],
+)
 def test_validate_statute_citation(title, section, expected):
     assert validate_statute_citation(title, section) == expected
 
-@pytest.mark.parametrize("text,expected", [
-    ("2 U.S.C. 432", set([(52, '30102')])),
-    ("52 U.S.C. 30116(a", set([(52, '30116')])),
-    ("52 USC § 30116a", set([(52, '30116a')])),
-    ("2 U.S.C. 441a-1", set([(52, '30117')])),
-    (" 2 U.S.C. §437f", set([(52, '30108')])),
-    ("52 U.S.C. §§ 30101-30146", set([(52, '30101')])),
-    ("52 U.S.C. § 30101", set([(52, '30101')])),
-    (" 2 USC §437f **test with no . in USC**", set([(52, '30108')])),
-    ("52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words", set([(52, '30101')])),
-    ("18 U.S.C. 613 (1970)", set([(18, '613')])),
-    # Test multiples
-    ("52 U.S.C §§ 30106(c), 30107(a)(7) other words.", set([(52, '30106'), (52, '30107')])),
-    ("2 U.S.C. §§431(9) and 439a;", set([(52, '30101'), (52, '30114')])),
-    ("2 U.S.C. 441b, 441c, 441e.", set([(52, '30118'), (52, '30119'), (52, '30121')])),
-    ("52 U.S.C. 30101, 30108 and 10 days.", set([(52, '30101'), (52, '30108')])),
-    ("18 U.S.C. §§610, 611, 613, 614 and 615.", set([(18, '610'), (18, '611'), (18, '613'), (18, '613'), (18, '614'), (18, '615')])),
-    ("2 U.S.C. §§434(b)(2)(A) and (3)(A), and 431(13) *we need the sentence to end*.", set([(52, '30104'), (52, '30101')])),
-    ("2 U.S.C. 439a and 11 CFR Part 113.", set([(52, '30114')])),
-    ("52 U.S.C. §§ 30101(4) (defining political committee), 30104(a), (b) (reporting requirements of political committees).", set([(52, '30101'), (52, '30104')])),
-    ("2 U.S.C. 432(e)(1), 433, and 434(a).", set([(52, '30102'), (52, '30103'), (52, '30104')])),
-])
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("2 U.S.C. 432", set([(52, '30102')])),
+        ("52 U.S.C. 30116(a", set([(52, '30116')])),
+        ("52 USC § 30116a", set([(52, '30116a')])),
+        ("2 U.S.C. 441a-1", set([(52, '30117')])),
+        (" 2 U.S.C. §437f", set([(52, '30108')])),
+        ("52 U.S.C. §§ 30101-30146", set([(52, '30101')])),
+        ("52 U.S.C. § 30101", set([(52, '30101')])),
+        (" 2 USC §437f **test with no . in USC**", set([(52, '30108')])),
+        (
+            "52 U.S.C. § 30101 **newline needed to ensure two entries**,\n 52 USC. § 30101 other words",
+            set([(52, '30101')]),
+        ),
+        ("18 U.S.C. 613 (1970)", set([(18, '613')])),
+        # Test multiples
+        (
+            "52 U.S.C §§ 30106(c), 30107(a)(7) other words.",
+            set([(52, '30106'), (52, '30107')]),
+        ),
+        ("2 U.S.C. §§431(9) and 439a;", set([(52, '30101'), (52, '30114')])),
+        (
+            "2 U.S.C. 441b, 441c, 441e.",
+            set([(52, '30118'), (52, '30119'), (52, '30121')]),
+        ),
+        ("52 U.S.C. 30101, 30108 and 10 days.", set([(52, '30101'), (52, '30108')])),
+        (
+            "18 U.S.C. §§610, 611, 613, 614 and 615.",
+            set(
+                [
+                    (18, '610'),
+                    (18, '611'),
+                    (18, '613'),
+                    (18, '613'),
+                    (18, '614'),
+                    (18, '615'),
+                ]
+            ),
+        ),
+        (
+            "2 U.S.C. §§434(b)(2)(A) and (3)(A), and 431(13) *we need the sentence to end*.",
+            set([(52, '30104'), (52, '30101')]),
+        ),
+        ("2 U.S.C. 439a and 11 CFR Part 113.", set([(52, '30114')])),
+        (
+            "52 U.S.C. §§ 30101(4) (defining political committee), 30104(a), \
+            (b) (reporting requirements of political committees).",
+            set([(52, '30101'), (52, '30104')]),
+        ),
+        (
+            "2 U.S.C. 432(e)(1), 433, and 434(a).",
+            set([(52, '30102'), (52, '30103'), (52, '30104')]),
+        ),
+    ],
+)
 def test_parse_statutory_citations(text, expected):
     assert parse_statutory_citations(text) == expected
 
 
-@pytest.mark.parametrize("title,part,expected", [
-    ("11", "123c", False),
-    ("11", "1", True),
-    ("11", "9", False),
-    ("11", "100", True),
-    ("11", "121", False),
-    ("11", "200", True),
-    ("11", "210", False),
-    ("11", "300", True),
-    ("11", "310", False),
-    ("11", "9001", True),
-    ("11", "9100", False),
-    ("12", "544", True),
-    ("11", "400", True),
-    # Check on 11 CFR 140.8-142
-])
+@pytest.mark.parametrize(
+    "title,part,expected",
+    [
+        ("11", "123c", False),
+        ("11", "1", True),
+        ("11", "9", False),
+        ("11", "100", True),
+        ("11", "121", False),
+        ("11", "200", True),
+        ("11", "210", False),
+        ("11", "300", True),
+        ("11", "310", False),
+        ("11", "9001", True),
+        ("11", "9100", False),
+        ("12", "544", True),
+        ("11", "400", True),
+        # Check on 11 CFR 140.8-142
+    ],
+)
 def test_validate_regulation_citation(title, part, expected):
     assert validate_regulation_citation(title, part) == expected
 
 
-@pytest.mark.parametrize("text,expected", [
-    ("11 CFR 113.2", set([(11, 113, 2)])),
-    ("11 CFR §9034.4(b)(4)", set([(11, 9034, 4)])),
-    # Doubles
-    ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),
-    ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
-    ("11 C.F.R. § 100.15 **newline needed to ensure two entries**,\n 11 C.F.R. § 100.15", set([(11, 100, 15)])),
-    ("11 CFR 300.60 through 300.65", set([(11, 300, 60), (11, 300, 65)])),
-    ("11 C.F.R. §§ 100.73,100.132; The next", set([(11, 100, 73), (11, 100, 132)])),
-    ("11 C.F.R. §§ 100.5(g)(4)(ii)(F) and 110.3(a)(3)(ii)(F)",
-        set([(11, 100, 5), (11, 110, 3)])),
-    ("11 CFR 300.60 and 300.61.", set([(11, 300, 60), (11, 300, 61)])),
-    # Three or more
-    ("2 U.S.C. 432(e)(1), 433, and 434(a); 11 CFR 101.1, 102.1, and 104.1; Then the 10-day rule applies.", set([(11, 101, 1), (11, 102, 1), (11, 104, 1)])),
-    ("11 CFR 100.7(a)(1), 110.1(b)(3), 110.2(b)(3), and 110.3(g)",
-            set([(11, 100, 7), (11, 110, 1), (11, 110, 2), (11, 110, 3)])),
-    ("11 CFR 101.1, 102.1, 103.1, 104.1 and 105.1; Then the 10-day rule applies.",
-        set([(11, 101, 1), (11, 102, 1), (11, 103, 1), (11, 104, 1), (11, 105, 1)])),
-    # Sets
-    ("11 CFR 100.4(b)(15) and 100.7(b)(17) as 11 CFR 100.6(b)(20) and 100.8(b)(20)", set([(11, 100, 4), (11, 100, 7), (11, 100, 6), (11, 100, 8)])),
-
-
-])
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("11 CFR 113.2", set([(11, 113, 2)])),
+        ("11 CFR §9034.4(b)(4)", set([(11, 9034, 4)])),
+        # Doubles
+        ("11 CFR 300.60 and 11 CFR 300.62", set([(11, 300, 60), (11, 300, 62)])),
+        ("11 C.F.R. § 100.15", set([(11, 100, 15)])),
+        (
+            "11 C.F.R. § 100.15 **newline needed to ensure two entries**,\n 11 C.F.R. § 100.15",
+            set([(11, 100, 15)]),
+        ),
+        ("11 CFR 300.60 through 300.65", set([(11, 300, 60), (11, 300, 65)])),
+        ("11 C.F.R. §§ 100.73,100.132; The next", set([(11, 100, 73), (11, 100, 132)])),
+        (
+            "11 C.F.R. §§ 100.5(g)(4)(ii)(F) and 110.3(a)(3)(ii)(F)",
+            set([(11, 100, 5), (11, 110, 3)]),
+        ),
+        ("11 CFR 300.60 and 300.61.", set([(11, 300, 60), (11, 300, 61)])),
+        # Three or more
+        (
+            "2 U.S.C. 432(e)(1), 433, and 434(a); 11 CFR 101.1, 102.1, and 104.1; Then the 10-day rule applies.",
+            set([(11, 101, 1), (11, 102, 1), (11, 104, 1)]),
+        ),
+        (
+            "11 CFR 100.7(a)(1), 110.1(b)(3), 110.2(b)(3), and 110.3(g)",
+            set([(11, 100, 7), (11, 110, 1), (11, 110, 2), (11, 110, 3)]),
+        ),
+        (
+            "11 CFR 101.1, 102.1, 103.1, 104.1 and 105.1; Then the 10-day rule applies.",
+            set([(11, 101, 1), (11, 102, 1), (11, 103, 1), (11, 104, 1), (11, 105, 1)]),
+        ),
+        # Sets
+        (
+            "11 CFR 100.4(b)(15) and 100.7(b)(17) as 11 CFR 100.6(b)(20) and 100.8(b)(20)",
+            set([(11, 100, 4), (11, 100, 7), (11, 100, 6), (11, 100, 8)]),
+        ),
+    ],
+)
 def test_parse_regulatory_citations(text, expected):
     assert parse_regulatory_citations(text) == expected
 
 
 class TestManualCitations(unittest.TestCase):
     def test_exclude_citations(self):
-        original_ao_citations = set(['2011-12', '2017-03', '2014-18', '2010-11', '2004-41', '2007-13', '1996-26', '2005-17', '2017-01', '2016-02', '2012-21', '2012-23', '2014-11', '2002-15', '2006-12', '2015-16', '2014-21'])
+        original_ao_citations = set(
+            [
+                '2011-12',
+                '2017-03',
+                '2014-18',
+                '2010-11',
+                '2004-41',
+                '2007-13',
+                '1996-26',
+                '2005-17',
+                '2017-01',
+                '2016-02',
+                '2012-21',
+                '2012-23',
+                '2014-11',
+                '2002-15',
+                '2006-12',
+                '2015-16',
+                '2014-21',
+            ]
+        )
         fixed_citations = fix_citations('2017-03', 'ao', original_ao_citations)
         assert '2010-11' not in fixed_citations
         assert '2011-12' not in fixed_citations
         assert '2015-16' not in fixed_citations
 
     def test_include_citations(self):
-        original_reg_citations = set([(11, 110, 4), (11, 110, 1), (11, 102, 9), (11, 102, 6), (11, 114, 5), (11, 100, 8), (11, 114, 1), (11, 100, 5), (11, 103, 3), (11, 104, 14), (11, 100, 6), (11, 102, 8), (11, 114, 7)])
+        original_reg_citations = set(
+            [
+                (11, 110, 4),
+                (11, 110, 1),
+                (11, 102, 9),
+                (11, 102, 6),
+                (11, 114, 5),
+                (11, 100, 8),
+                (11, 114, 1),
+                (11, 100, 5),
+                (11, 103, 3),
+                (11, 104, 14),
+                (11, 100, 6),
+                (11, 102, 8),
+                (11, 114, 7),
+            ]
+        )
         fixed_citations = fix_citations('1999-40', 'regulation', original_reg_citations)
         assert (11, 110, 3) in fixed_citations

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,7 @@ class OverallTest(ApiBaseTest):
 
     def test_full_text_no_results(self):
         results = self._results(api.url_for(CandidateList, q='asdfasdf'))
-        self.assertEquals(results, [])
+        self.assertEqual(results, [])
 
     def test_cycle_filter(self):
         factories.CandidateFactory(cycles=[1986, 1988])
@@ -56,22 +56,22 @@ class OverallTest(ApiBaseTest):
     def test_per_page_defaults_to_20(self):
         [factories.CandidateFactory() for _ in range(40)]
         results = self._results(api.url_for(CandidateList))
-        self.assertEquals(len(results), 20)
+        self.assertEqual(len(results), 20)
 
     def test_per_page_param(self):
         [factories.CandidateFactory() for _ in range(20)]
         results = self._results(api.url_for(CandidateList, per_page=5))
-        self.assertEquals(len(results), 5)
+        self.assertEqual(len(results), 5)
 
     def test_invalid_per_page_param(self):
         results = self.app.get(api.url_for(CandidateList, per_page=-10))
-        self.assertEquals(results.status_code, 422)
+        self.assertEqual(results.status_code, 422)
         results = self.app.get(api.url_for(CandidateList, per_page=101))
-        self.assertEquals(results.status_code, 422)
+        self.assertEqual(results.status_code, 422)
         results = self.app.get(api.url_for(CandidateList, per_page=34.2))
-        self.assertEquals(results.status_code, 422)
+        self.assertEqual(results.status_code, 422)
         results = self.app.get(api.url_for(CandidateList, per_page='dynamic-wombats'))
-        self.assertEquals(results.status_code, 422)
+        self.assertEqual(results.status_code, 422)
 
     def test_page_param(self):
         [factories.CandidateFactory() for _ in range(20)]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,8 +19,7 @@ class OverallTest(ApiBaseTest):
     def test_full_text_search(self):
         candidate = factories.CandidateFactory(name='Josiah Bartlet')
         factories.CandidateSearchFactory(
-            id=candidate.candidate_id,
-            fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
+            id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
         rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='bartlet'))
@@ -30,8 +29,7 @@ class OverallTest(ApiBaseTest):
     def test_full_text_search_with_whitespace(self):
         candidate = factories.CandidateFactory(name='Josiah Bartlet')
         factories.CandidateSearchFactory(
-            id=candidate.candidate_id,
-            fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
+            id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
         rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='bartlet josiah'))
@@ -77,7 +75,9 @@ class OverallTest(ApiBaseTest):
 
     def test_page_param(self):
         [factories.CandidateFactory() for _ in range(20)]
-        page_one_and_two = self._results(api.url_for(CandidateList, per_page=10, page=1))
+        page_one_and_two = self._results(
+            api.url_for(CandidateList, per_page=10, page=1)
+        )
         page_two = self._results(api.url_for(CandidateList, per_page=5, page=2))
         self.assertEqual(page_two[0], page_one_and_two[5])
         for itm in page_two:
@@ -103,8 +103,7 @@ class OverallTest(ApiBaseTest):
 
     def test_typeahead_candidate_search_id(self):
         row = factories.CandidateSearchFactory(
-            name='Bartlet',
-            fulltxt=sa.func.to_tsvector('Bartlet P0123'),
+            name='Bartlet', fulltxt=sa.func.to_tsvector('Bartlet P0123'),
         )
         decoy = factories.CandidateSearchFactory()  # noqa
         rest.db.session.flush()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -3,17 +3,33 @@ from tests import factories
 from tests.common import ApiBaseTest
 from webservices.rest import api
 from webservices import rest
-from webservices.resources.audit import AuditCaseView, AuditCategoryView, AuditPrimaryCategoryView
-from webservices.resources.audit import AuditCandidateNameSearch, AuditCommitteeNameSearch
-from webservices.schemas import AuditCaseSchema, AuditCategorySchema, AuditPrimaryCategorySchema
+from webservices.resources.audit import (
+    AuditCaseView,
+    AuditCategoryView,
+    AuditPrimaryCategoryView,
+)
+from webservices.resources.audit import (
+    AuditCandidateNameSearch,
+    AuditCommitteeNameSearch,
+)
+from webservices.schemas import (
+    AuditCaseSchema,
+    AuditCategorySchema,
+    AuditPrimaryCategorySchema,
+)
+
 
 class TestAuditCase(ApiBaseTest):
     def test_combination_primarykey(self):
         factories.AuditCaseFactory()
-        results = self._results(api.url_for(AuditCaseView,
-            audit_case_id='2219',
-            primary_category_id='3',
-            sub_category_id='227'))
+        results = self._results(
+            api.url_for(
+                AuditCaseView,
+                audit_case_id='2219',
+                primary_category_id='3',
+                sub_category_id='227',
+            )
+        )
         assert len(results) == 1
         assert results[0].keys() == AuditCaseSchema().fields.keys()
 
@@ -21,8 +37,7 @@ class TestAuditCase(ApiBaseTest):
 class TestAuditCategory(ApiBaseTest):
     def test_primarykey(self):
         factories.AuditCategoryFactory()
-        results = self._results(api.url_for(AuditCategoryView,
-            primary_category_id='3'))
+        results = self._results(api.url_for(AuditCategoryView, primary_category_id='3'))
         assert len(results) == 1
         assert results[0].keys() == AuditCategorySchema().fields.keys()
 
@@ -30,17 +45,24 @@ class TestAuditCategory(ApiBaseTest):
 class TestAuditPrimaryCategory(ApiBaseTest):
     def test_primarykey(self):
         factories.AuditPrimaryCategoryFactory()
-        results = self._results(api.url_for(AuditPrimaryCategoryView,
-            primary_category_id='3'))
+        results = self._results(
+            api.url_for(AuditPrimaryCategoryView, primary_category_id='3')
+        )
         assert len(results) == 1
         assert results[0].keys() == AuditPrimaryCategorySchema().fields.keys()
 
 
 class TestAuditCandidateNameSearch(ApiBaseTest):
     def test_fulltext_match(self):
-        factories.AuditCandidateSearchFactory(id='S2TX00312', fulltxt=sa.func.to_tsvector('CRUZ, RAFAEL EDWARD TED'))
-        factories.AuditCandidateSearchFactory(id='H4TX02108', fulltxt=sa.func.to_tsvector('POE, TED'))
-        factories.AuditCandidateSearchFactory(id='H4CA33119', fulltxt=sa.func.to_tsvector('LIEU, TED'))
+        factories.AuditCandidateSearchFactory(
+            id='S2TX00312', fulltxt=sa.func.to_tsvector('CRUZ, RAFAEL EDWARD TED')
+        )
+        factories.AuditCandidateSearchFactory(
+            id='H4TX02108', fulltxt=sa.func.to_tsvector('POE, TED')
+        )
+        factories.AuditCandidateSearchFactory(
+            id='H4CA33119', fulltxt=sa.func.to_tsvector('LIEU, TED')
+        )
         rest.db.session.flush()
         results = self._results(api.url_for(AuditCandidateNameSearch, q='TED'))
         self.assertEqual(len(results), 3)
@@ -49,11 +71,19 @@ class TestAuditCandidateNameSearch(ApiBaseTest):
 
 class TestAuditCommitteeNameSearch(ApiBaseTest):
     def test_fulltext_match(self):
-        factories.AuditCommitteeSearchFactory(id='C00495622', fulltxt=sa.func.to_tsvector('GARY JOHNSON 2012 INC'))
-        factories.AuditCommitteeSearchFactory(id='C00431205', fulltxt=sa.func.to_tsvector('JOHN EDWARDS FOR PRESIDENT'))
-        factories.AuditCommitteeSearchFactory(id='C00396044',
-            fulltxt=sa.func.to_tsvector('JOHN KENNEDY FOR US SENATE INC'))
-        factories.AuditCommitteeSearchFactory(id='C00366773', fulltxt=sa.func.to_tsvector('JOHN SULLIVAN FOR CONGRESS'))
+        factories.AuditCommitteeSearchFactory(
+            id='C00495622', fulltxt=sa.func.to_tsvector('GARY JOHNSON 2012 INC')
+        )
+        factories.AuditCommitteeSearchFactory(
+            id='C00431205', fulltxt=sa.func.to_tsvector('JOHN EDWARDS FOR PRESIDENT')
+        )
+        factories.AuditCommitteeSearchFactory(
+            id='C00396044',
+            fulltxt=sa.func.to_tsvector('JOHN KENNEDY FOR US SENATE INC'),
+        )
+        factories.AuditCommitteeSearchFactory(
+            id='C00366773', fulltxt=sa.func.to_tsvector('JOHN SULLIVAN FOR CONGRESS')
+        )
         rest.db.session.flush()
         results = self._results(api.url_for(AuditCommitteeNameSearch, q='JOHN'))
         self.assertEqual(len(results), 4)

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -34,13 +34,19 @@ fields = dict(
 
 class CandidateFormatTest(ApiBaseTest):
     """Test/Document expected formats"""
+
     def test_candidate(self):
         """Compare results to expected fields."""
         candidate = factories.CandidateDetailFactory(**fields)
         response = self._response(
             api.url_for(CandidateView, candidate_id=candidate.candidate_id)
         )
-        assert response['pagination'] == {'count': 1, 'page': 1, 'pages': 1, 'per_page': 20}
+        assert response['pagination'] == {
+            'count': 1,
+            'page': 1,
+            'pages': 1,
+            'per_page': 20,
+        }
         # we are showing the full history rather than one result
         assert len(response['results']) == 1
 
@@ -94,7 +100,7 @@ class CandidateFormatTest(ApiBaseTest):
 
     def test_fields(self):
         candidate = factories.CandidateDetailFactory()
-        flags = factories.CandidateFlagsFactory(candidate_id=candidate.candidate_id)
+        factories.CandidateFlagsFactory(candidate_id=candidate.candidate_id)
         response = self._results(
             api.url_for(CandidateView, candidate_id=candidate.candidate_id)
         )
@@ -103,8 +109,7 @@ class CandidateFormatTest(ApiBaseTest):
 
     def test_extra_fields(self):
         candidate = factories.CandidateDetailFactory(
-            address_street_1='PO Box 8102',
-            address_zip='60680',
+            address_street_1='PO Box 8102', address_zip='60680',
         )
         response = self._results(
             api.url_for(CandidateView, candidate_id=candidate.candidate_id)
@@ -115,9 +120,13 @@ class CandidateFormatTest(ApiBaseTest):
 
     def test_fulltext_match(self):
         danielle = factories.CandidateFactory(name='Danielle')
-        factories.CandidateSearchFactory(id=danielle.candidate_id, fulltxt=sa.func.to_tsvector('Danielle'))
+        factories.CandidateSearchFactory(
+            id=danielle.candidate_id, fulltxt=sa.func.to_tsvector('Danielle')
+        )
         dana = factories.CandidateFactory(name='Dana')
-        factories.CandidateSearchFactory(id=dana.candidate_id, fulltxt=sa.func.to_tsvector('Dana'))
+        factories.CandidateSearchFactory(
+            id=dana.candidate_id, fulltxt=sa.func.to_tsvector('Dana')
+        )
         rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='danielle'))
         self.assertEqual(len(results), 1)
@@ -174,9 +183,13 @@ class CandidateFormatTest(ApiBaseTest):
         ]
         candidate_ids = [each.candidate_id for each in candidates]
         results = self._results(api.url_for(CandidateList, sort='candidate_status'))
-        self.assertEqual([each['candidate_id'] for each in results], candidate_ids[::-1])
+        self.assertEqual(
+            [each['candidate_id'] for each in results], candidate_ids[::-1]
+        )
         results = self._results(api.url_for(CandidateSearch, sort='candidate_status'))
-        self.assertEqual([each['candidate_id'] for each in results], candidate_ids[::-1])
+        self.assertEqual(
+            [each['candidate_id'] for each in results], candidate_ids[::-1]
+        )
         results = self._results(api.url_for(CandidateList, sort='-candidate_status'))
         self.assertEqual([each['candidate_id'] for each in results], candidate_ids)
         results = self._results(api.url_for(CandidateSearch, sort='-candidate_status'))
@@ -193,13 +206,19 @@ class CandidateFormatTest(ApiBaseTest):
             factories.CandidateFactory(candidate_id='3', candidate_status='C'),
         ]
         candidate_ids = [each.candidate_id for each in candidates]
-        results = self._results(api.url_for(CandidateList, sort='candidate_status', sort_nulls_last=True))
-        self.assertEqual([each['candidate_id'] for each in results], candidate_ids[::-1])
-        results = self._results(api.url_for(CandidateList, sort='-candidate_status', sort_nulls_last=True))
+        results = self._results(
+            api.url_for(CandidateList, sort='candidate_status', sort_nulls_last=True)
+        )
+        self.assertEqual(
+            [each['candidate_id'] for each in results], candidate_ids[::-1]
+        )
+        results = self._results(
+            api.url_for(CandidateList, sort='-candidate_status', sort_nulls_last=True)
+        )
         self.assertEqual([each['candidate_id'] for each in results], ['2', '3', '1'])
 
-class TestCandidateHistory(ApiBaseTest):
 
+class TestCandidateHistory(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.committee = factories.CommitteeDetailFactory()
@@ -239,7 +258,9 @@ class TestCandidateHistory(ApiBaseTest):
 
     def test_history(self):
         history_2012 = factories.CandidateHistoryFactory(two_year_period=2012)
-        history_2008 = factories.CandidateHistoryFactory(two_year_period=2008, candidate_id=history_2012.candidate_id)
+        history_2008 = factories.CandidateHistoryFactory(
+            two_year_period=2008, candidate_id=history_2012.candidate_id
+        )
         results = self._results(
             api.url_for(CandidateHistoryView, candidate_id=history_2012.candidate_id)
         )
@@ -282,8 +303,13 @@ class TestCandidateHistory(ApiBaseTest):
         )
         assert len(results_false) == 1
         assert results_false[0]['candidate_id'] == first_two_year_period.candidate_id
-        assert results_false[0]['two_year_period'] == first_two_year_period.two_year_period
-        assert results_false[0]['candidate_election_year'] == first_two_year_period.candidate_election_year
+        assert (
+            results_false[0]['two_year_period'] == first_two_year_period.two_year_period
+        )
+        assert (
+            results_false[0]['candidate_election_year']
+            == first_two_year_period.candidate_election_year
+        )
 
         # test election_full='true'
         results_true = self._results(
@@ -296,18 +322,30 @@ class TestCandidateHistory(ApiBaseTest):
         )
         assert len(results_true) == 2
         assert results_true[0]['candidate_id'] == second_two_year_period.candidate_id
-        assert results_true[0]['two_year_period'] == second_two_year_period.two_year_period
-        assert results_true[0]['candidate_election_year'] == second_two_year_period.candidate_election_year
+        assert (
+            results_true[0]['two_year_period'] == second_two_year_period.two_year_period
+        )
+        assert (
+            results_true[0]['candidate_election_year']
+            == second_two_year_period.candidate_election_year
+        )
         # Default sort is two_year_period descending
         assert results_true[1]['candidate_id'] == first_two_year_period.candidate_id
-        assert results_true[1]['two_year_period'] == first_two_year_period.two_year_period
-        assert results_true[1]['candidate_election_year'] == first_two_year_period.candidate_election_year
+        assert (
+            results_true[1]['two_year_period'] == first_two_year_period.two_year_period
+        )
+        assert (
+            results_true[1]['candidate_election_year']
+            == first_two_year_period.candidate_election_year
+        )
 
     def test_committee_cycle(self):
         results = self._results(
             api.url_for(
                 CandidateHistoryView,
-                committee_id=self.committee.committee_id, cycle=2012, election_full=False
+                committee_id=self.committee.committee_id,
+                cycle=2012,
+                election_full=False,
             )
         )
         assert len(results) == 1

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -124,8 +124,8 @@ class CommitteeFormatTest(ApiBaseTest):
             party='REP', party_full='Republican Party',
         )
         response = self._results(api.url_for(CommitteeList, party='REP'))
-        self.assertEquals(response[0]['party'], 'REP')
-        self.assertEquals(response[0]['party_full'], 'Republican Party')
+        self.assertEqual(response[0]['party'], 'REP')
+        self.assertEqual(response[0]['party_full'], 'Republican Party')
 
     def test_filters_generic(self):
         self._check_filter('designation', ['B', 'P'])
@@ -275,7 +275,7 @@ class CommitteeFormatTest(ApiBaseTest):
         results = self._results(
             api.url_for(CandidateView, committee_id=committee.committee_id)
         )
-        self.assertEquals(1, len(results))
+        self.assertEqual(1, len(results))
 
     def test_committee_sort(self):
         committees = [

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -15,8 +15,6 @@ from webservices.resources.candidates import CandidateView
 
 
 class CommitteeFormatTest(ApiBaseTest):
-
-
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
             first_file_date=datetime.date.fromisoformat('1982-12-31'),
@@ -24,21 +22,27 @@ class CommitteeFormatTest(ApiBaseTest):
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
         )
-        response = self._response(api.url_for(CommitteeView, committee_id=committee.committee_id))
+        response = self._response(
+            api.url_for(CommitteeView, committee_id=committee.committee_id)
+        )
         result = response['results'][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
-        self.assertEqual(result['first_file_date'], datetime.date.fromisoformat('1982-12-31').isoformat())
+        self.assertEqual(
+            result['first_file_date'],
+            datetime.date.fromisoformat('1982-12-31').isoformat(),
+        )
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
 
     def test_fulltext_search(self):
-        committee = factories.CommitteeFactory(name='Americans for a Better Tomorrow, Tomorrow')
+        committee = factories.CommitteeFactory(
+            name='Americans for a Better Tomorrow, Tomorrow'
+        )
         decoy_committee = factories.CommitteeFactory()
         factories.CommitteeSearchFactory(
-            id=committee.committee_id,
-            fulltxt=sa.func.to_tsvector(committee.name),
+            id=committee.committee_id, fulltxt=sa.func.to_tsvector(committee.name),
         )
         queries = [
             'america',
@@ -50,27 +54,36 @@ class CommitteeFormatTest(ApiBaseTest):
             results = self._results(api.url_for(CommitteeList, q=query))
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['committee_id'], committee.committee_id)
-            self.assertNotEqual(results[0]['committee_id'], decoy_committee.committee_id)
+            self.assertNotEqual(
+                results[0]['committee_id'], decoy_committee.committee_id
+            )
 
     def test_filter_by_candidate_id(self):
         candidate_id = 'ID0'
-        candidate_committees = [factories.CommitteeFactory(candidate_ids=[candidate_id]) for _ in range(2)]
+        candidate_committees = [
+            factories.CommitteeFactory(candidate_ids=[candidate_id]) for _ in range(2)
+        ]
         other_committees = [factories.CommitteeFactory() for _ in range(3)]  # noqa
         response = self._response(api.url_for(CommitteeList, candidate_id=candidate_id))
-        self.assertEqual(
-            len(response['results']),
-            len(candidate_committees)
-        )
+        self.assertEqual(len(response['results']), len(candidate_committees))
 
     def test_filter_by_candidate_ids(self):
         candidate_ids = ['ID0', 'ID1']
-        candidate1_committees = [factories.CommitteeFactory(candidate_ids=[candidate_ids[0]]) for _ in range(2)]
-        candidate2_committees = [factories.CommitteeFactory(candidate_ids=[candidate_ids[1]]) for _ in range(2)]
+        candidate1_committees = [
+            factories.CommitteeFactory(candidate_ids=[candidate_ids[0]])
+            for _ in range(2)
+        ]
+        candidate2_committees = [
+            factories.CommitteeFactory(candidate_ids=[candidate_ids[1]])
+            for _ in range(2)
+        ]
         other_committees = [factories.CommitteeFactory() for _ in range(3)]  # noqa
-        response = self._response(api.url_for(CommitteeList, candidate_id=candidate_ids))
+        response = self._response(
+            api.url_for(CommitteeList, candidate_id=candidate_ids)
+        )
         self.assertEqual(
             len(response['results']),
-            len(candidate1_committees) + len(candidate2_committees)
+            len(candidate1_committees) + len(candidate2_committees),
         )
 
     def test_committee_detail_fields(self):
@@ -83,10 +96,14 @@ class CommitteeFormatTest(ApiBaseTest):
             street_1='1795 Peachtree Road',
             zip='30309',
         )
-        response = self._response(api.url_for(CommitteeView, committee_id=committee.committee_id))
+        response = self._response(
+            api.url_for(CommitteeView, committee_id=committee.committee_id)
+        )
         result = response['results'][0]
         # main fields
-        self.assertEqual(result['first_file_date'], committee.first_file_date.isoformat())
+        self.assertEqual(
+            result['first_file_date'], committee.first_file_date.isoformat()
+        )
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
@@ -104,8 +121,7 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_party(self):
         factories.CommitteeFactory(
-            party='REP',
-            party_full='Republican Party',
+            party='REP', party_full='Republican Party',
         )
         response = self._results(api.url_for(CommitteeList, party='REP'))
         self.assertEquals(response[0]['party'], 'REP')
@@ -176,12 +192,17 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_year_filter_skips_null_first_file_date(self):
         # Build fixtures
-        dates = [datetime.date.fromisoformat('2012-01-01'), datetime.date.fromisoformat('2015-01-01')]
+        dates = [
+            datetime.date.fromisoformat('2012-01-01'),
+            datetime.date.fromisoformat('2015-01-01'),
+        ]
         [
             factories.CommitteeFactory(first_file_date=None, last_file_date=None),
             factories.CommitteeFactory(first_file_date=dates[0], last_file_date=None),
             factories.CommitteeFactory(first_file_date=None, last_file_date=dates[1]),
-            factories.CommitteeFactory(first_file_date=dates[0], last_file_date=dates[1]),
+            factories.CommitteeFactory(
+                first_file_date=dates[0], last_file_date=dates[1]
+            ),
         ]
 
         # Check committee list results
@@ -201,7 +222,9 @@ class CommitteeFormatTest(ApiBaseTest):
             )
             for committee in committees
         ]
-        results = self._results(api.url_for(CommitteeView, candidate_id=candidate.candidate_id))
+        results = self._results(
+            api.url_for(CommitteeView, candidate_id=candidate.candidate_id)
+        )
 
         self.assertEqual(
             set((each['committee_id'] for each in results)),
@@ -222,7 +245,9 @@ class CommitteeFormatTest(ApiBaseTest):
                 committee_id=committee.committee_id,
             ),
         ]
-        response = self._response(api.url_for(CommitteeView, candidate_id=candidate.candidate_id))
+        response = self._response(
+            api.url_for(CommitteeView, candidate_id=candidate.candidate_id)
+        )
         self.assertEqual(response['pagination']['count'], 1)
         self.assertEqual(len(response['results']), 1)
 
@@ -231,11 +256,12 @@ class CommitteeFormatTest(ApiBaseTest):
         candidate = factories.CandidateFactory()
         db.session.flush()
         factories.CandidateCommitteeLinkFactory(
-            candidate_id=candidate.candidate_id,
-            committee_id=committee.committee_id,
+            candidate_id=candidate.candidate_id, committee_id=committee.committee_id,
         )
         results = self._results(
-            api.url_for(CommitteeView, candidate_id=candidate.candidate_id, designation='P')
+            api.url_for(
+                CommitteeView, candidate_id=candidate.candidate_id, designation='P'
+            )
         )
         self.assertEqual(1, len(results))
 
@@ -244,10 +270,11 @@ class CommitteeFormatTest(ApiBaseTest):
         candidate = factories.CandidateFactory()
         db.session.flush()
         factories.CandidateCommitteeLinkFactory(
-            candidate_id=candidate.candidate_id,
-            committee_id=committee.committee_id,
+            candidate_id=candidate.candidate_id, committee_id=committee.committee_id,
         )
-        results = self._results(api.url_for(CandidateView, committee_id=committee.committee_id))
+        results = self._results(
+            api.url_for(CandidateView, committee_id=committee.committee_id)
+        )
         self.assertEquals(1, len(results))
 
     def test_committee_sort(self):
@@ -259,7 +286,9 @@ class CommitteeFormatTest(ApiBaseTest):
         results = self._results(api.url_for(CommitteeList, sort='designation'))
         self.assertEqual([each['committee_id'] for each in results], committee_ids)
         results = self._results(api.url_for(CommitteeList, sort='-designation'))
-        self.assertEqual([each['committee_id'] for each in results], committee_ids[::-1])
+        self.assertEqual(
+            [each['committee_id'] for each in results], committee_ids[::-1]
+        )
 
     def test_committee_sort_default(self):
         committees = [
@@ -268,12 +297,18 @@ class CommitteeFormatTest(ApiBaseTest):
         ]
         committee_ids = [each.committee_id for each in committees]
         results = self._results(api.url_for(CommitteeList))
-        self.assertEqual([each['committee_id'] for each in results], committee_ids[::-1])
+        self.assertEqual(
+            [each['committee_id'] for each in results], committee_ids[::-1]
+        )
 
     def test_treasurer_filter(self):
         committees = [
-            factories.CommitteeFactory(treasurer_text=sa.func.to_tsvector('uncle pennybags')),
-            factories.CommitteeFactory(treasurer_text=sa.func.to_tsvector('eve moneypenny')),
+            factories.CommitteeFactory(
+                treasurer_text=sa.func.to_tsvector('uncle pennybags')
+            ),
+            factories.CommitteeFactory(
+                treasurer_text=sa.func.to_tsvector('eve moneypenny')
+            ),
         ]
         results = self._results(api.url_for(CommitteeList, treasurer_name='moneypenny'))
         assert len(results) == 1
@@ -281,19 +316,45 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_date_filters(self):
         [
-            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-01-01')),
-            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-02-01')),
-            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-03-01')),
-            factories.CommitteeFactory(first_file_date=datetime.date.fromisoformat('2015-04-01')),
+            factories.CommitteeFactory(
+                first_file_date=datetime.date.fromisoformat('2015-01-01')
+            ),
+            factories.CommitteeFactory(
+                first_file_date=datetime.date.fromisoformat('2015-02-01')
+            ),
+            factories.CommitteeFactory(
+                first_file_date=datetime.date.fromisoformat('2015-03-01')
+            ),
+            factories.CommitteeFactory(
+                first_file_date=datetime.date.fromisoformat('2015-04-01')
+            ),
         ]
         results = self._results(
-            api.url_for(CommitteeList, min_first_file_date=datetime.date.fromisoformat('2015-02-01')))
+            api.url_for(
+                CommitteeList,
+                min_first_file_date=datetime.date.fromisoformat('2015-02-01'),
+            )
+        )
         self.assertTrue(
-            all(each['first_file_date'] >= datetime.date.fromisoformat('2015-02-01').isoformat() for each in results))
+            all(
+                each['first_file_date']
+                >= datetime.date.fromisoformat('2015-02-01').isoformat()
+                for each in results
+            )
+        )
         results = self._results(
-            api.url_for(CommitteeList, max_first_file_date=datetime.date.fromisoformat('2015-02-03')))
+            api.url_for(
+                CommitteeList,
+                max_first_file_date=datetime.date.fromisoformat('2015-02-03'),
+            )
+        )
         self.assertTrue(
-            all(each['first_file_date'] <= datetime.date.fromisoformat('2015-02-03').isoformat() for each in results))
+            all(
+                each['first_file_date']
+                <= datetime.date.fromisoformat('2015-02-03').isoformat()
+                for each in results
+            )
+        )
         results = self._results(
             api.url_for(
                 CommitteeList,
@@ -303,13 +364,15 @@ class CommitteeFormatTest(ApiBaseTest):
         )
         self.assertTrue(
             all(
-                datetime.date.fromisoformat('2015-02-01').isoformat() <= each['first_file_date'] <= datetime.date.fromisoformat('2015-03-01').isoformat()
+                datetime.date.fromisoformat('2015-02-01').isoformat()
+                <= each['first_file_date']
+                <= datetime.date.fromisoformat('2015-03-01').isoformat()
                 for each in results
             )
         )
 
-class TestCommitteeHistory(ApiBaseTest):
 
+class TestCommitteeHistory(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
@@ -318,27 +381,27 @@ class TestCommitteeHistory(ApiBaseTest):
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[0].committee_id,
                 cycle=2010,
-                designation='P'
+                designation='P',
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[1].committee_id,
                 cycle=2012,
-                designation='P'
+                designation='P',
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
-                designation='P'
+                designation='P',
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[3].committee_id,
                 cycle=2014,
-                designation='A'
+                designation='A',
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
-                designation='J'
+                designation='J',
             ),
         ]
 
@@ -392,14 +455,16 @@ class TestCommitteeHistory(ApiBaseTest):
                 candidate_id=self.candidate.candidate_id,
                 cand_election_year=2016,
                 prev_election_year=2012,
-            )
+            ),
         ]
 
     def test_candidate_cycle(self):
         results = self._results(
             api.url_for(
                 CommitteeHistoryView,
-                candidate_id=self.candidate.candidate_id, cycle=2012, election_full=False
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                election_full=False,
             )
         )
         assert len(results) == 1
@@ -412,7 +477,7 @@ class TestCommitteeHistory(ApiBaseTest):
                 CommitteeHistoryView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2012,
-                election_full=True
+                election_full=True,
             )
         )
         assert len(results) == 2
@@ -427,7 +492,7 @@ class TestCommitteeHistory(ApiBaseTest):
             api.url_for(
                 CommitteeHistoryView,
                 candidate_id=self.candidate.candidate_id,
-                designation=['P', 'A']
+                designation=['P', 'A'],
             )
         )
         assert len(results) == 4

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -8,7 +8,6 @@ from webservices.resources.costs import CommunicationCostView, ElectioneeringVie
 
 
 class TestCommunicationCost(ApiBaseTest):
-
     def test_fields(self):
         factories.CommunicationCostFactory()
         results = self._results(api.url_for(CommunicationCostView))
@@ -26,12 +25,14 @@ class TestCommunicationCost(ApiBaseTest):
                 factories.CommunicationCostFactory(**{column.key: value})
                 for value in values
             ]
-            results = self._results(api.url_for(CommunicationCostView, **{label: values[0]}))
+            results = self._results(
+                api.url_for(CommunicationCostView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
-class TestElectioneering(ApiBaseTest):
 
+class TestElectioneering(ApiBaseTest):
     def test_fields(self):
         factories.ElectioneeringFactory()
         results = self._results(api.url_for(ElectioneeringView))
@@ -45,11 +46,10 @@ class TestElectioneering(ApiBaseTest):
             ('candidate_id', Electioneering.candidate_id, ['S01', 'S02']),
         ]
         for label, column, values in filters:
-            [
-                factories.ElectioneeringFactory(**{column.key: value})
-                for value in values
-            ]
-            results = self._results(api.url_for(ElectioneeringView, **{label: values[0]}))
+            [factories.ElectioneeringFactory(**{column.key: value}) for value in values]
+            results = self._results(
+                api.url_for(ElectioneeringView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -9,41 +9,48 @@ from webservices.resources import sched_e
 from webservices.rest import db
 from webservices.common import models, counts
 
+
 @mock.patch.object(counts, 'get_query_plan')
 class TestCounts(ApiBaseTest):
-
     def test_schedule_e_efile_uses_exact_count(self, get_query_plan_mock):
-        schedule_e_efile = [
-            factories.ScheduleEEfileFactory() for i in range(5)
-        ]
+        schedule_e_efile = [factories.ScheduleEEfileFactory() for i in range(5)]  # noqa
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
 
         query = db.session.query(models.ScheduleEEfile)
         # Estimated rows = 6000000
-        get_query_plan_mock.return_value = [('Seq Scan on real_efile_se_f57_vw  (cost=0.00..10.60 rows=6000000 width=1289)',)]
+        get_query_plan_mock.return_value = [
+            (
+                'Seq Scan on real_efile_se_f57_vw  \
+            (cost=0.00..10.60 rows=6000000 width=1289)',
+            )
+        ]
         resource = sched_e.ScheduleEEfileView()
-        count, estimate = counts.get_count(query, db.session, resource.use_estimated_counts)
+        count, estimate = counts.get_count(
+            query, db.session, resource.use_estimated_counts
+        )
         # Always use exact count for Schedule E efile
         self.assertEqual(count, 5)
         self.assertEqual(estimate, False)
 
     def test_use_actual_counts_under_threshold(self, get_query_plan_mock):
-        receipts = [
+        receipts = [  # noqa
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
             ),
             factories.ScheduleAFactory(
                 report_year=2015,
                 contribution_receipt_date=datetime.date(2015, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
             ),
         ]
         query = db.session.query(models.ScheduleA)
         # Estimated rows == 200
-        get_query_plan_mock.return_value = [('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)]
+        get_query_plan_mock.return_value = [
+            ('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)
+        ]
         count, estimate = counts.get_count(query, db.session)
         self.assertEqual(count, 2)
         self.assertEqual(estimate, False)
@@ -51,7 +58,12 @@ class TestCounts(ApiBaseTest):
     def test_use_estimated_counts_over_threshold(self, get_query_plan_mock):
         query = db.session.query(models.ScheduleA)
         # Estimated rows == 2000000
-        get_query_plan_mock.return_value = [('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=2000000 width=1289)',)]
+        get_query_plan_mock.return_value = [
+            (
+                'Seq Scan on fec_fitem_sched_a  \
+            (cost=0.00..10.60 rows=2000000 width=1289)',
+            )
+        ]
         count, estimate = counts.get_count(query, db.session)
         self.assertEqual(count, 2000000)
         self.assertEqual(estimate, True)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -13,11 +13,14 @@ from tests.common import ApiBaseTest
 from webservices.rest import api
 from webservices.common.models import db
 from webservices.resources.dates import ElectionDatesView
-from webservices.resources.dates import ReportingDatesView, CalendarDatesView, CalendarDatesExport
+from webservices.resources.dates import (
+    ReportingDatesView,
+    CalendarDatesView,
+    CalendarDatesExport,
+)
 
 
 class TestReportingDates(ApiBaseTest):
-
     def test_reporting_dates_filters(self):
         factories.ReportTypeFactory(report_type='YE', report_type_full='Year End')
         factories.ReportDateFactory(due_date=datetime.datetime(2014, 1, 2))
@@ -43,18 +46,16 @@ class TestReportingDates(ApiBaseTest):
     def test_clean_report_type(self):
         factories.ReportTypeFactory(
             report_type='Q1',
-            report_type_full='April Quarterly {One of 4 valid Report Codes on Form 5, RptCode}'
+            report_type_full='April Quarterly {One of 4 valid Report Codes on Form 5, RptCode}',
         )
         report_date = factories.ReportDateFactory(
-            report_type='Q1',
-            due_date=datetime.datetime(2015, 1, 2),
+            report_type='Q1', due_date=datetime.datetime(2015, 1, 2),
         )
         db.session.flush()
         assert report_date.report_type_full == 'April Quarterly'
 
 
 class TestElectionDates(ApiBaseTest):
-
     def test_election_type(self):
         election_date = factories.ElectionDateFactory(election_type_id='PR')
         assert election_date.election_type_full == 'Primary runoff'
@@ -73,7 +74,6 @@ class TestElectionDates(ApiBaseTest):
 
 
 class TestCalendarDates(ApiBaseTest):
-
     def test_filters(self):
         factories.CalendarDateFactory(start_date=datetime.datetime(2016, 1, 2))
         factories.CalendarDateFactory(location='Mississippi, CA')
@@ -82,7 +82,9 @@ class TestCalendarDates(ApiBaseTest):
         # factories.CalendarDateFactory(state=['CA'])
         factories.CalendarDateFactory(calendar_category_id=7)
         factories.CalendarDateFactory(description='a really interesting event')
-        factories.CalendarDateFactory(summary='Meeting that will solve all the problems')
+        factories.CalendarDateFactory(
+            summary='Meeting that will solve all the problems'
+        )
         factories.CalendarDateFactory(end_date=datetime.datetime(2015, 1, 2))
 
         filter_fields = [
@@ -90,7 +92,7 @@ class TestCalendarDates(ApiBaseTest):
             ('calendar_category_id', 7),
             ('min_end_date', '2014-01-01'),
             # this is not passing or working :/
-            #('state', 'CA'),
+            # ('state', 'CA'),
             ('description', 'interesting event'),
             ('summary', 'solve all the problems'),
             ('event_id', 123),
@@ -110,7 +112,6 @@ class TestCalendarDates(ApiBaseTest):
 
 
 class TestCalendarExport(ApiBaseTest):
-
     def setUp(self):
         super().setUp()
         self.year = datetime.date.today().year
@@ -123,7 +124,7 @@ class TestCalendarExport(ApiBaseTest):
             factories.CalendarDateFactory(
                 category='Roundtables',
                 start_date=datetime.datetime(self.year, 10, 31, 2),
-                end_date=datetime.datetime(self.year, 10, 31, 3)
+                end_date=datetime.datetime(self.year, 10, 31, 3),
             ),
         ]
 
@@ -133,7 +134,9 @@ class TestCalendarExport(ApiBaseTest):
         reader = csv.DictReader(sio)
         rows = list(reader)
         assert len(rows) == len(self.dates)
-        assert set(rows[0].keys()) == set(['summary', 'description', 'location', 'start_date', 'end_date', 'category'])
+        assert set(rows[0].keys()) == set(
+            ['summary', 'description', 'location', 'start_date', 'end_date', 'category']
+        )
 
     def test_ics_export(self):
         resp = self.app.get(api.url_for(CalendarDatesExport, renderer='ics'))
@@ -143,4 +146,6 @@ class TestCalendarExport(ApiBaseTest):
         assert str(components[0]['CATEGORIES']) == 'election'
         timezone = pytz.timezone('US/Eastern')
         assert components[0]['DTSTART'].dt == datetime.date(self.year, 10, 1)
-        assert components[1]['DTSTART'].dt == timezone.localize(datetime.datetime(self.year, 10, 31, 2))
+        assert components[1]['DTSTART'].dt == timezone.localize(
+            datetime.datetime(self.year, 10, 31, 2)
+        )

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -290,29 +290,29 @@ class TestElections(ApiBaseTest):
 
     def test_missing_params(self):
         response = self.app.get(api.url_for(ElectionView))
-        self.assertEquals(response.status_code, 422)
+        self.assertEqual(response.status_code, 422)
 
     def test_conditional_missing_params(self):
         response = self.app.get(
             api.url_for(ElectionView, office='president', cycle=2012)
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
-        self.assertEquals(response.status_code, 422)
+        self.assertEqual(response.status_code, 422)
         response = self.app.get(
             api.url_for(ElectionView, office='senate', cycle=2012, state='NY')
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         response = self.app.get(
             api.url_for(ElectionView, office='house', cycle=2012, state='NY')
         )
-        self.assertEquals(response.status_code, 422)
+        self.assertEqual(response.status_code, 422)
         response = self.app.get(
             api.url_for(
                 ElectionView, office='house', cycle=2012, state='NY', district='01'
             )
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_empty_query(self):
         results = self._results(

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -1,33 +1,58 @@
 import datetime
-import functools
-from webservices import filters
 from tests import factories
 from tests.common import ApiBaseTest, assert_dicts_subset
 
 from webservices.rest import db, api
-from webservices.common import models
-from webservices.resources.elections import ElectionsListView, ElectionView, ElectionSummary, StateElectionOfficeInfoView
-from webservices.common.models.elections import StateElectionOfficeInfo
-from webservices.schemas import StateElectionOfficeInfoSchema
-class TestElectionSearch(ApiBaseTest):
+from webservices.resources.elections import (
+    ElectionsListView,
+    ElectionView,
+    ElectionSummary,
+    StateElectionOfficeInfoView,
+)
 
+
+class TestElectionSearch(ApiBaseTest):
     def setUp(self):
         super().setUp()
-        factories.ElectionsListFactory(office='P', state='US', district='00', incumbent_id='P12345')
-        factories.ElectionsListFactory(office='S', state='NJ', district='00', incumbent_id='SNJ123')
-        factories.ElectionsListFactory(office='H', state='NJ', district='09', incumbent_id='HNJ123')
-        factories.ElectionsListFactory(office='S', state='VA', district='00', incumbent_id='SVA123')
-        factories.ElectionsListFactory(office='H', state='VA', district='04', incumbent_id='HVA121')
-        factories.ElectionsListFactory(office='H', state='VA', district='05', incumbent_id='HVA123')
-        factories.ElectionsListFactory(office='H', state='VA', district='06', incumbent_id='HVA124')
-        factories.ElectionsListFactory(office='S', state='GA', district='00', incumbent_id='SGA123')
+        factories.ElectionsListFactory(
+            office='P', state='US', district='00', incumbent_id='P12345'
+        )
+        factories.ElectionsListFactory(
+            office='S', state='NJ', district='00', incumbent_id='SNJ123'
+        )
+        factories.ElectionsListFactory(
+            office='H', state='NJ', district='09', incumbent_id='HNJ123'
+        )
+        factories.ElectionsListFactory(
+            office='S', state='VA', district='00', incumbent_id='SVA123'
+        )
+        factories.ElectionsListFactory(
+            office='H', state='VA', district='04', incumbent_id='HVA121'
+        )
+        factories.ElectionsListFactory(
+            office='H', state='VA', district='05', incumbent_id='HVA123'
+        )
+        factories.ElectionsListFactory(
+            office='H', state='VA', district='06', incumbent_id='HVA124'
+        )
+        factories.ElectionsListFactory(
+            office='S', state='GA', district='00', incumbent_id='SGA123'
+        )
 
     def test_search_district(self):
-        results = self._results(api.url_for(ElectionsListView, state='NJ', district='09'))
+        results = self._results(
+            api.url_for(ElectionsListView, state='NJ', district='09')
+        )
         self.assertEqual(len(results), 3)
-        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'})
-        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'})
+        assert_dicts_subset(
+            results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'}
+        )
+        assert_dicts_subset(
+            results[1], {'cycle': 2012, 'office': 'S', 'state': 'NJ', 'district': '00'}
+        )
+        assert_dicts_subset(
+            results[2], {'cycle': 2012, 'office': 'H', 'state': 'NJ', 'district': '09'}
+        )
 
     def test_search_district_padding(self):
         results_padded = self._results(api.url_for(ElectionsListView, district='09'))
@@ -41,13 +66,21 @@ class TestElectionSearch(ApiBaseTest):
         self.assertTrue(all([each['office'] == 'S' for each in results]))
 
     def test_search_zip(self):
-        factories.ZipsDistrictsFactory(district='05', zip_code='22902', state_abbrevation='VA')
+        factories.ZipsDistrictsFactory(
+            district='05', zip_code='22902', state_abbrevation='VA'
+        )
 
         results = self._results(api.url_for(ElectionsListView, zip='22902'))
         assert len(results) == 3
-        assert_dicts_subset(results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'})
-        assert_dicts_subset(results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'})
-        assert_dicts_subset(results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'})
+        assert_dicts_subset(
+            results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'}
+        )
+        assert_dicts_subset(
+            results[1], {'cycle': 2012, 'office': 'S', 'state': 'VA', 'district': '00'}
+        )
+        assert_dicts_subset(
+            results[2], {'cycle': 2012, 'office': 'H', 'state': 'VA', 'district': '05'}
+        )
 
     def test_counts(self):
         response = self._response(api.url_for(ElectionsListView))
@@ -67,12 +100,11 @@ class TestElectionSearch(ApiBaseTest):
         results = self._results(api.url_for(ElectionsListView))
         self.assertTrue(
             [each['state'] for each in results],
-            ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA']
+            ['GA', 'NJ', 'NJ', 'US', 'VA', 'VA', 'VA', 'VA'],
         )
 
 
 class TestElections(ApiBaseTest):
-
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
@@ -101,7 +133,9 @@ class TestElections(ApiBaseTest):
             factories.CommitteeHistoryFactory(cycle=2012, designation='A'),
         ]
         [
-            factories.CandidateElectionFactory(candidate_id=self.candidate.candidate_id, cand_election_year=year)
+            factories.CandidateElectionFactory(
+                candidate_id=self.candidate.candidate_id, cand_election_year=year
+            )
             for year in [2010, 2012]
         ]
         [
@@ -115,28 +149,28 @@ class TestElections(ApiBaseTest):
                 committee_id=self.committees[0].committee_id,
                 committee_designation='A',
                 fec_election_year=2012,
-                election_yr_to_be_included = 2012,
+                election_yr_to_be_included=2012,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[1].committee_id,
                 committee_designation='P',
                 fec_election_year=2012,
-                election_yr_to_be_included = 2012,
+                election_yr_to_be_included=2012,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[1].committee_id,
                 committee_designation='P',
                 fec_election_year=2010,
-                election_yr_to_be_included = 2012,
+                election_yr_to_be_included=2012,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[1].committee_id,
                 committee_designation='P',
                 fec_election_year=2010,
-            )
+            ),
         ]
         self.totals = [
             factories.TotalsHouseSenateFactory(
@@ -167,7 +201,6 @@ class TestElections(ApiBaseTest):
 
         self.president_candidate = factories.CandidateDetailFactory()
         self.president_candidates = [
-
             factories.CandidateHistoryFactory(
                 candidate_id=self.president_candidate.candidate_id,
                 state='NY',
@@ -190,7 +223,10 @@ class TestElections(ApiBaseTest):
             factories.CommitteeHistoryFactory(cycle=2020, designation='J'),
         ]
         [
-            factories.CandidateElectionFactory(candidate_id=self.president_candidate.candidate_id, cand_election_year=year)
+            factories.CandidateElectionFactory(
+                candidate_id=self.president_candidate.candidate_id,
+                cand_election_year=year,
+            )
             for year in [2016, 2020]
         ]
         [
@@ -205,16 +241,15 @@ class TestElections(ApiBaseTest):
                 committee_designation='P',
                 fec_election_year=2020,
                 cand_election_year=2020,
-                election_yr_to_be_included = 2020,
+                election_yr_to_be_included=2020,
             ),
-
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.president_candidate.candidate_id,
                 committee_id=self.president_committees[0].committee_id,
                 committee_designation='P',
                 fec_election_year=2018,
                 cand_election_year=2020,
-                election_yr_to_be_included = 2020,
+                election_yr_to_be_included=2020,
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.president_candidate.candidate_id,
@@ -222,8 +257,8 @@ class TestElections(ApiBaseTest):
                 committee_designation='P',
                 fec_election_year=2018,
                 cand_election_year=2020,
-                election_yr_to_be_included = 2020,
-            )
+                election_yr_to_be_included=2020,
+            ),
         ]
 
         self.presidential_totals = [
@@ -258,23 +293,43 @@ class TestElections(ApiBaseTest):
         self.assertEquals(response.status_code, 422)
 
     def test_conditional_missing_params(self):
-        response = self.app.get(api.url_for(ElectionView, office='president', cycle=2012))
+        response = self.app.get(
+            api.url_for(ElectionView, office='president', cycle=2012)
+        )
         self.assertEquals(response.status_code, 200)
         response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012))
         self.assertEquals(response.status_code, 422)
-        response = self.app.get(api.url_for(ElectionView, office='senate', cycle=2012, state='NY'))
+        response = self.app.get(
+            api.url_for(ElectionView, office='senate', cycle=2012, state='NY')
+        )
         self.assertEquals(response.status_code, 200)
-        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY'))
+        response = self.app.get(
+            api.url_for(ElectionView, office='house', cycle=2012, state='NY')
+        )
         self.assertEquals(response.status_code, 422)
-        response = self.app.get(api.url_for(ElectionView, office='house', cycle=2012, state='NY', district='01'))
+        response = self.app.get(
+            api.url_for(
+                ElectionView, office='house', cycle=2012, state='NY', district='01'
+            )
+        )
         self.assertEquals(response.status_code, 200)
 
     def test_empty_query(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ'))
+        results = self._results(
+            api.url_for(ElectionView, office='senate', cycle=2012, state='ZZ')
+        )
         assert len(results) == 0
 
     def test_elections(self):
-        results = self._results(api.url_for(ElectionView, office='senate', cycle=2012, state='NY', election_full=False))
+        results = self._results(
+            api.url_for(
+                ElectionView,
+                office='senate',
+                cycle=2012,
+                state='NY',
+                election_full=False,
+            )
+        )
         self.assertEqual(len(results), 1)
         totals = [each for each in self.totals if each.cycle == 2012]
         expected = {
@@ -284,16 +339,23 @@ class TestElections(ApiBaseTest):
             'party_full': self.candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in totals),
+            'cash_on_hand_end_period': sum(
+                each.last_cash_on_hand_end_period for each in totals
+            ),
         }
         assert_dicts_subset(results[0], expected)
-        assert set(each.committee_id for each in self.committees) == set(results[0]['committee_ids'])
+        assert set(each.committee_id for each in self.committees) == set(
+            results[0]['committee_ids']
+        )
 
     def test_elections_full(self):
         results = self._results(
             api.url_for(
                 ElectionView,
-                office='senate', cycle=2012, state='NY', election_full='true',
+                office='senate',
+                cycle=2012,
+                state='NY',
+                election_full='true',
             )
         )
         totals = self.totals
@@ -305,30 +367,34 @@ class TestElections(ApiBaseTest):
             'party_full': self.candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
+            'cash_on_hand_end_period': sum(
+                each.last_cash_on_hand_end_period for each in cash_on_hand_totals
+            ),
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
         assert set(results[0]['committee_ids']) == set(
-            each.committee_id for each in self.committees
-            if each.designation != 'J')
+            each.committee_id for each in self.committees if each.designation != 'J'
+        )
 
     def test_elections_year_null(self):
         results = self._results(
             api.url_for(
                 ElectionView,
-                office='senate', cycle=2010, state='NY', election_full='true',
+                office='senate',
+                cycle=2010,
+                state='NY',
+                election_full='true',
             )
         )
-        totals = self.totals
-        cash_on_hand_totals = self.totals[:2]
+        totals = self.totals  # noqa
+        cash_on_hand_totals = self.totals[:2]  # noqa
         assert len(results) == 0
 
     def test_president_elections_full(self):
         results = self._results(
             api.url_for(
-                ElectionView,
-                office='president', cycle=2020, election_full='true',
+                ElectionView, office='president', cycle=2020, election_full='true',
             )
         )
         totals = self.presidential_totals
@@ -340,7 +406,9 @@ class TestElections(ApiBaseTest):
             'party_full': self.president_candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
+            'cash_on_hand_end_period': sum(
+                each.last_cash_on_hand_end_period for each in cash_on_hand_totals
+            ),
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
@@ -352,7 +420,10 @@ class TestElections(ApiBaseTest):
         results = self._results(
             api.url_for(
                 ElectionView,
-                office='senate', cycle=2012, state='NY', election_full='true',
+                office='senate',
+                cycle=2012,
+                state='NY',
+                election_full='true',
             )
         )
         # Joint Fundraising Committees raise money for multiple
@@ -370,23 +441,38 @@ class TestElections(ApiBaseTest):
             'incumbent_challenge_full': self.candidate.incumbent_challenge_full,
             'party_full': self.candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals_without_jfc),
-            'total_disbursements': sum(each.disbursements for each in totals_without_jfc),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in cash_on_hand_without_jfc),
+            'total_disbursements': sum(
+                each.disbursements for each in totals_without_jfc
+            ),
+            'cash_on_hand_end_period': sum(
+                each.last_cash_on_hand_end_period for each in cash_on_hand_without_jfc
+            ),
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
         assert set(results[0]['committee_ids']) == set(
-            each.committee_id for each in self.committees
-            if each.designation != 'J')
+            each.committee_id for each in self.committees if each.designation != 'J'
+        )
+
     def test_election_summary(self):
-        results = self._response(api.url_for(ElectionSummary, office='senate', cycle=2012, state='NY', election_full=False))
+        results = self._response(
+            api.url_for(
+                ElectionSummary,
+                office='senate',
+                cycle=2012,
+                state='NY',
+                election_full=False,
+            )
+        )
         totals = [each for each in self.totals if each.cycle == 2012]
         self.assertEqual(results['count'], 1)
         self.assertEqual(results['receipts'], sum(each.receipts for each in totals))
-        self.assertEqual(results['disbursements'], sum(each.disbursements for each in totals))
+        self.assertEqual(
+            results['disbursements'], sum(each.disbursements for each in totals)
+        )
+
 
 class TestPRElections(ApiBaseTest):
-
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
@@ -417,7 +503,9 @@ class TestPRElections(ApiBaseTest):
             factories.CommitteeHistoryFactory(cycle=2020, designation='A'),
         ]
         [
-            factories.CandidateElectionFactory(candidate_id=self.candidate.candidate_id, cand_election_year=year)
+            factories.CandidateElectionFactory(
+                candidate_id=self.candidate.candidate_id, cand_election_year=year
+            )
             for year in [2016, 2020]
         ]
         [
@@ -476,7 +564,16 @@ class TestPRElections(ApiBaseTest):
         db.session.flush()
 
     def test_elections_2_year(self):
-        results = self._results(api.url_for(ElectionView, office='house', district='00',cycle=2020, state='PR', election_full=False))
+        results = self._results(
+            api.url_for(
+                ElectionView,
+                office='house',
+                district='00',
+                cycle=2020,
+                state='PR',
+                election_full=False,
+            )
+        )
         self.assertEqual(len(results), 1)
         totals = [each for each in self.totals if each.cycle == 2020]
         expected = {
@@ -486,16 +583,24 @@ class TestPRElections(ApiBaseTest):
             'party_full': self.candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': sum(each.last_cash_on_hand_end_period for each in totals),
+            'cash_on_hand_end_period': sum(
+                each.last_cash_on_hand_end_period for each in totals
+            ),
         }
         assert_dicts_subset(results[0], expected)
-        assert set(each.committee_id for each in self.committees) == set(results[0]['committee_ids'])
+        assert set(each.committee_id for each in self.committees) == set(
+            results[0]['committee_ids']
+        )
 
     def test_elections_full(self):
         results = self._results(
             api.url_for(
                 ElectionView,
-                office='house', district='00', cycle=2020, state='PR', election_full='true',
+                office='house',
+                district='00',
+                cycle=2020,
+                state='PR',
+                election_full='true',
             )
         )
         totals = self.totals
@@ -507,20 +612,27 @@ class TestPRElections(ApiBaseTest):
             'party_full': self.candidate.party_full,
             'total_receipts': sum(each.receipts for each in totals),
             'total_disbursements': sum(each.disbursements for each in totals),
-            'cash_on_hand_end_period': max(each.last_cash_on_hand_end_period for each in cash_on_hand_totals),
+            'cash_on_hand_end_period': max(
+                each.last_cash_on_hand_end_period for each in cash_on_hand_totals
+            ),
         }
         assert len(results) == 1
         assert_dicts_subset(results[0], expected)
 
 
 class TestStateElectionOffices(ApiBaseTest):
-
     def test_filter_match(self):
         # Filter for a single string value
         [
-            factories.StateElectionOfficesFactory(state='TX', office_type='STATE CAMPAIGN FINANCE'),
-            factories.StateElectionOfficesFactory(state='AK', office_type='STATE CAMPAIGN FINANCE'),
-            factories.StateElectionOfficesFactory(state='WA', office_type='STATE CAMPAIGN FINANCE'),
+            factories.StateElectionOfficesFactory(
+                state='TX', office_type='STATE CAMPAIGN FINANCE'
+            ),
+            factories.StateElectionOfficesFactory(
+                state='AK', office_type='STATE CAMPAIGN FINANCE'
+            ),
+            factories.StateElectionOfficesFactory(
+                state='WA', office_type='STATE CAMPAIGN FINANCE'
+            ),
         ]
         results = self._results(api.url_for(StateElectionOfficeInfoView, state='TX'))
 

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -6,7 +6,6 @@ from webservices.resources.rad_analyst import RadAnalystView
 
 
 class TestFilerResources(ApiBaseTest):
-
     def test_committee_id_fetch(self):
         """ Check Analyst is returned with a specified committee id"""
         committee_id = 'C8675309'
@@ -25,12 +24,21 @@ class TestFilerResources(ApiBaseTest):
 
     def test_filters(self):
         [
-            factories.RadAnalystFactory(telephone_ext=123, committee_id='C0001', title='xyz 111'),
-            factories.RadAnalystFactory(telephone_ext=456, committee_id='C0002', title='abc',
-                                        email='test2@fec.gov'),
-            factories.RadAnalystFactory(analyst_id=789, committee_id='C0003',
-                                        email='test1@fec.gov'),
-            factories.RadAnalystFactory(analyst_id=1011, analyst_short_id=11, committee_id='C0004'),
+            factories.RadAnalystFactory(
+                telephone_ext=123, committee_id='C0001', title='xyz 111'
+            ),
+            factories.RadAnalystFactory(
+                telephone_ext=456,
+                committee_id='C0002',
+                title='abc',
+                email='test2@fec.gov',
+            ),
+            factories.RadAnalystFactory(
+                analyst_id=789, committee_id='C0003', email='test1@fec.gov'
+            ),
+            factories.RadAnalystFactory(
+                analyst_id=1011, analyst_short_id=11, committee_id='C0004'
+            ),
         ]
 
         filter_fields = (
@@ -63,25 +71,36 @@ class TestFilerResources(ApiBaseTest):
         ]
         results = self._results(api.url_for(RadAnalystView, sort='last_name'))
         self.assertEqual(
-            [each['last_name'] for each in results],
-            ['Old', 'Someone-Else', 'Young']
+            [each['last_name'] for each in results], ['Old', 'Someone-Else', 'Young']
         )
 
     def test_assignment_date_filters(self):
         [
-            factories.RadAnalystFactory(assignment_update_date='2015-01-01', committee_id='C0007'),
-            factories.RadAnalystFactory(assignment_update_date='2015-02-01', committee_id='C0008'),
-            factories.RadAnalystFactory(assignment_update_date='2015-03-01', committee_id='C0009'),
-            factories.RadAnalystFactory(assignment_update_date='2015-04-01', committee_id='C0010'),
+            factories.RadAnalystFactory(
+                assignment_update_date='2015-01-01', committee_id='C0007'
+            ),
+            factories.RadAnalystFactory(
+                assignment_update_date='2015-02-01', committee_id='C0008'
+            ),
+            factories.RadAnalystFactory(
+                assignment_update_date='2015-03-01', committee_id='C0009'
+            ),
+            factories.RadAnalystFactory(
+                assignment_update_date='2015-04-01', committee_id='C0010'
+            ),
         ]
         results = self._results(
-            api.url_for(RadAnalystView, min_assignment_update_date='2015-02-01'))
+            api.url_for(RadAnalystView, min_assignment_update_date='2015-02-01')
+        )
         self.assertTrue(
-            all(each['assignment_update_date'] >= '2015-02-01' for each in results))
+            all(each['assignment_update_date'] >= '2015-02-01' for each in results)
+        )
         results = self._results(
-            api.url_for(RadAnalystView, max_assignment_update_date='2015-02-03'))
+            api.url_for(RadAnalystView, max_assignment_update_date='2015-02-03')
+        )
         self.assertTrue(
-            all(each['assignment_update_date'] <= '2015-02-03' for each in results))
+            all(each['assignment_update_date'] <= '2015-02-03' for each in results)
+        )
         results = self._results(
             api.url_for(
                 RadAnalystView,

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -5,8 +5,8 @@ from tests.common import ApiBaseTest
 from webservices.rest import api
 from webservices.resources.filings import FilingsView, FilingsList, EFilingsView
 
-class TestFilings(ApiBaseTest):
 
+class TestFilings(ApiBaseTest):
     def test_committee_filings(self):
         """ Check filing returns with a specified committee id"""
         committee_id = 'C8675309'
@@ -39,14 +39,27 @@ class TestFilings(ApiBaseTest):
         ]
         min_date = datetime.date(2013, 1, 1)
         results = self._results(api.url_for(FilingsList, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
-        max_date = datetime.date(2014, 1, 1)
-        results = self._results(api.url_for(FilingsList, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
-        results = self._results(api.url_for(FilingsList, min_receipt_date=min_date, max_receipt_date=max_date))
         self.assertTrue(
             all(
-                each for each in results
+                each for each in results if each['receipt_date'] >= min_date.isoformat()
+            )
+        )
+        max_date = datetime.date(2014, 1, 1)
+        results = self._results(api.url_for(FilingsList, max_receipt_date=max_date))
+        self.assertTrue(
+            all(
+                each for each in results if each['receipt_date'] <= max_date.isoformat()
+            )
+        )
+        results = self._results(
+            api.url_for(
+                FilingsList, min_receipt_date=min_date, max_receipt_date=max_date
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
                 if min_date.isoformat() <= each['receipt_date'] <= max_date.isoformat()
             )
         )
@@ -112,10 +125,7 @@ class TestFilings(ApiBaseTest):
             factories.FilingsFactory(beginning_image_number=1),
         ]
         results = self._results(api.url_for(FilingsList, sort='beginning_image_number'))
-        self.assertTrue(
-            [each['beginning_image_number'] for each in results],
-            [1, 2]
-        )
+        self.assertTrue([each['beginning_image_number'] for each in results], [1, 2])
 
     def test_sort_bad_column(self):
         response = self.app.get(api.url_for(FilingsList, sort='request_type'))
@@ -123,30 +133,60 @@ class TestFilings(ApiBaseTest):
 
     def test_secondary_sort_ascending(self):
         [
-            factories.FilingsFactory(beginning_image_number=2, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=1, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=0, coverage_end_date='2017-01-02'),
+            factories.FilingsFactory(
+                beginning_image_number=2, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=1, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=0, coverage_end_date='2017-01-02'
+            ),
         ]
-        results = self._results(api.url_for(FilingsList, sort=['coverage_end_date', 'beginning_image_number']))
+        results = self._results(
+            api.url_for(
+                FilingsList, sort=['coverage_end_date', 'beginning_image_number']
+            )
+        )
         self.assertEqual(results[0]['beginning_image_number'], '1')
         self.assertEqual(results[2]['beginning_image_number'], '0')
 
     def test_secondary_sort_descending(self):
         [
-            factories.FilingsFactory(beginning_image_number=2, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=1, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=0, coverage_end_date='2017-01-02'),
+            factories.FilingsFactory(
+                beginning_image_number=2, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=1, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=0, coverage_end_date='2017-01-02'
+            ),
         ]
-        results = self._results(api.url_for(FilingsList, sort=['coverage_end_date', '-beginning_image_number']))
+        results = self._results(
+            api.url_for(
+                FilingsList, sort=['coverage_end_date', '-beginning_image_number']
+            )
+        )
         self.assertEqual(results[0]['beginning_image_number'], '2')
 
     def test_primary_sort_takes_overrides_secondary_sort(self):
         [
-            factories.FilingsFactory(beginning_image_number=2, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=1, coverage_end_date='2017-01-01'),
-            factories.FilingsFactory(beginning_image_number=0, coverage_end_date='2017-01-02'),
+            factories.FilingsFactory(
+                beginning_image_number=2, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=1, coverage_end_date='2017-01-01'
+            ),
+            factories.FilingsFactory(
+                beginning_image_number=0, coverage_end_date='2017-01-02'
+            ),
         ]
-        results = self._results(api.url_for(FilingsList, sort=['-coverage_end_date', '-beginning_image_number']))
+        results = self._results(
+            api.url_for(
+                FilingsList, sort=['-coverage_end_date', '-beginning_image_number']
+            )
+        )
         self.assertEqual(results[0]['beginning_image_number'], '0')
 
     def test_regex(self):
@@ -164,7 +204,6 @@ class TestFilings(ApiBaseTest):
 
 
 class TestEfileFiles(ApiBaseTest):
-
     def test_filter_date_efile(self):
         [
             factories.EFilingsFactory(
@@ -180,25 +219,34 @@ class TestEfileFiles(ApiBaseTest):
             factories.EFilingsFactory(
                 committee_id='C012',
                 beginning_image_number=4,
-                filed_date=datetime.date(2014, 1, 1)
+                filed_date=datetime.date(2014, 1, 1),
             ),
             factories.EFilingsFactory(
                 committee_id='C013',
                 beginning_image_number=5,
-                filed_date=datetime.date(2015, 1, 1)
+                filed_date=datetime.date(2015, 1, 1),
             ),
         ]
 
         min_date = datetime.date(2013, 1, 1)
         results = self._results(api.url_for(EFilingsView, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['filed_date'] >= min_date.isoformat()))
+        self.assertTrue(
+            all(each for each in results if each['filed_date'] >= min_date.isoformat())
+        )
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(EFilingsView, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['filed_date'] <= max_date.isoformat()))
-        results = self._results(api.url_for(EFilingsView, min_receipt_date=min_date, max_receipt_date=max_date))
+        self.assertTrue(
+            all(each for each in results if each['filed_date'] <= max_date.isoformat())
+        )
+        results = self._results(
+            api.url_for(
+                EFilingsView, min_receipt_date=min_date, max_receipt_date=max_date
+            )
+        )
         self.assertTrue(
             all(
-                each for each in results
+                each
+                for each in results
                 if min_date.isoformat() <= each['filed_date'] <= max_date.isoformat()
             )
         )
@@ -206,13 +254,24 @@ class TestEfileFiles(ApiBaseTest):
     def test_filter_receipt_date_efile(self):
 
         [
-            factories.EFilingsFactory(committee_id='C013', beginning_image_number=5,
-                filed_date=datetime.date(2015, 1, 1)),
-            factories.EFilingsFactory(committee_id='C014', beginning_image_number=6,
-                filed_date=datetime.date(2015, 1, 2)),
+            factories.EFilingsFactory(
+                committee_id='C013',
+                beginning_image_number=5,
+                filed_date=datetime.date(2015, 1, 1),
+            ),
+            factories.EFilingsFactory(
+                committee_id='C014',
+                beginning_image_number=6,
+                filed_date=datetime.date(2015, 1, 2),
+            ),
         ]
-        results = self._results(api.url_for(EFilingsView,
-            min_receipt_date=datetime.date(2015, 1, 1), max_receipt_date=datetime.date(2015, 1, 2)))
+        results = self._results(
+            api.url_for(
+                EFilingsView,
+                min_receipt_date=datetime.date(2015, 1, 1),
+                max_receipt_date=datetime.date(2015, 1, 2),
+            )
+        )
         self.assertEqual(len(results), 2)
 
     def test_efilings(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,15 +9,26 @@ from webservices.resources.reports import get_match_filters
 
 
 class TestFilterMatch(ApiBaseTest):
-
     def setUp(self):
         super(TestFilterMatch, self).setUp()
         self.dates = [
-            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
-            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
-            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
-            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
-            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
+            factories.CalendarDateFactory(
+                event_id=123,
+                calendar_category_id=1,
+                summary='July Quarterly Report Due',
+            ),
+            factories.CalendarDateFactory(
+                event_id=321, calendar_category_id=1, summary='TX Primary Runoff'
+            ),
+            factories.CalendarDateFactory(
+                event_id=111, calendar_category_id=2, summary='EC Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=222, calendar_category_id=2, summary='IE Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=333, calendar_category_id=3, summary='Executive Session'
+            ),
             factories.CalendarDateFactory(calendar_category_id=3, summary='Missing ID'),
         ]
         self.reports = [
@@ -31,54 +42,73 @@ class TestFilterMatch(ApiBaseTest):
         query_dates = filters.filter_match(
             models.CalendarDate.query,
             {'event_id': 123},
-            CalendarDatesView.filter_match_fields
+            CalendarDatesView.filter_match_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if each.event_id == 123))
+            set(each for each in self.dates if each.event_id == 123),
+        )
 
         # Filter for a single string value
         query_reports = filters.filter_match(
             models.CommitteeReportsHouseSenate.query,
             {'filer_type': 'e-file'},
-            get_match_filters()
+            get_match_filters(),
         )
         self.assertEqual(
             set(query_reports.all()),
-            set(each for each in self.reports if each.means_filed == 'e-file'))
+            set(each for each in self.reports if each.means_filed == 'e-file'),
+        )
 
     def test_filter_match_exclude(self):
         # Exclude a single integer value
         query_dates = filters.filter_match(
             models.CalendarDate.query,
             {'event_id': -321},
-            CalendarDatesView.filter_match_fields
+            CalendarDatesView.filter_match_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if each.event_id != 321 or each.event_id is None))
+            set(
+                each
+                for each in self.dates
+                if each.event_id != 321 or each.event_id is None
+            ),
+        )
 
         # Exclude a single string value
         query_reports = filters.filter_match(
             models.CommitteeReportsHouseSenate.query,
             {'filer_type': '-paper'},
-            get_match_filters()
+            get_match_filters(),
         )
         self.assertEqual(
             set(query_reports.all()),
-            set(each for each in self.reports if each.means_filed != 'paper'))
+            set(each for each in self.reports if each.means_filed != 'paper'),
+        )
 
 
 class TestFilterMulti(ApiBaseTest):
-
     def setUp(self):
         super(TestFilterMulti, self).setUp()
         self.dates = [
-            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
-            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
-            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
-            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
-            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
+            factories.CalendarDateFactory(
+                event_id=123,
+                calendar_category_id=1,
+                summary='July Quarterly Report Due',
+            ),
+            factories.CalendarDateFactory(
+                event_id=321, calendar_category_id=1, summary='TX Primary Runoff'
+            ),
+            factories.CalendarDateFactory(
+                event_id=111, calendar_category_id=2, summary='EC Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=222, calendar_category_id=2, summary='IE Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=333, calendar_category_id=3, summary='Executive Session'
+            ),
             factories.CalendarDateFactory(calendar_category_id=3, summary='Missing ID'),
         ]
         self.committees = [
@@ -94,67 +124,85 @@ class TestFilterMulti(ApiBaseTest):
         query_dates = filters.filter_multi(
             models.CalendarDate.query,
             {'calendar_category_id': [1, 3]},
-            CalendarDatesView.filter_multi_fields
+            CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id in [1,3]))
+            set(each for each in self.dates if each.calendar_category_id in [1, 3]),
+        )
 
         # Filter for multiple string values
         query_committees = filters.filter_multi(
             models.Committee.query,
             {'designation': ['P', 'U']},
-            CommitteeList.filter_multi_fields
+            CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
             set(query_committees.all()),
-            set(each for each in self.committees if each.designation in ['P','U']))
+            set(each for each in self.committees if each.designation in ['P', 'U']),
+        )
 
     def test_filter_multi_exclude(self):
         # Exclude multiple integer values
         query_dates = filters.filter_multi(
             models.CalendarDate.query,
             {'calendar_category_id': [-1, -3]},
-            CalendarDatesView.filter_multi_fields
+            CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id not in [1,3]))
+            set(each for each in self.dates if each.calendar_category_id not in [1, 3]),
+        )
 
         # Exclude multiple string values
         query_committees = filters.filter_multi(
             models.Committee.query,
             {'designation': ['-P', '-U']},
-            CommitteeList.filter_multi_fields
+            CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
             set(query_committees.all()),
-            set(each for each in self.committees if each.designation not in ['P','U'] or each.designation is None))
+            set(
+                each
+                for each in self.committees
+                if each.designation not in ['P', 'U'] or each.designation is None
+            ),
+        )
 
     def test_filter_multi_combo(self):
         # Exclude/include multiple integer values
         query_dates = filters.filter_multi(
             models.CalendarDate.query,
             {'calendar_category_id': [-1, 3]},
-            CalendarDatesView.filter_multi_fields
+            CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if each.calendar_category_id not in [1] and each.calendar_category_id in [3]))
+            set(
+                each
+                for each in self.dates
+                if each.calendar_category_id not in [1]
+                and each.calendar_category_id in [3]
+            ),
+        )
 
         # Exclude/include multiple string values
         query_committees = filters.filter_multi(
             models.Committee.query,
             {'designation': ['-P', 'U']},
-            CommitteeList.filter_multi_fields
+            CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
             set(query_committees.all()),
-            set(each for each in self.committees if each.designation not in ['P'] and each.designation in ['U']))
+            set(
+                each
+                for each in self.committees
+                if each.designation not in ['P'] and each.designation in ['U']
+            ),
+        )
 
 
 class TestFilterOther(ApiBaseTest):
-
     def setUp(self):
         super(TestFilterOther, self).setUp()
         self.receipts = [
@@ -165,11 +213,23 @@ class TestFilterOther(ApiBaseTest):
             factories.ScheduleAFactory(entity_type='PAC'),
         ]
         self.dates = [
-            factories.CalendarDateFactory(event_id=123, calendar_category_id=1, summary='July Quarterly Report Due'),
-            factories.CalendarDateFactory(event_id=321, calendar_category_id=1, summary='TX Primary Runoff'),
-            factories.CalendarDateFactory(event_id=111, calendar_category_id=2, summary='EC Reporting Period'),
-            factories.CalendarDateFactory(event_id=222, calendar_category_id=2, summary='IE Reporting Period'),
-            factories.CalendarDateFactory(event_id=333, calendar_category_id=3, summary='Executive Session'),
+            factories.CalendarDateFactory(
+                event_id=123,
+                calendar_category_id=1,
+                summary='July Quarterly Report Due',
+            ),
+            factories.CalendarDateFactory(
+                event_id=321, calendar_category_id=1, summary='TX Primary Runoff'
+            ),
+            factories.CalendarDateFactory(
+                event_id=111, calendar_category_id=2, summary='EC Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=222, calendar_category_id=2, summary='IE Reporting Period'
+            ),
+            factories.CalendarDateFactory(
+                event_id=333, calendar_category_id=3, summary='Executive Session'
+            ),
         ]
 
     def test_filter_contributor_type_individual(self):
@@ -180,7 +240,7 @@ class TestFilterOther(ApiBaseTest):
         )
         self.assertEqual(
             set(query.all()),
-            set(each for each in self.receipts if each.entity_type == 'IND')
+            set(each for each in self.receipts if each.entity_type == 'IND'),
         )
 
     def test_filter_contributor_type_committee(self):
@@ -191,7 +251,7 @@ class TestFilterOther(ApiBaseTest):
         )
         self.assertEqual(
             set(query.all()),
-            set(each for each in self.receipts if each.entity_type != 'IND')
+            set(each for each in self.receipts if each.entity_type != 'IND'),
         )
 
     def test_filter_contributor_type_none(self):
@@ -208,8 +268,13 @@ class TestFilterOther(ApiBaseTest):
         query_dates = filters.filter_fulltext(
             models.CalendarDate.query,
             {'summary': ['Report', '-IE']},
-            CalendarDatesView.filter_fulltext_fields
+            CalendarDatesView.filter_fulltext_fields,
         )
         self.assertEqual(
             set(query_dates.all()),
-            set(each for each in self.dates if 'Report' in each.summary and 'IE' not in each.summary))
+            set(
+                each
+                for each in self.dates
+                if 'Report' in each.summary and 'IE' not in each.summary
+            ),
+        )

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1109,7 +1109,7 @@ class TestScheduleE(ApiBaseTest):
         payee_names = ['#', '##', '@#$%^&*', '%', '', '  ']
         [factories.ScheduleEFactory(payee_name_text=payee) for payee in payee_names]
         results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
-        self.assertEquals(len(results), 0)
+        self.assertEqual(len(results), 0)
 
     def test_schedule_e_sort_args_descending(self):
         [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -6,11 +6,17 @@ from tests.common import ApiBaseTest
 from webservices.rest import db, api
 from webservices.schemas import ScheduleASchema
 from webservices.schemas import ScheduleBSchema
-from webservices.common.models import ScheduleA, ScheduleB, ScheduleE, ScheduleAEfile, ScheduleBEfile, ScheduleEEfile, ScheduleH4, EFilings
+from webservices.common.models import (
+    ScheduleE,
+    ScheduleAEfile,
+    ScheduleBEfile,
+    ScheduleEEfile,
+)
 from webservices.resources.sched_a import ScheduleAView, ScheduleAEfileView
 from webservices.resources.sched_b import ScheduleBView, ScheduleBEfileView
 from webservices.resources.sched_e import ScheduleEView, ScheduleEEfileView
 from webservices.resources.sched_h4 import ScheduleH4View
+
 
 class TestItemized(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
@@ -36,49 +42,52 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
             ),
             factories.ScheduleAFactory(
                 report_year=2015,
                 contribution_receipt_date=datetime.date(2015, 1, 1),
-                two_year_transaction_period=2016
+                two_year_transaction_period=2016,
             ),
         ]
-        response = self._response(api.url_for(ScheduleAView, sort='contribution_receipt_date', **self.kwargs))
+        response = self._response(
+            api.url_for(ScheduleAView, sort='contribution_receipt_date', **self.kwargs)
+        )
         self.assertEqual(
-            [each['report_year'] for each in response['results']],
-            [2015, 2016]
+            [each['report_year'] for each in response['results']], [2015, 2016]
         )
         self.assertEqual(
             response['pagination']['last_indexes'],
             {
                 'last_index': str(receipts[0].sub_id),
-                'last_contribution_receipt_date': receipts[0].contribution_receipt_date.isoformat(),
-            }
+                'last_contribution_receipt_date': receipts[
+                    0
+                ].contribution_receipt_date.isoformat(),
+            },
         )
 
     def test_schedule_a_multiple_two_year_transaction_period(self):
         """
         testing schedule_a api can take multiple cycles now
         """
-        receipts = [
+        receipts = [  # noqa
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
                 two_year_transaction_period=2014,
-                committee_id='C001'
+                committee_id='C001',
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
                 two_year_transaction_period=2016,
-                committee_id='C001'
+                committee_id='C001',
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
                 two_year_transaction_period=2018,
-                committee_id='C001'
+                committee_id='C001',
             ),
         ]
         response = self._response(
@@ -86,20 +95,21 @@ class TestScheduleA(ApiBaseTest):
                 ScheduleAView,
                 two_year_transaction_period=[2016, 2018],
                 committee_id='C001',
-        ))
+            )
+        )
         self.assertEqual(len(response['results']), 2)
 
     def test_schedule_a_two_year_transaction_period_limits_results_per_cycle(self):
-        receipts = [
+        receipts = [  # noqa
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
-                two_year_transaction_period=2014
+                two_year_transaction_period=2014,
             ),
             factories.ScheduleAFactory(
                 report_year=2012,
                 contribution_receipt_date=datetime.date(2012, 1, 1),
-                two_year_transaction_period=2012
+                two_year_transaction_period=2012,
             ),
         ]
         response = self._response(
@@ -117,7 +127,9 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(contributor_state='NY'),
             factories.ScheduleAFactory(contributor_state='CA'),
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_state='CA', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_state='CA', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_state'], 'CA')
 
@@ -126,20 +138,28 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(contributor_zip=96789),
             factories.ScheduleAFactory(contributor_zip=9678912),
             factories.ScheduleAFactory(contributor_zip=967891234),
-            factories.ScheduleAFactory(contributor_zip='M4C 1M7')
+            factories.ScheduleAFactory(contributor_zip='M4C 1M7'),
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_zip=967893405, **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_zip=967893405, **self.kwargs)
+        )
         self.assertEqual(len(results), 3)
 
-        results = self._results(api.url_for(ScheduleAView, contributor_zip='M4C 1M55', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_zip='M4C 1M55', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
 
         contributor_zips = ['M4C 1M5555', 96789]
-        results = self._results(api.url_for(ScheduleAView, contributor_zip=contributor_zips, **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_zip=contributor_zips, **self.kwargs)
+        )
         self.assertEqual(len(results), 4)
 
     def test_schedule_a_invalid_zip(self):
-        response = self.app.get(api.url_for(ScheduleAView, contributor_zip='96%', cycle=2018))
+        response = self.app.get(
+            api.url_for(ScheduleAView, contributor_zip='96%', cycle=2018)
+        )
         self.assertEqual(response.status_code, 400)
 
     def test_schedule_a_recipient_committee_type_filter(self):
@@ -148,7 +168,9 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(recipient_committee_type='S'),
             factories.ScheduleAFactory(recipient_committee_type='P'),
         ]
-        results = self._results(api.url_for(ScheduleAView, recipient_committee_type='S', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, recipient_committee_type='S', **self.kwargs)
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_a_recipient_org_type_filter(self):
@@ -157,7 +179,9 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(recipient_committee_org_type='W'),
             factories.ScheduleAFactory(recipient_committee_org_type='C'),
         ]
-        results = self._results(api.url_for(ScheduleAView, recipient_committee_org_type='W', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, recipient_committee_org_type='W', **self.kwargs)
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_a_recipient_designation_filter(self):
@@ -166,14 +190,18 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(recipient_committee_designation='P'),
             factories.ScheduleAFactory(recipient_committee_designation='A'),
         ]
-        results = self._results(api.url_for(ScheduleAView, recipient_committee_designation='P', **self.kwargs))
+        results = self._results(
+            api.url_for(
+                ScheduleAView, recipient_committee_designation='P', **self.kwargs
+            )
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_a_filter_multi_start_with(self):
-        [
-            factories.ScheduleAFactory(contributor_zip=1296789)
-        ]
-        results = self._results(api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs))
+        [factories.ScheduleAFactory(contributor_zip=1296789)]
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_zip=96789, **self.kwargs)
+        )
         self.assertEqual(len(results), 0)
 
     def test_schedule_a_filter_case_insensitive(self):
@@ -181,7 +209,9 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(contributor_city='NEW YORK'),
             factories.ScheduleAFactory(contributor_city='DES MOINES'),
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_city='new york', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_city='new york', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_city'], 'NEW YORK')
 
@@ -191,47 +221,58 @@ class TestScheduleA(ApiBaseTest):
         If this is removed, please add a test to test_filters.py
         """
         names = ['David Koch', 'George Soros']
-        filings = [
-            factories.ScheduleAFactory(contributor_name=name)
-            for name in names
+        filings = [  # noqa
+            factories.ScheduleAFactory(contributor_name=name) for name in names
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_name='soros', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_name='soros', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_name'], 'George Soros')
 
     def test_schedule_a_filter_line_number(self):
         [
             factories.ScheduleAFactory(line_number='16', filing_form='F3X'),
-            factories.ScheduleAFactory(line_number='17', filing_form='F3X')
+            factories.ScheduleAFactory(line_number='17', filing_form='F3X'),
         ]
-        results = self._results(api.url_for(ScheduleAView, line_number='f3X-16', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, line_number='f3X-16', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
 
         [
             factories.ScheduleBFactory(line_number='21', filing_form='F3X'),
-            factories.ScheduleBFactory(line_number='22', filing_form='F3X')
+            factories.ScheduleBFactory(line_number='22', filing_form='F3X'),
         ]
 
-        results = self._results(api.url_for(ScheduleBView, line_number='f3X-21', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleBView, line_number='f3X-21', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
 
         # invalid line_number testing for sched_b
-        response = self.app.get(api.url_for(ScheduleBView, line_number='f3x21', **self.kwargs))
+        response = self.app.get(
+            api.url_for(ScheduleBView, line_number='f3x21', **self.kwargs)
+        )
         self.assertEqual(response.status_code, 400)
         self.assertIn(b'Invalid line_number', response.data)
 
         # invalid line_number testing for sched_a
-        response = self.app.get(api.url_for(ScheduleAView, line_number='f3x16', **self.kwargs))
+        response = self.app.get(
+            api.url_for(ScheduleAView, line_number='f3x16', **self.kwargs)
+        )
         self.assertEqual(response.status_code, 400)
         self.assertIn(b'Invalid line_number', response.data)
 
     def test_schedule_a_filter_fulltext_employer(self):
         employers = ['Acme Corporation', 'Vandelay Industries']
-        filings = [
+        filings = [  # noqa
             factories.ScheduleAFactory(contributor_employer=employer)
             for employer in employers
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='vandelay', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='vandelay', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_employer'], 'Vandelay Industries')
 
@@ -241,37 +282,48 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(contributor_employer=employer)
             for employer in employers
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test&Test', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='Test&Test', **self.kwargs)
+        )
         self.assertIn(results[0]['contributor_employer'], employers)
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test & Test', **self.kwargs))
+        results = self._results(
+            api.url_for(
+                ScheduleAView, contributor_employer='Test & Test', **self.kwargs
+            )
+        )
         self.assertIn(results[0]['contributor_employer'], employers)
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test& Test', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='Test& Test', **self.kwargs)
+        )
         self.assertIn(results[0]['contributor_employer'], employers)
-        results = self._results(api.url_for(ScheduleAView, contributor_employer='Test &Test', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='Test &Test', **self.kwargs)
+        )
         self.assertIn(results[0]['contributor_employer'], employers)
 
     def test_schedule_a_filter_fulltext_occupation(self):
         occupations = ['Attorney at Law', 'Doctor of Philosophy']
-        filings = [
+        filings = [  # noqa
             factories.ScheduleAFactory(contributor_occupation=occupation)
             for occupation in occupations
         ]
-        results = self._results(api.url_for(ScheduleAView, contributor_occupation='doctor', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_occupation='doctor', **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_occupation'], 'Doctor of Philosophy')
 
     def test_schedule_a_pagination(self):
-        filings = [
-            factories.ScheduleAFactory()
-            for _ in range(30)
-        ]
+        filings = [factories.ScheduleAFactory() for _ in range(30)]
         page1 = self._results(api.url_for(ScheduleAView, **self.kwargs))
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
             [each.sub_id for each in filings[:20]],
         )
-        page2 = self._results(api.url_for(ScheduleAView, last_index=page1[-1]['sub_id'], **self.kwargs))
+        page2 = self._results(
+            api.url_for(ScheduleAView, last_index=page1[-1]['sub_id'], **self.kwargs)
+        )
         self.assertEqual(len(page2), 10)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -280,8 +332,7 @@ class TestScheduleA(ApiBaseTest):
 
     def test_schedule_a_pagination_with_null_sort_column_values(self):
         filings = [
-            factories.ScheduleAFactory(contribution_receipt_date=None)
-            for _ in range(5)
+            factories.ScheduleAFactory(contribution_receipt_date=None) for _ in range(5)
         ]
         filings = filings + [
             factories.ScheduleAFactory(
@@ -289,11 +340,9 @@ class TestScheduleA(ApiBaseTest):
             )
             for _ in range(25)
         ]
-        page1 = self._results(api.url_for(
-            ScheduleAView,
-            sort='contribution_receipt_date',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(ScheduleAView, sort='contribution_receipt_date', **self.kwargs)
+        )
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
@@ -301,8 +350,12 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page1],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d')
-            if each.contribution_receipt_date else None for each in filings[5:25]]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[5:25]
+            ],
         )
         page2 = self._results(
             api.url_for(
@@ -319,14 +372,18 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d')
-            if each.contribution_receipt_date else None for each in filings[25:]]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[25:]
+            ],
         )
 
     def test_schedule_a_null_pagination_with_null_sort_column_values_descending(self):
         filings = [
             factories.ScheduleAFactory(contribution_receipt_date=None)
-            #this range should ensure the page has a null transition
+            # this range should ensure the page has a null transition
             for _ in range(10)
         ]
         filings = filings + [
@@ -336,12 +393,14 @@ class TestScheduleA(ApiBaseTest):
             for _ in range(15)
         ]
 
-        page1 = self._results(api.url_for(
-            ScheduleAView,
-            sort='-contribution_receipt_date',
-            sort_reverse_nulls='true',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(
+                ScheduleAView,
+                sort='-contribution_receipt_date',
+                sort_reverse_nulls='true',
+                **self.kwargs
+            )
+        )
 
         self.assertEqual(len(page1), 20)
 
@@ -354,16 +413,22 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page1],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d')
-            if each.contribution_receipt_date else None for each in top_reversed_from_middle]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in top_reversed_from_middle
+            ],
         )
-        page2 = self._results(api.url_for(
-            ScheduleAView,
-            last_index=page1[-1]['sub_id'],
-            last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
-            sort='-contribution_receipt_date',
-            **self.kwargs
-        ))
+        page2 = self._results(
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
+                sort='-contribution_receipt_date',
+                **self.kwargs
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -371,8 +436,12 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d')
-            if each.contribution_receipt_date else None for each in filings[14:9:-1]]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[14:9:-1]
+            ],
         )
 
     def test_schedule_a_null_pagination_with_null_sort_column_values_ascending(self):
@@ -388,12 +457,14 @@ class TestScheduleA(ApiBaseTest):
             for _ in range(15)
         ]
 
-        page1 = self._results(api.url_for(
-            ScheduleAView,
-            sort='contribution_receipt_date',
-            sort_reverse_nulls='true',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(
+                ScheduleAView,
+                sort='contribution_receipt_date',
+                sort_reverse_nulls='true',
+                **self.kwargs
+            )
+        )
 
         self.assertEqual(len(page1), 20)
 
@@ -406,16 +477,22 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page1],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in
-             top_reversed_from_middle]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in top_reversed_from_middle
+            ],
         )
-        page2 = self._results(api.url_for(
-            ScheduleAView,
-            last_index=page1[-1]['sub_id'],
-            sort_null_only=True,
-            sort='contribution_receipt_date',
-            **self.kwargs
-        ))
+        page2 = self._results(
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                sort_null_only=True,
+                sort='contribution_receipt_date',
+                **self.kwargs
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -423,8 +500,12 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
-            [each.contribution_receipt_date.strftime('%Y-%m-%d') if each.contribution_receipt_date else None for each in
-             filings[5:10:]]
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[5:10:]
+            ],
         )
 
     def test_schedule_a_pagination_with_null_sort_column_parameter(self):
@@ -432,13 +513,15 @@ class TestScheduleA(ApiBaseTest):
             api.url_for(
                 ScheduleAView,
                 sort='contribution_receipt_date',
-                last_contribution_receipt_date='null'
+                last_contribution_receipt_date='null',
             )
         )
         self.assertEqual(response.status_code, 422)
 
     def test_schedule_a_pagination_bad_per_page(self):
-        response = self.app.get(api.url_for(ScheduleAView, two_year_transaction_period=2018, per_page=999))
+        response = self.app.get(
+            api.url_for(ScheduleAView, two_year_transaction_period=2018, per_page=999)
+        )
         self.assertEqual(response.status_code, 422)
 
     def test_schedule_a_image_number(self):
@@ -447,7 +530,9 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(),
             factories.ScheduleAFactory(image_number=image_number),
         ]
-        results = self._results(api.url_for(ScheduleAView, image_number=image_number, **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleAView, image_number=image_number, **self.kwargs)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['image_number'], image_number)
 
@@ -458,11 +543,26 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(image_number='3'),
             factories.ScheduleAFactory(image_number='4'),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2', two_year_transaction_period=2016))
+        results = self._results(
+            api.url_for(
+                ScheduleAView, min_image_number='2', two_year_transaction_period=2016
+            )
+        )
         self.assertTrue(all(each['image_number'] >= '2' for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_image_number='3', two_year_transaction_period=2016))
+        results = self._results(
+            api.url_for(
+                ScheduleAView, max_image_number='3', two_year_transaction_period=2016
+            )
+        )
         self.assertTrue(all(each['image_number'] <= '3' for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_image_number='2', max_image_number='3', two_year_transaction_period=2016))
+        results = self._results(
+            api.url_for(
+                ScheduleAView,
+                min_image_number='2',
+                max_image_number='3',
+                two_year_transaction_period=2016,
+            )
+        )
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
     def test_schedule_a_amount(self):
@@ -472,28 +572,48 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(contribution_receipt_amount=150),
             factories.ScheduleAFactory(contribution_receipt_amount=200),
         ]
-        results = self._results(api.url_for(ScheduleAView, min_amount=100, two_year_transaction_period=2016))
-        self.assertTrue(all(each['contribution_receipt_amount'] >= 100 for each in results))
-        results = self._results(api.url_for(ScheduleAView, max_amount=150, two_year_transaction_period=2016))
-        self.assertTrue(all(each['contribution_receipt_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleAView, min_amount=100, max_amount=150, two_year_transaction_period=2016))
-        self.assertTrue(all(100 <= each['contribution_receipt_amount'] <= 150 for each in results))
+        results = self._results(
+            api.url_for(ScheduleAView, min_amount=100, two_year_transaction_period=2016)
+        )
+        self.assertTrue(
+            all(each['contribution_receipt_amount'] >= 100 for each in results)
+        )
+        results = self._results(
+            api.url_for(ScheduleAView, max_amount=150, two_year_transaction_period=2016)
+        )
+        self.assertTrue(
+            all(each['contribution_receipt_amount'] <= 150 for each in results)
+        )
+        results = self._results(
+            api.url_for(
+                ScheduleAView,
+                min_amount=100,
+                max_amount=150,
+                two_year_transaction_period=2016,
+            )
+        )
+        self.assertTrue(
+            all(100 <= each['contribution_receipt_amount'] <= 150 for each in results)
+        )
 
     def test_schedule_a_efile_filters(self):
         filters = [
             ('image_number', ScheduleAEfile.image_number, ['123', '456']),
             ('committee_id', ScheduleAEfile.committee_id, ['C01', 'C02']),
-            #may have to rethink this, currently on efile itemized resources the city isn't all caps
-            #but for processed it is, is that something we are forcing when when
-            #we build the tables?
-            ('contributor_city', ScheduleAEfile.contributor_city, ['KANSAS CITY', 'HONOLULU']),
+            # may have to rethink this, currently on efile itemized resources the city isn't all caps
+            # but for processed it is, is that something we are forcing when when
+            # we build the tables?
+            (
+                'contributor_city',
+                ScheduleAEfile.contributor_city,
+                ['KANSAS CITY', 'HONOLULU'],
+            ),
         ]
         for label, column, values in filters:
-            [
-                factories.ScheduleAEfileFactory(**{column.key: value})
-                for value in values
-            ]
-            results = self._results(api.url_for(ScheduleAEfileView, **{label: values[0]}))
+            [factories.ScheduleAEfileFactory(**{column.key: value}) for value in values]
+            results = self._results(
+                api.url_for(ScheduleAEfileView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
@@ -505,25 +625,20 @@ class TestScheduleB(ApiBaseTest):
         """
         testing schedule_b api can take multiple cyccles now
         """
-        disbursements = [
+        disbursements = [  # noqa
             factories.ScheduleBFactory(
-                report_year=2014,
-                two_year_transaction_period=2014
+                report_year=2014, two_year_transaction_period=2014
             ),
             factories.ScheduleBFactory(
-                report_year=2016,
-                two_year_transaction_period=2016
+                report_year=2016, two_year_transaction_period=2016
             ),
             factories.ScheduleBFactory(
-                report_year=2018,
-                two_year_transaction_period=2018
+                report_year=2018, two_year_transaction_period=2018
             ),
         ]
         response = self._response(
-            api.url_for(
-                ScheduleBView,
-                two_year_transaction_period=[2016, 2018],
-        ))
+            api.url_for(ScheduleBView, two_year_transaction_period=[2016, 2018],)
+        )
         self.assertEqual(len(response['results']), 2)
 
     def test_schedule_b_spender_committee_type_filter(self):
@@ -532,7 +647,9 @@ class TestScheduleB(ApiBaseTest):
             factories.ScheduleBFactory(spender_committee_type='S'),
             factories.ScheduleBFactory(spender_committee_type='P'),
         ]
-        results = self._results(api.url_for(ScheduleBView, spender_committee_type='S', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleBView, spender_committee_type='S', **self.kwargs)
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_b_spender_org_type_filter(self):
@@ -541,7 +658,9 @@ class TestScheduleB(ApiBaseTest):
             factories.ScheduleBFactory(spender_committee_org_type='W'),
             factories.ScheduleBFactory(spender_committee_org_type='C'),
         ]
-        results = self._results(api.url_for(ScheduleBView, spender_committee_org_type='W', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleBView, spender_committee_org_type='W', **self.kwargs)
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_b_spender_designation_filter(self):
@@ -550,7 +669,9 @@ class TestScheduleB(ApiBaseTest):
             factories.ScheduleBFactory(spender_committee_designation='P'),
             factories.ScheduleBFactory(spender_committee_designation='A'),
         ]
-        results = self._results(api.url_for(ScheduleBView, spender_committee_designation='P', **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleBView, spender_committee_designation='P', **self.kwargs)
+        )
         self.assertEqual(len(results), 2)
 
     def test_schedule_b_pagination_with_sort_expression(self):
@@ -558,43 +679,37 @@ class TestScheduleB(ApiBaseTest):
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
         # by default (in descending order), so we must account for that with the
         # results and slice the baseline list of objects accordingly!
-        filings = [
-            factories.ScheduleBFactory()
-            for _ in range(30)
-        ]
+        filings = [factories.ScheduleBFactory() for _ in range(30)]
         page1 = self._results(api.url_for(ScheduleBView, **self.kwargs))
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
             [each.sub_id for each in filings[:-21:-1]],
         )
-        page2 = self._results(api.url_for(ScheduleBView, last_index=page1[-1]['sub_id'], **self.kwargs))
+        page2 = self._results(
+            api.url_for(ScheduleBView, last_index=page1[-1]['sub_id'], **self.kwargs)
+        )
         self.assertEqual(len(page2), 10)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
             [each.sub_id for each in filings[9::-1]],
         )
 
-    def test_schedule_b_pagination_with_null_sort_column_values_with_sort_expression(self):
+    def test_schedule_b_pagination_with_null_sort_column_values_with_sort_expression(
+        self,
+    ):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
         # by default (in descending order), so we must account for that with the
         # results and slice the baseline list of objects accordingly!
-        filings = [
-            factories.ScheduleBFactory(disbursement_date=None)
-            for _ in range(5)
-        ]
+        filings = [factories.ScheduleBFactory(disbursement_date=None) for _ in range(5)]
         filings = filings + [
-            factories.ScheduleBFactory(
-                disbursement_date=datetime.date(2016, 1, 1)
-            )
+            factories.ScheduleBFactory(disbursement_date=datetime.date(2016, 1, 1))
             for _ in range(25)
         ]
-        page1 = self._results(api.url_for(
-            ScheduleBView,
-            sort='disbursement_date',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(ScheduleBView, sort='disbursement_date', **self.kwargs)
+        )
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
@@ -602,7 +717,12 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page1],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[5:25]]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in filings[5:25]
+            ],
         )
         page2 = self._results(
             api.url_for(
@@ -619,32 +739,39 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page2],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in filings[25:]]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in filings[25:]
+            ],
         )
 
-    def test_schedule_b_null_pagination_with_null_sort_column_values_descending_with_sort_expression(self):
+    def test_schedule_b_null_pagination_with_null_sort_column_values_descending_with_sort_expression(
+        self,
+    ):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
         # by default (in descending order), so we must account for that with the
         # results and slice the baseline list of objects accordingly!
         filings = [
             factories.ScheduleBFactory(disbursement_date=None)
-            #this range should ensure the page has a null transition
+            # this range should ensure the page has a null transition
             for _ in range(10)
         ]
         filings = filings + [
-            factories.ScheduleBFactory(
-                disbursement_date=datetime.date(2016, 1, 1)
-            )
+            factories.ScheduleBFactory(disbursement_date=datetime.date(2016, 1, 1))
             for _ in range(15)
         ]
 
-        page1 = self._results(api.url_for(
-            ScheduleBView,
-            sort='-disbursement_date',
-            sort_reverse_nulls='true',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(
+                ScheduleBView,
+                sort='-disbursement_date',
+                sort_reverse_nulls='true',
+                **self.kwargs
+            )
+        )
 
         self.assertEqual(len(page1), 20)
 
@@ -657,16 +784,22 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page1],
-            [each.disbursement_date.strftime('%Y-%m-%d')
-            if each.disbursement_date else None for each in top_reversed_from_middle]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in top_reversed_from_middle
+            ],
         )
-        page2 = self._results(api.url_for(
-            ScheduleBView,
-            last_index=page1[-1]['sub_id'],
-            last_disbursement_date=page1[-1]['disbursement_date'],
-            sort='-disbursement_date',
-            **self.kwargs
-        ))
+        page2 = self._results(
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                last_disbursement_date=page1[-1]['disbursement_date'],
+                sort='-disbursement_date',
+                **self.kwargs
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -674,11 +807,17 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page2],
-            [each.disbursement_date.strftime('%Y-%m-%d')
-            if each.disbursement_date else None for each in filings[14:9:-1]]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in filings[14:9:-1]
+            ],
         )
 
-    def test_schedule_b_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(self):
+    def test_schedule_b_null_pagination_with_null_sort_column_values_ascending_with_sort_expression(
+        self,
+    ):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
         # by default (in descending order), so we must account for that with the
@@ -689,18 +828,18 @@ class TestScheduleB(ApiBaseTest):
             for _ in range(10)
         ]
         filings = filings + [
-            factories.ScheduleBFactory(
-                disbursement_date=datetime.date(2016, 1, 1)
-            )
+            factories.ScheduleBFactory(disbursement_date=datetime.date(2016, 1, 1))
             for _ in range(15)
         ]
 
-        page1 = self._results(api.url_for(
-            ScheduleBView,
-            sort='disbursement_date',
-            sort_reverse_nulls='true',
-            **self.kwargs
-        ))
+        page1 = self._results(
+            api.url_for(
+                ScheduleBView,
+                sort='disbursement_date',
+                sort_reverse_nulls='true',
+                **self.kwargs
+            )
+        )
 
         self.assertEqual(len(page1), 20)
 
@@ -713,16 +852,22 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page1],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in
-             top_reversed_from_middle]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in top_reversed_from_middle
+            ],
         )
-        page2 = self._results(api.url_for(
-            ScheduleBView,
-            last_index=page1[-1]['sub_id'],
-            sort_null_only=True,
-            sort='disbursement_date',
-            **self.kwargs
-        ))
+        page2 = self._results(
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                sort_null_only=True,
+                sort='disbursement_date',
+                **self.kwargs
+            )
+        )
         self.assertEqual(len(page2), 5)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
@@ -730,20 +875,24 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page2],
-            [each.disbursement_date.strftime('%Y-%m-%d') if each.disbursement_date else None for each in
-             filings[5:10:]]
+            [
+                each.disbursement_date.strftime('%Y-%m-%d')
+                if each.disbursement_date
+                else None
+                for each in filings[5:10:]
+            ],
         )
 
-    def test_schedule_b_pagination_with_null_sort_column_parameter_with_sort_expression(self):
+    def test_schedule_b_pagination_with_null_sort_column_parameter_with_sort_expression(
+        self,
+    ):
         # NOTE:  Schedule B is sorted by disbursement date with the expression
         # sa.func.coalesce(self.disbursement_date, sa.cast('9999-12-31', sa.Date))
         # by default (in descending order), so we must account for that with the
         # results and slice the baseline list of objects accordingly!
         response = self.app.get(
             api.url_for(
-                ScheduleBView,
-                sort='disbursement_date',
-                last_disbursement_date='null'
+                ScheduleBView, sort='disbursement_date', last_disbursement_date='null'
             )
         )
         self.assertEqual(response.status_code, 422)
@@ -759,46 +908,77 @@ class TestScheduleB(ApiBaseTest):
         self.assertTrue(all(each['disbursement_amount'] >= 100 for each in results))
         results = self._results(api.url_for(ScheduleBView, max_amount=150))
         self.assertTrue(all(each['disbursement_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleBView, min_amount=100, max_amount=150))
-        self.assertTrue(all(100 <= each['disbursement_amount'] <= 150 for each in results))
+        results = self._results(
+            api.url_for(ScheduleBView, min_amount=100, max_amount=150)
+        )
+        self.assertTrue(
+            all(100 <= each['disbursement_amount'] <= 150 for each in results)
+        )
 
     def test_schedule_b_sort_ignores_nulls_last_parameter(self):
         disbursements = [
             factories.ScheduleBFactory(disbursement_amount=50),
-            factories.ScheduleBFactory(disbursement_amount=200, disbursement_date=datetime.date(2016, 3, 1)),
-            factories.ScheduleBFactory(disbursement_amount=150, disbursement_date=datetime.date(2016, 2, 1)),
-            factories.ScheduleBFactory(disbursement_amount=100, disbursement_date=datetime.date(2016, 1, 1)),
+            factories.ScheduleBFactory(
+                disbursement_amount=200, disbursement_date=datetime.date(2016, 3, 1)
+            ),
+            factories.ScheduleBFactory(
+                disbursement_amount=150, disbursement_date=datetime.date(2016, 2, 1)
+            ),
+            factories.ScheduleBFactory(
+                disbursement_amount=100, disbursement_date=datetime.date(2016, 1, 1)
+            ),
         ]
         sub_ids = [str(each.sub_id) for each in disbursements]
-        results = self._results(api.url_for(ScheduleBView, sort='-disbursement_date', sort_nulls_last=True, **self.kwargs))
+        results = self._results(
+            api.url_for(
+                ScheduleBView,
+                sort='-disbursement_date',
+                sort_nulls_last=True,
+                **self.kwargs
+            )
+        )
         self.assertEqual([each['sub_id'] for each in results], sub_ids)
 
     def test_schedule_b_efile_filters(self):
         filters = [
             ('image_number', ScheduleBEfile.image_number, ['123', '456']),
             ('committee_id', ScheduleBEfile.committee_id, ['C01', 'C02']),
-            ('recipient_state', ScheduleBEfile.recipient_state, ['MISSOURI', 'NEW YORK']),
+            (
+                'recipient_state',
+                ScheduleBEfile.recipient_state,
+                ['MISSOURI', 'NEW YORK'],
+            ),
         ]
         for label, column, values in filters:
-            [
-                factories.ScheduleBEfileFactory(**{column.key: value})
-                for value in values
-            ]
-            results = self._results(api.url_for(ScheduleBEfileView, **{label: values[0]}))
+            [factories.ScheduleBEfileFactory(**{column.key: value}) for value in values]
+            results = self._results(
+                api.url_for(ScheduleBEfileView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
+
 
 class TestScheduleE(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
 
     def test_schedule_e_sort_args_ascending(self):
         [
-            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
-                    committee_id='101', support_oppose_indicator='s'),
-            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
-                    committee_id='101', support_oppose_indicator='o'),
+            factories.ScheduleEFactory(
+                expenditure_amount=100,
+                expenditure_date=datetime.date(2016, 1, 1),
+                committee_id='101',
+                support_oppose_indicator='s',
+            ),
+            factories.ScheduleEFactory(
+                expenditure_amount=100,
+                expenditure_date=datetime.date(2016, 1, 1),
+                committee_id='101',
+                support_oppose_indicator='o',
+            ),
         ]
-        results = self._results(api.url_for(ScheduleEView, sort='support_oppose_indicator'))
+        results = self._results(
+            api.url_for(ScheduleEView, sort='support_oppose_indicator')
+        )
         self.assertEqual(results[0]['support_oppose_indicator'], 'o')
 
     def test_schedule_e_filter_dissemination_date_range(self):
@@ -808,12 +988,20 @@ class TestScheduleE(ApiBaseTest):
         factories.ScheduleEFactory(dissemination_date=datetime.datetime(2017, 6, 22))
         factories.ScheduleEFactory(dissemination_date=datetime.datetime(2015, 10, 15))
 
-        results = self._results(api.url_for(ScheduleEView,
-            min_dissemination_date=datetime.date.fromisoformat('2015-01-01')))
+        results = self._results(
+            api.url_for(
+                ScheduleEView,
+                min_dissemination_date=datetime.date.fromisoformat('2015-01-01'),
+            )
+        )
         assert len(results) == 5
 
-        results = self._results(api.url_for(ScheduleEView,
-            max_dissemination_date=datetime.date.fromisoformat('2021-10-25')))
+        results = self._results(
+            api.url_for(
+                ScheduleEView,
+                max_dissemination_date=datetime.date.fromisoformat('2021-10-25'),
+            )
+        )
         assert len(results) == 4
 
     def test_schedule_e_filters_date_range(self):
@@ -823,12 +1011,18 @@ class TestScheduleE(ApiBaseTest):
         factories.ScheduleEFactory(filing_date=datetime.datetime(2017, 6, 22))
         factories.ScheduleEFactory(filing_date=datetime.datetime(2015, 10, 15))
 
-        results = self._results(api.url_for(ScheduleEView,
-            min_filing_date=datetime.date.fromisoformat('2015-01-01')))
+        results = self._results(
+            api.url_for(
+                ScheduleEView, min_filing_date=datetime.date.fromisoformat('2015-01-01')
+            )
+        )
         assert len(results) == 5
 
-        results = self._results(api.url_for(ScheduleEView,
-            max_filing_date=datetime.date.fromisoformat('2021-10-25')))
+        results = self._results(
+            api.url_for(
+                ScheduleEView, max_filing_date=datetime.date.fromisoformat('2021-10-25')
+            )
+        )
         assert len(results) == 4
 
     def test_schedule_e_amount(self):
@@ -842,36 +1036,53 @@ class TestScheduleE(ApiBaseTest):
         self.assertTrue(all(each['expenditure_amount'] >= 100 for each in results))
         results = self._results(api.url_for(ScheduleEView, max_amount=150))
         self.assertTrue(all(each['expenditure_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleEView, min_amount=100, max_amount=150))
-        self.assertTrue(all(100 <= each['expenditure_amount'] <= 150 for each in results))
+        results = self._results(
+            api.url_for(ScheduleEView, min_amount=100, max_amount=150)
+        )
+        self.assertTrue(
+            all(100 <= each['expenditure_amount'] <= 150 for each in results)
+        )
 
     def test_schedule_e_sort(self):
         expenditures = [
             factories.ScheduleEFactory(expenditure_amount=50),
-            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1)),
-            factories.ScheduleEFactory(expenditure_amount=150, expenditure_date=datetime.date(2016, 2, 1)),
-            factories.ScheduleEFactory(expenditure_amount=200, expenditure_date=datetime.date(2016, 3, 1)),
+            factories.ScheduleEFactory(
+                expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1)
+            ),
+            factories.ScheduleEFactory(
+                expenditure_amount=150, expenditure_date=datetime.date(2016, 2, 1)
+            ),
+            factories.ScheduleEFactory(
+                expenditure_amount=200, expenditure_date=datetime.date(2016, 3, 1)
+            ),
         ]
         sub_ids = [str(each.sub_id) for each in expenditures]
-        results = self._results(api.url_for(ScheduleEView, sort='-expenditure_date', sort_nulls_last=True))
+        results = self._results(
+            api.url_for(ScheduleEView, sort='-expenditure_date', sort_nulls_last=True)
+        )
         self.assertEqual([each['sub_id'] for each in results], sub_ids[::-1])
 
     def test_schedule_e_filters(self):
         filters = [
             ('image_number', ScheduleE.image_number, ['123', '456']),
             ('committee_id', ScheduleE.committee_id, ['C01', 'C02']),
-            ('support_oppose_indicator', ScheduleE.support_oppose_indicator, ['S', 'O']),
+            (
+                'support_oppose_indicator',
+                ScheduleE.support_oppose_indicator,
+                ['S', 'O'],
+            ),
             ('is_notice', ScheduleE.is_notice, [True, False]),
             ('candidate_office_state', ScheduleE.candidate_office_state, ['AZ', 'AK']),
-            ('candidate_office_district', ScheduleE.candidate_office_district, ['00', '01']),
+            (
+                'candidate_office_district',
+                ScheduleE.candidate_office_district,
+                ['00', '01'],
+            ),
             ('candidate_party', ScheduleE.candidate_party, ['DEM', 'REP']),
             ('candidate_office', ScheduleE.candidate_office, ['H', 'S', 'P']),
         ]
         for label, column, values in filters:
-            [
-                factories.ScheduleEFactory(**{column.key: value})
-                for value in values
-            ]
+            [factories.ScheduleEFactory(**{column.key: value}) for value in values]
             results = self._results(api.url_for(ScheduleEView, **{label: values[0]}))
             assert len(results) == 1
             assert results[0][column.key] == values[0]
@@ -881,12 +1092,13 @@ class TestScheduleE(ApiBaseTest):
         test names that expect to be returned
         """
         payee_names = [
-            'Test.com', 'Test com', 'Testerosa', 'Test#com', 'Test.com and Test.com'
+            'Test.com',
+            'Test com',
+            'Testerosa',
+            'Test#com',
+            'Test.com and Test.com',
         ]
-        [
-            factories.ScheduleEFactory(payee_name=payee)
-            for payee in payee_names
-        ]
+        [factories.ScheduleEFactory(payee_name=payee) for payee in payee_names]
         results = self._results(api.url_for(ScheduleEView, payee_name='test'))
         self.assertEqual(len(results), len(payee_names))
 
@@ -894,45 +1106,61 @@ class TestScheduleE(ApiBaseTest):
         """
         test names that expect no returns
         """
-        payee_names = [
-            '#', '##', '@#$%^&*', '%', '', '  '
-        ]
-        [
-            factories.ScheduleEFactory(payee_name_text=payee)
-            for payee in payee_names
-        ]
+        payee_names = ['#', '##', '@#$%^&*', '%', '', '  ']
+        [factories.ScheduleEFactory(payee_name_text=payee) for payee in payee_names]
         results = self._results(api.url_for(ScheduleEView, payee_name=payee_names))
         self.assertEquals(len(results), 0)
 
     def test_schedule_e_sort_args_descending(self):
         [
-            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
-                    committee_id='101', support_oppose_indicator='s'),
-            factories.ScheduleEFactory(expenditure_amount=100, expenditure_date=datetime.date(2016, 1, 1),
-                    committee_id='101', support_oppose_indicator='o'),
+            factories.ScheduleEFactory(
+                expenditure_amount=100,
+                expenditure_date=datetime.date(2016, 1, 1),
+                committee_id='101',
+                support_oppose_indicator='s',
+            ),
+            factories.ScheduleEFactory(
+                expenditure_amount=100,
+                expenditure_date=datetime.date(2016, 1, 1),
+                committee_id='101',
+                support_oppose_indicator='o',
+            ),
         ]
-        results = self._results(api.url_for(ScheduleEView, sort='-support_oppose_indicator'))
-        self.assertEqual(results[0]['support_oppose_indicator'], 's')  
+        results = self._results(
+            api.url_for(ScheduleEView, sort='-support_oppose_indicator')
+        )
+        self.assertEqual(results[0]['support_oppose_indicator'], 's')
 
     def test_schedule_e_efile_filters(self):
         filters = [
             ('image_number', ScheduleEEfile.image_number, ['456', '789']),
             ('committee_id', ScheduleEEfile.committee_id, ['C01', 'C02']),
-            ('support_oppose_indicator', ScheduleEEfile.support_oppose_indicator, ['S', 'O']),
+            (
+                'support_oppose_indicator',
+                ScheduleEEfile.support_oppose_indicator,
+                ['S', 'O'],
+            ),
             ('candidate_office', ScheduleEEfile.candidate_office, ['H', 'S', 'P']),
             ('candidate_party', ScheduleEEfile.candidate_party, ['DEM', 'REP']),
-            ('candidate_office_state', ScheduleEEfile.candidate_office_state, ['AZ', 'AK']),
-            ('candidate_office_district', ScheduleEEfile.candidate_office_district, ['00', '01']),
+            (
+                'candidate_office_state',
+                ScheduleEEfile.candidate_office_state,
+                ['AZ', 'AK'],
+            ),
+            (
+                'candidate_office_district',
+                ScheduleEEfile.candidate_office_district,
+                ['00', '01'],
+            ),
             ('filing_form', ScheduleEEfile.filing_form, ['F3X', 'F5']),
             ('is_notice', ScheduleE.is_notice, [True, False]),
         ]
         factories.EFilingsFactory(file_number=123)
         for label, column, values in filters:
-            [
-                factories.ScheduleEEfileFactory(**{column.key: value})
-                for value in values
-            ]
-            results = self._results(api.url_for(ScheduleEEfileView, **{label: values[0]}))
+            [factories.ScheduleEEfileFactory(**{column.key: value}) for value in values]
+            results = self._results(
+                api.url_for(ScheduleEEfileView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
@@ -942,11 +1170,10 @@ class TestScheduleE(ApiBaseTest):
         ]
         factories.EFilingsFactory(file_number=123)
         for label, column, values in filters:
-            [
-                factories.ScheduleEEfileFactory(**{column.key: value})
-                for value in values
-            ]
-            results = self._results(api.url_for(ScheduleEEfileView, **{label: values[0]}))
+            [factories.ScheduleEEfileFactory(**{column.key: value}) for value in values]
+            results = self._results(
+                api.url_for(ScheduleEEfileView, **{label: values[0]})
+            )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
@@ -955,25 +1182,52 @@ class TestScheduleE(ApiBaseTest):
         min_date = datetime.date(2018, 1, 1)
         max_date = datetime.date(2019, 12, 31)
 
-        results = self._results(api.url_for(ScheduleEEfileView, min_dissemination_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
-
-        results = self._results(api.url_for(ScheduleEEfileView, max_dissemination_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
-
-        results = self._results(api.url_for(ScheduleEEfileView, min_dissemination_date=min_date, max_dissemination_date=max_date))
+        results = self._results(
+            api.url_for(ScheduleEEfileView, min_dissemination_date=min_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
-                if min_date.isoformat() <= each['dissemination_date'] <= max_date.isoformat()
+                each for each in results if each['receipt_date'] >= min_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(ScheduleEEfileView, max_dissemination_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                each for each in results if each['receipt_date'] <= max_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(
+                ScheduleEEfileView,
+                min_dissemination_date=min_date,
+                max_dissemination_date=max_date,
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if min_date.isoformat()
+                <= each['dissemination_date']
+                <= max_date.isoformat()
             )
         )
 
     def test_schedule_e_efile_filter_cand_search(self):
         [
-            factories.ScheduleEEfileFactory(cand_fulltxt=sa.func.to_tsvector('C001, Rob, Senior')),
-            factories.ScheduleEEfileFactory(cand_fulltxt=sa.func.to_tsvector('C002, Ted, Berry')),
-            factories.ScheduleEEfileFactory(cand_fulltxt=sa.func.to_tsvector('C003, Rob, Junior')),
+            factories.ScheduleEEfileFactory(
+                cand_fulltxt=sa.func.to_tsvector('C001, Rob, Senior')
+            ),
+            factories.ScheduleEEfileFactory(
+                cand_fulltxt=sa.func.to_tsvector('C002, Ted, Berry')
+            ),
+            factories.ScheduleEEfileFactory(
+                cand_fulltxt=sa.func.to_tsvector('C003, Rob, Junior')
+            ),
         ]
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
@@ -982,35 +1236,54 @@ class TestScheduleE(ApiBaseTest):
 
     def test_filter_sched_e_most_recent(self):
         [
-            factories.ScheduleEFactory(committee_id='C001', filing_form='F24', most_recent=True),
-            factories.ScheduleEFactory(committee_id='C002', filing_form='F5', most_recent=False),
-            factories.ScheduleEFactory(committee_id='C003', filing_form='F24', most_recent=True),
-            factories.ScheduleEFactory(committee_id='C004', filing_form='F3X', most_recent=True),
+            factories.ScheduleEFactory(
+                committee_id='C001', filing_form='F24', most_recent=True
+            ),
+            factories.ScheduleEFactory(
+                committee_id='C002', filing_form='F5', most_recent=False
+            ),
+            factories.ScheduleEFactory(
+                committee_id='C003', filing_form='F24', most_recent=True
+            ),
+            factories.ScheduleEFactory(
+                committee_id='C004', filing_form='F3X', most_recent=True
+            ),
             factories.ScheduleEFactory(committee_id='C005', filing_form='F3X'),
             factories.ScheduleEFactory(committee_id='C006', filing_form='F3X'),
         ]
-        results = self._results(api.url_for(ScheduleEView, most_recent=True, **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleEView, most_recent=True, **self.kwargs)
+        )
         # Most recent should include null values
         self.assertEqual(len(results), 5)
 
     def test_filter_sched_e_efile_most_recent(self):
         [
-            factories.ScheduleEEfileFactory(committee_id='C001', filing_form='F24', most_recent=True),
-            factories.ScheduleEEfileFactory(committee_id='C002', filing_form='F5', most_recent=False),
-            factories.ScheduleEEfileFactory(committee_id='C003', filing_form='F24', most_recent=True),
-            factories.ScheduleEEfileFactory(committee_id='C004', filing_form='F3X', most_recent=True),
+            factories.ScheduleEEfileFactory(
+                committee_id='C001', filing_form='F24', most_recent=True
+            ),
+            factories.ScheduleEEfileFactory(
+                committee_id='C002', filing_form='F5', most_recent=False
+            ),
+            factories.ScheduleEEfileFactory(
+                committee_id='C003', filing_form='F24', most_recent=True
+            ),
+            factories.ScheduleEEfileFactory(
+                committee_id='C004', filing_form='F3X', most_recent=True
+            ),
             factories.ScheduleEEfileFactory(committee_id='C005', filing_form='F3X'),
             factories.ScheduleEEfileFactory(committee_id='C006', filing_form='F3X'),
         ]
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
-        results = self._results(api.url_for(ScheduleEEfileView, most_recent=True, **self.kwargs))
+        results = self._results(
+            api.url_for(ScheduleEEfileView, most_recent=True, **self.kwargs)
+        )
         # Most recent should include null values
         self.assertEqual(len(results), 5)
 
 
 class TestScheduleH4(ApiBaseTest):
-
     def test_schedule_h4_basic_accessibility(self):
         """
         testing schedule_h4 api_for very basic accessibility
@@ -1023,9 +1296,13 @@ class TestScheduleH4(ApiBaseTest):
 
     def test_schedule_h4_image_number(self):
         factories.ScheduleH4Factory(report_year=2016, cycle=2016, image_number='111')
-        results = self._results(api.url_for(ScheduleH4View, cycle=2016, image_number='112'))
+        results = self._results(
+            api.url_for(ScheduleH4View, cycle=2016, image_number='112')
+        )
         self.assertEqual(len(results), 0)
-        results = self._results(api.url_for(ScheduleH4View, cycle=2016, image_number='111'))
+        results = self._results(
+            api.url_for(ScheduleH4View, cycle=2016, image_number='111')
+        )
         self.assertEqual(len(results), 1)
 
     def test_schedule_h4_filters(self):
@@ -1039,4 +1316,3 @@ class TestScheduleH4(ApiBaseTest):
         self.assertEqual(len(results), 3)
         results = self._results(api.url_for(ScheduleH4View, committee_id='C001'))
         self.assertEqual(len(results), 1)
-

--- a/tests/test_large_aggregates.py
+++ b/tests/test_large_aggregates.py
@@ -1,26 +1,32 @@
-import datetime
-
-import sqlalchemy as sa
-
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api, db
+from webservices.rest import api
 from webservices.resources.large_aggregates import EntityReceiptDisbursementTotalsView
 
 
 class TestEntityReceiptDisbursementTotals(ApiBaseTest):
-
     def test_basic_receipts_test(self):
         [
-            factories.EntityReceiptDisbursementTotalsFactory(cycle=2000, cumulative_candidate_receipts=50000, month=3, year=1999),
-            factories.EntityReceiptDisbursementTotalsFactory(cycle=2020, cumulative_party_receipts=90000, month=3, year=2019),
-            factories.EntityReceiptDisbursementTotalsFactory(cycle=1998, cumulative_pac_disbursements=50000, month=3, year=1997),
-            factories.EntityReceiptDisbursementTotalsFactory(cycle=2008, cumulative_candidate_disbursements=90000, month=3, year=2008)
+            factories.EntityReceiptDisbursementTotalsFactory(
+                cycle=2000, cumulative_candidate_receipts=50000, month=3, year=1999
+            ),
+            factories.EntityReceiptDisbursementTotalsFactory(
+                cycle=2020, cumulative_party_receipts=90000, month=3, year=2019
+            ),
+            factories.EntityReceiptDisbursementTotalsFactory(
+                cycle=1998, cumulative_pac_disbursements=50000, month=3, year=1997
+            ),
+            factories.EntityReceiptDisbursementTotalsFactory(
+                cycle=2008, cumulative_candidate_disbursements=90000, month=3, year=2008
+            ),
         ]
 
         filter_fields = (
-            ('cycle', int(2020)), ('cycle', int(2000)), ('cycle', int(1998)), ('cycle', int(2008)),
+            ('cycle', int(2020)),
+            ('cycle', int(2000)),
+            ('cycle', int(1998)),
+            ('cycle', int(2008)),
         )
 
         for field, example in filter_fields:

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -12,6 +12,7 @@ import datetime
 # TODO: integrate more with API Schema so that __API_VERSION__ is returned
 # self.assertEqual(result['api_version'], __API_VERSION__)
 
+
 def get_path(obj, path):
     parts = path.split('.')
     first = parts[0]
@@ -24,42 +25,108 @@ def get_path(obj, path):
 
 
 def es_advisory_opinion(*args, **kwargs):
-    return {'hits': {'hits': [{'_source': {'text': 'abc'}, '_type': 'advisory_opinions'},
-           {'_source': {'no': '123'}, '_type': 'advisory_opinions'}]}}
+    return {
+        'hits': {
+            'hits': [
+                {'_source': {'text': 'abc'}, '_type': 'advisory_opinions'},
+                {'_source': {'no': '123'}, '_type': 'advisory_opinions'},
+            ]
+        }
+    }
+
 
 def es_mur(*args, **kwargs):
-    return {'hits': {'hits': [{'_source': {'text': 'abc'}, '_type': 'murs'},
-           {'_source': {'no': '123'}, '_type': 'murs'}]}}
+    return {
+        'hits': {
+            'hits': [
+                {'_source': {'text': 'abc'}, '_type': 'murs'},
+                {'_source': {'no': '123'}, '_type': 'murs'},
+            ]
+        }
+    }
+
 
 def es_invalid_search(*args, **kwargs):
     raise RequestError("invalid query")
+
 
 def es_search(**kwargs):
     _type = kwargs["body"]["query"]["bool"]["must"][0]["term"]["_type"]
 
     if _type == 'regulations':
-        return {'hits': {'hits': [{'highlight': {'text': ['a', 'b']},
-                                   '_source': {}, '_type': 'regulations'}], 'total': 1}}
+        return {
+            'hits': {
+                'hits': [
+                    {
+                        'highlight': {'text': ['a', 'b']},
+                        '_source': {},
+                        '_type': 'regulations',
+                    }
+                ],
+                'total': 1,
+            }
+        }
     if _type == 'advisory_opinions':
-        return {'hits': {'hits': [{'highlight': {'text': ['a', 'b']},
-                                    '_source': {}, '_type': 'advisory_opinions'},
-                                  {'highlight': {'text': ['c', 'd']},
-                                    '_source': {}, '_type': 'advisory_opinions'}], 'total': 2}}
+        return {
+            'hits': {
+                'hits': [
+                    {
+                        'highlight': {'text': ['a', 'b']},
+                        '_source': {},
+                        '_type': 'advisory_opinions',
+                    },
+                    {
+                        'highlight': {'text': ['c', 'd']},
+                        '_source': {},
+                        '_type': 'advisory_opinions',
+                    },
+                ],
+                'total': 2,
+            }
+        }
     if _type == 'statutes':
-        return {'hits': {'hits': [{'highlight': {'text': ['e']},
-                                    '_source': {}, '_type': 'statutes'}], 'total': 3}}
+        return {
+            'hits': {
+                'hits': [
+                    {'highlight': {'text': ['e']}, '_source': {}, '_type': 'statutes'}
+                ],
+                'total': 3,
+            }
+        }
 
     if _type == 'murs':
-        return {'hits': {'hits': [{'highlight': {'text': ['f']},
-                                    '_source': {}, '_type': 'murs'}], 'total': 4}}
+        return {
+            'hits': {
+                'hits': [
+                    {'highlight': {'text': ['f']}, '_source': {}, '_type': 'murs'}
+                ],
+                'total': 4,
+            }
+        }
 
     if _type == 'adrs':
-        return {'hits': {'hits': [{'highlight': {'text': ['f']},
-                                    '_source': {}, '_type': 'adrs'}], 'total': 2}}
+        return {
+            'hits': {
+                'hits': [
+                    {'highlight': {'text': ['f']}, '_source': {}, '_type': 'adrs'}
+                ],
+                'total': 2,
+            }
+        }
 
     if _type == 'admin_fines':
-        return {'hits': {'hits': [{'highlight': {'text': ['f']},
-                                    '_source': {}, '_type': 'admin_fines'}], 'total': 5}}
+        return {
+            'hits': {
+                'hits': [
+                    {
+                        'highlight': {'text': ['f']},
+                        '_source': {},
+                        '_type': 'admin_fines',
+                    }
+                ],
+                'total': 5,
+            }
+        }
 
 
 class CanonicalPageTest(unittest.TestCase):
@@ -88,12 +155,22 @@ class CanonicalPageTest(unittest.TestCase):
         # This is mostly copy/pasted from the dict-based query. This is not a
         # very meaningful test but helped to ensure we're using the
         # elasitcsearch_dsl correctly.
-        expected_query = {"query": {"bool": {"must": [{"term": {"no": "1993-02"}},
-                          {"term": {"_type": "advisory_opinions"}}]}},
-                          "_source": {"exclude": "documents.text"}, "size": 200}
-        es_search.assert_called_with(body=expected_query,
-                                     doc_type=mock.ANY,
-                                     index=mock.ANY)
+        expected_query = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"no": "1993-02"}},
+                        {"term": {"_type": "advisory_opinions"}},
+                    ]
+                }
+            },
+            "_source": {"exclude": "documents.text"},
+            "size": 200,
+        }
+        es_search.assert_called_with(
+            body=expected_query, doc_type=mock.ANY, index=mock.ANY
+        )
+
 
 class SearchTest(unittest.TestCase):
     def setUp(self):
@@ -105,141 +182,191 @@ class SearchTest(unittest.TestCase):
         assert response.status_code == 200
         result = json.loads(codecs.decode(response.data))
         assert result == {
-            'regulations': [
-                {'highlights': ['a', 'b'], 'document_highlights': {}}
-            ],
+            'regulations': [{'highlights': ['a', 'b'], 'document_highlights': {}}],
             'total_regulations': 1,
-            'statutes': [
-                {'highlights': ['e'], 'document_highlights': {}}
-            ],
+            'statutes': [{'highlights': ['e'], 'document_highlights': {}}],
             'total_statutes': 3,
-            'murs': [
-                {'highlights': ['f'], 'document_highlights': {}}
-            ],
+            'murs': [{'highlights': ['f'], 'document_highlights': {}}],
             'total_murs': 4,
-            'adrs': [
-                {'highlights': ['f'], 'document_highlights': {}}
-            ],
+            'adrs': [{'highlights': ['f'], 'document_highlights': {}}],
             'total_adrs': 2,
-            'admin_fines': [
-                {'highlights': ['f'], 'document_highlights': {}}
-            ],
+            'admin_fines': [{'highlights': ['f'], 'document_highlights': {}}],
             'total_admin_fines': 5,
             'advisory_opinions': [
                 {'highlights': ['a', 'b'], 'document_highlights': {}},
-                {'highlights': ['c', 'd'], 'document_highlights': {}}
+                {'highlights': ['c', 'd'], 'document_highlights': {}},
             ],
             'total_advisory_opinions': 2,
-            'total_all': 17}
+            'total_all': 17,
+        }
 
     @patch('webservices.rest.legal.es.search', es_search)
     def test_type_search(self):
-        response = self.app.get('/v1/legal/search/' +
-                                '?q=president&type=advisory_opinions')
+        response = self.app.get(
+            '/v1/legal/search/' + '?q=president&type=advisory_opinions'
+        )
         assert response.status_code == 200
         result = json.loads(codecs.decode(response.data))
         assert result == {
             'total_advisory_opinions': 2,
             'advisory_opinions': [
                 {'highlights': ['a', 'b'], 'document_highlights': {}},
-                {'highlights': ['c', 'd'], 'document_highlights': {}}
+                {'highlights': ['c', 'd'], 'document_highlights': {}},
             ],
-            'total_all': 2
+            'total_all': 2,
         }
 
     @patch('webservices.rest.legal.es.search', es_invalid_search)
     def test_invalid_search(self):
-        response = self.app.get('/v1/legal/search/' +
-                                '?q=president%20AND%20OR&type=advisory_opinions')
+        response = self.app.get(
+            '/v1/legal/search/' + '?q=president%20AND%20OR&type=advisory_opinions'
+        )
         assert response.status_code == 400
 
     @patch.object(es, 'search')
     def test_query_dsl(self, es_search):
-        response = self.app.get('/v1/legal/search/', query_string={
-                                'q': 'president',
-                                'type': 'statutes'})
+        response = self.app.get(
+            '/v1/legal/search/', query_string={'q': 'president', 'type': 'statutes'}
+        )
         assert response.status_code == 200
 
         # This is mostly copy/pasted from the dict-based query. This is not a
         # very meaningful test but helped to ensure we're using the
         # elasitcsearch_dsl correctly.
 
-        expected_query = {'from': 0,
-        'sort': ['sort1', 'sort2'],
+        expected_query = {
+            'from': 0,
+            'sort': ['sort1', 'sort2'],
             'size': 20,
-            'query': {'bool': {'must': [{'term': {'_type': 'statutes'}},
-            {'query_string': {'query': 'president'}}]}},
-            'highlight': {'fields': {'documents.text': {}, 'text': {},
-            'no': {}, 'name': {}, 'documents.description': {}, 'summary': {}},
-            'require_field_match': False},
-            '_source': {'exclude': ['text', 'documents.text', 'sort1', 'sort2']}}
+            'query': {
+                'bool': {
+                    'must': [
+                        {'term': {'_type': 'statutes'}},
+                        {'query_string': {'query': 'president'}},
+                    ]
+                }
+            },
+            'highlight': {
+                'fields': {
+                    'documents.text': {},
+                    'text': {},
+                    'no': {},
+                    'name': {},
+                    'documents.description': {},
+                    'summary': {},
+                },
+                'require_field_match': False,
+            },
+            '_source': {'exclude': ['text', 'documents.text', 'sort1', 'sort2']},
+        }
 
-        es_search.assert_called_with(body=expected_query,
-                                     index=mock.ANY,
-                                     doc_type=mock.ANY)
+        es_search.assert_called_with(
+            body=expected_query, index=mock.ANY, doc_type=mock.ANY
+        )
 
     @patch.object(es, 'search')
     def test_query_dsl_with_ao_category_filter(self, es_search):
-        response = self.app.get('/v1/legal/search/', query_string={
-                                'q': 'president',
-                                'type': 'advisory_opinions'})
+        response = self.app.get(
+            '/v1/legal/search/',
+            query_string={'q': 'president', 'type': 'advisory_opinions'},
+        )
         assert response.status_code == 200
 
         # This is mostly copy/pasted from the dict-based query. This is not a
         # very meaningful test but helped to ensure we're using the
         # elasitcsearch_dsl correctly.
-        expected_query = {'query':
-            {'bool':
-                {'must': [{'term': {'_type': 'advisory_opinions'}},
-                {'bool': {'minimum_should_match': 1}}],
+        expected_query = {
+            'query': {
+                'bool': {
+                    'must': [
+                        {'term': {'_type': 'advisory_opinions'}},
+                        {'bool': {'minimum_should_match': 1}},
+                    ],
                     'minimum_should_match': 1,
-                    'should': [{'nested': {'path': 'documents',
-                'inner_hits': {'_source': False,
-                'highlight': {'require_field_match': False,
-                'fields': {'documents.text': {}, 'documents.description': {}}}},
-                        'query': {'bool': {'must': [{'query_string': {'query': 'president',
-                        'fields': ['documents.text']}}]}}}},
-                    {'query_string': {'query': 'president', 'fields': ['no', 'name', 'summary']}}]}},
-            'highlight': {'require_field_match': False,
-                'fields': {'text': {}, 'documents.text': {}, 'summary': {},
-                'name': {}, 'documents.description': {}, 'no': {}}},
-            'from': 0, 'size': 20,
-            '_source': {'exclude': ['text', 'documents.text', 'sort1', 'sort2']}, 'sort': ['sort1', 'sort2']}
+                    'should': [
+                        {
+                            'nested': {
+                                'path': 'documents',
+                                'inner_hits': {
+                                    '_source': False,
+                                    'highlight': {
+                                        'require_field_match': False,
+                                        'fields': {
+                                            'documents.text': {},
+                                            'documents.description': {},
+                                        },
+                                    },
+                                },
+                                'query': {
+                                    'bool': {
+                                        'must': [
+                                            {
+                                                'query_string': {
+                                                    'query': 'president',
+                                                    'fields': ['documents.text'],
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                            }
+                        },
+                        {
+                            'query_string': {
+                                'query': 'president',
+                                'fields': ['no', 'name', 'summary'],
+                            }
+                        },
+                    ],
+                }
+            },
+            'highlight': {
+                'require_field_match': False,
+                'fields': {
+                    'text': {},
+                    'documents.text': {},
+                    'summary': {},
+                    'name': {},
+                    'documents.description': {},
+                    'no': {},
+                },
+            },
+            'from': 0,
+            'size': 20,
+            '_source': {'exclude': ['text', 'documents.text', 'sort1', 'sort2']},
+            'sort': ['sort1', 'sort2'],
+        }
 
-        es_search.assert_called_with(body=expected_query,
-                                     index=mock.ANY,
-                                     doc_type=mock.ANY)
+        es_search.assert_called_with(
+            body=expected_query, index=mock.ANY, doc_type=mock.ANY
+        )
 
     @patch.object(es, 'search')
     def test_query_dsl_with_case_filters(self, es_search):
-        response = self.app.get('/v1/legal/search/', query_string={
-                                'q': 'embezzle',
-                                'type': 'murs',
-                                'case_min_open_date': '2012-01-01',
-                                'case_max_open_date': '2013-12-31',
-                                'case_min_close_date': '2014-01-01',
-                                'case_max_close_date': '2015-12-31'})
+        response = self.app.get(
+            '/v1/legal/search/',
+            query_string={
+                'q': 'embezzle',
+                'type': 'murs',
+                'case_min_open_date': '2012-01-01',
+                'case_max_open_date': '2013-12-31',
+                'case_min_close_date': '2014-01-01',
+                'case_max_close_date': '2015-12-31',
+            },
+        )
         assert response.status_code == 200
 
         expected_query = {
             "query": {
                 "bool": {
                     "must": [
-                        {
-                            "term": {
-                                "_type": "murs"
-                            }
-                        },
-                        {
-                            "query_string": {
-                                "query": "embezzle"
-                            }
-                        },
+                        {"term": {"_type": "murs"}},
+                        {"query_string": {"query": "embezzle"}},
                         {
                             "range": {
                                 "open_date": {
                                     "gte": datetime.date(2012, 1, 1),
-                                    "lte": datetime.date(2013, 12, 31)
+                                    "lte": datetime.date(2013, 12, 31),
                                 }
                             }
                         },
@@ -247,26 +374,16 @@ class SearchTest(unittest.TestCase):
                             "range": {
                                 "close_date": {
                                     "gte": datetime.date(2014, 1, 1),
-                                    "lte": datetime.date(2015, 12, 31)
+                                    "lte": datetime.date(2015, 12, 31),
                                 }
                             }
-                        }
+                        },
                     ]
                 }
             },
-            "sort": [
-                "sort1",
-                "sort2"
-            ],
+            "sort": ["sort1", "sort2"],
             "from": 0,
-            "_source": {
-                "exclude": [
-                    "text",
-                    "documents.text",
-                    "sort1",
-                    "sort2"
-                ]
-            },
+            "_source": {"exclude": ["text", "documents.text", "sort1", "sort2"]},
             "highlight": {
                 "fields": {
                     "text": {},
@@ -274,13 +391,13 @@ class SearchTest(unittest.TestCase):
                     "documents.description": {},
                     "documents.text": {},
                     "summary": {},
-                    "name": {}
+                    "name": {},
                 },
-                "require_field_match": False
+                "require_field_match": False,
             },
-            "size": 20
+            "size": 20,
         }
 
-        es_search.assert_called_with(body=expected_query,
-                                     index=mock.ANY,
-                                     doc_type=mock.ANY)
+        es_search.assert_called_with(
+            body=expected_query, index=mock.ANY, doc_type=mock.ANY
+        )

--- a/tests/test_load_legal_docs.py
+++ b/tests/test_load_legal_docs.py
@@ -6,7 +6,7 @@ from webservices.legal_docs import (
     index_regulations,
     index_statutes,
     load_archived_murs,
-    create_docs_index
+    create_docs_index,
 )
 
 from webservices.legal_docs.load_legal_docs import (
@@ -20,12 +20,14 @@ from zipfile import ZipFile
 from tempfile import NamedTemporaryFile
 import json
 
+
 def test_get_subject_tree():
     assert get_subject_tree("foo") == [{"text": "Foo"}]
     assert get_subject_tree("<li>foo</li>") == [{"text": "Foo"}]
     assert get_subject_tree(
-        "foo<ul class='no-top-margin'><li>bar</li><li>baz</li></ul>") == [
-            {"text": "Foo", "children": [{"text": "Bar"}, {"text": "Baz"}]}]
+        "foo<ul class='no-top-margin'><li>bar</li><li>baz</li></ul>"
+    ) == [{"text": "Foo", "children": [{"text": "Bar"}, {"text": "Baz"}]}]
+
 
 class ElasticSearchMock:
     class ElasticSearchIndicesMock:
@@ -53,7 +55,9 @@ class ElasticSearchMock:
 def get_es_with_doc(doc):
     def get_es():
         return ElasticSearchMock(doc)
+
     return get_es
+
 
 def mock_xml(xml):
     def request_zip(url, stream=False):
@@ -67,16 +71,20 @@ def mock_xml(xml):
 
     return request_zip
 
+
 def mock_archived_murs_get_request(html):
     def request_murs_data(url, stream=False):
         if stream:
             return [b'ABC', b'def']
         else:
             return RequestResult(html)
+
     return request_murs_data
+
 
 def get_credential_mock(var, default):
     return 'https://eregs.api.com/'
+
 
 class RequestResult:
     def __init__(self, result):
@@ -86,16 +94,32 @@ class RequestResult:
     def json(self):
         return self.result
 
+
 def mock_get_regulations(url):
     if url.endswith('regulation'):
-        return RequestResult({'versions': [{'version': 'versionA',
-                             'regulation': 'reg104'}]})
+        return RequestResult(
+            {'versions': [{'version': 'versionA', 'regulation': 'reg104'}]}
+        )
     if url.endswith('reg104/versionA'):
-        return RequestResult({'children': [{'children': [{'label': ['104', '1'],
-                               'title': 'Section 104.1 Title',
-                               'text': 'sectionContentA',
-                               'children': [{'text': 'sectionContentB',
-                               'children': []}]}]}]})
+        return RequestResult(
+            {
+                'children': [
+                    {
+                        'children': [
+                            {
+                                'label': ['104', '1'],
+                                'title': 'Section 104.1 Title',
+                                'text': 'sectionContentA',
+                                'children': [
+                                    {'text': 'sectionContentB', 'children': []}
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+
 
 class S3Objects:
     def __init__(self):
@@ -103,6 +127,7 @@ class S3Objects:
 
     def filter(self, Prefix):
         return [o for o in self.objects if o.key.startswith(Prefix)]
+
 
 class BucketMock:
     def __init__(self, keys):
@@ -112,25 +137,42 @@ class BucketMock:
     def put_object(self, Key, Body, ContentType, ACL):
         assert Key in self.keys
 
+
 def get_bucket_mock(keys):
     def get_bucket():
         return BucketMock(keys)
+
     return get_bucket
 
+
 class IndexStatutesTest(unittest.TestCase):
-    @patch('webservices.legal_docs.load_legal_docs.requests.get', mock_xml('<test></test>'))
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get', mock_xml('<test></test>')
+    )
     def test_get_xml_tree_from_url(self):
         etree = get_xml_tree_from_url('anything.com')
         assert etree.getroot().tag == 'test'
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-            get_es_with_doc({'name': 'title',
-            'chapter': '1', 'title': '26', 'no': '123',
-            'text': '   title  content ', 'doc_id': '/us/usc/t26/s123',
-            'url': 'https://www.govinfo.gov/link/uscode/26/123',
-            'sort1': 26, 'sort2': 123}))
-    @patch('webservices.legal_docs.load_legal_docs.requests.get', mock_xml(
-        """<?xml version="1.0" encoding="UTF-8"?>
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(
+            {
+                'name': 'title',
+                'chapter': '1',
+                'title': '26',
+                'no': '123',
+                'text': '   title  content ',
+                'doc_id': '/us/usc/t26/s123',
+                'url': 'https://www.govinfo.gov/link/uscode/26/123',
+                'sort1': 26,
+                'sort2': 123,
+            }
+        ),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_xml(
+            """<?xml version="1.0" encoding="UTF-8"?>
             <uscDoc xmlns="http://xml.house.gov/schemas/uslm/1.0">
             <subtitle identifier="/us/usc/t26/stH">
             <chapter identifier="/us/usc/t26/stH/ch1">
@@ -138,19 +180,33 @@ class IndexStatutesTest(unittest.TestCase):
             <heading>title</heading>
             <subsection>content</subsection>
             </section></chapter></subtitle></uscDoc>
-            """))
+            """
+        ),
+    )
     def test_title_26(self):
         get_title_26_statutes()
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-            get_es_with_doc({'subchapter': 'I',
-            'doc_id': '/us/usc/t52/s123', 'chapter': '1',
-            'text': '   title  content ',
-            'url': 'https://www.govinfo.gov/link/uscode/52/123',
-            'title': '52', 'name': 'title', 'no': '123',
-            'sort1': 52, 'sort2': 123}))
-    @patch('webservices.legal_docs.load_legal_docs.requests.get', mock_xml(
-        """<?xml version="1.0" encoding="UTF-8"?>
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(
+            {
+                'subchapter': 'I',
+                'doc_id': '/us/usc/t52/s123',
+                'chapter': '1',
+                'text': '   title  content ',
+                'url': 'https://www.govinfo.gov/link/uscode/52/123',
+                'title': '52',
+                'name': 'title',
+                'no': '123',
+                'sort1': 52,
+                'sort2': 123,
+            }
+        ),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_xml(
+            """<?xml version="1.0" encoding="UTF-8"?>
             <uscDoc xmlns="http://xml.house.gov/schemas/uslm/1.0">
             <subtitle identifier="/us/usc/t52/stIII">
             <subchapter identifier="/us/usc/t52/stIII/ch1/schI">
@@ -158,7 +214,9 @@ class IndexStatutesTest(unittest.TestCase):
             <heading>title</heading>
             <subsection>content</subsection>
             </section></subchapter></subtitle></uscDoc>
-            """))
+            """
+        ),
+    )
     def test_title_52(self):
         get_title_52_statutes()
 
@@ -167,15 +225,26 @@ class IndexStatutesTest(unittest.TestCase):
     def test_index_statutes(self):
         index_statutes()
 
+
 class IndexRegulationsTest(unittest.TestCase):
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', get_credential_mock)
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential', get_credential_mock
+    )
     @patch('webservices.legal_docs.load_legal_docs.requests.get', mock_get_regulations)
-    @patch('webservices.utils.get_elasticsearch_connection',
-            get_es_with_doc({'text': 'sectionContentA sectionContentB',
-            'no': '104.1', 'name': 'Title',
-            'url': '/regulations/104-1/versionA#104-1',
-            'doc_id': '104_1',
-            'sort1': 104, 'sort2': 1}))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(
+            {
+                'text': 'sectionContentA sectionContentB',
+                'no': '104.1',
+                'name': 'Title',
+                'url': '/regulations/104-1/versionA#104-1',
+                'doc_id': '104_1',
+                'sort1': 104,
+                'sort2': 1,
+            }
+        ),
+    )
     def test_index_regulations(self):
         index_regulations()
 
@@ -183,88 +252,170 @@ class IndexRegulationsTest(unittest.TestCase):
     def test_no_env_variable(self):
         index_regulations()
 
+
 class InitializeLegalDocsTest(unittest.TestCase):
-    @patch('webservices.utils.get_elasticsearch_connection',
-    get_es_with_doc({}))
+    @patch('webservices.utils.get_elasticsearch_connection', get_es_with_doc({}))
     def test_create_docs_index(self):
         create_docs_index()
+
 
 def raise_pdf_exception(PDF):
     raise Exception('Could not parse PDF')
 
+
 class LoadArchivedMursTest(unittest.TestCase):
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
-    @patch('webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2'])
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_data.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2']
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_data.html').read()
+        ),
+    )
     def test_base_case(self):
         # Management command brings this in as a string
         load_archived_murs(specific_mur_no='1')
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_multi_part_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock(['legal/murs/3_A.pdf', 'legal/murs/3_B.pdf', 'legal/murs/3_C.pdf']))
-    @patch('webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2'])
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_multi_part_data.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_multi_part_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock(
+            ['legal/murs/3_A.pdf', 'legal/murs/3_B.pdf', 'legal/murs/3_C.pdf']
+        ),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2']
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_multi_part_data.html').read()
+        ),
+    )
     def test_multi_file(self):
         # Management command brings this in as a string
         load_archived_murs(specific_mur_no='3')
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
-    @patch('webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2'])
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_empty_data.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2']
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_empty_data.html').read()
+        ),
+    )
     def test_with_empty_data(self):
         load_archived_murs()
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
-    @patch('webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2'])
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_bad_subject.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2']
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_bad_subject.html').read()
+        ),
+    )
     def test_bad_parse(self):
         with self.assertRaises(Exception):
             load_archived_murs()
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
-    @patch('webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2'])
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_bad_citation.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_empty_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.slate.PDF', lambda t: ['page1', 'page2']
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_bad_citation.html').read()
+        ),
+    )
     def test_bad_citation(self):
         with self.assertRaises(Exception):
             load_archived_murs()
 
-    @patch('webservices.utils.get_elasticsearch_connection',
-        get_es_with_doc(json.load(open('tests/data/archived_mur_bad_pdf_doc.json'))))
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
-    @patch('webservices.legal_docs.load_legal_docs.env.get_credential', lambda e: 'bucket123')
-    @patch('webservices.legal_docs.load_legal_docs.requests.get',
-        mock_archived_murs_get_request(open('tests/data/archived_mur_data.html').read()))
+    @patch(
+        'webservices.utils.get_elasticsearch_connection',
+        get_es_with_doc(json.load(open('tests/data/archived_mur_bad_pdf_doc.json'))),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.env.get_credential',
+        lambda e: 'bucket123',
+    )
+    @patch(
+        'webservices.legal_docs.load_legal_docs.requests.get',
+        mock_archived_murs_get_request(
+            open('tests/data/archived_mur_data.html').read()
+        ),
+    )
     @patch('webservices.legal_docs.load_legal_docs.slate.PDF', raise_pdf_exception)
     def test_with_bad_pdf(self):
         load_archived_murs(specific_mur_no='1')
 
-    @patch('webservices.legal_docs.load_legal_docs.get_bucket',
-        get_bucket_mock('legal/murs/1.pdf'))
+    @patch(
+        'webservices.legal_docs.load_legal_docs.get_bucket',
+        get_bucket_mock('legal/murs/1.pdf'),
+    )
     def test_delete_murs_from_s3(self):
         delete_murs_from_s3()
 

--- a/tests/test_map_citations_murs.py
+++ b/tests/test_map_citations_murs.py
@@ -5,16 +5,22 @@ from webservices.legal_docs import load_legal_docs, reclassify_statutory_citatio
 
 
 class TestGetCitations(unittest.TestCase):
-
     def test_reclassify_statutory_citation(self):
         # spot check a few cases from the csv
-        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '431') == ('52', '30101')
-        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '437g') == ('52', '30109')
-        assert reclassify_statutory_citation.reclassify_statutory_citation('2', '441a-1') == ('52', '30117')
+        assert reclassify_statutory_citation.reclassify_statutory_citation(
+            '2', '431'
+        ) == ('52', '30101')
+        assert reclassify_statutory_citation.reclassify_statutory_citation(
+            '2', '437g'
+        ) == ('52', '30109')
+        assert reclassify_statutory_citation.reclassify_statutory_citation(
+            '2', '441a-1'
+        ) == ('52', '30117')
 
         # and a fallback
-        assert reclassify_statutory_citation.reclassify_statutory_citation('99', '12345') == ('99', '12345')
-
+        assert reclassify_statutory_citation.reclassify_statutory_citation(
+            '99', '12345'
+        ) == ('99', '12345')
 
     @mock.patch.object(reclassify_statutory_citation, 'reclassify_statutory_citation')
     def test_get_citations_statute(self, reclassify_statutory_citation):
@@ -60,7 +66,6 @@ class TestGetCitations(unittest.TestCase):
         assert len(regulations) == 1
 
         assert regulations[0]['url'] == '/regulations/23-421/CURRENT'
-
 
     def test_get_citations_regulation_no_section(self):
         citation_text = [

--- a/tests/test_operations_log.py
+++ b/tests/test_operations_log.py
@@ -1,4 +1,3 @@
-
 import datetime
 
 from tests import factories
@@ -6,37 +5,67 @@ from tests.common import ApiBaseTest
 from webservices.rest import api
 from webservices.resources.operations_log import OperationsLogView
 
-class TestOperationsLog(ApiBaseTest):
 
+class TestOperationsLog(ApiBaseTest):
     def setUp(self):
         super().setUp()
-        factories.OperationsLogFactory(candidate_committee_id='00', report_year=2000, status_num=1),
-        factories.OperationsLogFactory(candidate_committee_id='01', report_year=2012, status_num=0),
-        factories.OperationsLogFactory(candidate_committee_id='02', report_year=2014, status_num=1),
-        factories.OperationsLogFactory(candidate_committee_id='03', report_year=2017, receipt_date=datetime.date(2017, 3, 1)),
-        factories.OperationsLogFactory(candidate_committee_id='03', report_year=2017, coverage_end_date=datetime.date(2018, 4, 30)),
-        factories.OperationsLogFactory(candidate_committee_id='03', report_year=2017, transaction_data_complete_date=datetime.date(2016, 10, 15)),
+        factories.OperationsLogFactory(
+            candidate_committee_id='00', report_year=2000, status_num=1
+        ),
+        factories.OperationsLogFactory(
+            candidate_committee_id='01', report_year=2012, status_num=0
+        ),
+        factories.OperationsLogFactory(
+            candidate_committee_id='02', report_year=2014, status_num=1
+        ),
+        factories.OperationsLogFactory(
+            candidate_committee_id='03',
+            report_year=2017,
+            receipt_date=datetime.date(2017, 3, 1),
+        ),
+        factories.OperationsLogFactory(
+            candidate_committee_id='03',
+            report_year=2017,
+            coverage_end_date=datetime.date(2018, 4, 30),
+        ),
+        factories.OperationsLogFactory(
+            candidate_committee_id='03',
+            report_year=2017,
+            transaction_data_complete_date=datetime.date(2016, 10, 15),
+        ),
 
     def test_empty_query(self):
 
-        results = self._results(api.url_for(OperationsLogView, candidate_committee_id='10', report_year=2030))
+        results = self._results(
+            api.url_for(
+                OperationsLogView, candidate_committee_id='10', report_year=2030
+            )
+        )
         self.assertEqual(len(results), 0)
 
     def test_search_cand_cmte_id(self):
 
-        response = self.app.get(api.url_for(OperationsLogView, candidate_committee_id='01', report_year=2012))
+        response = self.app.get(
+            api.url_for(
+                OperationsLogView, candidate_committee_id='01', report_year=2012
+            )
+        )
         self.assertEquals(response.status_code, 200)
 
     def test_unverified_reports(self):
 
-        results = self._results(api.url_for(OperationsLogView, candidate_committee_id='01', status_num=0))
+        results = self._results(
+            api.url_for(OperationsLogView, candidate_committee_id='01', status_num=0)
+        )
         self.assertEqual(len(results), 1)
         for result in results:
             self.assertTrue(1, result['status_num'])
 
     def test_verified_reports(self):
 
-        results = self._results(api.url_for(OperationsLogView, candidate_committee_id='02', status_num=1))
+        results = self._results(
+            api.url_for(OperationsLogView, candidate_committee_id='02', status_num=1)
+        )
         self.assertEqual(len(results), 1)
         for result in results:
             self.assertTrue(1, result['status_num'])
@@ -46,16 +75,33 @@ class TestOperationsLog(ApiBaseTest):
         min_date = datetime.date(2017, 1, 1)
         max_date = datetime.date(2017, 12, 31)
 
-        results = self._results(api.url_for(OperationsLogView, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, min_receipt_date=min_date, max_receipt_date=max_date))
+        results = self._results(
+            api.url_for(OperationsLogView, min_receipt_date=min_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
+                each for each in results if each['receipt_date'] >= min_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(OperationsLogView, max_receipt_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                each for each in results if each['receipt_date'] <= max_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(
+                OperationsLogView, min_receipt_date=min_date, max_receipt_date=max_date
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
                 if min_date.isoformat() <= each['receipt_date'] <= max_date.isoformat()
             )
         )
@@ -65,17 +111,42 @@ class TestOperationsLog(ApiBaseTest):
         min_date = datetime.date(2018, 1, 1)
         max_date = datetime.date(2018, 12, 31)
 
-        results = self._results(api.url_for(OperationsLogView, min_coverage_end_date=min_date))
-        self.assertTrue(all(each for each in results if each['coverage_end_date'] >= min_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, max_coverage_end_date=max_date))
-        self.assertTrue(all(each for each in results if each['coverage_end_date'] <= max_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, min_coverage_end_date=min_date, max_coverage_end_date=max_date))
+        results = self._results(
+            api.url_for(OperationsLogView, min_coverage_end_date=min_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
-                if min_date.isoformat() <= each['coverage_end_date'] <= max_date.isoformat()
+                each
+                for each in results
+                if each['coverage_end_date'] >= min_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(OperationsLogView, max_coverage_end_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if each['coverage_end_date'] <= max_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(
+                OperationsLogView,
+                min_coverage_end_date=min_date,
+                max_coverage_end_date=max_date,
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if min_date.isoformat()
+                <= each['coverage_end_date']
+                <= max_date.isoformat()
             )
         )
 
@@ -84,16 +155,41 @@ class TestOperationsLog(ApiBaseTest):
         min_date = datetime.date(2016, 1, 1)
         max_date = datetime.date(2016, 12, 31)
 
-        results = self._results(api.url_for(OperationsLogView, min_transaction_data_complete_date=min_date))
-        self.assertTrue(all(each for each in results if each['transaction_data_complete_date'] >= min_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, max_transaction_data_complete_date=max_date))
-        self.assertTrue(all(each for each in results if each['transaction_data_complete_date'] <= max_date.isoformat()))
-
-        results = self._results(api.url_for(OperationsLogView, min_transaction_data_complete_date=min_date, max_transaction_data_complete_date=max_date))
+        results = self._results(
+            api.url_for(OperationsLogView, min_transaction_data_complete_date=min_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
-                if min_date.isoformat() <= each['transaction_data_complete_date'] <= max_date.isoformat()
+                each
+                for each in results
+                if each['transaction_data_complete_date'] >= min_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(OperationsLogView, max_transaction_data_complete_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if each['transaction_data_complete_date'] <= max_date.isoformat()
+            )
+        )
+
+        results = self._results(
+            api.url_for(
+                OperationsLogView,
+                min_transaction_data_complete_date=min_date,
+                max_transaction_data_complete_date=max_date,
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if min_date.isoformat()
+                <= each['transaction_data_complete_date']
+                <= max_date.isoformat()
             )
         )

--- a/tests/test_operations_log.py
+++ b/tests/test_operations_log.py
@@ -50,7 +50,7 @@ class TestOperationsLog(ApiBaseTest):
                 OperationsLogView, candidate_committee_id='01', report_year=2012
             )
         )
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_unverified_reports(self):
 

--- a/tests/test_parse_mur_citations.py
+++ b/tests/test_parse_mur_citations.py
@@ -5,78 +5,232 @@ from webservices.legal_docs.current_cases import (
     parse_statutory_citations,
 )
 
-@pytest.mark.parametrize("test_input,case_id,entity_id,expected", [
-    ("110", 1, 2,
-        [{'text': '110', 'title': '11', 'type': 'regulation', 'url': '/regulations/110/CURRENT'}]),
-    ("110.21", 1, 2,
-        [{'text': '110.21', 'title': '11', 'type': 'regulation', 'url': '/regulations/110-21/CURRENT'}]),
-    ("114.5(a)(3)", 1, 2,
-        [{'text': '114.5(a)(3)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}]),
-    ("114.5(a)(3)-(5)", 1, 2,
-        [{'text': '114.5(a)(3)-(5)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}]),
-    ("102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)", 1, 2,
-        [{'text': '102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)', 'title': '11',
-          'type': 'regulation', 'url': '/regulations/102-17/CURRENT'}
-         ]),
-    ("102.5(a)(2); 104.3(a)(4)(i); 114.5(a)(3)-(5); 114.5(g)(1)", 1, 2,
-        [{'text': '102.5(a)(2)', 'title': '11', 'type': 'regulation', 'url': '/regulations/102-5/CURRENT'},
-         {'text': '104.3(a)(4)(i)', 'title': '11', 'type': 'regulation', 'url': '/regulations/104-3/CURRENT'},
-         {'text': '114.5(a)(3)-(5)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'},
-         {'text': '114.5(g)(1)', 'title': '11', 'type': 'regulation', 'url': '/regulations/114-5/CURRENT'}
-         ]),
-])
+
+@pytest.mark.parametrize(
+    "test_input,case_id,entity_id,expected",
+    [
+        (
+            "110",
+            1,
+            2,
+            [
+                {
+                    'text': '110',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/110/CURRENT',
+                }
+            ],
+        ),
+        (
+            "110.21",
+            1,
+            2,
+            [
+                {
+                    'text': '110.21',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/110-21/CURRENT',
+                }
+            ],
+        ),
+        (
+            "114.5(a)(3)",
+            1,
+            2,
+            [
+                {
+                    'text': '114.5(a)(3)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/114-5/CURRENT',
+                }
+            ],
+        ),
+        (
+            "114.5(a)(3)-(5)",
+            1,
+            2,
+            [
+                {
+                    'text': '114.5(a)(3)-(5)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/114-5/CURRENT',
+                }
+            ],
+        ),
+        (
+            "102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)",
+            1,
+            2,
+            [
+                {
+                    'text': '102.17(a)(l)(i), (b)(l), (b)(2), and (c)(3)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/102-17/CURRENT',
+                }
+            ],
+        ),
+        (
+            "102.5(a)(2); 104.3(a)(4)(i); 114.5(a)(3)-(5); 114.5(g)(1)",
+            1,
+            2,
+            [
+                {
+                    'text': '102.5(a)(2)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/102-5/CURRENT',
+                },
+                {
+                    'text': '104.3(a)(4)(i)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/104-3/CURRENT',
+                },
+                {
+                    'text': '114.5(a)(3)-(5)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/114-5/CURRENT',
+                },
+                {
+                    'text': '114.5(g)(1)',
+                    'title': '11',
+                    'type': 'regulation',
+                    'url': '/regulations/114-5/CURRENT',
+                },
+            ],
+        ),
+    ],
+)
 def test_parse_regulatory_citations(test_input, case_id, entity_id, expected):
     assert parse_regulatory_citations(test_input, case_id, entity_id) == expected
 
-@pytest.mark.parametrize("test_input,case_id,entity_id,expected", [
-    ("431", 1, 2,    # With reclassification
-        [{'text': '431',
-          'title': '2',
-          'type': 'statute',
-          'url': 'https://www.govinfo.gov/link/uscode/52/30101'}]),
-    ("30116", 1, 2,  # Already reclassified
-        [{'text': '30116',
-          'title': '52',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/52/30116'}]),
-    ("434(a)(11)", 1, 2,
-        [{'text': '434(a)(11)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/52/30104'}]),
-    ("9999", 1, 2,
-        [{'text': '9999',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9999'}]),
-    ("9993(c)(2)", 1, 2,
-        [{'text': '9993(c)(2)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9993'}]),
-    ("9993(a)(4) formerly 438(a)(4)", 1, 2,
-        [{'text': '9993(a)(4)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9993'}]),
-    ("9116(a)(2)(A), 9114(b) (formerly 441a(a)(2)(A), 434(b)), 30116(f) (formerly 441a(f))", 1, 2,
-        [{'text': '9116(a)(2)(A)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9116'},
-        {'text': '9114(b)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9114'},
-        {'text': '30116(f)',
-          'title': '52',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/52/30116'}]),
-    ("9993(a)(4) (formerly 438(a)(4)", 1, 2,  # No matching ')' for (formerly
-        [{'text': '9993(a)(4)',
-          'title': '2',
-          'type': 'statute',
-        'url': 'https://www.govinfo.gov/link/uscode/2/9993'}]),
-])
+
+@pytest.mark.parametrize(
+    "test_input,case_id,entity_id,expected",
+    [
+        (
+            "431",
+            1,
+            2,  # With reclassification
+            [
+                {
+                    'text': '431',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/52/30101',
+                }
+            ],
+        ),
+        (
+            "30116",
+            1,
+            2,  # Already reclassified
+            [
+                {
+                    'text': '30116',
+                    'title': '52',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/52/30116',
+                }
+            ],
+        ),
+        (
+            "434(a)(11)",
+            1,
+            2,
+            [
+                {
+                    'text': '434(a)(11)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/52/30104',
+                }
+            ],
+        ),
+        (
+            "9999",
+            1,
+            2,
+            [
+                {
+                    'text': '9999',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9999',
+                }
+            ],
+        ),
+        (
+            "9993(c)(2)",
+            1,
+            2,
+            [
+                {
+                    'text': '9993(c)(2)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9993',
+                }
+            ],
+        ),
+        (
+            "9993(a)(4) formerly 438(a)(4)",
+            1,
+            2,
+            [
+                {
+                    'text': '9993(a)(4)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9993',
+                }
+            ],
+        ),
+        (
+            "9116(a)(2)(A), 9114(b) (formerly 441a(a)(2)(A), 434(b)), 30116(f) (formerly 441a(f))",
+            1,
+            2,
+            [
+                {
+                    'text': '9116(a)(2)(A)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9116',
+                },
+                {
+                    'text': '9114(b)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9114',
+                },
+                {
+                    'text': '30116(f)',
+                    'title': '52',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/52/30116',
+                },
+            ],
+        ),
+        (
+            "9993(a)(4) (formerly 438(a)(4)",
+            1,
+            2,  # No matching ')' for (formerly
+            [
+                {
+                    'text': '9993(a)(4)',
+                    'title': '2',
+                    'type': 'statute',
+                    'url': 'https://www.govinfo.gov/link/uscode/2/9993',
+                }
+            ],
+        ),
+    ],
+)
 def test_parse_statutory_citations(test_input, case_id, entity_id, expected):
     assert parse_statutory_citations(test_input, case_id, entity_id) == expected

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -138,8 +138,8 @@ class PresidentialByState(ApiBaseTest):
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2016)
         factories.PresidentialByStateFactory(candidate_id='C001', election_year=2020)
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='C003', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='C004', election_year=2020)
 
         filter_fields = (('candidate_id', ['C001', 'C002']),)
 
@@ -154,7 +154,7 @@ class PresidentialByState(ApiBaseTest):
             self.assertGreater(len(results), 0)
             # doesn't return all results, but return same records
             response = self._response(page)
-            self.assertEqual(original_count, response['pagination']['count'])
+            self.assertGreater(original_count, response['pagination']['count'])
 
     def test_sort(self):
         factories.PresidentialByStateFactory(
@@ -189,27 +189,31 @@ class PresidentialSummary(ApiBaseTest):
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(len(results), 4)
 
-    # Fixing these in another commit
+    def test_filters(self):
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
+        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
+        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
+        factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
+        factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
 
-    # def test_filters(self):
-    #     factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
-    #     factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
-    #     factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
-    #     factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
-    #     factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
-    #     factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
+        filter_fields = (
+            ('election_year', [2020]),
+            ('candidate_id', ['C001', 'C002']),
+        )
 
-    #     filter_fields = (
-    #         ('election_year', [2020]),
-    #         ('candidate_id', ['C001', 'C002']),
-    #     )
+        # checking one example from each field
+        orig_response = self._response(api.url_for(PresidentialSummaryView))
+        original_count = orig_response['pagination']['count']
 
-    #     # checking one example from each field
-    #     orig_response = self._response(api.url_for(PresidentialSummaryView))
-    #     original_count = orig_response['pagination']['count']
-
-    #     for field, example in filter_fields:
-    #         page = api.url_for(PresidentialSummaryView, **{field: example})
+        for field, example in filter_fields:
+            page = api.url_for(PresidentialSummaryView, **{field: example})
+            # returns at least one result
+            results = self._results(page)
+            self.assertGreater(len(results), 0)
+            # doesn't return all results, but return same records
+            response = self._response(page)
+            self.assertGreater(original_count, response['pagination']['count'])
 
 
 class PresidentialBySize(ApiBaseTest):
@@ -266,8 +270,8 @@ class PresidentialBySize(ApiBaseTest):
         factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016)
         factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020)
         factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='C003', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='C004', election_year=2020)
 
         filter_fields = (('candidate_id', ['C001', 'C002']),)
 
@@ -282,7 +286,7 @@ class PresidentialBySize(ApiBaseTest):
             self.assertGreater(len(results), 0)
             # doesn't return all results, but return same records
             response = self._response(page)
-            self.assertEqual(original_count, response['pagination']['count'])
+            self.assertGreater(original_count, response['pagination']['count'])
 
     def test_sort(self):
         factories.PresidentialSummaryFactory(candidate_id='C003', net_receipts=333)

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -80,11 +80,10 @@ class PresidentialByCandidate(ApiBaseTest):
 
         results = self._results(api.url_for(PresidentialByCandidateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
 
-        
+
 class PresidentialByState(ApiBaseTest):
     """ Test /presidential/contributions/by_state/"""
 
@@ -142,9 +141,7 @@ class PresidentialByState(ApiBaseTest):
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
         factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
 
-        filter_fields = (
-            ('candidate_id', ['C001', 'C002']),
-        )
+        filter_fields = (('candidate_id', ['C001', 'C002']),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialByStateView))
@@ -160,15 +157,22 @@ class PresidentialByState(ApiBaseTest):
             self.assertEqual(original_count, response['pagination']['count'])
 
     def test_sort(self):
-        factories.PresidentialByStateFactory(candidate_id='C003', contribution_receipt_amount=333)
-        factories.PresidentialByStateFactory(candidate_id='C001', contribution_receipt_amount=222)
-        factories.PresidentialByStateFactory(candidate_id='C004', contribution_receipt_amount=111)
-        factories.PresidentialByStateFactory(candidate_id='C002', contribution_receipt_amount=444)
+        factories.PresidentialByStateFactory(
+            candidate_id='C003', contribution_receipt_amount=333
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C001', contribution_receipt_amount=222
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C004', contribution_receipt_amount=111
+        )
+        factories.PresidentialByStateFactory(
+            candidate_id='C002', contribution_receipt_amount=444
+        )
 
         results = self._results(api.url_for(PresidentialByStateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
 
 
@@ -185,25 +189,27 @@ class PresidentialSummary(ApiBaseTest):
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(len(results), 4)
 
-    def test_filters(self):
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
-        factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
-        factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
+    # Fixing these in another commit
 
-        filter_fields = (
-            ('election_year', [2020]),
-            ('candidate_id', ['C001', 'C002']),
-        )
+    # def test_filters(self):
+    #     factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
+    #     factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
+    #     factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
+    #     factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
+    #     factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
+    #     factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
 
-        # checking one example from each field
-        orig_response = self._response(api.url_for(PresidentialSummaryView))
-        original_count = orig_response['pagination']['count']
+    #     filter_fields = (
+    #         ('election_year', [2020]),
+    #         ('candidate_id', ['C001', 'C002']),
+    #     )
 
-        for field, example in filter_fields:
-            page = api.url_for(PresidentialSummaryView, **{field: example})
+    #     # checking one example from each field
+    #     orig_response = self._response(api.url_for(PresidentialSummaryView))
+    #     original_count = orig_response['pagination']['count']
+
+    #     for field, example in filter_fields:
+    #         page = api.url_for(PresidentialSummaryView, **{field: example})
 
 
 class PresidentialBySize(ApiBaseTest):
@@ -220,16 +226,26 @@ class PresidentialBySize(ApiBaseTest):
         self.assertEqual(len(results), 4)
 
     def test_filters_election_year(self):
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2016, contribution_receipt_amount=100)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016, contribution_receipt_amount=200)
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020, contribution_receipt_amount=300)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=400)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=500)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020, contribution_receipt_amount=600)
-
-        filter_fields = (
-            ('election_year', [2020]),
+        factories.PresidentialBySizeFactory(
+            candidate_id='C001', election_year=2016, contribution_receipt_amount=100
         )
+        factories.PresidentialBySizeFactory(
+            candidate_id='C002', election_year=2016, contribution_receipt_amount=200
+        )
+        factories.PresidentialBySizeFactory(
+            candidate_id='C001', election_year=2020, contribution_receipt_amount=300
+        )
+        factories.PresidentialBySizeFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=400
+        )
+        factories.PresidentialBySizeFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=500
+        )
+        factories.PresidentialBySizeFactory(
+            candidate_id='C002', election_year=2020, contribution_receipt_amount=600
+        )
+
+        filter_fields = (('election_year', [2020]),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialBySizeView))
@@ -253,9 +269,7 @@ class PresidentialBySize(ApiBaseTest):
         factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
         factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
 
-        filter_fields = (
-            ('candidate_id', ['C001', 'C002']),
-        )
+        filter_fields = (('candidate_id', ['C001', 'C002']),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialBySizeView))
@@ -278,8 +292,7 @@ class PresidentialBySize(ApiBaseTest):
 
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(
-            [each['candidate_id'] for each in results],
-            ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
         )
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -9,28 +9,36 @@ from tests.common import ApiBaseTest
 from webservices import schemas
 from webservices.rest import db
 from webservices.rest import api
-from webservices.resources.reports import ReportsView, CommitteeReportsView, EFilingHouseSenateSummaryView, EFilingPresidentialSummaryView, EFilingPacPartySummaryView
+from webservices.resources.reports import (
+    ReportsView,
+    CommitteeReportsView,
+    EFilingHouseSenateSummaryView,
+    EFilingPresidentialSummaryView,
+    EFilingPacPartySummaryView,
+)
 
 
 class TestReports(ApiBaseTest):
-
     def _check_committee_ids(self, results, positives=None, negatives=None):
         ids = [each['committee_id'] for each in results]
-        for positive in (positives or []):
+        for positive in positives or []:
             self.assertIn(positive.committee_id, ids)
-        for negative in (negatives or []):
+        for negative in negatives or []:
             self.assertNotIn(negative.committee_id, ids)
 
     def test_reports_by_committee_id(self):
         committee = factories.CommitteeFactory(committee_type='P')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='P',
+            committee_id=committee_id, committee_type='P',
         )
-        committee_report = factories.ReportsPresidentialFactory(committee_id=committee_id)
+        committee_report = factories.ReportsPresidentialFactory(
+            committee_id=committee_id
+        )
         other_report = factories.ReportsPresidentialFactory()
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(CommitteeReportsView, committee_id=committee_id)
+        )
         self._check_committee_ids(results, [committee_report], [other_report])
 
     def test_reports_by_committee_type(self):
@@ -44,11 +52,7 @@ class TestReports(ApiBaseTest):
         presidential_report_2016 = factories.ReportsPresidentialFactory(cycle=2016)
         house_report_2016 = factories.ReportsHouseSenateFactory(cycle=2016)
         results = self._results(
-            api.url_for(
-                ReportsView,
-                committee_type='presidential',
-                cycle=2016,
-            )
+            api.url_for(ReportsView, committee_type='presidential', cycle=2016,)
         )
         self._check_committee_ids(
             results,
@@ -57,11 +61,7 @@ class TestReports(ApiBaseTest):
         )
         # Test repeated cycle parameter
         results = self._results(
-            api.url_for(
-                ReportsView,
-                committee_type='presidential',
-                cycle=[2016, 2018],
-            )
+            api.url_for(ReportsView, committee_type='presidential', cycle=[2016, 2018],)
         )
         self._check_committee_ids(
             results,
@@ -86,24 +86,28 @@ class TestReports(ApiBaseTest):
             results = self._results(api.url_for(ReportsView, committee_type=category))
             self.assertEqual(len(results), 2)
 
-            results = self._results(api.url_for(ReportsView, committee_type=category, is_amended='false'))
+            results = self._results(
+                api.url_for(ReportsView, committee_type=category, is_amended='false')
+            )
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['committee_id'], reports[0].committee_id)
 
-            results = self._results(api.url_for(ReportsView, committee_type=category, is_amended='true'))
+            results = self._results(
+                api.url_for(ReportsView, committee_type=category, is_amended='true')
+            )
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['committee_id'], reports[1].committee_id)
 
     def test_reports_by_committee_type_and_year(self):
-        presidential_report_2012 = factories.ReportsPresidentialFactory(report_year=2012)
-        presidential_report_2016 = factories.ReportsPresidentialFactory(report_year=2016)
+        presidential_report_2012 = factories.ReportsPresidentialFactory(
+            report_year=2012
+        )
+        presidential_report_2016 = factories.ReportsPresidentialFactory(
+            report_year=2016
+        )
         house_report_2016 = factories.ReportsHouseSenateFactory(report_year=2016)
         results = self._results(
-            api.url_for(
-                ReportsView,
-                committee_type='presidential',
-                year=2016,
-            )
+            api.url_for(ReportsView, committee_type='presidential', year=2016,)
         )
         self._check_committee_ids(
             results,
@@ -112,11 +116,7 @@ class TestReports(ApiBaseTest):
         )
         # Test repeated cycle parameter
         results = self._results(
-            api.url_for(
-                ReportsView,
-                committee_type='presidential',
-                year=[2016, 2018],
-            )
+            api.url_for(ReportsView, committee_type='presidential', year=[2016, 2018],)
         )
         self._check_committee_ids(
             results,
@@ -128,31 +128,49 @@ class TestReports(ApiBaseTest):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='H',
+            committee_id=committee_id, committee_type='H',
         )
         contributions = [0, 100]
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, net_contributions_period=contributions[0])
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, net_contributions_period=contributions[1])
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id, sort=['-net_contributions_period']))
-        self.assertEqual([each['net_contributions_period'] for each in results], contributions[::-1])
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, net_contributions_period=contributions[0]
+        )
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, net_contributions_period=contributions[1]
+        )
+        results = self._results(
+            api.url_for(
+                CommitteeReportsView,
+                committee_id=committee_id,
+                sort=['-net_contributions_period'],
+            )
+        )
+        self.assertEqual(
+            [each['net_contributions_period'] for each in results], contributions[::-1]
+        )
 
     def test_reports_sort_default(self):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='H',
+            committee_id=committee_id, committee_type='H',
         )
         dates = [
             datetime.datetime(2015, 7, 4),
             datetime.datetime(2015, 7, 5),
         ]
         dates_formatted = [isoformat(each) for each in dates]
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, coverage_end_date=dates[0])
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, coverage_end_date=dates[1])
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id))
-        self.assertEqual([each['coverage_end_date'] for each in results], dates_formatted[::-1])
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, coverage_end_date=dates[0]
+        )
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, coverage_end_date=dates[1]
+        )
+        results = self._results(
+            api.url_for(CommitteeReportsView, committee_id=committee_id)
+        )
+        self.assertEqual(
+            [each['coverage_end_date'] for each in results], dates_formatted[::-1]
+        )
 
     def test_reports_for_pdf_link(self):
         committee = factories.CommitteeFactory(committee_type='P')
@@ -160,9 +178,7 @@ class TestReports(ApiBaseTest):
         db.session.flush()
         number = 12345678901
         factories.ReportsPresidentialFactory(
-            report_year=2016,
-            beginning_image_number=number,
-            committee_id=committee_id,
+            report_year=2016, beginning_image_number=number, committee_id=committee_id,
         )
 
         results = self._results(
@@ -186,9 +202,7 @@ class TestReports(ApiBaseTest):
         db.session.flush()
         number = 56789012345
         factories.ReportsPresidentialFactory(
-            report_year=1990,
-            beginning_image_number=number,
-            committee_id=committee_id,
+            report_year=1990, beginning_image_number=number, committee_id=committee_id,
         )
 
         results = self._results(
@@ -209,9 +223,7 @@ class TestReports(ApiBaseTest):
         db.session.flush()
         number = 56789012346
         factories.ReportsHouseSenateFactory(
-            report_year=1999,
-            beginning_image_number=number,
-            committee_id=committee_id,
+            report_year=1999, beginning_image_number=number, committee_id=committee_id,
         )
 
         results = self._results(
@@ -227,26 +239,38 @@ class TestReports(ApiBaseTest):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='H',
+            committee_id=committee_id, committee_type='H',
         )
         factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='Q2')
         factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3')
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER')
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id, report_type=['Q2', 'M3']))
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, report_type='TER'
+        )
+        results = self._results(
+            api.url_for(
+                CommitteeReportsView,
+                committee_id=committee_id,
+                report_type=['Q2', 'M3'],
+            )
+        )
         self.assertTrue(all(each['report_type'] in ['Q2', 'M3'] for each in results))
 
     def test_report_type_exclude(self):
         committee = factories.CommitteeFactory(committee_type='H')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='H',
+            committee_id=committee_id, committee_type='H',
         )
         factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='Q2')
         factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='M3')
-        factories.ReportsHouseSenateFactory(committee_id=committee_id, report_type='TER')
-        results = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id, report_type=['-M3']))
+        factories.ReportsHouseSenateFactory(
+            committee_id=committee_id, report_type='TER'
+        )
+        results = self._results(
+            api.url_for(
+                CommitteeReportsView, committee_id=committee_id, report_type=['-M3']
+            )
+        )
         self.assertTrue(all(each['report_type'] in ['Q2', 'TER'] for each in results))
 
     def test_ie_only(self):
@@ -258,21 +282,22 @@ class TestReports(ApiBaseTest):
         )
         results = self._results(
             api.url_for(
-                ReportsView,
-                committee_type='ie-only',
-                beginning_image_number=number,
+                ReportsView, committee_type='ie-only', beginning_image_number=number,
             )
         )
         result = results[0]
-        for key in ['report_form', 'independent_contributions_period', 'independent_expenditures_period']:
+        for key in [
+            'report_form',
+            'independent_contributions_period',
+            'independent_expenditures_period',
+        ]:
             self.assertEqual(result[key], getattr(report, key))
 
     def test_ie_committee(self):
         committee = factories.CommitteeFactory(committee_type='I')
         committee_id = committee.committee_id
         factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='I',
+            committee_id=committee_id, committee_type='I',
         )
         report = factories.ReportsIEOnlyFactory(
             committee_id=committee_id,
@@ -280,13 +305,14 @@ class TestReports(ApiBaseTest):
             independent_expenditures_period=100,
         )
         results = self._results(
-            api.url_for(
-                CommitteeReportsView,
-                committee_id=committee_id,
-            )
+            api.url_for(CommitteeReportsView, committee_id=committee_id,)
         )
         result = results[0]
-        for key in ['report_form', 'independent_contributions_period', 'independent_expenditures_period']:
+        for key in [
+            'report_form',
+            'independent_contributions_period',
+            'independent_expenditures_period',
+        ]:
             self.assertEqual(result[key], getattr(report, key))
 
     def _check_reports(self, committee_type, factory, schema):
@@ -301,13 +327,13 @@ class TestReports(ApiBaseTest):
         db.session.flush()
         [
             factory(
-                committee_id=committee_id,
-                coverage_end_date=end_date,
-                report_year=2011,
+                committee_id=committee_id, coverage_end_date=end_date, report_year=2011,
             )
             for end_date in end_dates
         ]
-        response = self._results(api.url_for(CommitteeReportsView, committee_id=committee_id))
+        response = self._results(
+            api.url_for(CommitteeReportsView, committee_id=committee_id)
+        )
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['coverage_end_date'], isoformat(end_dates[0]))
         self.assertEqual(response[1]['coverage_end_date'], isoformat(end_dates[1]))
@@ -315,10 +341,26 @@ class TestReports(ApiBaseTest):
 
     # TODO(jmcarp) Refactor as parameterized tests
     def test_reports(self):
-        self._check_reports('H', factories.ReportsHouseSenateFactory, schemas.CommitteeReportsHouseSenateSchema)
-        self._check_reports('S', factories.ReportsHouseSenateFactory, schemas.CommitteeReportsHouseSenateSchema)
-        self._check_reports('P', factories.ReportsPresidentialFactory, schemas.CommitteeReportsPresidentialSchema)
-        self._check_reports('X', factories.ReportsPacPartyFactory, schemas.CommitteeReportsPacPartySchema)
+        self._check_reports(
+            'H',
+            factories.ReportsHouseSenateFactory,
+            schemas.CommitteeReportsHouseSenateSchema,
+        )
+        self._check_reports(
+            'S',
+            factories.ReportsHouseSenateFactory,
+            schemas.CommitteeReportsHouseSenateSchema,
+        )
+        self._check_reports(
+            'P',
+            factories.ReportsPresidentialFactory,
+            schemas.CommitteeReportsPresidentialSchema,
+        )
+        self._check_reports(
+            'X',
+            factories.ReportsPacPartyFactory,
+            schemas.CommitteeReportsPacPartySchema,
+        )
 
     def test_reports_committee_not_found(self):
         resp = self.app.get(api.url_for(CommitteeReportsView, committee_id='fake'))
@@ -329,26 +371,29 @@ class TestReports(ApiBaseTest):
 
 
 class TestEFileReports(ApiBaseTest):
-
     def _check_committee_ids(self, results, positives=None, negatives=None):
         ids = [each['committee_id'] for each in results]
-        for positive in (positives or []):
+        for positive in positives or []:
             self.assertIn(positive.committee_id, ids)
-        for negative in (negatives or []):
+        for negative in negatives or []:
             self.assertNotIn(negative.committee_id, ids)
 
     def test_efile_presidential_reports(self):
         committee_id = 'C86753090'
         other_id = 'C2222222'
 
-        committee_efile = factories.EfileReportsPresidentialFactory(committee_id=committee_id, cash_on_hand_end_period=20)
-        other_efile = factories.EfileReportsPresidentialFactory(committee_id=other_id, cash_on_hand_end_period=40)
+        committee_efile = factories.EfileReportsPresidentialFactory(
+            committee_id=committee_id, cash_on_hand_end_period=20
+        )
+        other_efile = factories.EfileReportsPresidentialFactory(
+            committee_id=other_id, cash_on_hand_end_period=40
+        )
 
         results = self._results(
             api.url_for(
                 EFilingPresidentialSummaryView,
                 committee_type='presidential',
-                committee_id=committee_id
+                committee_id=committee_id,
             )
         )
 
@@ -361,14 +406,13 @@ class TestEFileReports(ApiBaseTest):
         committee_id = 'C8675310'
         other_id = 'C3333333'
 
-        committee_efile = factories.EfileReportsPacPartyFactory(committee_id=committee_id)
+        committee_efile = factories.EfileReportsPacPartyFactory(
+            committee_id=committee_id
+        )
         other_efile = factories.EfileReportsPacPartyFactory(committee_id=other_id)
 
         results = self._results(
-            api.url_for(
-                EFilingPacPartySummaryView,
-                committee_id=committee_id
-            )
+            api.url_for(EFilingPacPartySummaryView, committee_id=committee_id)
         )
 
         self.assertEqual(results[0]['committee_id'], committee_id)
@@ -378,14 +422,16 @@ class TestEFileReports(ApiBaseTest):
         committee_id = 'C8675311'
         other_id = 'C1111111'
 
-        committee_efile = factories.EfileReportsHouseSenateFactory(committee_id=committee_id)
+        committee_efile = factories.EfileReportsHouseSenateFactory(
+            committee_id=committee_id
+        )
         other_efile = factories.EfileReportsHouseSenateFactory(committee_id=other_id)
 
         results = self._results(
             api.url_for(
                 EFilingHouseSenateSummaryView,
                 committee_type='house-senate',
-                committee_id=committee_id
+                committee_id=committee_id,
             )
         )
 
@@ -395,22 +441,49 @@ class TestEFileReports(ApiBaseTest):
 
     def test_filter_date_efile_reports(self):
         [
-            factories.EfileReportsPacPartyFactory(receipt_date=datetime.date(2012, 1, 1)),
-            factories.EfileReportsPacPartyFactory(receipt_date=datetime.date(2013, 1, 1)),
-            factories.EfileReportsPacPartyFactory(receipt_date=datetime.date(2014, 1, 1)),
-            factories.EfileReportsPacPartyFactory(receipt_date=datetime.date(2015, 1, 1)),
+            factories.EfileReportsPacPartyFactory(
+                receipt_date=datetime.date(2012, 1, 1)
+            ),
+            factories.EfileReportsPacPartyFactory(
+                receipt_date=datetime.date(2013, 1, 1)
+            ),
+            factories.EfileReportsPacPartyFactory(
+                receipt_date=datetime.date(2014, 1, 1)
+            ),
+            factories.EfileReportsPacPartyFactory(
+                receipt_date=datetime.date(2015, 1, 1)
+            ),
         ]
 
         min_date = datetime.date(2013, 1, 1)
-        results = self._results(api.url_for(EFilingPacPartySummaryView, min_receipt_date=min_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] >= min_date.isoformat()))
-        max_date = datetime.date(2014, 1, 1)
-        results = self._results(api.url_for(EFilingPacPartySummaryView, max_receipt_date=max_date))
-        self.assertTrue(all(each for each in results if each['receipt_date'] <= max_date.isoformat()))
-        results = self._results(api.url_for(EFilingPacPartySummaryView, min_receipt_date=min_date, max_receipt_date=max_date))
+        results = self._results(
+            api.url_for(EFilingPacPartySummaryView, min_receipt_date=min_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
+                each for each in results if each['receipt_date'] >= min_date.isoformat()
+            )
+        )
+        max_date = datetime.date(2014, 1, 1)
+        results = self._results(
+            api.url_for(EFilingPacPartySummaryView, max_receipt_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                each for each in results if each['receipt_date'] <= max_date.isoformat()
+            )
+        )
+        results = self._results(
+            api.url_for(
+                EFilingPacPartySummaryView,
+                min_receipt_date=min_date,
+                max_receipt_date=max_date,
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
                 if min_date.isoformat() <= each['receipt_date'] <= max_date.isoformat()
             )
         )

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -8,6 +8,7 @@ from webservices.rest import api
 from webservices.schemas import ScheduleCSchema
 from webservices.resources.sched_c import ScheduleCView, ScheduleCViewBySubId
 
+
 class TestScheduleCView(ApiBaseTest):
     def test_fields(self):
         [
@@ -20,66 +21,56 @@ class TestScheduleCView(ApiBaseTest):
     def test_sort_incurred_date(self):
         [
             factories.ScheduleCFactory(
-                incurred_date=datetime.date(2019, 1, 1),
-                payment_to_date=10.55,
+                incurred_date=datetime.date(2019, 1, 1), payment_to_date=10.55,
             ),
             factories.ScheduleCFactory(
-                incurred_date=datetime.date(2019, 12, 2),
-                payment_to_date=20.55,
+                incurred_date=datetime.date(2019, 12, 2), payment_to_date=20.55,
             ),
         ]
         response1 = self._response(api.url_for(ScheduleCView, sort='-incurred_date',))
         self.assertEqual(
-            [each['payment_to_date'] for each in response1['results']],
-            [20.55, 10.55]
+            [each['payment_to_date'] for each in response1['results']], [20.55, 10.55]
         )
 
         response2 = self._response(api.url_for(ScheduleCView, sort='incurred_date',))
         self.assertEqual(
-            [each['payment_to_date'] for each in response2['results']],
-            [10.55, 20.55]
+            [each['payment_to_date'] for each in response2['results']], [10.55, 20.55]
         )
 
     def test_sort_payment_to_date(self):
         [
-            factories.ScheduleCFactory(
-                payment_to_date=10.55,
-            ),
-            factories.ScheduleCFactory(
-                payment_to_date=20.55,
-            ),
+            factories.ScheduleCFactory(payment_to_date=10.55,),
+            factories.ScheduleCFactory(payment_to_date=20.55,),
         ]
         response1 = self._response(api.url_for(ScheduleCView, sort='-payment_to_date',))
         self.assertEqual(
-            [each['payment_to_date'] for each in response1['results']],
-            [20.55, 10.55]
+            [each['payment_to_date'] for each in response1['results']], [20.55, 10.55]
         )
 
         response2 = self._response(api.url_for(ScheduleCView, sort='payment_to_date',))
         self.assertEqual(
-            [each['payment_to_date'] for each in response2['results']],
-            [10.55, 20.55]
+            [each['payment_to_date'] for each in response2['results']], [10.55, 20.55]
         )
 
     def test_sort_original_loan_amount(self):
         [
-            factories.ScheduleCFactory(
-                original_loan_amount=10.55,
-            ),
-            factories.ScheduleCFactory(
-                original_loan_amount=20.55,
-            ),
+            factories.ScheduleCFactory(original_loan_amount=10.55,),
+            factories.ScheduleCFactory(original_loan_amount=20.55,),
         ]
-        response1 = self._response(api.url_for(ScheduleCView, sort='-original_loan_amount',))
+        response1 = self._response(
+            api.url_for(ScheduleCView, sort='-original_loan_amount',)
+        )
         self.assertEqual(
             [each['original_loan_amount'] for each in response1['results']],
-            [20.55, 10.55]
+            [20.55, 10.55],
         )
 
-        response2 = self._response(api.url_for(ScheduleCView, sort='original_loan_amount',))
+        response2 = self._response(
+            api.url_for(ScheduleCView, sort='original_loan_amount',)
+        )
         self.assertEqual(
             [each['original_loan_amount'] for each in response2['results']],
-            [10.55, 20.55]
+            [10.55, 20.55],
         )
 
     def test_sort_bad_column(self):
@@ -118,7 +109,9 @@ class TestScheduleCView(ApiBaseTest):
         self.assertTrue(all(each['payment_to_date'] >= 100 for each in results))
         results = self._results(api.url_for(ScheduleCView, max_payment_to_date=150))
         self.assertTrue(all(each['payment_to_date'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleCView, min_payment_to_date=100, max_payment_to_date=200))
+        results = self._results(
+            api.url_for(ScheduleCView, min_payment_to_date=100, max_payment_to_date=200)
+        )
         self.assertTrue(all(100 <= each['payment_to_date'] <= 200 for each in results))
 
     def test_filter_original_loan_amount(self):
@@ -132,8 +125,12 @@ class TestScheduleCView(ApiBaseTest):
         self.assertTrue(all(each['original_loan_amount'] >= 100 for each in results))
         results = self._results(api.url_for(ScheduleCView, max_amount=150))
         self.assertTrue(all(each['original_loan_amount'] <= 150 for each in results))
-        results = self._results(api.url_for(ScheduleCView, min_amount=100, max_amount=200))
-        self.assertTrue(all(100 <= each['original_loan_amount'] <= 200 for each in results))
+        results = self._results(
+            api.url_for(ScheduleCView, min_amount=100, max_amount=200)
+        )
+        self.assertTrue(
+            all(100 <= each['original_loan_amount'] <= 200 for each in results)
+        )
 
     def test_filter_incurred_date(self):
         [
@@ -144,14 +141,31 @@ class TestScheduleCView(ApiBaseTest):
         ]
         min_date = datetime.date(2015, 1, 1)
         results = self._results(api.url_for(ScheduleCView, min_incurred_date=min_date))
-        self.assertTrue(all(each for each in results if each['incurred_date'] >= min_date.isoformat()))
-        max_date = datetime.date(2018, 1, 1)
-        results = self._results(api.url_for(ScheduleCView, max_incurred_date=max_date))
-        self.assertTrue(all(each for each in results if each['incurred_date'] <= max_date.isoformat()))
-        results = self._results(api.url_for(ScheduleCView, min_incurred_date=min_date, max_incurred_date=max_date))
         self.assertTrue(
             all(
-                each for each in results
+                each
+                for each in results
+                if each['incurred_date'] >= min_date.isoformat()
+            )
+        )
+        max_date = datetime.date(2018, 1, 1)
+        results = self._results(api.url_for(ScheduleCView, max_incurred_date=max_date))
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if each['incurred_date'] <= max_date.isoformat()
+            )
+        )
+        results = self._results(
+            api.url_for(
+                ScheduleCView, min_incurred_date=min_date, max_incurred_date=max_date
+            )
+        )
+        self.assertTrue(
+            all(
+                each
+                for each in results
                 if min_date.isoformat() <= each['incurred_date'] <= max_date.isoformat()
             )
         )
@@ -177,8 +191,11 @@ class TestScheduleCView(ApiBaseTest):
         self.assertTrue(all(each['image_number'] >= '2' for each in results))
         results = self._results(api.url_for(ScheduleCView, max_image_number='3'))
         self.assertTrue(all(each['image_number'] <= '3' for each in results))
-        results = self._results(api.url_for(ScheduleCView, min_image_number='2', max_image_number='3'))
+        results = self._results(
+            api.url_for(ScheduleCView, min_image_number='2', max_image_number='3')
+        )
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
+
 
 class TestScheduleCViewBySubId(ApiBaseTest):
     def test_fields(self):

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -9,7 +9,6 @@ from webservices.resources.sched_d import ScheduleDView, ScheduleDViewBySubId
 
 
 class TestScheduleDView(ApiBaseTest):
-
     def test_fields(self):
         [
             factories.ScheduleDViewFactory(),
@@ -25,31 +24,26 @@ class TestScheduleDView(ApiBaseTest):
             ('candidate_id', ScheduleD.candidate_id, ['S01', 'S02']),
         ]
         for label, column, values in filters:
-            [
-                factories.ScheduleDViewFactory(**{column.key: value})
-                for value in values
-            ]
+            [factories.ScheduleDViewFactory(**{column.key: value}) for value in values]
             results = self._results(api.url_for(ScheduleDView, **{label: values[0]}))
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
     def test_filter_fulltext_field(self):
         names = ['OFFICE MAX', 'MAX AND ERMAS', 'OFFICE MAX CONSUMER CREDIT CARD']
-        [
-            factories.ScheduleDViewFactory(creditor_debtor_name=name)
-            for name in names
-        ]
-        results = self._results(api.url_for(ScheduleDView, creditor_debtor_name='OFFICE'))
+        [factories.ScheduleDViewFactory(creditor_debtor_name=name) for name in names]
+        results = self._results(
+            api.url_for(ScheduleDView, creditor_debtor_name='OFFICE')
+        )
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['creditor_debtor_name'], 'OFFICE MAX')
 
     def test_filter_match_field(self):
         names = ['DUES', 'PRINTING', 'ENTERTAIMENT']
-        [
-            factories.ScheduleDViewFactory(nature_of_debt=name)
-            for name in names
-        ]
-        results = self._results(api.url_for(ScheduleDView, nature_of_debt='ENTERTAIMENT'))
+        [factories.ScheduleDViewFactory(nature_of_debt=name) for name in names]
+        results = self._results(
+            api.url_for(ScheduleDView, nature_of_debt='ENTERTAIMENT')
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['nature_of_debt'], 'ENTERTAIMENT')
 
@@ -62,17 +56,25 @@ class TestScheduleDView(ApiBaseTest):
         ]
         min_date = datetime.date(2013, 1, 1)
         results = self._results(api.url_for(ScheduleDView, min_load_date=min_date))
-        self.assertTrue(all(each for each in results if each['load_date'] >= min_date.isoformat()))
+        self.assertTrue(
+            all(each for each in results if each['load_date'] >= min_date.isoformat())
+        )
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(ScheduleDView, max_load_date=max_date))
-        self.assertTrue(all(each for each in results if each['load_date'] <= max_date.isoformat()))
-        results = self._results(api.url_for(ScheduleDView, min_load_date=min_date, max_load_date=max_date))
+        self.assertTrue(
+            all(each for each in results if each['load_date'] <= max_date.isoformat())
+        )
+        results = self._results(
+            api.url_for(ScheduleDView, min_load_date=min_date, max_load_date=max_date)
+        )
         self.assertTrue(
             all(
-                each for each in results
+                each
+                for each in results
                 if min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
             )
         )
+
     def test_sort_ascending(self):
         [
             factories.ScheduleDViewFactory(sub_id=1, load_date='2017-01-02'),
@@ -91,8 +93,8 @@ class TestScheduleDView(ApiBaseTest):
         self.assertEqual(results[0]['sub_id'], '2')
         self.assertEqual(results[1]['sub_id'], '1')
 
-class TestScheduleDViewBySubId(ApiBaseTest):
 
+class TestScheduleDViewBySubId(ApiBaseTest):
     def test_sub_id_field(self):
         [
             factories.ScheduleDViewBySubIdFactory(sub_id='101'),

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -5,7 +5,7 @@ from webservices.rest import db, api
 from webservices.resources.spending_by_others import (
     ECTotalsByCandidateView,
     IETotalsByCandidateView,
-    CCTotalsByCandidateView
+    CCTotalsByCandidateView,
 )
 from webservices.resources.aggregates import (
     CCAggregatesView,
@@ -14,39 +14,35 @@ from webservices.resources.aggregates import (
 
 # test endpoint: /electioneering/totals/by_candidate/ under tag:electioneering
 class TestTotalElectioneering(ApiBaseTest):
-
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S01',
-            two_year_period=2018,
-            candidate_election_year=2024
+            candidate_id='S01', two_year_period=2018, candidate_election_year=2024
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='S01',
-            two_year_period=2020,
-            candidate_election_year=2024
+            candidate_id='S01', two_year_period=2020, candidate_election_year=2024
         ),
 
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01',
-            total=300,
-            cycle=2018,
-            committee_id='C01'
+            candidate_id='S01', total=300, cycle=2018, committee_id='C01'
         ),
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01',
-            total=200,
-            cycle=2020,
-            committee_id='C02'
+            candidate_id='S01', total=200, cycle=2020, committee_id='C02'
         ),
 
-        results = self._results(api.url_for(ECTotalsByCandidateView, candidate_id='S01', election_full=False))
+        results = self._results(
+            api.url_for(
+                ECTotalsByCandidateView, candidate_id='S01', election_full=False
+            )
+        )
         assert len(results) == 2
 
-        results = self._results(api.url_for(ECTotalsByCandidateView, candidate_id='S01', election_full=True))
+        results = self._results(
+            api.url_for(ECTotalsByCandidateView, candidate_id='S01', election_full=True)
+        )
         assert len(results) == 1
         assert results[0]['total'] == 500
+
 
 # test endpoint: /electioneering/aggregates/ under tag:electioneering
 class TestElectioneeringAggregates(ApiBaseTest):
@@ -56,9 +52,15 @@ class TestElectioneeringAggregates(ApiBaseTest):
         assert len(results) == 1
 
     def test_filters_committee_candidate_id_cycle(self):
-        factories.ElectioneeringByCandidateFactory(committee_id='P001', candidate_id='C001', cycle=2000)
-        factories.ElectioneeringByCandidateFactory(committee_id='P001', candidate_id='C002', cycle=2000)
-        factories.ElectioneeringByCandidateFactory(committee_id='P002', candidate_id='C001', cycle=2004)
+        factories.ElectioneeringByCandidateFactory(
+            committee_id='P001', candidate_id='C001', cycle=2000
+        )
+        factories.ElectioneeringByCandidateFactory(
+            committee_id='P001', candidate_id='C002', cycle=2000
+        )
+        factories.ElectioneeringByCandidateFactory(
+            committee_id='P002', candidate_id='C001', cycle=2004
+        )
         db.session.flush()
         results = self._results(api.url_for(ECAggregatesView, committee_id='P001'))
         self.assertEqual(len(results), 2)
@@ -72,18 +74,13 @@ class TestElectioneeringAggregates(ApiBaseTest):
 
 # test endpoint: /schedules/schedule_e/totals/by_candidate/ under tag:independent expenditures
 class TestTotalIndependentExpenditure(ApiBaseTest):
-
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='P01',
-            two_year_period=2014,
-            candidate_election_year=2016
+            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01',
-            two_year_period=2016,
-            candidate_election_year=2016
+            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.ScheduleEByCandidateFactory(
@@ -91,41 +88,47 @@ class TestTotalIndependentExpenditure(ApiBaseTest):
             total=100,
             cycle=2012,
             committee_id='C01',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
             candidate_id='P01',
             total=200,
             cycle=2014,
             committee_id='C02',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
             candidate_id='P01',
             total=300,
             cycle=2014,
             committee_id='C02',
-            support_oppose_indicator='O'
+            support_oppose_indicator='O',
         ),
         factories.ScheduleEByCandidateFactory(
             candidate_id='P01',
             total=400,
             cycle=2016,
             committee_id='C03',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
             candidate_id='P01',
             total=500,
             cycle=2016,
             committee_id='C03',
-            support_oppose_indicator='O'
+            support_oppose_indicator='O',
         ),
 
-        results = self._results(api.url_for(IETotalsByCandidateView, candidate_id='P01', election_full=False))
+        results = self._results(
+            api.url_for(
+                IETotalsByCandidateView, candidate_id='P01', election_full=False
+            )
+        )
         assert len(results) == 4
 
-        results = self._results(api.url_for(IETotalsByCandidateView, candidate_id='P01', election_full=True))
+        results = self._results(
+            api.url_for(IETotalsByCandidateView, candidate_id='P01', election_full=True)
+        )
         assert len(results) == 2
         assert results[0]['total'] == 800
         assert results[1]['total'] == 600
@@ -133,18 +136,13 @@ class TestTotalIndependentExpenditure(ApiBaseTest):
 
 # test /communication_costs/by_candidate/total/ under tag: communication cost
 class TestTotalCommunicationsCosts(ApiBaseTest):
-
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='P01',
-            two_year_period=2014,
-            candidate_election_year=2016
+            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01',
-            two_year_period=2016,
-            candidate_election_year=2016
+            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.CommunicationCostByCandidateFactory(
@@ -152,54 +150,59 @@ class TestTotalCommunicationsCosts(ApiBaseTest):
             total=100,
             cycle=2012,
             committee_id='C01',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
             candidate_id='P01',
             total=200,
             cycle=2014,
             committee_id='C02',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
             candidate_id='P01',
             total=300,
             cycle=2014,
             committee_id='C02',
-            support_oppose_indicator='O'
+            support_oppose_indicator='O',
         ),
         factories.CommunicationCostByCandidateFactory(
             candidate_id='P01',
             total=400,
             cycle=2016,
             committee_id='C03',
-            support_oppose_indicator='S'
+            support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
             candidate_id='P01',
             total=500,
             cycle=2016,
             committee_id='C03',
-            support_oppose_indicator='O'
+            support_oppose_indicator='O',
         ),
 
-        results = self._results(api.url_for(
-            CCTotalsByCandidateView,
-            cycle='2016',
-            candidate_id='P01',
-            election_full=False
-        ))
+        results = self._results(
+            api.url_for(
+                CCTotalsByCandidateView,
+                cycle='2016',
+                candidate_id='P01',
+                election_full=False,
+            )
+        )
         assert len(results) == 2
 
-        results = self._results(api.url_for(
-            CCTotalsByCandidateView,
-            cycle='2016',
-            candidate_id='P01',
-            election_full=True
-        ))
+        results = self._results(
+            api.url_for(
+                CCTotalsByCandidateView,
+                cycle='2016',
+                candidate_id='P01',
+                election_full=True,
+            )
+        )
         assert len(results) == 2
         assert results[0]['total'] == 800
         assert results[1]['total'] == 600
+
 
 # test endpoint: /communication_costs/aggregates/ under tag:communication costs
 class TestCommunicationCostAggregates(ApiBaseTest):
@@ -209,9 +212,15 @@ class TestCommunicationCostAggregates(ApiBaseTest):
         assert len(results) == 1
 
     def test_filters_committee_candidate_id_cycle(self):
-        factories.CommunicationCostByCandidateFactory(committee_id='P001', candidate_id='C001', cycle=2000)
-        factories.CommunicationCostByCandidateFactory(committee_id='P001', candidate_id='C002', cycle=2000)
-        factories.CommunicationCostByCandidateFactory(committee_id='P002', candidate_id='C001', cycle=2004)
+        factories.CommunicationCostByCandidateFactory(
+            committee_id='P001', candidate_id='C001', cycle=2000
+        )
+        factories.CommunicationCostByCandidateFactory(
+            committee_id='P001', candidate_id='C002', cycle=2000
+        )
+        factories.CommunicationCostByCandidateFactory(
+            committee_id='P002', candidate_id='C001', cycle=2004
+        )
         db.session.flush()
         results = self._results(api.url_for(CCAggregatesView, committee_id='P001'))
         self.assertEqual(len(results), 2)

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -12,8 +12,11 @@ from webservices.resources.aggregates import (
     ECAggregatesView,
 )
 
-# test endpoint: /electioneering/totals/by_candidate/ under tag:electioneering
+
 class TestTotalElectioneering(ApiBaseTest):
+    """
+    test endpoint: /electioneering/totals/by_candidate/ under tag:electioneering
+    """
     def test_fields(self):
 
         factories.CandidateHistoryFactory(

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2,12 +2,11 @@ import unittest
 from apispec import utils, exceptions
 
 import webservices.rest
-import webservices.schemas  # needed to generate full spec
+import webservices.schemas  # noqa: needed to generate full spec
 from webservices.spec import spec, format_docstring
 
 
 class TestSwagger(unittest.TestCase):
-
     def test_swagger_valid(self):
         try:
             utils.validate_spec(spec)

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -5,7 +5,10 @@ from tests.common import ApiBaseTest
 
 from webservices import utils
 from webservices.rest import api
-from webservices.resources.totals import TotalsView, TotalsCommitteeView, ScheduleAByStateRecipientTotalsView
+from webservices.resources.totals import (
+    TotalsCommitteeView,
+    ScheduleAByStateRecipientTotalsView,
+)
 
 
 shared_fields = {
@@ -40,21 +43,20 @@ shared_fields = {
     'committee_designation': "",
     'committee_type_full': "",
     'committee_designation_full': "",
-    'party_full': ""
+    'party_full': "",
 }
 
 transaction_coverage_fields = {'transaction_coverage_date': None}
 
-class TestTotals(ApiBaseTest):
 
+class TestTotals(ApiBaseTest):
     def test_Presidential_totals(self):
         committee_id = 'C8675309'
-        transaction_coverage = factories.TransactionCoverageFactory(
-            committee_id=committee_id,
-            fec_election_year=2016)
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='P',
+        transaction_coverage = factories.TransactionCoverageFactory(  # noqa
+            committee_id=committee_id, fec_election_year=2016
+        )
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='P',
         )
         presidential_fields = {
             'committee_id': 'C8675309',
@@ -75,25 +77,25 @@ class TestTotals(ApiBaseTest):
             'repayments_other_loans': 13,
             'transfers_from_affiliated_committee': 14,
             'transfers_to_other_authorized_committee': 15,
-
         }
 
         fields = utils.extend(shared_fields, presidential_fields)
-        committee_total = factories.CommitteeTotalsPerCycleFactory(**fields)
+        committee_total = factories.CommitteeTotalsPerCycleFactory(**fields)  # noqa
 
         fields = utils.extend(fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_House_Senate_totals(self):
         committee_id = 'C8675310'
-        transaction_coverage = factories.TransactionCoverageFactory(
-            committee_id=committee_id,
-            fec_election_year=2016)
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='S',
+        transaction_coverage = factories.TransactionCoverageFactory(  # noqa
+            committee_id=committee_id, fec_election_year=2016
+        )
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='S',
         )
 
         house_senate_fields = {
@@ -113,21 +115,22 @@ class TestTotals(ApiBaseTest):
             'net_operating_expenditures': 128,
         }
         fields = utils.extend(house_senate_fields, shared_fields)
-        committee_total = factories.TotalsHouseSenateFactory(**fields)
+        committee_total = factories.TotalsHouseSenateFactory(**fields)  # noqa
 
         fields = utils.extend(fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_Pac_Party_totals(self):
         committee_id = 'C8675311'
-        transaction_coverage = factories.TransactionCoverageFactory(
-            committee_id=committee_id,
-            fec_election_year=2016)
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='Q',
+        transaction_coverage = factories.TransactionCoverageFactory(  # noqa
+            committee_id=committee_id, fec_election_year=2016
+        )
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='Q',
         )
         pac_party_fields = {
             'committee_id': committee_id,
@@ -180,21 +183,22 @@ class TestTotals(ApiBaseTest):
             'unitemized_other_disb': 4,
         }
         fields = utils.extend(pac_party_fields, shared_fields)
-        committee_total = factories.TotalsPacPartyFactory(**fields)
+        committee_total = factories.TotalsPacPartyFactory(**fields)  # noqa
 
         fields = utils.extend(fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_Pac_totals(self):
         committee_id = 'C8675311'
-        transaction_coverage = factories.TransactionCoverageFactory(
-            committee_id=committee_id,
-            fec_election_year=2016)
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='O',
+        transaction_coverage = factories.TransactionCoverageFactory(  # noqa
+            committee_id=committee_id, fec_election_year=2016
+        )
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='O',
         )
         pac_fields = {
             'committee_id': committee_id,
@@ -247,22 +251,23 @@ class TestTotals(ApiBaseTest):
             'unitemized_other_disb': 4,
         }
         fields = utils.extend(pac_fields, shared_fields)
-        committee_total = factories.TotalsPacFactory(**fields)
+        committee_total = factories.TotalsPacFactory(**fields)  # noqa
 
         fields = utils.extend(fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_party_totals(self):
 
         committee_id = 'C00540005'
-        transaction_coverage = factories.TransactionCoverageFactory(
-            committee_id=committee_id,
-            fec_election_year=2014)
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='X',
+        transaction_coverage = factories.TransactionCoverageFactory(  # noqa
+            committee_id=committee_id, fec_election_year=2014
+        )
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='X',
         )
         party_fields = {
             'committee_id': committee_id,
@@ -318,18 +323,19 @@ class TestTotals(ApiBaseTest):
             'unitemized_other_disb': 4,
         }
         fields = utils.extend(party_fields, shared_fields)
-        committee_total = factories.TotalsPartyFactory(**fields)
+        committee_total = factories.TotalsPartyFactory(**fields)  # noqa
 
         fields = utils.extend(fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_ie_totals(self):
         committee_id = 'C8675312'
-        history = factories.CommitteeHistoryFactory(
-            committee_id=committee_id,
-            committee_type='I',
+        history = factories.CommitteeHistoryFactory(  # noqa
+            committee_id=committee_id, committee_type='I',
         )
         ie_fields = {
             'committee_id': committee_id,
@@ -339,11 +345,13 @@ class TestTotals(ApiBaseTest):
             'total_independent_contributions': 1,
             'total_independent_expenditures': 2,
         }
-        committee_total = factories.TotalsIEOnlyFactory(**ie_fields)
+        committee_total = factories.TotalsIEOnlyFactory(**ie_fields)  # noqa
 
         fields = utils.extend(ie_fields, transaction_coverage_fields)
 
-        results = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        results = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(results[0], fields)
 
     def test_totals_house_senate(self):
@@ -351,18 +359,20 @@ class TestTotals(ApiBaseTest):
         committee_id = committee.committee_id
         [
             factories.TransactionCoverageFactory(
-                committee_id=committee_id,
-                fec_election_year=2008),
+                committee_id=committee_id, fec_election_year=2008
+            ),
             factories.TransactionCoverageFactory(
-                committee_id=committee_id,
-                fec_election_year=2012),
+                committee_id=committee_id, fec_election_year=2012
+            ),
         ]
         factories.CommitteeHistoryFactory(committee_id=committee_id, committee_type='H')
         [
             factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2008),
             factories.TotalsHouseSenateFactory(committee_id=committee_id, cycle=2012),
         ]
-        response = self._results(api.url_for(TotalsCommitteeView, committee_id=committee_id))
+        response = self._results(
+            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+        )
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['cycle'], 2012)
         self.assertEqual(response[1]['cycle'], 2008)
@@ -375,7 +385,7 @@ class TestTotals(ApiBaseTest):
         self.assertIn('not found', data['message'].lower())
 
     def test_sched_a_by_state_recipient_totals(self):
-        rows = [
+        rows = [  # noqa
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=50000,
                 count=10,
@@ -383,7 +393,7 @@ class TestTotals(ApiBaseTest):
                 state='CA',
                 state_full='California',
                 committee_type='P',
-                committee_type_full='Presidential'
+                committee_type_full='Presidential',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=10000,
@@ -392,7 +402,7 @@ class TestTotals(ApiBaseTest):
                 state='ND',
                 state_full='North Dakota',
                 committee_type='H',
-                committee_type_full='House'
+                committee_type_full='House',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=20000,
@@ -401,7 +411,7 @@ class TestTotals(ApiBaseTest):
                 state='NC',
                 state_full='North Carolina',
                 committee_type='S',
-                committee_type_full='Senate'
+                committee_type_full='Senate',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=90000,
@@ -410,7 +420,7 @@ class TestTotals(ApiBaseTest):
                 state='NY',
                 state_full='New York',
                 committee_type='U',
-                committee_type_full='single candidate independent expenditure'
+                committee_type_full='single candidate independent expenditure',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=150000,
@@ -419,13 +429,11 @@ class TestTotals(ApiBaseTest):
                 state='TX',
                 state_full='Texas',
                 committee_type='',
-                committee_type_full='All'
+                committee_type_full='All',
             ),
         ]
 
-        response = self._results(
-            api.url_for(ScheduleAByStateRecipientTotalsView)
-        )
+        response = self._results(api.url_for(ScheduleAByStateRecipientTotalsView))
 
         self.assertEqual(len(response), 5)
         self.assertEqual(response[0]['total'], 50000)
@@ -438,7 +446,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(response[4]['committee_type'], '')
 
     def test_sched_a_by_state_recipient_totals_sort_by_cycle(self):
-        rows = [
+        rows = [  # noqa
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=50000,
                 count=10,
@@ -446,7 +454,7 @@ class TestTotals(ApiBaseTest):
                 state='CA',
                 state_full='California',
                 committee_type='P',
-                committee_type_full='Presidential'
+                committee_type_full='Presidential',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=10000,
@@ -455,7 +463,7 @@ class TestTotals(ApiBaseTest):
                 state='ND',
                 state_full='North Dakota',
                 committee_type='H',
-                committee_type_full='House'
+                committee_type_full='House',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=20000,
@@ -464,7 +472,7 @@ class TestTotals(ApiBaseTest):
                 state='NC',
                 state_full='North Carolina',
                 committee_type='S',
-                committee_type_full='Senate'
+                committee_type_full='Senate',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=90000,
@@ -473,7 +481,7 @@ class TestTotals(ApiBaseTest):
                 state='NY',
                 state_full='New York',
                 committee_type='U',
-                committee_type_full='single candidate independent expenditure'
+                committee_type_full='single candidate independent expenditure',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=150000,
@@ -482,15 +490,12 @@ class TestTotals(ApiBaseTest):
                 state='TX',
                 state_full='Texas',
                 committee_type='',
-                committee_type_full='All'
+                committee_type_full='All',
             ),
         ]
 
         response = self._results(
-            api.url_for(
-                ScheduleAByStateRecipientTotalsView,
-                sort='-cycle'
-            )
+            api.url_for(ScheduleAByStateRecipientTotalsView, sort='-cycle')
         )
 
         self.assertEqual(len(response), 5)
@@ -504,7 +509,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(response[4]['committee_type'], 'P')
 
     def test_sched_a_by_state_recipient_totals_filter_by_committee_types(self):
-        rows = [
+        rows = [  # noqa
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=50000,
                 count=10,
@@ -512,7 +517,7 @@ class TestTotals(ApiBaseTest):
                 state='CA',
                 state_full='California',
                 committee_type='P',
-                committee_type_full='Presidential'
+                committee_type_full='Presidential',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=10000,
@@ -521,7 +526,7 @@ class TestTotals(ApiBaseTest):
                 state='ND',
                 state_full='North Dakota',
                 committee_type='H',
-                committee_type_full='House'
+                committee_type_full='House',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=20000,
@@ -530,7 +535,7 @@ class TestTotals(ApiBaseTest):
                 state='NC',
                 state_full='North Carolina',
                 committee_type='S',
-                committee_type_full='Senate'
+                committee_type_full='Senate',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=90000,
@@ -539,7 +544,7 @@ class TestTotals(ApiBaseTest):
                 state='NY',
                 state_full='New York',
                 committee_type='U',
-                committee_type_full='single candidate independent expenditure'
+                committee_type_full='single candidate independent expenditure',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=150000,
@@ -548,14 +553,13 @@ class TestTotals(ApiBaseTest):
                 state='TX',
                 state_full='Texas',
                 committee_type='',
-                committee_type_full='All'
+                committee_type_full='All',
             ),
         ]
 
         response = self._results(
             api.url_for(
-                ScheduleAByStateRecipientTotalsView,
-                committee_type=['P', 'H', 'S',]
+                ScheduleAByStateRecipientTotalsView, committee_type=['P', 'H', 'S', ]
             )
         )
 
@@ -576,7 +580,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(response[2]['committee_type'], 'S')
 
     def test_sched_a_by_state_recipient_totals_filter_by_state(self):
-        rows = [
+        rows = [  # noqa
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=50000,
                 count=10,
@@ -584,7 +588,7 @@ class TestTotals(ApiBaseTest):
                 state='CA',
                 state_full='California',
                 committee_type='P',
-                committee_type_full='Presidential'
+                committee_type_full='Presidential',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=10000,
@@ -593,7 +597,7 @@ class TestTotals(ApiBaseTest):
                 state='ND',
                 state_full='North Dakota',
                 committee_type='H',
-                committee_type_full='House'
+                committee_type_full='House',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=20000,
@@ -602,7 +606,7 @@ class TestTotals(ApiBaseTest):
                 state='NC',
                 state_full='North Carolina',
                 committee_type='S',
-                committee_type_full='Senate'
+                committee_type_full='Senate',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=90000,
@@ -611,7 +615,7 @@ class TestTotals(ApiBaseTest):
                 state='NY',
                 state_full='New York',
                 committee_type='U',
-                committee_type_full='single candidate independent expenditure'
+                committee_type_full='single candidate independent expenditure',
             ),
             factories.ScheduleAByStateRecipientTotalsFactory(
                 total=150000,
@@ -620,15 +624,12 @@ class TestTotals(ApiBaseTest):
                 state='TX',
                 state_full='Texas',
                 committee_type='',
-                committee_type_full='All'
+                committee_type_full='All',
             ),
         ]
 
         response = self._results(
-            api.url_for(
-                ScheduleAByStateRecipientTotalsView,
-                state='NY'
-            )
+            api.url_for(ScheduleAByStateRecipientTotalsView, state='NY')
         )
 
         self.assertEqual(len(response), 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,13 +16,14 @@ from webservices.common import models
 
 
 class TestSort(ApiBaseTest):
-
     def test_single_column(self):
         candidates = [
             factories.CandidateFactory(district='01'),
             factories.CandidateFactory(district='02'),
         ]
-        query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate)
+        query, columns = sorting.sort(
+            models.Candidate.query, 'district', model=models.Candidate
+        )
         self.assertEqual(query.all(), candidates)
 
     def test_single_column_reverse(self):
@@ -30,33 +31,125 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(district='01'),
             factories.CandidateFactory(district='02'),
         ]
-        query, columns = sorting.sort(models.Candidate.query, '-district', model=models.Candidate)
+        query, columns = sorting.sort(
+            models.Candidate.query, '-district', model=models.Candidate
+        )
         self.assertEqual(query.all(), candidates[::-1])
 
     def test_multi_column(self):
         audit = [
-            factories.AuditCaseFactory(cycle=2012, committee_name='Boy', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Girl', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Ted', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Zoo', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='Abc', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='John', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='Ted', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Boy',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Girl',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Ted',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Zoo',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='Abc',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='John',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='Ted',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
         ]
-        query, columns = sorting.multi_sort(models.AuditCase.query, ['cycle', 'committee_name', ], model=models.AuditCase)
+        query, columns = sorting.multi_sort(
+            models.AuditCase.query, ['cycle', 'committee_name', ], model=models.AuditCase
+        )
         self.assertEqual(query.all(), audit)
 
     def test_multi_column_reverse_first_column(self):
         audit = [
-            factories.AuditCaseFactory(cycle=2012, committee_name='Zoo', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Ted', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Girl', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2012, committee_name='Abc', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='Ted', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='John', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
-            factories.AuditCaseFactory(cycle=2014, committee_name='Abc', primary_category_id=-1, sub_category_id=-2, audit_case_id=1000),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Zoo',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Ted',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Girl',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2012,
+                committee_name='Abc',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='Ted',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='John',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
+            factories.AuditCaseFactory(
+                cycle=2014,
+                committee_name='Abc',
+                primary_category_id=-1,
+                sub_category_id=-2,
+                audit_case_id=1000,
+            ),
         ]
-        query, columns = sorting.multi_sort(models.AuditCase.query, ['-cycle', 'committee_name', ], model=models.AuditCase)
+        query, columns = sorting.multi_sort(
+            models.AuditCase.query,
+            ['-cycle', 'committee_name', ],
+            model=models.AuditCase,
+        )
         self.assertEqual(query.all(), audit[::-1])
 
     def test_hide_null(self):
@@ -65,34 +158,63 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(district='02'),
             factories.CandidateFactory(),
         ]
-        query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate)
+        query, columns = sorting.sort(
+            models.Candidate.query, 'district', model=models.Candidate
+        )
         self.assertEqual(query.all(), candidates)
-        query, columns = sorting.sort(models.Candidate.query, 'district', model=models.Candidate, hide_null=True)
+        query, columns = sorting.sort(
+            models.Candidate.query, 'district', model=models.Candidate, hide_null=True
+        )
         self.assertEqual(query.all(), candidates[:2])
 
     def test_hide_null_candidate_totals(self):
         candidates = [
             factories.CandidateFactory(candidate_id='C1234'),
             factories.CandidateFactory(candidate_id='C5678'),
-
         ]
-        candidateHistory = [
-            factories.CandidateHistoryFutureFactory(candidate_id='C1234', two_year_period=2016, election_years=[2016], cycles=[2016],candidate_election_year=2016),
-            factories.CandidateHistoryFutureFactory(candidate_id='C5678', two_year_period=2016, election_years=[2016], cycles=[2016],candidate_election_year=2016)
+        candidateHistory = [  # noqa
+            factories.CandidateHistoryFutureFactory(
+                candidate_id='C1234',
+                two_year_period=2016,
+                election_years=[2016],
+                cycles=[2016],
+                candidate_election_year=2016,
+            ),
+            factories.CandidateHistoryFutureFactory(
+                candidate_id='C5678',
+                two_year_period=2016,
+                election_years=[2016],
+                cycles=[2016],
+                candidate_election_year=2016,
+            ),
         ]
-        candidateTotals = [
-            factories.CandidateTotalFactory(candidate_id='C1234', is_election=False, cycle=2016),
-            factories.CandidateTotalFactory(candidate_id='C5678', disbursements='9999.99', is_election=False, cycle=2016)
+        candidateTotals = [  # noqa
+            factories.CandidateTotalFactory(
+                candidate_id='C1234', is_election=False, cycle=2016
+            ),
+            factories.CandidateTotalFactory(
+                candidate_id='C5678',
+                disbursements='9999.99',
+                is_election=False,
+                cycle=2016,
+            ),
         ]
-        candidateFlags = [
+        candidateFlags = [  # noqa
             factories.CandidateFlagsFactory(candidate_id='C1234'),
-            factories.CandidateFlagsFactory(candidate_id='C5678')
+            factories.CandidateFlagsFactory(candidate_id='C5678'),
         ]
 
         tcv = candidate_aggregates.TotalsCandidateView()
-        query, columns = sorting.sort(tcv.build_query(election_full=False), 'disbursements', model=None)
+        query, columns = sorting.sort(
+            tcv.build_query(election_full=False), 'disbursements', model=None
+        )
         self.assertEqual(len(query.all()), len(candidates))
-        query, columns = sorting.sort(tcv.build_query(election_full=False), 'disbursements', model=None, hide_null=True)
+        query, columns = sorting.sort(
+            tcv.build_query(election_full=False),
+            'disbursements',
+            model=None,
+            hide_null=True,
+        )
         self.assertEqual(len(query.all()), len(candidates) - 1)
         self.assertTrue(candidates[1].candidate_id in query.all()[0])
 
@@ -101,62 +223,101 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(candidate_id='C1234'),
             factories.CandidateFactory(candidate_id='C5678'),
         ]
-        cmteFacorty = [
+        cmteFacorty = [  # noqa
             factories.CommitteeDetailFactory(committee_id='H1234'),
-            factories.CommitteeDetailFactory(committee_id='H5678')
+            factories.CommitteeDetailFactory(committee_id='H5678'),
         ]
         db.session.flush()
-        candidateHistory = [
-            factories.CandidateHistoryFactory(candidate_id='C1234', two_year_period=2016, state='MO',
-                                              candidate_election_year=2016, candidate_inactive=False, district='01',
-                                              office='S', election_years=[2016], cycles=[2016]),
-            factories.CandidateHistoryFactory(candidate_id='C5678',  candidate_election_year=2016,
-                                              two_year_period=2016, state='MO', election_years=[2016], cycles=[2016],
-                                              candidate_inactive=False, district='02', office='S')
+        candidateHistory = [  # noqa
+            factories.CandidateHistoryFactory(
+                candidate_id='C1234',
+                two_year_period=2016,
+                state='MO',
+                candidate_election_year=2016,
+                candidate_inactive=False,
+                district='01',
+                office='S',
+                election_years=[2016],
+                cycles=[2016],
+            ),
+            factories.CandidateHistoryFactory(
+                candidate_id='C5678',
+                candidate_election_year=2016,
+                two_year_period=2016,
+                state='MO',
+                election_years=[2016],
+                cycles=[2016],
+                candidate_inactive=False,
+                district='02',
+                office='S',
+            ),
         ]
-        candidateCmteLinks = [
-            factories.CandidateCommitteeLinkFactory(committee_id='H1234', candidate_id='C1234', fec_election_year=2016,committee_designation='P', election_yr_to_be_included = 2016),
-            factories.CandidateCommitteeLinkFactory(committee_id='H5678', candidate_id='C5678', fec_election_year=2016,
-                                                    committee_designation='P', election_yr_to_be_included = 2016)
-
+        candidateCmteLinks = [  # noqa
+            factories.CandidateCommitteeLinkFactory(
+                committee_id='H1234',
+                candidate_id='C1234',
+                fec_election_year=2016,
+                committee_designation='P',
+                election_yr_to_be_included=2016,
+            ),
+            factories.CandidateCommitteeLinkFactory(
+                committee_id='H5678',
+                candidate_id='C5678',
+                fec_election_year=2016,
+                committee_designation='P',
+                election_yr_to_be_included=2016,
+            ),
         ]
-        cmteTotalsFactory = [
-            factories.CommitteeTotalsHouseSenateFactory(committee_id='H1234', cycle=2016),
-            factories.CommitteeTotalsHouseSenateFactory(committee_id='H1234', cycle=2016, disbursements='9999.99'),
-            factories.CommitteeTotalsHouseSenateFactory(committee_id='H5678', cycle=2016)
-
+        cmteTotalsFactory = [  # noqa
+            factories.CommitteeTotalsHouseSenateFactory(
+                committee_id='H1234', cycle=2016
+            ),
+            factories.CommitteeTotalsHouseSenateFactory(
+                committee_id='H1234', cycle=2016, disbursements='9999.99'
+            ),
+            factories.CommitteeTotalsHouseSenateFactory(
+                committee_id='H5678', cycle=2016
+            ),
         ]
         db.session.flush()
 
         electionView = elections.ElectionView()
-        query, columns = sorting.sort(electionView.build_query(office='senate', cycle=2016, state='MO'), 'total_disbursements', model=None)
+        query, columns = sorting.sort(
+            electionView.build_query(office='senate', cycle=2016, state='MO'),
+            'total_disbursements',
+            model=None,
+        )
 
-        #print(str(query.statement.compile(dialect=postgresql.dialect())))
+        # print(str(query.statement.compile(dialect=postgresql.dialect())))
         self.assertEqual(len(query.all()), len(candidates))
-        query, columns = sorting.sort(electionView.build_query(office='senate', cycle=2016, state='MO'), 'total_disbursements', model=None, hide_null=True)
-        #Taking this assert statement out because I believe, at least how the FEC interprets null (i.e. none) primary
-        #committees for a candidate is that they have in fact raised/spent 0.0 dollars, this can be shown as true
-        #using the Alabama special election as an example
-        #self.assertEqual(len(query.all()), len(candidates) - 1)
+        query, columns = sorting.sort(
+            electionView.build_query(office='senate', cycle=2016, state='MO'),
+            'total_disbursements',
+            model=None,
+            hide_null=True,
+        )
+        # Taking this assert statement out because I believe, at least how the FEC interprets null (i.e. none) primary
+        # committees for a candidate is that they have in fact raised/spent 0.0 dollars, this can be shown as true
+        # using the Alabama special election as an example
+        # self.assertEqual(len(query.all()), len(candidates) - 1)
         self.assertTrue(candidates[1].candidate_id in query.all()[0])
         self.assertEqual(query.all()[0].total_disbursements, 0.0)
 
 
 class TestArgs(TestCase):
-
     def test_currency(self):
         with rest.app.test_request_context('?dollars=$24.50'):
             parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request)
             self.assertEqual(parsed, {'dollars': 24.50})
 
-class TestEnvVarSplit(TestCase):
 
+class TestEnvVarSplit(TestCase):
     def test_env_var_split(self):
         test_cases = [
             "1.2.3.4, 5.6.7.8",
             "1.2.3.4,  5.6.7.8",
             "1.2.3.4,5.6.7.8",
-            " 1.2.3.4,  5.6.7.8 "
+            " 1.2.3.4,  5.6.7.8 ",
         ]
         expected = ["1.2.3.4", "5.6.7.8"]
         for test_case in test_cases:

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1,14 +1,13 @@
 import functools
-
-from marshmallow.compat import text_type
-
 import sqlalchemy as sa
 
+from marshmallow.compat import text_type
 from webargs import fields, validate
 
 from webservices import docs
 from webservices import exceptions
 from webservices.common.models import db
+
 
 def _validate_natural(value):
     if value < 0:
@@ -25,6 +24,7 @@ per_page = Natural(
     description='The number of results returned per page. Defaults to 20.',
 )
 
+
 class Currency(fields.Decimal):
 
     def __init__(self, places=2, **kwargs):
@@ -40,6 +40,7 @@ class IStr(fields.Str):
 
     def _deserialize(self, value, attr, data):
         return super()._deserialize(value, attr, data).upper()
+
 
 class District(fields.Str):
 
@@ -73,6 +74,7 @@ paging = {
     'page': Natural(missing=1, description='For paginating through results, starting at page 1'),
     'per_page': per_page,
 }
+
 
 class OptionValidator(object):
     """Ensure that value is one of acceptable options.
@@ -134,6 +136,7 @@ class IndicesValidator(IndexValidator):
                     status_code=422,
                 )
 
+
 def make_sort_args(default=None, validator=None, default_hide_null=False,
         default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True):
     args = {
@@ -166,6 +169,7 @@ def make_multi_sort_args(default=None, validator=None, default_hide_null=False,
     args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True,
         description='Provide a field to sort by. Use - for descending order.',)
     return args
+
 
 def make_seek_args(field=fields.Int, description=None):
     return {
@@ -536,7 +540,7 @@ schedule_a = {
 
 schedule_a_e_file = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    #'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
+    # 'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
     'contributor_name': fields.List(fields.Str, description=docs.CONTRIBUTOR_NAME),
     'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
     'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
@@ -632,9 +636,9 @@ schedule_b = {
 
 schedule_b_efile = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    #'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here
+    # 'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here
     # if the contributor is registered with the FEC.'),
-    #'recipient_name': fields.List(fields.Str, description='Name of recipient'),
+    # 'recipient_name': fields.List(fields.Str, description='Name of recipient'),
     'disbursement_description': fields.List(fields.Str, description='Description of disbursement'),
     'image_number': fields.List(
         fields.Str,
@@ -679,7 +683,7 @@ schedule_c = {
     'max_incurred_date': fields.Date(missing=None, description=docs.MAX_INCURRED_DATE),
 }
 
-#These arguments will evolve with updated filtering needs
+# These arguments will evolve with updated filtering needs
 schedule_d = {
     'min_payment_period': fields.Float(),
     'max_payment_period': fields.Float(),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -490,9 +490,24 @@ schedule_a = {
     'contributor_zip': fields.List(IStr, description=docs.CONTRIBUTOR_ZIP),
     'contributor_employer': fields.List(fields.Str, description=docs.CONTRIBUTOR_EMPLOYER),
     'contributor_occupation': fields.List(fields.Str, description=docs.CONTRIBUTOR_OCCUPATION),
-    'last_contribution_receipt_date': fields.Date(missing=None, description='When sorting by `contribution_receipt_date`, this is populated with the `contribution_receipt_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'last_contribution_receipt_amount': fields.Float(missing=None, description='When sorting by `contribution_receipt_amount`, this is populated with the `contribution_receipt_amount` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'last_contributor_aggregate_ytd': fields.Float(missing=None, description='When sorting by `contributor_aggregate_ytd`, this is populated with the `contributor_aggregate_ytd` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
+    'last_contribution_receipt_date': fields.Date(
+        missing=None,
+        description='When sorting by `contribution_receipt_date`, this is populated with the \
+        `contribution_receipt_date` of the last result. However, you will need to pass the index \
+        of that last result to `last_index` to get the next page.'
+    ),
+    'last_contribution_receipt_amount': fields.Float(
+        missing=None,
+        description='When sorting by `contribution_receipt_amount`, this is populated with the \
+        `contribution_receipt_amount` of the last result. However, you will need to pass the index \
+        of that last result to `last_index` to get the next page.'
+    ),
+    'last_contributor_aggregate_ytd': fields.Float(
+        missing=None,
+        description='When sorting by `contributor_aggregate_ytd`, this is populated with the \
+        `contributor_aggregate_ytd` of the last result. However, you will need to pass the index \
+        of that last result to `last_index` to get the next page.'
+    ),
     'is_individual': fields.Bool(missing=None, description=docs.IS_INDIVIDUAL),
     'contributor_type': fields.List(
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
@@ -627,8 +642,18 @@ schedule_b_efile = {
     ),
     'recipient_city': fields.List(IStr, description='City of recipient'),
     'recipient_state': fields.List(IStr, description='State of recipient'),
-    'max_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
-    'min_date': fields.Date(missing=None, description='When sorting by `disbursement_date`, this is populated with the `disbursement_date` of the last result. However, you will need to pass the index of that last result to `last_index` to get the next page.'),
+    'max_date': fields.Date(
+        missing=None,
+        description='When sorting by `disbursement_date`, this is populated with the \
+        `disbursement_date` of the last result. However, you will need to pass the index \
+        of that last result to `last_index` to get the next page.'
+    ),
+    'min_date': fields.Date(
+        missing=None,
+        description='When sorting by `disbursement_date`, this is populated with the \
+        `disbursement_date` of the last result. However, you will need to pass the index \
+        of that last result to `last_index` to get the next page.'
+    ),
     'min_amount': Currency(description='Filter for all amounts less than a value.'),
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
 }
@@ -954,21 +979,21 @@ totals_by_office_by_party = {
 }
 
 totals_by_candidate_other_costs_EC = {
-    
+
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'election_full': election_full,
 }
 
 schedule_e_totals_by_candidate_other_costs_IE = {
-    
+
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'election_full': election_full,
 }
 
 totals_by_candidate_other_costs_CC = {
-    
+
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'election_full': election_full,
@@ -1000,10 +1025,4 @@ presidential_by_size = {
 presidential_by_candidate = {
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
     'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-}
-
-presidential_by_size = {
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
 }

--- a/webservices/calendar.py
+++ b/webservices/calendar.py
@@ -9,6 +9,7 @@ from marshmallow import Schema, fields
 
 timezone = pytz.timezone('US/Eastern')
 
+
 def render_date(value, fmt=True):
     return (
         value.isoformat()
@@ -16,12 +17,14 @@ def render_date(value, fmt=True):
         else value
     )
 
+
 def localize(value):
     return (
         timezone.localize(value)
         if isinstance(value, datetime.datetime)
         else value
     )
+
 
 def format_start_date(row, context=None, fmt=True):
     """Cast start date to appropriate type. If no end date is present, the start
@@ -38,6 +41,7 @@ def format_start_date(row, context=None, fmt=True):
         fmt=fmt,
     )
 
+
 def format_end_date(row, context=None, fmt=True):
     """Round end date to start of next day for all-day events.
     """
@@ -50,6 +54,7 @@ def format_end_date(row, context=None, fmt=True):
         fmt=fmt,
     )
 
+
 def render_ical(rows, schema):
     calendar = Calendar()
     for row in rows:
@@ -60,6 +65,7 @@ def render_ical(rows, schema):
         calendar.add_component(event)
     return calendar.to_ical()
 
+
 def render_csv(rows, schema):
     sio = io.StringIO()
     writer = csv.DictWriter(sio, fieldnames=schema.fields.keys())
@@ -68,15 +74,18 @@ def render_csv(rows, schema):
         writer.writerow(row)
     return sio.getvalue()
 
+
 class BaseEventSchema(Schema):
     summary = fields.String()
     description = fields.String()
     location = fields.String()
 
+
 class ICalEventSchema(BaseEventSchema):
     dtstart = fields.Function(functools.partial(format_start_date, fmt=False))
     dtend = fields.Function(functools.partial(format_end_date, fmt=False))
     categories = fields.String(attribute='category')
+
 
 class EventSchema(BaseEventSchema):
     start_date = fields.Function(format_start_date)

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -9,8 +9,7 @@ class BaseAggregate(BaseModel):
     committee = utils.related_committee_history('committee_id', cycle_label='cycle')
     committee_id = db.Column('cmte_id', db.String, primary_key=True, doc=docs.COMMITTEE_ID)
     cycle = db.Column(db.Integer, primary_key=True, doc=docs.RECORD_CYCLE)
-    #? not sure how to document this
-    total = db.Column(db.Numeric(30, 2), index=True,)
+    total = db.Column(db.Numeric(30, 2), index=True, doc='Sum of transactions')
     count = db.Column(db.Integer, index=True, doc=docs.COUNT)
 
 
@@ -99,6 +98,7 @@ class ScheduleEByCandidate(BaseSpendingAggregate):
 class CommunicationCostByCandidate(BaseSpendingAggregate):
     __tablename__ = 'ofec_communication_cost_aggregate_candidate_mv'
     support_oppose_indicator = db.Column(db.String, primary_key=True, doc=docs.SUPPORT_OPPOSE_INDICATOR)
+
 
 class ElectioneeringByCandidate(BaseSpendingAggregate):
     __tablename__ = 'ofec_electioneering_aggregate_candidate_mv'

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -27,15 +27,15 @@ class RoutingSession(SignallingSession):
     def use_follower(self):
         # Check for read operations and configured followers.
         use_follower = (
-            not self._flushing and
-            len(self.followers) > 0
+            not self._flushing
+            and len(self.followers) > 0
         )
 
         # Optionally restrict traffic to followers for only supported tasks.
         if use_follower and self.restrict_follower_traffic_to_tasks:
             use_follower = (
-                celery.current_task and
-                celery.current_task.name in self.follower_tasks
+                celery.current_task
+                and celery.current_task.name in self.follower_tasks
             )
 
         return use_follower
@@ -53,6 +53,7 @@ class RoutingSQLAlchemy(SQLAlchemyBase):
 
     def create_session(self, options):
         return orm.sessionmaker(class_=RoutingSession, db=self, **options)
+
 
 db = RoutingSQLAlchemy()
 

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -8,7 +8,7 @@ from .base import db, BaseModel
 
 
 class CandidateSearch(BaseModel):
-    __tablename__ = 'ofec_candidate_fulltext_mv'
+    __tablename__ = "ofec_candidate_fulltext_mv"
 
     id = db.Column(db.String)
     name = db.Column(db.String, doc=docs.CANDIDATE_NAME)
@@ -20,9 +20,11 @@ class CandidateSearch(BaseModel):
 
 
 class CandidateFlags(db.Model):
-    __tablename__ = 'ofec_candidate_flag_mv'
+    __tablename__ = "ofec_candidate_flag_mv"
 
-    candidate_id = db.Column(db.String, index=True, primary_key=True, doc=docs.CANDIDATE_ID)
+    candidate_id = db.Column(
+        db.String, index=True, primary_key=True, doc=docs.CANDIDATE_ID
+    )
     federal_funds_flag = db.Column(db.Boolean, index=True, doc=docs.FEDERAL_FUNDS_FLAG)
     has_raised_funds = db.Column(db.Boolean, index=True, doc=docs.HAS_RAISED_FUNDS)
 
@@ -40,11 +42,17 @@ class BaseCandidate(BaseModel):
     # ? difference between district and district_number
     district_number = db.Column(db.Integer, index=True, doc=docs.CANDIDATE_STATUS)
     election_districts = db.Column(ARRAY(db.String), index=True, doc=docs.DISTRICT)
-    election_years = db.Column(ARRAY(db.Integer), index=True, doc=docs.CANDIDATE_ELECTION_YEARS)
+    election_years = db.Column(
+        ARRAY(db.Integer), index=True, doc=docs.CANDIDATE_ELECTION_YEARS
+    )
     cycles = db.Column(ARRAY(db.Integer), index=True, doc=docs.CANDIDATE_CYCLE)
     candidate_status = db.Column(db.String(1), index=True, doc=docs.CANDIDATE_STATUS)
-    incumbent_challenge = db.Column(db.String(1), index=True, doc=docs.INCUMBENT_CHALLENGE)
-    incumbent_challenge_full = db.Column(db.String(10), doc=docs.INCUMBENT_CHALLENGE_FULL)
+    incumbent_challenge = db.Column(
+        db.String(1), index=True, doc=docs.INCUMBENT_CHALLENGE
+    )
+    incumbent_challenge_full = db.Column(
+        db.String(10), doc=docs.INCUMBENT_CHALLENGE_FULL
+    )
     load_date = db.Column(db.DateTime, index=True, doc=docs.LOAD_DATE)
 
     first_file_date = db.Column(db.Date, index=True, doc=docs.FIRST_CANDIDATE_FILE_DATE)
@@ -55,59 +63,83 @@ class BaseCandidate(BaseModel):
     def flags(self):
         return sa.orm.relationship(
             CandidateFlags,
-            primaryjoin=sa.orm.foreign(CandidateFlags.candidate_id) == self.candidate_id,
+            primaryjoin=sa.orm.foreign(CandidateFlags.candidate_id)
+            == self.candidate_id,
             uselist=False,
         )
 
 
 class BaseConcreteCandidate(BaseCandidate):
-    __tablename__ = 'ofec_candidate_detail_mv'
+    __tablename__ = "ofec_candidate_detail_mv"
 
     candidate_id = db.Column(db.String, unique=True, doc=docs.CANDIDATE_ID)
 
 
 class Candidate(BaseConcreteCandidate):
-    __table_args__ = {'extend_existing': True}
-    __tablename__ = 'ofec_candidate_detail_mv'
+    __table_args__ = {"extend_existing": True}
+    __tablename__ = "ofec_candidate_detail_mv"
 
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
     candidate_inactive = db.Column(db.Boolean, doc=docs.ACTIVE_CANDIDATE)
-    inactive_election_years = db.Column(ARRAY(db.Integer), index=True, doc='inactive years')
+    inactive_election_years = db.Column(
+        ARRAY(db.Integer), index=True, doc="inactive years"
+    )
 
     # Customize join to restrict to principal committees
     principal_committees = db.relationship(
-        'Committee',
-        secondary='ofec_cand_cmte_linkage_mv',
-        secondaryjoin='''and_(
+        "Committee",
+        secondary="ofec_cand_cmte_linkage_mv",
+        secondaryjoin="""and_(
             Committee.committee_id == ofec_cand_cmte_linkage_mv.c.cmte_id,
             ofec_cand_cmte_linkage_mv.c.cmte_dsgn == 'P',
-        )''',
+        )""",
         order_by=(
-            'desc(ofec_cand_cmte_linkage_mv.c.cand_election_yr),'
-            'desc(Committee.last_file_date),'
-        )
+            "desc(ofec_cand_cmte_linkage_mv.c.cand_election_yr),"
+            "desc(Committee.last_file_date),"
+        ),
     )
 
 
 class CandidateDetail(BaseConcreteCandidate):
-    __table_args__ = {'extend_existing': True}
-    __tablename__ = 'ofec_candidate_detail_mv'
+    __table_args__ = {"extend_existing": True}
+    __tablename__ = "ofec_candidate_detail_mv"
 
-    address_city = db.Column(db.String(100), doc='City of candidate\'s address, as reported on their Form 2.')
-    address_state = db.Column(db.String(2), doc='State of candidate\'s address, as reported on their Form 2.')
-    address_street_1 = db.Column(db.String(200), doc='Street of candidate\'s address, as reported on their Form 2.')
-    address_street_2 = db.Column(db.String(200), doc='Additional street information of candidate\'s address, as reported on their Form 2.')
-    address_zip = db.Column(db.String(10), doc='Zip code of candidate\'s address, as reported on their Form 2.')
-    candidate_inactive = db.Column(db.Boolean, doc='True indicates that a candidate is inactive.')
+    address_city = db.Column(
+        db.String(100), doc="City of candidate's address, as reported on their Form 2."
+    )
+    address_state = db.Column(
+        db.String(2), doc="State of candidate's address, as reported on their Form 2."
+    )
+    address_street_1 = db.Column(
+        db.String(200),
+        doc="Street of candidate's address, as reported on their Form 2.",
+    )
+    address_street_2 = db.Column(
+        db.String(200),
+        doc="Additional street information of candidate's address, as reported on their Form 2.",
+    )
+    address_zip = db.Column(
+        db.String(10),
+        doc="Zip code of candidate's address, as reported on their Form 2.",
+    )
+    candidate_inactive = db.Column(
+        db.Boolean, doc="True indicates that a candidate is inactive."
+    )
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
 
 
 class CandidateHistory(BaseCandidate):
-    __tablename__ = 'ofec_candidate_history_mv'
+    __tablename__ = "ofec_candidate_history_mv"
 
-    candidate_id = db.Column(db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID)
-    two_year_period = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_CYCLE)
-    candidate_election_year = db.Column(db.Integer, doc=docs.LAST_CANDIDATE_ELECTION_YEAR)
+    candidate_id = db.Column(
+        db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID
+    )
+    two_year_period = db.Column(
+        db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_CYCLE
+    )
+    candidate_election_year = db.Column(
+        db.Integer, doc=docs.LAST_CANDIDATE_ELECTION_YEAR
+    )
     address_city = db.Column(db.String(100), doc=docs.F2_CANDIDATE_CITY)
     address_state = db.Column(db.String(2), doc=docs.F2_CANDIDATE_STATE)
     address_street_1 = db.Column(db.String(200), doc=docs.F2_CANDIDATE_STREET_1)
@@ -115,15 +147,26 @@ class CandidateHistory(BaseCandidate):
     address_zip = db.Column(db.String(10), doc=docs.F2_CANDIDATE_ZIP)
     candidate_inactive = db.Column(db.Boolean, doc=docs.CANDIDATE_INACTIVE)
     active_through = db.Column(db.Integer, doc=docs.ACTIVE_THROUGH)
-    rounded_election_years = db.Column(ARRAY(db.Integer), index=True, doc=docs.ROUNDED_ELECTION_YEARS)
-    fec_cycles_in_election = db.Column(ARRAY(db.Integer), index=True, doc=docs.FEC_CYCLES_IN_ELECTION)
+    rounded_election_years = db.Column(
+        ARRAY(db.Integer), index=True, doc=docs.ROUNDED_ELECTION_YEARS
+    )
+    fec_cycles_in_election = db.Column(
+        ARRAY(db.Integer), index=True, doc=docs.FEC_CYCLES_IN_ELECTION
+    )
+
 
 class CandidateHistoryWithFuture(BaseCandidate):
-    __tablename__ = 'ofec_candidate_history_with_future_election_mv'
+    __tablename__ = "ofec_candidate_history_with_future_election_mv"
 
-    candidate_id = db.Column(db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID)
-    two_year_period = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_CYCLE)
-    candidate_election_year = db.Column(db.Integer, doc=docs.LAST_CANDIDATE_ELECTION_YEAR)
+    candidate_id = db.Column(
+        db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID
+    )
+    two_year_period = db.Column(
+        db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_CYCLE
+    )
+    candidate_election_year = db.Column(
+        db.Integer, doc=docs.LAST_CANDIDATE_ELECTION_YEAR
+    )
     address_city = db.Column(db.String(100), doc=docs.F2_CANDIDATE_CITY)
     address_state = db.Column(db.String(2), doc=docs.F2_CANDIDATE_STATE)
     address_street_1 = db.Column(db.String(200), doc=docs.F2_CANDIDATE_STREET_1)
@@ -134,9 +177,11 @@ class CandidateHistoryWithFuture(BaseCandidate):
 
 
 class CandidateTotal(db.Model):
-    __tablename__ = 'ofec_candidate_totals_mv'
+    __tablename__ = "ofec_candidate_totals_mv"
     candidate_id = db.Column(db.String, index=True, primary_key=True)
-    election_year = db.Column(db.Integer, index=True, primary_key=True, autoincrement=True)
+    election_year = db.Column(
+        db.Integer, index=True, primary_key=True, autoincrement=True
+    )
     cycle = db.Column(db.Integer, index=True, primary_key=True)
     is_election = db.Column(db.Boolean, index=True, primary_key=True)
     receipts = db.Column(db.Numeric(30, 2), index=True)
@@ -151,9 +196,14 @@ class CandidateTotal(db.Model):
     office = db.Column(db.String(1), index=True, doc=docs.OFFICE)
     candidate_inactive = db.Column(db.Boolean, doc=docs.CANDIDATE_INACTIVE)
 
-class CandidateElection(db.Model):
-    __tablename__ = 'ofec_candidate_election_mv'
 
-    candidate_id = db.Column(db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID)
-    cand_election_year = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_ELECTION_YEAR)
+class CandidateElection(db.Model):
+    __tablename__ = "ofec_candidate_election_mv"
+
+    candidate_id = db.Column(
+        db.String, primary_key=True, index=True, doc=docs.CANDIDATE_ID
+    )
+    cand_election_year = db.Column(
+        db.Integer, primary_key=True, index=True, doc=docs.CANDIDATE_ELECTION_YEAR
+    )
     prev_election_year = db.Column(db.Integer, index=True)

--- a/webservices/common/models/costs.py
+++ b/webservices/common/models/costs.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.postgresql import TSVECTOR
 from .base import db
 from webservices import docs
 
+
 class CommunicationCost(db.Model):
     __tablename__ = 'ofec_communication_cost_mv'
 
@@ -30,7 +31,7 @@ class CommunicationCost(db.Model):
     purpose = db.Column('communication_class_desc', db.String, index=True)
     support_oppose_indicator = db.Column('s_o_ind', db.String, index=True)
 
-    #new columns added from ware house transition
+    # new columns added from ware house transition
     action_code = db.Column('action_cd', db.String)
     action_code_full = db.Column('action_cd_desc', db.String)
     primary_general_indicator = db.Column('s_o_rpt_pgi', db.String)
@@ -79,10 +80,10 @@ class Electioneering(db.Model):
     receipt_date = db.Column('receipt_dt', db.Date)
     election_type_raw = db.Column('election_tp', db.String)
     pdf_url = db.Column(db.String)
-
     purpose_description_text = db.Column(TSVECTOR)
     payee_name = db.Column('payee_nm', db.String, doc=docs.PAYEE_NAME)
     payee_state = db.Column('payee_st', db.String)
+
     @property
     def election_type(self):
         return self.election_type_raw[:1]

--- a/webservices/common/models/costs.py
+++ b/webservices/common/models/costs.py
@@ -20,7 +20,7 @@ class CommunicationCost(db.Model):
     state_full = db.Column('s_o_cand_office_st_desc', db.String)
     candidate_office_district = db.Column('s_o_cand_office_district', db.String, index=True)
     candidate_office = db.Column('s_o_cand_office', db.String, index=True)
-    candidate_office_full =db.Column('s_o_cand_office_desc', db.String)
+    candidate_office_full = db.Column('s_o_cand_office_desc', db.String)
     transaction_date = db.Column('communication_dt', db.Date, index=True)
     transaction_amount = db.Column('communication_cost', db.Numeric(30, 2), index=True)
     transaction_type = db.Column('transaction_tp', db.String)

--- a/webservices/common/models/dates.py
+++ b/webservices/common/models/dates.py
@@ -4,20 +4,25 @@ from webservices import decoders, docs
 from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
 from .base import db
 
+
 class DisclosureMixin(object):
     __table_args__ = {"schema": "disclosure"}
+
 
 class StagingMixin(object):
     __table_args__ = {"schema": "staging"}
 
+
 class FecAppMixin(object):
     __table_args__ = {"schema": "fecapp"}
+
 
 class ReportType(db.Model, StagingMixin):
     __tablename__ = 'ref_rpt_tp'
 
     report_type = db.Column('rpt_tp_cd', db.String, index=True, primary_key=True, doc=docs.REPORT_TYPE)
     report_type_full = db.Column('rpt_tp_desc', db.String, index=True, doc=docs.REPORT_TYPE)
+
 
 class DateMixin(object):
     trc_report_due_date_id = db.Column(db.BigInteger, primary_key=True)
@@ -39,6 +44,8 @@ class ReportDate(db.Model, DateMixin, FecAppMixin):
 
 
 REPORT_TYPE_CLEAN = re.compile(r'{[^)]*}')
+
+
 def clean_report_type(report_type):
     return REPORT_TYPE_CLEAN.sub('', report_type).strip()
 
@@ -79,7 +86,6 @@ class ElectionClassDate(db.Model):
     open_seat_flag = db.Column('open_seat_flg', db.String, doc=docs.OPEN_SEAT_FLAG)
     create_date = db.Column(db.Date, doc=docs.CREATE_DATE)
     election_type_id = db.Column(db.String, doc=docs.ELECTION_TYPE)
-    #? double check this
     cycle_start_date = db.Column('cycle_start_dt', db.Date)
     cycle_end_date = db.Column('cycle_end_dt', db.Date)
     election_date = db.Column('election_dt', db.Date, doc=docs.ELECTION_DATE)
@@ -100,6 +106,5 @@ class CalendarDate(db.Model):
     end_date = db.Column(db.DateTime, index=True, doc=docs.END_DATE)
     all_day = db.Column(db.Boolean)
     url = db.Column(db.String, doc=docs.EVENT_URL)
-
     summary_text = db.Column(TSVECTOR)
     description_text = db.Column(TSVECTOR)

--- a/webservices/common/models/dates.py
+++ b/webservices/common/models/dates.py
@@ -2,7 +2,7 @@ import re
 
 from webservices import decoders, docs
 from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
-from .base import db, BaseModel
+from .base import db
 
 class DisclosureMixin(object):
     __table_args__ = {"schema": "disclosure"}

--- a/webservices/common/models/elections.py
+++ b/webservices/common/models/elections.py
@@ -26,6 +26,7 @@ class ZipsDistricts(db.Model):
     state_abbrevation = db.Column(db.String)
     active = db.Column(db.String)
 
+
 class StateElectionOfficeInfo(db.Model):
     __table_args__ = {'schema': 'fecapp'}
     __tablename__ = 'trc_st_elect_office'

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -5,6 +5,7 @@ from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
 from .base import db
 
+
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
 
@@ -53,7 +54,7 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     is_amended = db.Column(db.Boolean)
     most_recent = db.Column(db.Boolean)
     html_url = db.Column(db.String, doc=docs.HTML_URL)
-    #If f2 filing, the state of the candidate, else the state of the committee
+    # If f2 filing, the state of the candidate, else the state of the committee
     state = db.Column(db.String, doc=docs.STATE)
     office = db.Column(db.String, doc=docs.OFFICE)
     # Filter filings based off candidate office or committee type H, S and P only. all other
@@ -78,6 +79,7 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
             self.form_type,
         )
 
+
 class EfilingsAmendments(db.Model):
     __tablename__ = 'efiling_amendment_chain_vw'
     file_number = db.Column('repid', db.BigInteger, index=True, primary_key=True, doc=docs.FILE_NUMBER)
@@ -94,6 +96,7 @@ class EfilingsAmendments(db.Model):
             return self.longest_chain[index + 1]
         else:
             return 0
+
 
 class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.Model):
     __table_args__ = {'schema': 'real_efile'}

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -392,7 +392,7 @@ class ScheduleBEfile(BaseRawItemized):
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
     committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
     recipient_name = db.Column('lname', db.String)
-    #recipient_name_text = db.Column(TSVECTOR)
+    # recipient_name_text = db.Column(TSVECTOR)
     # Street address omitted per FEC policy
     # recipient_street_1 = db.Column('recipient_st1', db.String)
     # recipient_street_2 = db.Column('recipient_st2', db.String)
@@ -401,17 +401,12 @@ class ScheduleBEfile(BaseRawItemized):
     recipient_zip = db.Column('zip', db.String)
     recipient_prefix = db.Column('prefix', db.String)
     recipient_suffix = db.Column('suffix', db.String)
-
     beneficiary_committee_name = db.Column('ben_comname', db.String)
-
     disbursement_type = db.Column('dis_code', db.String)
     disbursement_description = db.Column('transdesc', db.String)
-
     disbursement_date = db.Column('date_dis', db.Date)
     disbursement_amount = db.Column('amount', db.Numeric(30, 2))
-
     semi_annual_bundled_refund = db.Column('refund', db.Integer)
-
     candidate_office = db.Column('can_off', db.String)
     candidate_office_district = db.Column('can_dist', db.String)
 
@@ -434,6 +429,7 @@ class ScheduleBEfile(BaseRawItemized):
         foreign_keys=committee_id,
         lazy='joined',
     )
+
 
 class ScheduleC(PdfMixin, BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
@@ -587,7 +583,6 @@ class ScheduleE(PdfMixin, BaseItemized):
     payee_city = db.Column('pye_city', db.String)
     payee_state = db.Column('pye_st', db.String)
     payee_zip = db.Column('pye_zip', db.String)
-
     # Primary transaction info
     previous_file_number = db.Column('prev_file_num', db.Integer)
     amendment_indicator = db.Column('amndt_ind', db.String, doc=docs.AMENDMENT_INDICATOR)
@@ -603,11 +598,9 @@ class ScheduleE(PdfMixin, BaseItemized):
     category_code = db.Column('catg_cd', db.String)
     category_code_full = db.Column('catg_cd_desc', db.String)
     support_oppose_indicator = db.Column('s_o_ind', db.String)
-
     memo_code = db.Column('memo_cd', db.String)
     memo_code_full = db.Column('memo_cd_desc', db.String)
     memo_text = db.Column(db.String)
-
     # Candidate info
     candidate_id = db.Column('s_o_cand_id', db.String)
     candidate = utils.related_candidate_history('candidate_id', cycle_label='report_year')
@@ -621,7 +614,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     candidate_office_state = db.Column('cand_office_st', db.String, doc=docs.STATE_GENERIC)
     candidate_office_district = db.Column('cand_office_district', db.String, doc=docs.DISTRICT)
     candidate_party = db.Column('cand_pty_affiliation', db.String, doc=docs.PARTY)
-    #Conduit info
+    # Conduit info
     conduit_committee_id = db.Column('conduit_cmte_id', db.String)
     conduit_committee_name = db.Column('conduit_cmte_nm', db.String)
     conduit_committee_street1 = db.Column('conduit_cmte_st1', db.String)
@@ -629,36 +622,28 @@ class ScheduleE(PdfMixin, BaseItemized):
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
     conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
-
-    election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
-    election_type_full = db.Column('fec_election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
-
     # Transaction meta info
     independent_sign_name = db.Column('indt_sign_nm', db.String)
     independent_sign_date = db.Column('indt_sign_dt', db.Date)
     notary_sign_name = db.Column('notary_sign_nm', db.String)
     notary_sign_date = db.Column('notary_sign_dt', db.Date)
     notary_commission_expiration_date = db.Column('notary_commission_exprtn_dt', db.Date)
-
+    election_type = db.Column('election_tp', db.String, doc=docs.ELECTION_TYPE)
+    election_type_full = db.Column('fec_election_tp_desc', db.String, doc=docs.ELECTION_TYPE)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_name = db.Column('back_ref_sched_nm', db.String)
-
     filer_prefix = db.Column(db.String)
     filer_first_name = db.Column('filer_f_nm', db.String)
     filer_middle_name = db.Column('filer_m_nm', db.String)
     filer_last_name = db.Column('filer_l_nm', db.String)
     filer_suffix = db.Column(db.String)
-
     transaction_id = db.Column('tran_id', db.String)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
-
     action_code = db.Column('action_cd', db.String)
     action_code_full = db.Column('action_cd_desc', db.String)
-
     # Auxiliary fields
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
-
     pdf_url = db.Column(db.String)
 
 
@@ -672,8 +657,8 @@ class ScheduleEEfile(BaseRawItemized):
     committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
     # payee info
     payee_prefix = db.Column('prefix', db.String)
-    #need to add vectorized column
-    #payee_name_text = db.Column(TSVECTOR)
+    # need to add vectorized column
+    # payee_name_text = db.Column(TSVECTOR)
     payee_first_name = db.Column('fname', db.String)
     payee_middle_name = db.Column('mname', db.String)
     payee_last_name = db.Column('lname', db.String)
@@ -683,14 +668,12 @@ class ScheduleEEfile(BaseRawItemized):
     payee_city = db.Column('city', db.String)
     payee_state = db.Column('state', db.String)
     payee_zip = db.Column('zip', db.String)
-
     # pcf == person completing form -> filer?
     filer_first_name = db.Column('pcf_lname', db.String)
     filer_middle_name = db.Column('pcf_mname', db.String)
     filer_last_name = db.Column('pcf_fname', db.String)
     filer_suffix = db.Column('pcf_suffix', db.String)
     filer_prefix = db.Column('pcf_prefix', db.String)
-
     # Candidate info
     candidate_id = db.Column('so_canid', db.String)
     candidate_name = db.Column('so_can_name', db.String, doc=docs.CANDIDATE_NAME)
@@ -712,7 +695,6 @@ class ScheduleEEfile(BaseRawItemized):
     cand_fulltxt = db.Column(TSVECTOR, doc=docs.CANDIDATE_FULL_SEARCH)
     candidate_party = db.Column('cand_pty_affiliation', db.String, doc=docs.PARTY)
     most_recent = db.Column('most_recent', db.Boolean, doc=docs.MOST_RECENT)
-
     filing = db.relationship(
         'EFilings',
         primaryjoin='''and_(
@@ -722,7 +704,6 @@ class ScheduleEEfile(BaseRawItemized):
         lazy='joined',
         innerjoin='True',
     )
-
     committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -770,7 +751,6 @@ class ScheduleF(PdfMixin, BaseItemized):
             ScheduleF.report_year + ScheduleF.report_year % 2 == CommitteeHistory.cycle,
         )'''
     )
-
     subordinate_committee_id = db.Column('subord_cmte_id', db.String)
     """
     These are included here as well if subordinate is not null, but I
@@ -859,7 +839,6 @@ class ScheduleH4(BaseItemized):
     payee_state = db.Column('pye_st', db.String)
     payee_zip = db.Column('pye_zip', db.String)
     filer_committee_name = db.Column('filer_cmte_nm', db.String)
-
     # Primary transaction info
     # event_purpose_category_type = db.Column('evt_purpose_category_tp', db.String)
     # event_purpose_category_type_description = db.Column('evt_purpose_category_tp_desc', db.String)
@@ -872,7 +851,6 @@ class ScheduleH4(BaseItemized):
     memo_text = db.Column('memo_text', db.String)
     event_purpose_date = db.Column('evt_purpose_dt', db.Date)
     disbursement_amount = db.Column('ttl_amt_disb', db.Numeric(30, 2))
-
     # Related candidate info
     candidate_office = db.Column('cand_office', db.String)
     candidate_office_description = db.Column('cand_office_desc', db.String)
@@ -883,7 +861,6 @@ class ScheduleH4(BaseItemized):
     candidate_last_name = db.Column('cand_nm_last', db.String)
     candidate_office_state = db.Column('cand_office_st', db.String)
     candidate_office_state_full = db.Column('cand_office_st_desc', db.String)
-
     # Transaction meta info
     amendment_indicator = db.Column('action_cd', db.String)
     amendment_indicator_desc = db.Column('action_cd_desc', db.String)
@@ -894,18 +871,15 @@ class ScheduleH4(BaseItemized):
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)
     back_reference_schedule_id = db.Column('back_ref_sched_id', db.String)
-
     # Payee info
     payee_last_name = db.Column('payee_l_nm', db.String)
     payee_first_name = db.Column('payee_f_nm', db.String)
     payee_middle_name = db.Column('payee_m_nm', db.String)
     payee_prefix = db.Column(db.String)
     payee_suffix = db.Column(db.String)
-
     # Category info
     category_code = db.Column('catg_cd', db.String)
     category_code_full = db.Column('catg_cd_desc', db.String)
-
     # Conduit info
     conduit_committee_id = db.Column('conduit_cmte_id', db.String)
     conduit_committee_name = db.Column('conduit_cmte_nm', db.String)
@@ -914,7 +888,6 @@ class ScheduleH4(BaseItemized):
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
     conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
-
     # TODO: determine place for these:
     federal_share = db.Column('fed_share', db.Numeric(14, 2))
     nonfederal_share = db.Column('nonfed_share', db.Numeric(14, 2))

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -71,8 +71,11 @@ class ScheduleA(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_a'
 
-    # override the entry from the BaseItemized using either one of the following two
-    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    """
+    override the entry from the BaseItemized using either one of the following two
+    committee = utils.related_committee_history('committee_id',
+    cycle_label='two_year_transaction_period', use_modulus=False)
+    """
     committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -255,8 +258,11 @@ class ScheduleB(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'
 
-    # override the entry from the BaseItemized using either one of the following two
-    # committee = utils.related_committee_history('committee_id', cycle_label='two_year_transaction_period', use_modulus=False)
+    """
+    override the entry from the BaseItemized using either one of the following two
+    committee = utils.related_committee_history('committee_id',
+    cycle_label='two_year_transaction_period', use_modulus=False)
+    """
     committee = db.relationship(
         'CommitteeHistory',
         primaryjoin='''and_(
@@ -841,9 +847,9 @@ class ScheduleH4(BaseItemized):
             ScheduleH4.cycle == CommitteeHistory.cycle,
         )'''
     )
-    
+
     # Recipient info
-    committee_id = db.Column('filer_cmte_id', db.String) #override from BaseItemized
+    committee_id = db.Column('filer_cmte_id', db.String)  # override from BaseItemized
     entity_type = db.Column('entity_tp', db.String)
     entity_type_desc = db.Column('entity_tp_desc', db.String)
     payee_name = db.Column('pye_nm', db.String)
@@ -855,8 +861,8 @@ class ScheduleH4(BaseItemized):
     filer_committee_name = db.Column('filer_cmte_nm', db.String)
 
     # Primary transaction info
-    #event_purpose_category_type = db.Column('evt_purpose_category_tp', db.String)
-    #event_purpose_category_type_description = db.Column('evt_purpose_category_tp_desc', db.String)
+    # event_purpose_category_type = db.Column('evt_purpose_category_tp', db.String)
+    # event_purpose_category_type_description = db.Column('evt_purpose_category_tp_desc', db.String)
     event_purpose_name = db.Column('evt_purpose_nm', db.String)
     event_purpose_description = db.Column('evt_purpose_desc', db.String)
     event_purpose_category_type = db.Column('evt_purpose_category_tp', db.String)
@@ -909,15 +915,14 @@ class ScheduleH4(BaseItemized):
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
     conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
 
-
     # TODO: determine place for these:
-    federal_share = db.Column('fed_share', db.Numeric(14,2))
-    nonfederal_share = db.Column('nonfed_share', db.Numeric(14,2))
+    federal_share = db.Column('fed_share', db.Numeric(14, 2))
+    nonfederal_share = db.Column('nonfed_share', db.Numeric(14, 2))
     administrative_voter_drive_activity_indicator = db.Column('admin_voter_drive_acty_ind', db.String)
     fundraising_activity_indicator = db.Column('fndrsg_acty_ind', db.String)
     exempt_activity_indicator = db.Column('exempt_acty_ind', db.String)
     direct_candidate_support_activity_indicator = db.Column('direct_cand_supp_acty_ind', db.String)
-    event_amount_year_to_date = db.Column('evt_amt_ytd', db.Numeric(14,2))
+    event_amount_year_to_date = db.Column('evt_amt_ytd', db.Numeric(14, 2))
     additional_description = db.Column('add_desc', db.String)
     administrative_activity_inidcator = db.Column('admin_acty_ind', db.String)
     general_voter_drive_activity_indicator = db.Column('gen_voter_drive_acty_ind', db.String)
@@ -926,8 +931,8 @@ class ScheduleH4(BaseItemized):
     published_committee_reference_parity_check = db.Column('pub_comm_ref_pty_chk', db.String)
     filing_form = db.Column('filing_form', db.String)
     report_type = db.Column('rpt_tp', db.String)
-    report_year = db.Column('rpt_yr', db.Numeric(4,0))
-    cycle = db.Column('election_cycle', db.Numeric(4,0))
+    report_year = db.Column('rpt_yr', db.Numeric(4, 0))
+    cycle = db.Column('election_cycle', db.Numeric(4, 0))
 
     @hybrid_property
     def sort_expressions(self):

--- a/webservices/common/models/large_aggregates.py
+++ b/webservices/common/models/large_aggregates.py
@@ -1,6 +1,3 @@
-import calendar
-from datetime import date, datetime, timedelta
-
 from .base import db
 
 from webservices import docs
@@ -8,16 +5,35 @@ from webservices import docs
 
 class EntityReceiptDisbursementTotals(db.Model):
     """two year receipt and disbursement totals by entity type and two-year election period"""
-    __tablename__ = 'entity_chart_vw'
+
+    __tablename__ = "entity_chart_vw"
 
     idx = db.Column(db.Integer, primary_key=True)
     cycle = db.Column(db.Integer, doc=docs.RECORD_CYCLE)
     month = db.Column(db.Integer, doc="Numeric representation of year")
     year = db.Column(db.Integer, doc="Numeric representation of month")
     end_date = db.Column(db.Date, doc="Date representation of the month and year")
-    cumulative_candidate_receipts = db.Column(db.Float, doc="Cumulative candidate receipts in a two year period, adjusted to avoid double counting.")
-    cumulative_candidate_disbursements = db.Column(db.Float, doc="Cumulative candidate disbursements in a two year period, adjusted to avoid double counting.")
-    cumulative_pac_receipts = db.Column(db.Float, doc="Cumulative PAC recipts in a two year period, adjusted to avoid double counting.")
-    cumulative_pac_disbursements = db.Column(db.Float, doc="Cumulative PAC disbursements in a two year period, adjusted to avoid double counting.")
-    cumulative_party_receipts = db.Column(db.Float, doc="Cumulative party receipts in a two year period, adjusted to avoid double counting.")
-    cumulative_party_disbursements = db.Column(db.Float, doc="Cumulative party disbursements in a two year period, adjusted to avoid double counting.")
+    cumulative_candidate_receipts = db.Column(
+        db.Float,
+        doc="Cumulative candidate receipts in a two year period, adjusted to avoid double counting.",
+    )
+    cumulative_candidate_disbursements = db.Column(
+        db.Float,
+        doc="Cumulative candidate disbursements in a two year period, adjusted to avoid double counting.",
+    )
+    cumulative_pac_receipts = db.Column(
+        db.Float,
+        doc="Cumulative PAC recipts in a two year period, adjusted to avoid double counting.",
+    )
+    cumulative_pac_disbursements = db.Column(
+        db.Float,
+        doc="Cumulative PAC disbursements in a two year period, adjusted to avoid double counting.",
+    )
+    cumulative_party_receipts = db.Column(
+        db.Float,
+        doc="Cumulative party receipts in a two year period, adjusted to avoid double counting.",
+    )
+    cumulative_party_disbursements = db.Column(
+        db.Float,
+        doc="Cumulative party disbursements in a two year period, adjusted to avoid double counting.",
+    )

--- a/webservices/common/models/operations_log.py
+++ b/webservices/common/models/operations_log.py
@@ -1,6 +1,7 @@
 from .base import db
 from webservices import docs
 
+
 class OperationsLog(db.Model):
     __tablename__ = 'fec_operations_log_vw'
 

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -12,7 +12,6 @@ from webservices.common.models.dates import clean_report_type
 
 
 class PdfMixin(object):
-
     @property
     def pdf_url(self):
         if self.has_pdf:
@@ -29,6 +28,7 @@ class CsvMixin(object):
     def csv_url(self):
         if self.file_number:
             return utils.make_csv_url(self.file_number)
+
 
 class FecMixin(object):
     @property
@@ -47,22 +47,18 @@ class TreasurerMixin(object):
 
     @hybrid_property
     def treasurer_name(self):
-        name = name_generator(self.treasurer_last_name,
-                              self.prefix,
-                              self.treasurer_first_name,
-                              self.treasurer_middle_name,
-                              self.suffix
-                              )
-        name = (
-            name
-            if name
-            else None
+        name = name_generator(
+            self.treasurer_last_name,
+            self.prefix,
+            self.treasurer_first_name,
+            self.treasurer_middle_name,
+            self.suffix,
         )
+        name = name if name else None
         return name
 
 
 class AmendmentChainMixin(object):
-
     @property
     def most_recent(self):
         return self.file_number == self.amendment.most_recent_filing
@@ -92,7 +88,7 @@ class FecFileNumberMixin(object):
     @property
     def fec_file_id(self):
         if self.file_number and self.file_number > 0:
-            return ("FEC-" + str(self.file_number))
+            return "FEC-" + str(self.file_number)
         else:
             return None
 
@@ -102,9 +98,11 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
 
     committee_id = db.Column(db.String, index=True, doc=docs.COMMITTEE_ID)
     committee_name = db.Column(db.String, doc=docs.COMMITTEE_NAME)  # mapped
-    committee = utils.related('CommitteeHistory', 'committee_id', 'committee_id', 'report_year', 'cycle')
+    committee = utils.related(
+        'CommitteeHistory', 'committee_id', 'committee_id', 'report_year', 'cycle'
+    )
 
-    #These columns derived from amendments materializeds view
+    # These columns derived from amendments materializeds view
     amendment_chain = db.Column(ARRAY(db.Numeric), doc=docs.AMENDMENT_CHAIN)
     previous_file_number = db.Column(db.Numeric)
     most_recent_file_number = db.Column(db.Numeric)
@@ -113,84 +111,125 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
     file_number = db.Column(db.Integer)
     amendment_indicator = db.Column('amendment_indicator', db.String)
     amendment_indicator_full = db.Column(db.String)
-    beginning_image_number = db.Column(db.BigInteger,
-        doc=docs.BEGINNING_IMAGE_NUMBER)
-    cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2),
-        doc=docs.CASH_ON_HAND_BEGIN_PERIOD)  # P
-    cash_on_hand_end_period = db.Column('cash_on_hand_end_period', db.Numeric(30, 2),
-        doc=docs.CASH_ON_HAND_END_PERIOD)  # P
-    coverage_end_date = db.Column(db.DateTime, index=True,
-        doc=docs.COVERAGE_END_DATE)  # P
-    coverage_start_date = db.Column(db.DateTime, index=True,
-        doc=docs.COVERAGE_START_DATE)  # P
-    debts_owed_by_committee = db.Column('debts_owed_by_committee', db.Numeric(30, 2),
-        doc=docs.DEBTS_OWED_BY_COMMITTEE)  # P
-    debts_owed_to_committee = db.Column(db.Numeric(30, 2),
-        doc=docs.DEBTS_OWED_TO_COMMITTEE)  # P
-    end_image_number = db.Column(db.BigInteger,
-        doc=docs.ENDING_IMAGE_NUMBER)
-    other_disbursements_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.OTHER_DISBURSEMENTS))  # PX
-    other_disbursements_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.OTHER_DISBURSEMENTS))  # PX
-    other_political_committee_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
-    other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
-    political_party_committee_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
-    political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
-    report_type = db.Column(db.String,
-        doc=docs.REPORT_TYPE)
-    report_type_full = db.Column(db.String,
-        doc=docs.REPORT_TYPE)
-    report_year = db.Column(db.Integer,
-        doc=docs.REPORT_YEAR)
-    total_contribution_refunds_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.CONTRIBUTION_REFUNDS))  # P
-    total_contribution_refunds_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.CONTRIBUTION_REFUNDS))  # P
-    refunded_individual_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))  # P
-    refunded_individual_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS))  # P
-    refunded_other_political_committee_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
-    refunded_other_political_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS))  # P
-    refunded_political_party_committee_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
-    refunded_political_party_committee_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS))  # P
-    total_contributions_period = db.Column('total_contributions_period', db.Numeric(30, 2),
-        doc=docs.add_period(docs.CONTRIBUTIONS))  # P
-    total_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.CONTRIBUTIONS))  # P
-    total_disbursements_period = db.Column('total_disbursements_period', db.Numeric(30, 2),
-        doc=docs.add_period(docs.DISBURSEMENTS))  # P
-    total_disbursements_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.DISBURSEMENTS))  # P
-    total_receipts_period = db.Column('total_receipts_period', db.Numeric(30, 2),
-        doc=docs.add_period(docs.RECEIPTS))  # P
-    total_receipts_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.RECEIPTS))  # P
-    offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.OFFSETS_TO_OPERATING_EXPENDITURES))  # P
-    offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.OFFSETS_TO_OPERATING_EXPENDITURES))  # P
-    total_individual_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.INDIVIDUAL_CONTRIBUTIONS))  # P
-    total_individual_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.INDIVIDUAL_CONTRIBUTIONS))  # P
-    individual_unitemized_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))  # P \
-    individual_unitemized_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS))  # P
-    individual_itemized_contributions_ytd = db.Column(db.Numeric(30, 2),
-        doc=docs.add_ytd(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))  # P
-    individual_itemized_contributions_period = db.Column(db.Numeric(30, 2),
-        doc=docs.add_period(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS))  # P
+    beginning_image_number = db.Column(db.BigInteger, doc=docs.BEGINNING_IMAGE_NUMBER)
+    cash_on_hand_beginning_period = db.Column(
+        db.Numeric(30, 2), doc=docs.CASH_ON_HAND_BEGIN_PERIOD
+    )  # P
+    cash_on_hand_end_period = db.Column(
+        'cash_on_hand_end_period', db.Numeric(30, 2), doc=docs.CASH_ON_HAND_END_PERIOD
+    )  # P
+    coverage_end_date = db.Column(
+        db.DateTime, index=True, doc=docs.COVERAGE_END_DATE
+    )  # P
+    coverage_start_date = db.Column(
+        db.DateTime, index=True, doc=docs.COVERAGE_START_DATE
+    )  # P
+    debts_owed_by_committee = db.Column(
+        'debts_owed_by_committee', db.Numeric(30, 2), doc=docs.DEBTS_OWED_BY_COMMITTEE
+    )  # P
+    debts_owed_to_committee = db.Column(
+        db.Numeric(30, 2), doc=docs.DEBTS_OWED_TO_COMMITTEE
+    )  # P
+    end_image_number = db.Column(db.BigInteger, doc=docs.ENDING_IMAGE_NUMBER)
+    other_disbursements_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.OTHER_DISBURSEMENTS)
+    )  # PX
+    other_disbursements_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.OTHER_DISBURSEMENTS)
+    )  # PX
+    other_political_committee_contributions_period = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    other_political_committee_contributions_ytd = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    political_party_committee_contributions_period = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    political_party_committee_contributions_ytd = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    report_type = db.Column(db.String, doc=docs.REPORT_TYPE)
+    report_type_full = db.Column(db.String, doc=docs.REPORT_TYPE)
+    report_year = db.Column(db.Integer, doc=docs.REPORT_YEAR)
+    total_contribution_refunds_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.CONTRIBUTION_REFUNDS)
+    )  # P
+    total_contribution_refunds_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.CONTRIBUTION_REFUNDS)
+    )  # P
+    refunded_individual_contributions_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS)
+    )  # P
+    refunded_individual_contributions_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.REFUNDED_INDIVIDUAL_CONTRIBUTIONS)
+    )  # P
+    refunded_other_political_committee_contributions_period = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    refunded_other_political_committee_contributions_ytd = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    refunded_political_party_committee_contributions_period = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    refunded_political_party_committee_contributions_ytd = db.Column(
+        db.Numeric(30, 2),
+        doc=docs.add_ytd(docs.REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS),
+    )  # P
+    total_contributions_period = db.Column(
+        'total_contributions_period',
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.CONTRIBUTIONS),
+    )  # P
+    total_contributions_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.CONTRIBUTIONS)
+    )  # P
+    total_disbursements_period = db.Column(
+        'total_disbursements_period',
+        db.Numeric(30, 2),
+        doc=docs.add_period(docs.DISBURSEMENTS),
+    )  # P
+    total_disbursements_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.DISBURSEMENTS)
+    )  # P
+    total_receipts_period = db.Column(
+        'total_receipts_period', db.Numeric(30, 2), doc=docs.add_period(docs.RECEIPTS)
+    )  # P
+    total_receipts_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.RECEIPTS)
+    )  # P
+    offsets_to_operating_expenditures_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.OFFSETS_TO_OPERATING_EXPENDITURES)
+    )  # P
+    offsets_to_operating_expenditures_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.OFFSETS_TO_OPERATING_EXPENDITURES)
+    )  # P
+    total_individual_contributions_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_CONTRIBUTIONS)
+    )  # P
+    total_individual_contributions_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_CONTRIBUTIONS)
+    )  # P
+    individual_unitemized_contributions_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS)
+    )  # P \
+    individual_unitemized_contributions_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS)
+    )  # P
+    individual_itemized_contributions_ytd = db.Column(
+        db.Numeric(30, 2), doc=docs.add_ytd(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS)
+    )  # P
+    individual_itemized_contributions_period = db.Column(
+        db.Numeric(30, 2), doc=docs.add_period(docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS)
+    )  # P
     is_amended = db.Column('is_amended', db.Boolean, doc=docs.IS_AMENDED)
     receipt_date = db.Column('receipt_date', db.Date, doc=docs.RECEIPT_DATE)
     means_filed = db.Column('means_filed', db.String, doc=docs.MEANS_FILED)
@@ -210,16 +249,24 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
 
 class CommitteeReportsHouseSenate(CommitteeReports):
     __tablename__ = 'ofec_reports_house_senate_mv'
-    aggregate_amount_personal_contributions_general = db.Column(db.Numeric(30, 2))  # missing
-    aggregate_contributions_personal_funds_primary = db.Column(db.Numeric(30, 2))  # missing
+    aggregate_amount_personal_contributions_general = db.Column(
+        db.Numeric(30, 2)
+    )  # missing
+    aggregate_contributions_personal_funds_primary = db.Column(
+        db.Numeric(30, 2)
+    )  # missing
     all_other_loans_period = db.Column(db.Numeric(30, 2))  # mapped
     all_other_loans_ytd = db.Column(db.Numeric(30, 2))  # mapped
     candidate_contribution_period = db.Column(db.Numeric(30, 2))  # mapped
     candidate_contribution_ytd = db.Column(db.Numeric(30, 2))  # mapped
     gross_receipt_authorized_committee_general = db.Column(db.Numeric(30, 2))  # missing
     gross_receipt_authorized_committee_primary = db.Column(db.Numeric(30, 2))  # missing
-    gross_receipt_minus_personal_contribution_general = db.Column(db.Numeric(30, 2))  # missing
-    gross_receipt_minus_personal_contributions_primary = db.Column(db.Numeric(30, 2))  # missing
+    gross_receipt_minus_personal_contribution_general = db.Column(
+        db.Numeric(30, 2)
+    )  # missing
+    gross_receipt_minus_personal_contributions_primary = db.Column(
+        db.Numeric(30, 2)
+    )  # missing
     loan_repayments_candidate_loans_period = db.Column(db.Numeric(30, 2))  # mapped
     loan_repayments_candidate_loans_ytd = db.Column(db.Numeric(30, 2))  # mapped
     loan_repayments_other_loans_period = db.Column(db.Numeric(30, 2))  # mapped
@@ -234,7 +281,9 @@ class CommitteeReportsHouseSenate(CommitteeReports):
     operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     other_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
     other_receipts_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    refunds_total_contributions_col_total_ytd = db.Column(db.Numeric(30, 2))  # mapped, but maybe needs to be renamed?
+    refunds_total_contributions_col_total_ytd = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped, but maybe needs to be renamed?
     subtotal_period = db.Column(db.Numeric(30, 2))  # mapped
     # mapped, but rename to match column above
     total_contribution_refunds_col_total_period = db.Column(db.Numeric(30, 2))
@@ -243,13 +292,21 @@ class CommitteeReportsHouseSenate(CommitteeReports):
     total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # mapped
     total_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
     total_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
     total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     total_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
     total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    transfers_from_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
-    transfers_from_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_from_other_authorized_committee_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
+    transfers_from_other_authorized_committee_ytd = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
+    transfers_to_other_authorized_committee_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
     transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
     report_form = 'Form 3'
 
@@ -257,10 +314,13 @@ class CommitteeReportsHouseSenate(CommitteeReports):
     def has_pdf(self):
         committee = self.committee
         return (
-            self.report_year and committee and
-            (
-                committee.committee_type == 'H' and self.report_year >= 1996 or
-                committee.committee_type == 'S' and self.report_year >= 2000
+            self.report_year
+            and committee
+            and (
+                committee.committee_type == 'H'
+                and self.report_year >= 1996
+                or committee.committee_type == 'S'
+                and self.report_year >= 2000
             )
         )
 
@@ -270,19 +330,31 @@ class CommitteeReportsPacParty(CommitteeReports):
 
     all_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
     all_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    allocated_federal_election_levin_share_period = db.Column(db.Numeric(30, 2))  # missing
+    allocated_federal_election_levin_share_period = db.Column(
+        db.Numeric(30, 2)
+    )  # missing
     calendar_ytd = db.Column(db.Integer)  # missing
-    cash_on_hand_beginning_calendar_ytd = db.Column(db.Numeric(30, 2))  # mapped, but it's period not ytd
+    cash_on_hand_beginning_calendar_ytd = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped, but it's period not ytd
     cash_on_hand_close_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    coordinated_expenditures_by_party_committee_period = db.Column('coordinated_expenditures_by_party_committee_period',
-        db.Numeric(30, 2))  # mapped
-    coordinated_expenditures_by_party_committee_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    fed_candidate_committee_contribution_refunds_ytd = db.Column(db.Numeric(30, 2))  # mapped,should this match line 164
-    fed_candidate_committee_contributions_period = db.Column(db.Numeric(30, 2))  # mapped
+    coordinated_expenditures_by_party_committee_period = db.Column(
+        'coordinated_expenditures_by_party_committee_period', db.Numeric(30, 2)
+    )  # mapped
+    coordinated_expenditures_by_party_committee_ytd = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
+    fed_candidate_committee_contribution_refunds_ytd = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped,should this match line 164
+    fed_candidate_committee_contributions_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
     fed_candidate_committee_contributions_ytd = db.Column(db.Numeric(30, 2))  # mapped
     fed_candidate_contribution_refunds_period = db.Column(db.Numeric(30, 2))  # mapped
-    independent_expenditures_period = db.Column('independent_expenditures_period',
-        db.Numeric(30, 2))  # mapped
+    independent_expenditures_period = db.Column(
+        'independent_expenditures_period', db.Numeric(30, 2)
+    )  # mapped
     independent_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     loan_repayments_made_period = db.Column(db.Numeric(30, 2))  # mapped
     loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # mapped
@@ -296,7 +368,9 @@ class CommitteeReportsPacParty(CommitteeReports):
     net_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     non_allocated_fed_election_activity_period = db.Column(db.Numeric(30, 2))  # mapped
     non_allocated_fed_election_activity_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    nonfed_share_allocated_disbursements_period = db.Column(db.Numeric(30, 2))  # missing!
+    nonfed_share_allocated_disbursements_period = db.Column(
+        db.Numeric(30, 2)
+    )  # missing!
     other_fed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
     other_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     other_fed_receipts_period = db.Column(db.Numeric(30, 2))  # mapped
@@ -308,7 +382,9 @@ class CommitteeReportsPacParty(CommitteeReports):
     shared_fed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
     shared_nonfed_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
     shared_nonfed_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    subtotal_summary_page_period = db.Column(db.Numeric(30, 2))  # check this one in the json
+    subtotal_summary_page_period = db.Column(
+        db.Numeric(30, 2)
+    )  # check this one in the json
     subtotal_summary_ytd = db.Column(db.Numeric(30, 2))  # mapped
     total_fed_disbursements_period = db.Column(db.Numeric(30, 2))  # mapped
     total_fed_disbursements_ytd = db.Column(db.Numeric(30, 2))  # mapped
@@ -322,7 +398,9 @@ class CommitteeReportsPacParty(CommitteeReports):
     total_nonfed_transfers_ytd = db.Column(db.Numeric(30, 2))  # mapped
     total_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
     total_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    transfers_from_affiliated_party_period = db.Column(db.Numeric(30, 2))  # this should be committee not party
+    transfers_from_affiliated_party_period = db.Column(
+        db.Numeric(30, 2)
+    )  # this should be committee not party
     transfers_from_affiliated_party_ytd = db.Column(db.Numeric(30, 2))  # ditto
     transfers_from_nonfed_account_period = db.Column(db.Numeric(30, 2))  # mapped
     transfers_from_nonfed_account_ytd = db.Column(db.Numeric(30, 2))  # mapped
@@ -367,13 +445,17 @@ class CommitteeReportsPresidential(CommitteeReports):
     total_loan_repayments_made_ytd = db.Column(db.Numeric(30, 2))  # """
     total_loans_received_period = db.Column(db.Numeric(30, 2))  # mapped
     total_loans_received_ytd = db.Column(db.Numeric(30, 2))  # mapped
-    total_offsets_to_operating_expenditures_period = db.Column(db.Numeric(30, 2))  # mapped
+    total_offsets_to_operating_expenditures_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
     total_offsets_to_operating_expenditures_ytd = db.Column(db.Numeric(30, 2))  # """
     total_period = db.Column(db.Numeric(30, 2))  # mapped
     total_ytd = db.Column(db.Numeric(30, 2))  # mapped
     transfers_from_affiliated_committee_period = db.Column(db.Numeric(30, 2))  # mapped
     transfers_from_affiliated_committee_ytd = db.Column(db.Numeric(30, 2))  # """
-    transfers_to_other_authorized_committee_period = db.Column(db.Numeric(30, 2))  # mapped
+    transfers_to_other_authorized_committee_period = db.Column(
+        db.Numeric(30, 2)
+    )  # mapped
     transfers_to_other_authorized_committee_ytd = db.Column(db.Numeric(30, 2))  # """
     net_contributions_cycle_to_date = db.Column(db.Numeric(30, 2))  # mapped
     net_operating_expenditures_cycle_to_date = db.Column(db.Numeric(30, 2))  # mapped
@@ -389,7 +471,9 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     coverage_start_date = db.Column(db.DateTime(), index=True)
     coverage_end_date = db.Column(db.DateTime(), index=True)
     report_year = db.Column(db.Integer)
-    independent_contributions_period = db.Column('independent_contributions_period', db.Numeric(30, 2))
+    independent_contributions_period = db.Column(
+        'independent_contributions_period', db.Numeric(30, 2)
+    )
     independent_expenditures_period = db.Column(db.Numeric(30, 2))
     report_type = db.Column(db.String)
     report_type_full = db.Column(db.String)
@@ -407,6 +491,7 @@ class BaseFilingSummary(db.Model):
     line_number = db.Column('lineno', db.Integer, primary_key=True)
     column_a = db.Column('cola', db.Float)
     column_b = db.Column('colb', db.Float)
+
 
 class BaseFiling(FecFileNumberMixin, AmendmentChainMixin, PdfMixin, FecMixin, db.Model):
     __abstract__ = True
@@ -436,6 +521,7 @@ class BaseFiling(FecFileNumberMixin, AmendmentChainMixin, PdfMixin, FecMixin, db
             None,
             None,
         )
+
     @property
     def report_year(self):
         return self.coverage_end_date.year
@@ -445,11 +531,7 @@ def name_generator(*args):
     name = ''
     fields = []
     for field in args:
-        field = (
-            field.strip()
-            if field
-            else ''
-        )
+        field = field.strip() if field else ''
         fields.append(field)
     if fields.count('') == len(fields):
         return None
@@ -458,6 +540,7 @@ def name_generator(*args):
     for field in fields:
         name += field + ' '
     return name.strip()
+
 
 class BaseF3PFiling(TreasurerMixin, BaseFiling):
     __table_args__ = {'schema': 'real_efile'}
@@ -516,7 +599,9 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
     __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'f3'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
-    committee_name = db.Column('com_name', db.String, index=True, doc=docs.COMMITTEE_NAME)
+    committee_name = db.Column(
+        'com_name', db.String, index=True, doc=docs.COMMITTEE_NAME
+    )
     candidate_id = db.Column('canid', db.String)
     candidate_last_name = db.Column('can_lname', db.String)
     candidate_first_name = db.Column('can_fname', db.String)
@@ -539,13 +624,9 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
             self.candidate_prefix,
             self.candidate_first_name,
             self.candidate_middle_name,
-            self.candidate_suffix
+            self.candidate_suffix,
         )
-        name = (
-            name
-            if name
-            else None
-        )
+        name = name if name else None
         return name
 
     amendment = db.relationship(
@@ -576,12 +657,15 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
             lazy='subquery',
         )
 
+
 class BaseF3XFiling(BaseFiling):
     __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'f3x'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
 
-    committee_name = db.Column('com_name', db.String, index=True, doc=docs.COMMITTEE_NAME)
+    committee_name = db.Column(
+        'com_name', db.String, index=True, doc=docs.COMMITTEE_NAME
+    )
     sign_date = db.Column('date_signed', db.Date)
     amend_address = db.Column('amend_addr', db.String)
     qualified_multicandidate_committee = db.Column('qual', db.String)

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.declarative import declared_attr
 
 from webservices import docs
 
+
 class CommitteeTotals(BaseModel):
     __abstract__ = True
 
@@ -35,7 +36,7 @@ class CommitteeTotals(BaseModel):
     last_debts_owed_by_committee = db.Column(db.Numeric(30, 2))
     last_debts_owed_to_committee = db.Column(db.Numeric(30, 2))
 
-    #Add additional fields and filters to /totals/{committee-type} endpoint#2631
+    # Add additional fields and filters to /totals/{committee-type} endpoint#2631
     committee_name = db.Column(db.String, doc=docs.COMMITTEE_NAME)
     committee_type = db.Column(db.String, doc=docs.COMMITTEE_TYPE)
     committee_designation = db.Column(db.String, doc=docs.DESIGNATION)
@@ -58,9 +59,9 @@ class CommitteeTotals(BaseModel):
 
 class CandidateCommitteeTotals(db.Model):
     __abstract__ = True
-    #making this it's own model hieararchy until can figure out
-    #how to maybe use existing classes while removing primary
-    #key stuff on cycle
+    # making this it's own model hieararchy until can figure out
+    # how to maybe use existing classes while removing primary
+    # key stuff on cycle
     candidate_id = db.Column(db.String, primary_key=True, doc=docs.CANDIDATE_ID)
     cycle = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
     candidate_election_year = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
@@ -248,6 +249,7 @@ class CommitteeTotalsIEOnly(BaseModel):
         lazy='joined',
     )
 
+
 class ScheduleAByStateRecipientTotals(BaseModel):
     __tablename__ = 'ofec_sched_a_aggregate_state_recipient_totals_mv'
 
@@ -258,6 +260,7 @@ class ScheduleAByStateRecipientTotals(BaseModel):
     state_full = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
     committee_type = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
     committee_type_full = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
+
 
 class CommitteeTotalsCombined(CommitteeTotals):
     __tablename__ = 'ofec_totals_combined_vw'
@@ -281,6 +284,7 @@ class CommitteeTotalsCombined(CommitteeTotals):
     cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2))
     net_operating_expenditures = db.Column('last_net_operating_expenditures', db.Numeric(30, 2))
     net_contributions = db.Column('last_net_contributions', db.Numeric(30, 2))
+
 
 class CommitteeTotalsPerCycle(CommitteeTotals):
     __tablename__ = 'ofec_committee_totals_per_cycle_vw'

--- a/webservices/common/util.py
+++ b/webservices/common/util.py
@@ -44,5 +44,5 @@ def get_class_by_tablename(tablename):
     """
     from webservices.common.models import db
     for c in db.Model._decl_class_registry.values():
-        if hasattr(c, '_sa_class_manager') and c._sa_class_manager.mapper.mapped_table == tablename:
+        if hasattr(c, '_sa_class_manager') and c._sa_class_manager.mapper.persist_selectable == tablename:
             return c

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -12,11 +12,13 @@ def get_cycle_start(year):
     """
     return year if year % 2 == 1 else year - 1
 
+
 def get_cycle_end(year):
     """Round year up to the last year of the two-year election cycle. Used
     when querying partitioned itemized data for election cycle.
     """
     return year if year % 2 == 0 else year + 1
+
 
 CURRENT_YEAR = datetime.datetime.now().year
 
@@ -33,14 +35,12 @@ REQUIRED_CREDS = (
 
 REQUIRED_SERVICES = ('redis32', 's3', 'elasticsearch56')
 
-REQUIRED_TABLES = (
-    tuple(db.Model.metadata.tables.keys()) +
-    (
-        'ofec_pacronyms',
-        'ofec_nicknames',
-        'ofec_zips_districts',
-    )
+REQUIRED_TABLES = tuple(db.Model.metadata.tables.keys()) + (
+    'ofec_pacronyms',
+    'ofec_nicknames',
+    'ofec_zips_districts',
 )
+
 
 def load_table(name):
     try:
@@ -48,17 +48,24 @@ def load_table(name):
     except sa.exc.NoSuchTableError:
         return None
 
+
 def check_keys(keys, getter, formatter):
     missing = [key for key in keys if getter(key) is None]
     if missing:
         print(formatter.format(', '.join(keys)))
     return missing
 
+
 CHECKS = [
     (REQUIRED_CREDS, env.get_credential, 'Missing creds {}'),
-    (REQUIRED_SERVICES, lambda service: env.get_service(label=service), 'Missing services {}'),
+    (
+        REQUIRED_SERVICES,
+        lambda service: env.get_service(label=service),
+        'Missing services {}',
+    ),
     (REQUIRED_TABLES, load_table, 'Missing tables {}'),
 ]
+
 
 def check_config():
     results = [check_keys(*check) for check in CHECKS]

--- a/webservices/decoders.py
+++ b/webservices/decoders.py
@@ -1,8 +1,5 @@
 import json
 
-
-
-
 election_types = {
     'GR': 'General runoff',
     'SG': 'Special election general',
@@ -58,9 +55,3 @@ f3x_col_a = []
 f3x_col_b = []
 f3x_description = []
 dumper(f3x_col_a, f3x_col_b, f3x_description, dumped)
-
-
-
-
-
-

--- a/webservices/decoders.py
+++ b/webservices/decoders.py
@@ -27,6 +27,7 @@ form_types = {
     'F6': '48-hour notice of contribution/loans received',
 }
 
+
 def dumper(f3p_col_a, f3p_col_b, f3p_description, dumped):
     for row in dumped:
         description, col_a, col_b = row

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -655,7 +655,8 @@ Report is either new or is the most-recently filed amendment
 '''
 
 MOST_RECENT_IE = '''
-The report associated with the transaction is either new or is the most-recently filed amendment. Undetermined version (`null`) is always included.
+The report associated with the transaction is either new or is the most-recently \
+filed amendment. Undetermined version (`null`) is always included.
 '''
 
 HTML_URL = '''
@@ -690,16 +691,35 @@ Parameter `full_election` is replaced by `election_full`. Please use `election_f
 '''
 
 SCHEDULE_A_TAG = '''
-This collection of endpoints includes Schedule A records reported by a committee. Schedule A records describe itemized receipts, including contributions from individuals. If you are interested in contributions from individuals, use the /schedules/schedule_a/ endpoint. For a more complete description of all Schedule A records see the [receipts section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/) section of our “about the data” page. 
+This collection of endpoints includes Schedule A records reported by a committee. \
+Schedule A records describe itemized receipts, including contributions from individuals. \
+If you are interested in contributions from individuals, use the /schedules/schedule_a/ endpoint. \
+For a more complete description of all Schedule A records see the [receipts section] \
+(https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) \
+of our “about the data” page. If you are interested in our “is_individual” methodology see the \
+[methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/ \
+methodology/) section of our “about the data” page.
 
 '''
 
 SCHEDULE_A = '''
-This description is for both ​`/schedules​/schedule_a​/` and ​ `/schedules​/schedule_a​/{sub_id}​/`. 
+This description is for both ​`/schedules​/schedule_a​/` and ​ `/schedules​/schedule_a​/{sub_id}​/`.
 
-This endpoint provides itemized receipts. Schedule A records describe itemized receipts, including contributions from individuals. If you are interested in contributions from an individual, use the `/schedules/schedule_a/` endpoint. For a more complete description of all Schedule A records see the [receipts section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/) of our “about the data” page. 
+This endpoint provides itemized receipts. Schedule A records describe itemized receipts, \
+including contributions from individuals. If you are interested in contributions from an \
+individual, use the `/schedules/schedule_a/` endpoint. For a more complete description of all \
+Schedule A records see the [receipts section] (https://www.fec.gov/campaign-finance-data/ \
+about-campaign-finance-data/about-receipts-data/) of our “about the data” page. If you are \
+interested in our “is_individual” methodology see the [methodology section] \
+(https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/) of our \
+“about the data” page.
 
-​The `/schedules​/schedule_a​/` endpoint is not paginated by page number. This endpoint uses keyset pagination to improve query performance and these indices are required to properly page through this large dataset. To request the next page, you should append the values found in the `last_indexes` object from pagination to the URL of your last request as additional parameters. For example, when sorting by `contribution_receipt_date`, you might receive a page of results with the following pagination information:
+​The `/schedules​/schedule_a​/` endpoint is not paginated by page number. This endpoint uses keyset \
+pagination to improve query performance and these indices are required to properly page through \
+this large dataset. To request the next page, you should append the values found in the \
+`last_indexes` object from pagination to the URL of your last request as additional parameters. \
+For example, when sorting by `contribution_receipt_date`, you might receive a page of results \
+with the following pagination information:
 
 ```
 pagination: {\n\
@@ -713,11 +733,17 @@ pagination: {\n\
 }\n\
 ```
 
-To fetch the next page of sorted results, append `last_index=230880619` and `last_contribution_receipt_date=2014-01-01` to the URL. We strongly advise paging through these results using sort indices. The default sort is ascending by `contribution_receipt_date`. If you do not page using sort indices, some transactions may be unintentionally filtered out. 
+To fetch the next page of sorted results, append `last_index=230880619` and \
+`last_contribution_receipt_date=2014-01-01` to the URL. We strongly advise paging through \
+these results using sort indices. The default sort is ascending by `contribution_receipt_date`. \
+If you do not page using sort indices, some transactions may be unintentionally filtered out.
 
-Calls to ​`/schedules​/schedule_a​/` may return many records. For large result sets, the record counts found in the pagination object are approximate; you will need to page through the records until no records are returned. 
+Calls to ​`/schedules​/schedule_a​/` may return many records. For large result sets, the record \
+counts found in the pagination object are approximate; you will need to page through the records \
+until no records are returned.
 
-​The `/schedules​/schedule_a​/{sub_id}​/` endpoint returns a single transaction, but it does include a pagination object class. Please ignore the information in that object class.
+​The `/schedules​/schedule_a​/{sub_id}​/` endpoint returns a single transaction, but it does \
+include a pagination object class. Please ignore the information in that object class.
 
 '''
 
@@ -861,11 +887,12 @@ counting, memoed items are not included.
 '''
 
 SCHEDULE_E_INDEPENDENT_EXPENDITURES_TOTALS_BY_CANDIDATE = '''
-Total independent expenditure on supported or opposed candidates by cycle or candidate election year. 
+Total independent expenditure on supported or opposed candidates by cycle or candidate election year.
 '''
 
 COMMUNICATIONS_COSTS_TOTALS_BY_CANDIDATE = '''
-Total communications costs aggregated across committees on supported or opposed candidates by cycle or candidate election year. 
+Total communications costs aggregated across committees on supported or opposed candidates \
+by cycle or candidate election year.
 '''
 
 SCHEDULE_F_TAG = '''
@@ -893,18 +920,35 @@ The $200.00 and under category includes contributions of $200 or less combined w
 '''
 
 SCHEDULE_A_BY_STATE = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by the contributor’s state. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+the contributor’s state. If you are interested in our “is_individual” methodology see the \
+[methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/ \
+about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not \
+included.
 '''
 
 SCHEDULE_A_BY_ZIP = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by the contributor’s ZIP code. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) section of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+the contributor’s ZIP code. If you are interested in our “is_individual” methodology see the \
+[methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/ \
+about-receipts-data/) section of our “about the data” page. Unitemized individual contributions \
+are not included.
 '''
+
 SCHEDULE_A_BY_EMPLOYER = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by the contributor’s employer name. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+the contributor’s employer name. If you are interested in our “is_individual” methodology see the \
+[methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/ \
+about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not \
+included.
 '''
 
 SCHEDULE_A_BY_OCCUPATION = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by the contributor’s occupation. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+the contributor’s occupation. If you are interested in our “is_individual” methodology see the \
+[methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/ \
+about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not \
+included.
 '''
 
 CONTRIBUTION_RECEIPTS = '''
@@ -932,15 +976,26 @@ Number of records making up the total.
 '''
 
 SCHEDULE_A_SIZE_CANDIDATE_TAG = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by size of contribution and candidate. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+size of contribution and candidate. If you are interested in our “is_individual” methodology \
+see the [methodology section] (https://www.fec.gov/campaign-finance-data/ \
+about-campaign-finance-data/about-receipts-data/) of our “about the data” page. \
+Unitemized individual contributions are not included.
 '''
 
 SCHEDULE_A_STATE_CANDIDATE_TAG = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by contributor’s state and candidate. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated \
+by contributor’s state and candidate. If you are interested in our “is_individual” methodology \
+see the [methodology section] (https://www.fec.gov/campaign-finance-data/ \
+about-campaign-finance-data/about-receipts-data/) of our “about the data” page. \
+Unitemized individual contributions are not included.
 '''
 
 SCHEDULE_A_STATE_CANDIDATE_TOTAL_TAG = '''
-Itemized individual contributions aggregated by contributor’s state, candidate, committee type and cycle. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+Itemized individual contributions aggregated by contributor’s state, candidate, committee type \
+and cycle. If you are interested in our “is_individual” methodology see the [methodology section] \
+(https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of \
+our “about the data” page. Unitemized individual contributions are not included.
 
 '''
 
@@ -953,7 +1008,11 @@ Aggregated candidate receipts and disbursements grouped by cycle.
 '''
 
 STATE_AGGREGATE_RECIPIENT_TOTALS = '''
-This endpoint provides itemized individual contributions received by a committee, aggregated by contributor’s state, committee type and cycle. If you are interested in our “is_individual” methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/) of our “about the data” page. Unitemized individual contributions are not included.
+This endpoint provides itemized individual contributions received by a committee, aggregated by \
+contributor’s state, committee type and cycle. If you are interested in our “is_individual” \
+methodology see the [methodology section] (https://www.fec.gov/campaign-finance-data/ \
+about-campaign-finance-data/about-receipts-data/) of our “about the data” page. \
+Unitemized individual contributions are not included.
 '''
 
 API_KEY_DESCRIPTION = '''
@@ -1175,7 +1234,8 @@ FORM_TYPE = 'The form where the underlying data comes from, for example, Form 1 
     - F1M  Notification of Multicandidate Status\n\
     - F2   Statement of Candidacy\n\
     - F3   Report of Receipts and Disbursements for an Authorized Committee\n\
-    - F3P  Report of Receipts and Disbursements by an Authorized Committee of a Candidate for The Office of President or Vice President\n\
+    - F3P  Report of Receipts and Disbursements by an Authorized Committee of a Candidate for \
+    The Office of President or Vice President\n\
     - F3L  Report of Contributions Bundled by Lobbyists/Registrants and Lobbyist/Registrant PACs\n\
     - F3X  Report of Receipts and Disbursements for other than an Authorized Committee\n\
     - F4   Report of Receipts and Disbursements for a Committee or Organization Supporting a Nomination Convention\n\
@@ -1359,6 +1419,7 @@ def add_period(var):
 def add_ytd(var):
     return var + ' total for the year to date'
 
+
 # shared
 CASH_ON_HAND_BEGIN_PERIOD = 'Balance for the committee at the start of the two-year period'
 CASH_ON_HAND_END_PERIOD = 'Ending cash balance on the most recent filing'
@@ -1494,7 +1555,9 @@ This ID is not a permanent, persistent ID.'
 
 # efiling
 EFILING_TAG = '''
-Efiling endpoints provide real-time campaign finance data received from electronic filers. Efiling endpoints only contain the most recent four months of data and don't contain the processed and coded data that you can find on other endpoints.
+Efiling endpoints provide real-time campaign finance data received from electronic filers. \
+Efiling endpoints only contain the most recent four months of data and don't contain \
+the processed and coded data that you can find on other endpoints.
 '''
 
 EFILE_FILES = 'Basic information about electronic files coming into the FEC, posted as they are received.'
@@ -1722,7 +1785,7 @@ The identifier for each electioneering record.
 TOTAL_BY_OFFICE_TAG = ''' Aggregated candidate receipts and disbursements grouped by office by cycle.
 '''
 
-TOTAL_BY_OFFICE_BY_PARTY_TAG= ''' Aggregated candidate receipts and disbursements grouped by office by party by cycle.
+TOTAL_BY_OFFICE_BY_PARTY_TAG = ''' Aggregated candidate receipts and disbursements grouped by office by party by cycle.
 '''
 
 ACTIVE_CANDIDATE = ''' Candidates who are actively seeking office. If no value is specified, all candidates

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -33,7 +33,7 @@ PAGES = '''
 Number of pages in the document
 '''
 
-#======== candidate start ===========
+# ======== candidate start ===========
 CANDIDATE_TAG = '''
 Candidate endpoints give you access to information about the people running for office.
 This information is organized by candidate_id. If you're unfamiliar with candidate IDs,
@@ -183,9 +183,9 @@ F2_CANDIDATE_STREET_2 = 'Additional street information of candidate\'s address, 
 
 F2_CANDIDATE_ZIP = 'Zip code of candidate\'s address, as reported on their Form 2.'
 
-#======== candidate end ===========
+# ======== candidate end ===========
 
-#======== committee start ===========
+# ======== committee start ===========
 COMMITTEE_TAG = '''
 Committees are entities that spend and raise money in an election. Their characteristics and
 relationships with candidates can change over time.
@@ -510,10 +510,10 @@ MAX_LAST_F1_DATE = 'Filter for committees whose latest Form 1 was received on or
 AFFILIATED_COMMITTEE_NAME = '''
 Affiliated committee or connected organization
 '''
-#======== committee end ===========
+# ======== committee end ===========
 
 
-#======== election start ===========
+# ======== election start ===========
 ELECTION_SEARCH = '''
 List elections by cycle, office, state, and district.
 '''
@@ -591,10 +591,10 @@ The minimum date this record was last updated.(MM/DD/YYYY or YYYY-MM-DD)
 MAX_UPDATE_DATE = '''
 The maximum date this record was last updated.(MM/DD/YYYY or YYYY-MM-DD)
 '''
-#======== election end ===========
+# ======== election end ===========
 
 
-#======== financial start ===========
+# ======== financial start ===========
 FINANCIAL_TAG = '''
 Fetch key information about a committee's Form 3, Form 3X, or Form 3P financial reports.
 
@@ -1390,7 +1390,7 @@ CREATE_DATE = 'Date the record was created'
 UPDATE_DATE = 'Date the record was updated'
 ELECTION_DATE = 'Date of election'
 ELECTION_YEAR = 'Year of election'
-#? TODO: add more categories
+# ? TODO: add more categories
 ELECTION_TYPE = 'Election type \n\
 Convention, Primary,\n\
 General, Special,\n\
@@ -1411,6 +1411,7 @@ ENDING_IMAGE_NUMBER = 'Image number is an unique identifier for each page the el
 report. The last image number corresponds to the image number for the last page of the document.'
 
 # Reports and Totals
+
 
 def add_period(var):
     return var + ' total for the reporting period'
@@ -1471,7 +1472,7 @@ REFUNDED_POLITICAL_PARTY_COMMITTEE_CONTRIBUTIONS = 'Political party refunds'
 CONTRIBUTION_REFUNDS = 'Total contribution refunds'
 REFUNDED_OTHER_POLITICAL_COMMITTEE_CONTRIBUTIONS = 'Other committee refunds'
 
-#loans
+# loans
 LOAN_SOURCE = 'Source of the loan (i.e., bank loan, brokerage account, credit card, home equity line of credit, \
               other line of credit, or personal funds of the candidate'
 

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -7,6 +7,7 @@ from form F3X line number 16.
 FULL_ELECTION_ERROR = """Parameter 'full_election' is replaced by 'election_full'. Please use 'election_full' instead.
 """
 
+
 class ApiError(Exception):
     status_code = 400
 

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -33,7 +33,7 @@ def filter_match(query, kwargs, fields):
         if kwargs.get(key) is not None:
             if is_exclude_arg(kwargs[key]):
                 query = query.filter(sa.or_(column != parse_exclude_arg(kwargs[key]),
-                                            column == None))
+                                            column == None))  # noqa
             else:
                 query = query.filter(column == kwargs[key])
     return query
@@ -47,7 +47,7 @@ def filter_multi(query, kwargs, fields):
             include_list = build_include_list(kwargs.get(key))
             if exclude_list:
                 query = query.filter(sa.or_(column.notin_(exclude_list),
-                                            column == None))
+                                            column == None))  # noqa
             if include_list:
                 query = query.filter(column.in_(include_list))
     return query

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -1,5 +1,6 @@
 import networkx as nx
 
+
 def get_graph():
     """Build a `DiGraph` that captures dependencies between database migration
     tasks. Each node represents a migration script, and each edge represents

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -31,6 +31,7 @@ logger.setLevel('ERROR')
 logger = logging.getLogger('botocore')
 logger.setLevel('WARN')
 
+
 def load_current_legal_docs():
     index_statutes()
     index_regulations()
@@ -39,17 +40,19 @@ def load_current_legal_docs():
     load_adrs()
     load_admin_fines()
 
+
 def initialize_current_legal_docs():
     """
-    Creates the Elasticsearch index and loads all the different types of legal documents.
+    Create the Elasticsearch index and loads all the different types of legal documents.
     This would lead to a brief outage while the docs are reloaded.
     """
     create_docs_index()
     load_current_legal_docs()
 
+
 def refresh_current_legal_docs_zero_downtime():
     """
-    Creates a staging index and loads all the different types of legal documents into it.
+    Create a staging index and loads all the different types of legal documents into it.
     When done, moves the staging index to the production index with no downtime.
     This is typically used when there is a schema change.
     """

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -3,16 +3,7 @@ import sys
 
 from .advisory_opinions import load_advisory_opinions
 from .current_cases import load_current_murs, load_adrs, load_admin_fines
-
-logging.basicConfig(level=logging.INFO, stream=sys.stdout)
-logger = logging.getLogger('elasticsearch')
-logger.setLevel('WARN')
-logger = logging.getLogger('pdfminer')
-logger.setLevel('ERROR')
-logger = logging.getLogger('botocore')
-logger.setLevel('WARN')
-
-from .load_legal_docs import (
+from .load_legal_docs import (  # noqa
     delete_advisory_opinions_from_es,
     delete_current_murs_from_es,
     delete_murs_from_s3,
@@ -20,8 +11,7 @@ from .load_legal_docs import (
     index_statutes,
     load_archived_murs
 )
-
-from .index_management import (
+from .index_management import (  # noqa
     create_docs_index,
     create_archived_murs_index,
     delete_all_indices,
@@ -32,6 +22,14 @@ from .index_management import (
     create_elasticsearch_backup,
     restore_elasticsearch_backup,
 )
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+logger = logging.getLogger('elasticsearch')
+logger.setLevel('WARN')
+logger = logging.getLogger('pdfminer')
+logger.setLevel('ERROR')
+logger = logging.getLogger('botocore')
+logger.setLevel('WARN')
 
 def load_current_legal_docs():
     index_statutes()

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -418,7 +418,7 @@ def validate_statute_citation(title, section):
     """
     try:
         section_lookup = int(section[:3])
-    except:
+    except Exception:
         return False
 
     if title == '2':
@@ -477,7 +477,7 @@ def validate_regulation_citation(title, part):
     """
     try:
         part = int(part)
-    except:
+    except Exception:
         return False
 
     if title == '11':

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -168,11 +168,14 @@ CASE_NO_REGEX = re.compile(r'(?P<serial>\d+)')
 def load_current_murs(specific_mur_no=None):
     load_cases('MUR', specific_mur_no)
 
+
 def load_adrs(specific_adr_no=None):
     load_cases('ADR', specific_adr_no)
 
+
 def load_admin_fines(specific_af_no=None):
     load_cases('AF', specific_af_no)
+
 
 def get_es_type(case_type):
     case_type = case_type.upper()
@@ -182,6 +185,7 @@ def get_es_type(case_type):
         return 'adrs'
     else:
         return 'murs'
+
 
 def get_full_name(case_type):
     case_type = case_type.upper()
@@ -219,6 +223,7 @@ def load_cases(case_type, case_no=None):
                     logger.info('Successfully deleted {} {} from ES'.format(case_type, case['no']))
     else:
         logger.error("Invalid case_type: must be 'MUR', 'ADR', or 'AF'.")
+
 
 def get_cases(case_type, case_no=None):
     """
@@ -274,6 +279,7 @@ def get_single_case(case_type, case_no):
         else:
             logger.info("Not a valid {0} number.".format(case_type))
             return None
+
 
 def get_af_specific_fields(case_id):
     case = {}

--- a/webservices/legal_docs/index_management.py
+++ b/webservices/legal_docs/index_management.py
@@ -12,413 +12,184 @@ logger = logging.getLogger(__name__)
 CASE_DOCUMENT_MAPPINGS = {
     "type": "nested",
     "properties": {
-        "category": {
-            "type": "string",
-            "index": "not_analyzed"
-        },
-        "description": {
-            "type": "string"
-        },
-        "document_date": {
-            "type": "date",
-            "format": "dateOptionalTime"
-        },
-        "document_id": {
-            "type": "long",
-            "index": "no"
-        },
-        "length": {
-            "type": "long",
-            "index": "no"
-        },
-        "text": {
-            "type": "string"
-        },
-        "url": {
-            "type": "string",
-            "index": "no"
-        }
-    }
+        "category": {"type": "string", "index": "not_analyzed"},
+        "description": {"type": "string"},
+        "document_date": {"type": "date", "format": "dateOptionalTime"},
+        "document_id": {"type": "long", "index": "no"},
+        "length": {"type": "long", "index": "no"},
+        "text": {"type": "string"},
+        "url": {"type": "string", "index": "no"},
+    },
 }
 
 MUR_ADR_MAPPINGS = {
     "properties": {
-        "no": {
-            "type": "string",
-            "index": "not_analyzed"
-        },
-        "doc_id": {
-            "type": "string",
-            "index": "no"
-        },
-        "name": {
-            "type": "string",
-            "analyzer": "english"
-        },
-        "election_cycles": {
-            "type": "long"
-        },
-        "open_date": {
-            "type": "date",
-            "format": "dateOptionalTime"
-        },
-        "close_date": {
-            "type": "date",
-            "format": "dateOptionalTime"
-        },
-        "url": {
-            "type": "string",
-            "index": "no"
-        },
-        "subjects": {
-            "type": "string"
-        },
+        "no": {"type": "string", "index": "not_analyzed"},
+        "doc_id": {"type": "string", "index": "no"},
+        "name": {"type": "string", "analyzer": "english"},
+        "election_cycles": {"type": "long"},
+        "open_date": {"type": "date", "format": "dateOptionalTime"},
+        "close_date": {"type": "date", "format": "dateOptionalTime"},
+        "url": {"type": "string", "index": "no"},
+        "subjects": {"type": "string"},
         "commission_votes": {
             "properties": {
-                "text": {
-                    "type": "string"
-                },
-                "vote_date": {
-                    "type": "date",
-                    "format": "dateOptionalTime"
-                }
+                "text": {"type": "string"},
+                "vote_date": {"type": "date", "format": "dateOptionalTime"},
             }
         },
         "dispositions": {
             "properties": {
                 "citations": {
                     "properties": {
-                        "text": {
-                            "type": "string"
-                        },
-                        "title": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
-                        "url": {
-                            "type": "string"
-                        }
+                        "text": {"type": "string"},
+                        "title": {"type": "string"},
+                        "type": {"type": "string"},
+                        "url": {"type": "string"},
                     }
                 },
-                "disposition": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                },
-                "penalty": {
-                    "type": "double"
-                },
-                "respondent": {
-                    "type": "string"
-                }
+                "disposition": {"type": "string", "index": "not_analyzed"},
+                "penalty": {"type": "double"},
+                "respondent": {"type": "string"},
             }
         },
         "documents": CASE_DOCUMENT_MAPPINGS,
         "participants": {
             "properties": {
-                "citations": {
-                    "type": "object"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                }
+                "citations": {"type": "object"},
+                "name": {"type": "string"},
+                "role": {"type": "string"},
             }
         },
-        "respondents": {
-            "type": "string"
-        }
+        "respondents": {"type": "string"},
     }
 }
 
 MUR_MAPPINGS = copy.deepcopy(MUR_ADR_MAPPINGS)
 
-MUR_MAPPINGS["properties"]["mur_type"] = {
-    "type": "string"
-}
+MUR_MAPPINGS["properties"]["mur_type"] = {"type": "string"}
 
 MAPPINGS = {
     "_default_": {
         "properties": {
-            "sort1": {
-                "type": "integer",
-                "include_in_all": False
-            },
-            "sort2": {
-                "type": "integer",
-                "include_in_all": False
-            },
+            "sort1": {"type": "integer", "include_in_all": False},
+            "sort2": {"type": "integer", "include_in_all": False},
         }
     },
     "citations": {
         "properties": {
-            "citation_type": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "citation_text": {
-                "type": "string",
-                "index": "not_analyzed"
-            }
+            "citation_type": {"type": "string", "index": "not_analyzed"},
+            "citation_text": {"type": "string", "index": "not_analyzed"},
         }
     },
     "murs": MUR_MAPPINGS,
     "adrs": MUR_ADR_MAPPINGS,
     "admin_fines": {
         "properties": {
-            "no": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "doc_id": {
-                "type": "string",
-                "index": "no"
-            },
-            "name": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "url": {
-                "type": "string",
-                "index": "no"
-            },
-            "committee_id": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "report_year": {
-                "type": "string"
-            },
-            "report_type": {
-                "type": "string",
-                "index": "no"
-            },
+            "no": {"type": "string", "index": "not_analyzed"},
+            "doc_id": {"type": "string", "index": "no"},
+            "name": {"type": "string", "analyzer": "english"},
+            "url": {"type": "string", "index": "no"},
+            "committee_id": {"type": "string", "index": "not_analyzed"},
+            "report_year": {"type": "string"},
+            "report_type": {"type": "string", "index": "no"},
             "reason_to_believe_action_date": {
                 "type": "date",
-                "format": "dateOptionalTime"
+                "format": "dateOptionalTime",
             },
-            "reason_to_believe_fine_amount": {
-                "type": "long"
-            },
-            "challenge_receipt_date": {
-                "type": "date",
-                "format": "dateOptionalTime"
-            },
-            "challenge_outcome": {
-                "type": "string",
-                "index": "no"
-            },
-            "final_determination_date": {
-                "type": "date",
-                "format": "dateOptionalTime"
-            },
-            "final_determination_amount": {
-                "type": "long"
-            },
-            "check_amount": {
-                "type": "long",
-                "index": "no"
-            },
-            "treasury_referral_date": {
-                "type": "date",
-                "format": "dateOptionalTime"
-            },
-            "treasury_referral_amount": {
-                "type": "long",
-                "index": "no"
-            },
+            "reason_to_believe_fine_amount": {"type": "long"},
+            "challenge_receipt_date": {"type": "date", "format": "dateOptionalTime"},
+            "challenge_outcome": {"type": "string", "index": "no"},
+            "final_determination_date": {"type": "date", "format": "dateOptionalTime"},
+            "final_determination_amount": {"type": "long"},
+            "check_amount": {"type": "long", "index": "no"},
+            "treasury_referral_date": {"type": "date", "format": "dateOptionalTime"},
+            "treasury_referral_amount": {"type": "long", "index": "no"},
             "petition_court_filing_date": {
                 "type": "date",
-                "format": "dateOptionalTime"
+                "format": "dateOptionalTime",
             },
             "petition_court_decision_date": {
                 "type": "date",
-                "format": "dateOptionalTime"
+                "format": "dateOptionalTime",
             },
             "commission_votes": {
                 "properties": {
-                    "text": {
-                        "type": "string"
-                    },
-                    "vote_date": {
-                        "type": "date",
-                        "format": "dateOptionalTime"
-                    }
+                    "text": {"type": "string"},
+                    "vote_date": {"type": "date", "format": "dateOptionalTime"},
                 }
             },
-            "documents": CASE_DOCUMENT_MAPPINGS
+            "documents": CASE_DOCUMENT_MAPPINGS,
         }
     },
     "statutes": {
         "properties": {
-            "doc_id": {
-                "type": "string",
-                "index": "no"
-            },
-            "name": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "text": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "no": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "title": {
-                "type": "string"
-            },
-            "chapter": {
-                "type": "string"
-            },
-            "subchapter": {
-                "type": "string"
-            },
-            "url": {
-                "type": "string",
-                "index": "no"
-            }
+            "doc_id": {"type": "string", "index": "no"},
+            "name": {"type": "string", "analyzer": "english"},
+            "text": {"type": "string", "analyzer": "english"},
+            "no": {"type": "string", "index": "not_analyzed"},
+            "title": {"type": "string"},
+            "chapter": {"type": "string"},
+            "subchapter": {"type": "string"},
+            "url": {"type": "string", "index": "no"},
         }
     },
     "regulations": {
         "properties": {
-            "doc_id": {
-                "type": "string",
-                "index": "no"
-            },
-            "name": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "text": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "no": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "url": {
-                "type": "string",
-                "index": "no"
-            }
+            "doc_id": {"type": "string", "index": "no"},
+            "name": {"type": "string", "analyzer": "english"},
+            "text": {"type": "string", "analyzer": "english"},
+            "no": {"type": "string", "index": "not_analyzed"},
+            "url": {"type": "string", "index": "no"},
         }
     },
     "advisory_opinions": {
         "properties": {
-            "no": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
-            "name": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "summary": {
-                "type": "string",
-                "analyzer": "english"
-            },
-            "issue_date": {
-                "type": "date",
-                "format": "dateOptionalTime"
-            },
-            "is_pending": {
-                "type": "boolean"
-            },
-            "status": {
-                "type": "string"
-            },
+            "no": {"type": "string", "index": "not_analyzed"},
+            "name": {"type": "string", "analyzer": "english"},
+            "summary": {"type": "string", "analyzer": "english"},
+            "issue_date": {"type": "date", "format": "dateOptionalTime"},
+            "is_pending": {"type": "boolean"},
+            "status": {"type": "string"},
             "ao_citations": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "no": {
-                        "type": "string"
-                    }
-                }
+                "properties": {"name": {"type": "string"}, "no": {"type": "string"}}
             },
             "aos_cited_by": {
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "no": {
-                        "type": "string"
-                    }
-                }
+                "properties": {"name": {"type": "string"}, "no": {"type": "string"}}
             },
             "statutory_citations": {
                 "type": "nested",
                 "properties": {
-                    "section": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "long"
-                    }
-                }
+                    "section": {"type": "string"},
+                    "title": {"type": "long"},
+                },
             },
             "regulatory_citations": {
                 "type": "nested",
                 "properties": {
-                    "part": {
-                        "type": "long"
-                    },
-                    "section": {
-                        "type": "long"
-                    },
-                    "title": {
-                        "type": "long"
-                    }
-                }
+                    "part": {"type": "long"},
+                    "section": {"type": "long"},
+                    "title": {"type": "long"},
+                },
             },
-            "requestor_names": {
-                "type": "string"
-            },
-            "requestor_types": {
-                "type": "string",
-                "index": "not_analyzed"
-            },
+            "requestor_names": {"type": "string"},
+            "requestor_types": {"type": "string", "index": "not_analyzed"},
             "documents": {
                 "type": "nested",
                 "properties": {
-                    "document_id": {
-                        "type": "long",
-                        "index": "no"
-                    },
-                    "category": {
-                        "type": "string",
-                        "index": "not_analyzed"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "date": {
-                        "type": "date",
-                        "format": "dateOptionalTime"
-                    },
-                    "text": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string",
-                        "index": "no"
-                    }
-                }
-            }
+                    "document_id": {"type": "long", "index": "no"},
+                    "category": {"type": "string", "index": "not_analyzed"},
+                    "description": {"type": "string"},
+                    "date": {"type": "date", "format": "dateOptionalTime"},
+                    "text": {"type": "string"},
+                    "url": {"type": "string", "index": "no"},
+                },
+            },
         }
-    }
+    },
 }
 
-ANALYZER_SETTINGS = {
-    "analysis": {"analyzer": {"default": {"type": "english"}}}
-}
+ANALYZER_SETTINGS = {"analysis": {"analyzer": {"default": {"type": "english"}}}}
 
 BACKUP_REPOSITORY_NAME = "legal_s3_repository"
 
@@ -446,14 +217,14 @@ def create_docs_index():
         pass
 
     logger.info("Create index 'docs'")
-    es.indices.create('docs', {
-        "mappings": MAPPINGS,
-        "settings": ANALYZER_SETTINGS,
-        "aliases": {
-            'docs_index': {},
-            'docs_search': {}
-        }
-    })
+    es.indices.create(
+        'docs',
+        {
+            "mappings": MAPPINGS,
+            "settings": ANALYZER_SETTINGS,
+            "aliases": {'docs_index': {}, 'docs_search': {}},
+        },
+    )
 
 
 def create_archived_murs_index():
@@ -474,15 +245,17 @@ def create_archived_murs_index():
     except elasticsearch.exceptions.NotFoundError:
         pass
 
-    logger.info("Create index 'archived_murs' with aliases 'docs_search' and 'archived_murs_index'")
-    es.indices.create('archived_murs', {
-        "mappings": MAPPINGS,
-        "settings": ANALYZER_SETTINGS,
-        "aliases": {
-            'archived_murs_index': {},
-            'docs_search': {}
-        }
-    })
+    logger.info(
+        "Create index 'archived_murs' with aliases 'docs_search' and 'archived_murs_index'"
+    )
+    es.indices.create(
+        'archived_murs',
+        {
+            "mappings": MAPPINGS,
+            "settings": ANALYZER_SETTINGS,
+            "aliases": {'archived_murs_index': {}, 'docs_search': {}},
+        },
+    )
 
 
 def delete_all_indices():
@@ -514,20 +287,23 @@ def create_staging_index():
     try:
         logger.info("Delete index 'docs_staging'")
         es.indices.delete('docs_staging')
-    except:
+    except Exception:
         pass
 
     logger.info("Create index 'docs_staging'")
-    es.indices.create('docs_staging', {
-        "mappings": MAPPINGS,
-        "settings": ANALYZER_SETTINGS,
-    })
+    es.indices.create(
+        'docs_staging', {"mappings": MAPPINGS, "settings": ANALYZER_SETTINGS, }
+    )
 
     logger.info("Move alias 'docs_index' to point to 'docs_staging'")
-    es.indices.update_aliases(body={"actions": [
-        {"remove": {"index": 'docs', "alias": 'docs_index'}},
-        {"add": {"index": 'docs_staging', "alias": 'docs_index'}}
-    ]})
+    es.indices.update_aliases(
+        body={
+            "actions": [
+                {"remove": {"index": 'docs', "alias": 'docs_index'}},
+                {"add": {"index": 'docs_staging', "alias": 'docs_index'}},
+            ]
+        }
+    )
 
 
 def restore_from_staging_index():
@@ -542,28 +318,22 @@ def restore_from_staging_index():
     es = utils.get_elasticsearch_connection()
 
     logger.info("Move alias 'docs_search' to point to 'docs_staging'")
-    es.indices.update_aliases(body={"actions": [
-        {"remove": {"index": 'docs', "alias": 'docs_search'}},
-        {"add": {"index": 'docs_staging', "alias": 'docs_search'}}
-    ]})
+    es.indices.update_aliases(
+        body={
+            "actions": [
+                {"remove": {"index": 'docs', "alias": 'docs_search'}},
+                {"add": {"index": 'docs_staging', "alias": 'docs_search'}},
+            ]
+        }
+    )
 
     logger.info("Delete and re-create index 'docs'")
     es.indices.delete('docs')
-    es.indices.create('docs', {
-        "mappings": MAPPINGS,
-        "settings": ANALYZER_SETTINGS
-    })
+    es.indices.create('docs', {"mappings": MAPPINGS, "settings": ANALYZER_SETTINGS})
 
     logger.info("Reindex all documents from index 'docs_staging' to index 'docs'")
 
-    body = {
-      "source": {
-        "index": "docs_staging",
-      },
-      "dest": {
-        "index": "docs"
-      }
-    }
+    body = {"source": {"index": "docs_staging", }, "dest": {"index": "docs"}}
     es.reindex(body=body, wait_for_completion=True, request_timeout=1500)
 
     move_aliases_to_docs_index()
@@ -578,12 +348,16 @@ def move_aliases_to_docs_index():
     es = utils.get_elasticsearch_connection()
 
     logger.info("Move aliases 'docs_index' and 'docs_search' to point to 'docs'")
-    es.indices.update_aliases(body={"actions": [
-        {"remove": {"index": 'docs_staging', "alias": 'docs_index'}},
-        {"remove": {"index": 'docs_staging', "alias": 'docs_search'}},
-        {"add": {"index": 'docs', "alias": 'docs_index'}},
-        {"add": {"index": 'docs', "alias": 'docs_search'}}
-    ]})
+    es.indices.update_aliases(
+        body={
+            "actions": [
+                {"remove": {"index": 'docs_staging', "alias": 'docs_index'}},
+                {"remove": {"index": 'docs_staging', "alias": 'docs_search'}},
+                {"add": {"index": 'docs', "alias": 'docs_index'}},
+                {"add": {"index": 'docs', "alias": 'docs_search'}},
+            ]
+        }
+    )
     logger.info("Delete index 'docs_staging'")
     es.indices.delete('docs_staging')
 
@@ -598,19 +372,13 @@ def move_archived_murs():
     es = utils.get_elasticsearch_connection()
 
     body = {
-          "source": {
+        "source": {
             "index": "docs",
             "type": "murs",
-            "query": {
-              "match": {
-                "mur_type": "archived"
-              }
-            }
-          },
-          "dest": {
-            "index": "archived_murs"
-          }
-        }
+            "query": {"match": {"mur_type": "archived"}},
+        },
+        "dest": {"index": "archived_murs"},
+    }
 
     logger.info("Copy archived MURs from 'docs' index to 'archived_murs' index")
     es.reindex(body=body, wait_for_completion=True, request_timeout=1500)
@@ -649,9 +417,7 @@ def create_elasticsearch_backup(repository_name=None, snapshot_name="auto_backup
         datetime.datetime.today().strftime('%Y%m%d'), snapshot_name
     )
     logger.info("Creating snapshot {0}".format(snapshot_name))
-    result = es.snapshot.create(
-        repository=repository_name, snapshot=snapshot_name
-    )
+    result = es.snapshot.create(repository=repository_name, snapshot=snapshot_name)
     if result.get('accepted'):
         logger.info("Successfully created snapshot: {0}".format(snapshot_name))
     else:
@@ -675,7 +441,9 @@ def restore_elasticsearch_backup(repository_name=None, snapshot_name=None):
     snapshot_name = snapshot_name or most_recent_snapshot_name
 
     if es.indices.exists('docs'):
-        logger.info('Found docs index. Creating staging index for zero-downtime restore')
+        logger.info(
+            'Found docs index. Creating staging index for zero-downtime restore'
+        )
         create_staging_index()
 
     delete_all_indices()
@@ -707,8 +475,8 @@ def get_most_recent_snapshot(repository_name=None):
 
     repository_name = repository_name or BACKUP_REPOSITORY_NAME
     logger.info("Retreiving most recent snapshot")
-    snapshot_list = es.snapshot.get(
-        repository=repository_name, snapshot="*"
-    ).get('snapshots')
+    snapshot_list = es.snapshot.get(repository=repository_name, snapshot="*").get(
+        'snapshots'
+    )
 
     return snapshot_list.pop().get('snapshot')

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -19,23 +19,29 @@ from webservices.tasks.utils import get_bucket
 
 from . import reclassify_statutory_citation
 
-# sigh. This is a mess because slate uses a library also called utils.
+# This is a mess because slate uses a library also called utils.
 import importlib
+
 importlib.invalidate_caches()
-import sys
-from distutils.sysconfig import get_python_lib
+import sys  # noqa
+from distutils.sysconfig import get_python_lib  # noqa
+
 sys.path = [get_python_lib() + '/slate'] + sys.path
-import slate
+import slate  # noqa
+
 sys.path = sys.path[1:]
 
 logger = logging.getLogger('manager')
+
 
 def get_sections(reg):
     sections = {}
     for subpart in reg['children']:
         for node in subpart['children']:
-            sections[tuple(node['label'])] = {'text': get_text(node),
-                                              'title': node['title']}
+            sections[tuple(node['label'])] = {
+                'text': get_text(node),
+                'title': node['title'],
+            }
     return sections
 
 
@@ -55,7 +61,9 @@ def index_regulations():
     """
     eregs_api = env.get_credential('FEC_EREGS_API', '')
     if not eregs_api:
-        logger.error("Regs could not be indexed, environment variable FEC_EREGS_API not set.")
+        logger.error(
+            "Regs could not be indexed, environment variable FEC_EREGS_API not set."
+        )
         return
 
     logger.info("Indexing regulations")
@@ -63,8 +71,7 @@ def index_regulations():
     es = utils.get_elasticsearch_connection()
     reg_count = 0
     for reg in reg_versions:
-        url = '%sregulation/%s/%s' % (eregs_api, reg['regulation'],
-                                        reg['version'])
+        url = '%sregulation/%s/%s' % (eregs_api, reg['regulation'], reg['version'])
         regulation = requests.get(url).json()
         sections = get_sections(regulation)
 
@@ -72,8 +79,9 @@ def index_regulations():
         for section_label in sections:
             doc_id = '%s_%s' % (section_label[0], section_label[1])
             section_formatted = '%s-%s' % (section_label[0], section_label[1])
-            reg_url = '/regulations/{0}/{1}#{0}'.format(section_formatted,
-                                                        reg['version'])
+            reg_url = '/regulations/{0}/{1}#{0}'.format(
+                section_formatted, reg['version']
+            )
             no = '%s.%s' % (section_label[0], section_label[1])
             name = sections[section_label]['title'].split(no)[1].strip()
             doc = {
@@ -83,23 +91,28 @@ def index_regulations():
                 "url": reg_url,
                 "no": no,
                 "sort1": int(section_label[0]),
-                "sort2": int(section_label[1])
+                "sort2": int(section_label[1]),
             }
 
             es.index('docs_index', 'regulations', doc, id=doc['doc_id'])
         reg_count += 1
     logger.info("%d regulation parts indexed", reg_count)
 
+
 def get_ao_citations():
     logger.info("getting citations...")
-    ao_names_results = db.engine.execute("""SELECT ao_no, name FROM aouser.document
-                                  INNER JOIN aouser.ao ON ao.ao_id = document.ao_id""")
+    ao_names_results = db.engine.execute(
+        """SELECT ao_no, name FROM aouser.document
+                                  INNER JOIN aouser.ao ON ao.ao_id = document.ao_id"""
+    )
     ao_names = {}
     for row in ao_names_results:
         ao_names[row['ao_no']] = row['name']
 
-    text = db.engine.execute("""SELECT ao_no, category, ocrtext FROM aouser.document
-                                INNER JOIN aouser.ao ON ao.ao_id = document.ao_id""")
+    text = db.engine.execute(
+        """SELECT ao_no, category, ocrtext FROM aouser.document
+                                INNER JOIN aouser.ao ON ao.ao_id = document.ao_id"""
+    )
     citations = {}
     cited_by = {}
     for row in text:
@@ -112,8 +125,13 @@ def get_ao_citations():
             if citation_txt != row['ao_no'] and citation_txt in ao_names:
                 citations_in_doc.add(citation_txt)
 
-        citations[(row['ao_no'], row['category'])] = sorted([{'no': citation, 'name': ao_names[citation]}
-         for citation in citations_in_doc], key=lambda d: d['no'])
+        citations[(row['ao_no'], row['category'])] = sorted(
+            [
+                {'no': citation, 'name': ao_names[citation]}
+                for citation in citations_in_doc
+            ],
+            key=lambda d: d['no'],
+        )
 
         if row['category'] == 'Final Opinion':
             for citation in citations_in_doc:
@@ -123,11 +141,14 @@ def get_ao_citations():
                     cited_by[citation].add(row['ao_no'])
 
     for citation, cited_by_set in cited_by.items():
-        cited_by_with_name = sorted([{'no': c, 'name': ao_names[c]}
-            for c in cited_by_set], key=lambda d: d['no'])
+        cited_by_with_name = sorted(
+            [{'no': c, 'name': ao_names[c]} for c in cited_by_set],
+            key=lambda d: d['no'],
+        )
         cited_by[citation] = cited_by_with_name
 
     return citations, cited_by
+
 
 def get_xml_tree_from_url(url):
     r = requests.get(url, stream=True)
@@ -138,24 +159,30 @@ def get_xml_tree_from_url(url):
         f.seek(0)
         zip_file = ZipFile(f.name)
 
-        with zip_file.open(zip_file.namelist()[0]) as title,\
-         NamedTemporaryFile('wb+') as title_xml:
+        with zip_file.open(zip_file.namelist()[0]) as title, NamedTemporaryFile(
+            'wb+'
+        ) as title_xml:
             title_xml.write(title.read())
             title_xml.seek(0)
             return ET.parse(title_xml.name)
 
+
 def get_title_52_statutes():
     es = utils.get_elasticsearch_connection()
 
-    title_parsed = get_xml_tree_from_url('http://uscode.house.gov/download/' +
-                    'releasepoints/us/pl/114/219/xml_usc52@114-219.zip')
+    title_parsed = get_xml_tree_from_url(
+        'http://uscode.house.gov/download/ \
+        releasepoints/us/pl/114/219/xml_usc52@114-219.zip'
+    )
     tag_name = '{{http://xml.house.gov/schemas/uslm/1.0}}{0}'
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format('subtitle')):
         if subtitle.attrib['identifier'] == '/us/usc/t52/stIII':
             for subchapter in subtitle.iter(tag_name.format('subchapter')):
-                match = re.match("/us/usc/t52/stIII/ch([0-9]+)/sch([IVX]+)",
-                                    subchapter.attrib['identifier'])
+                match = re.match(
+                    "/us/usc/t52/stIII/ch([0-9]+)/sch([IVX]+)",
+                    subchapter.attrib['identifier'],
+                )
                 chapter = match.group(1)
                 subchapter_no = match.group(2)
                 for section in subchapter.iter(tag_name.format('section')):
@@ -164,10 +191,10 @@ def get_title_52_statutes():
                         if child.text:
                             text += ' %s ' % child.text.strip()
                     heading = section.find(tag_name.format('heading')).text.strip()
-                    section_no = re.match('/us/usc/t52/s([0-9]+)',
-                             section.attrib['identifier']).group(1)
-                    pdf_url = 'https://www.govinfo.gov/link/uscode/52/%s'\
-                              % section_no
+                    section_no = re.match(
+                        '/us/usc/t52/s([0-9]+)', section.attrib['identifier']
+                    ).group(1)
+                    pdf_url = 'https://www.govinfo.gov/link/uscode/52/%s' % section_no
                     doc = {
                         "doc_id": section.attrib['identifier'],
                         "text": text,
@@ -178,24 +205,28 @@ def get_title_52_statutes():
                         "subchapter": subchapter_no,
                         "url": pdf_url,
                         "sort1": 52,
-                        "sort2": int(section_no)
+                        "sort2": int(section_no),
                     }
                     es.index('docs_index', 'statutes', doc, id=doc['doc_id'])
                     section_count += 1
     return section_count
 
+
 def get_title_26_statutes():
     es = utils.get_elasticsearch_connection()
 
-    title_parsed = get_xml_tree_from_url('http://uscode.house.gov/download/' +
-                    'releasepoints/us/pl/114/219/xml_usc26@114-219.zip')
+    title_parsed = get_xml_tree_from_url(
+        'http://uscode.house.gov/download/\
+        releasepoints/us/pl/114/219/xml_usc26@114-219.zip'
+    )
     tag_name = '{{http://xml.house.gov/schemas/uslm/1.0}}{0}'
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format('subtitle')):
         if subtitle.attrib['identifier'] == '/us/usc/t26/stH':
             for chapter in subtitle.iter(tag_name.format('chapter')):
-                match = re.match("/us/usc/t26/stH/ch([0-9]+)",
-                                    chapter.attrib['identifier'])
+                match = re.match(
+                    "/us/usc/t26/stH/ch([0-9]+)", chapter.attrib['identifier']
+                )
                 chapter_no = match.group(1)
                 for section in chapter.iter(tag_name.format('section')):
                     text = ''
@@ -203,10 +234,10 @@ def get_title_26_statutes():
                         if child.text:
                             text += ' %s ' % child.text.strip()
                     heading = section.find(tag_name.format('heading')).text.strip()
-                    section_no = re.match('/us/usc/t26/s([0-9]+)',
-                             section.attrib['identifier']).group(1)
-                    pdf_url = 'https://www.govinfo.gov/link/uscode/26/%s'\
-                              % section_no
+                    section_no = re.match(
+                        '/us/usc/t26/s([0-9]+)', section.attrib['identifier']
+                    ).group(1)
+                    pdf_url = 'https://www.govinfo.gov/link/uscode/26/%s' % section_no
                     doc = {
                         "doc_id": section.attrib['identifier'],
                         "text": text,
@@ -216,7 +247,7 @@ def get_title_26_statutes():
                         "chapter": chapter_no,
                         "url": pdf_url,
                         "sort1": 26,
-                        "sort2": int(section_no)
+                        "sort2": int(section_no),
                     }
                     es.index('docs_index', 'statutes', doc, id=doc['doc_id'])
                     section_count += 1
@@ -231,13 +262,16 @@ def index_statutes():
     logger.info("Indexing statutes")
     title_26_section_count = get_title_26_statutes()
     title_52_section_count = get_title_52_statutes()
-    logger.info("%d statute sections indexed", title_26_section_count + title_52_section_count)
+    logger.info(
+        "%d statute sections indexed", title_26_section_count + title_52_section_count
+    )
 
 
 def process_mur_pdf(file_name, pdf_key, bucket):
     """Get Archived MUR PDFs from classic site, OCR them, and upload them to S3."""
-    response = requests.get('http://classic.fec.gov/disclosure_data/mur/%s.pdf'
-                            % file_name, stream=True)
+    response = requests.get(
+        'http://classic.fec.gov/disclosure_data/mur/%s.pdf' % file_name, stream=True
+    )
 
     with NamedTemporaryFile('wb+') as pdf:
         for chunk in response:
@@ -246,7 +280,7 @@ def process_mur_pdf(file_name, pdf_key, bucket):
         pdf.seek(0)
         try:
             pdf_doc = slate.PDF(pdf)
-        except:
+        except Exception:
             logger.error('Could not parse pdf: %s' % pdf_key)
             pdf_doc = []
         pdf_pages = len(pdf_doc)
@@ -254,9 +288,11 @@ def process_mur_pdf(file_name, pdf_key, bucket):
         pdf_size = getsize(pdf.name)
 
         pdf.seek(0)
-        bucket.put_object(Key=pdf_key, Body=pdf,
-                          ContentType='application/pdf', ACL='public-read')
+        bucket.put_object(
+            Key=pdf_key, Body=pdf, ContentType='application/pdf', ACL='public-read'
+        )
         return pdf_text, pdf_size, pdf_pages
+
 
 def get_subject_tree(html, tree=None):
     """This is a standard shift-reduce parser for extracting the tree of subject
@@ -271,9 +307,9 @@ def get_subject_tree(html, tree=None):
     # get next token
     root = re.match("([^<]+)(?:<br>)?(.*)", html, re.S)
     list_item = re.match("<li>(.*?)</li>(.*)", html, re.S)
-    unordered_list = re.match("<ul\s+class='no-top-margin'>(.*)", html, re.S)
+    unordered_list = re.match("<ul\s+class='no-top-margin'>(.*)", html, re.S)  # noqa
     end_list = re.match("</ul>(.*)", html, re.S)
-    empty = re.match("\s*<br>\s*", html)
+    empty = re.match("\s*<br>\s*", html)  # noqa
 
     if empty:
         pass
@@ -295,8 +331,12 @@ def get_subject_tree(html, tree=None):
         tree.append('ul_start')
     elif list_item or root:
         # shift
-        subject = re.sub('\s+', ' ', (list_item or root).group(1))\
-                    .strip().lower().capitalize()
+        subject = (
+            re.sub('\s+', ' ', (list_item or root).group(1))
+            .strip()
+            .lower()
+            .capitalize()
+        )  # noqa
         tree.append({'text': subject})
     else:
         print(html)
@@ -306,36 +346,53 @@ def get_subject_tree(html, tree=None):
         tree.append({'text': subject})
 
     if not empty:
-        tail = (root or list_item or unordered_list or end_list)
+        tail = root or list_item or unordered_list or end_list
         if tail:
             html = tail.groups()[-1].strip()
             if html:
                 get_subject_tree(html, tree)
     return tree
 
+
 def get_citations(citation_texts):
     us_codes = []
     regulations = []
 
     for citation_text in citation_texts:
-        us_code_match = re.match("(?P<title>[0-9]+) U\.S\.C\. (?P<section>[0-9a-z-]+)(?P<paragraphs>.*)", citation_text)
+        us_code_match = re.match(
+            "(?P<title>[0-9]+) U\.S\.C\. (?P<section>[0-9a-z-]+)(?P<paragraphs>.*)",
+            citation_text,
+        )  # noqa
         regulation_match = re.match(
-            "(?P<title>[0-9]+) C\.F\.R\. (?P<part>[0-9]+)(?:\.(?P<section>[0-9]+))?", citation_text)
+            "(?P<title>[0-9]+) C\.F\.R\. (?P<part>[0-9]+)(?:\.(?P<section>[0-9]+))?",
+            citation_text,
+        )  # noqa
 
         if us_code_match:
-            title, section = reclassify_statutory_citation.reclassify_statutory_citation(
-                us_code_match.group('title'), us_code_match.group('section'))
-            citation_text = '%s U.S.C. %s%s' % (title, section, us_code_match.group('paragraphs'))
+            (
+                title,
+                section,
+            ) = reclassify_statutory_citation.reclassify_statutory_citation(
+                us_code_match.group('title'), us_code_match.group('section')
+            )
+            citation_text = '%s U.S.C. %s%s' % (
+                title,
+                section,
+                us_code_match.group('paragraphs'),
+            )
             url = 'https://www.govinfo.gov/link/uscode/{0}/{1}'.format(title, section)
             us_codes.append({"text": citation_text, "url": url})
         elif regulation_match:
-            url = utils.create_eregs_link(regulation_match.group('part'), regulation_match.group('section'))
+            url = utils.create_eregs_link(
+                regulation_match.group('part'), regulation_match.group('section')
+            )
             regulations.append({"text": citation_text, "url": url})
 
         else:
             print(citation_text)
             raise Exception("Could not parse citation")
     return {"us_code": us_codes, "regulations": regulations}
+
 
 def delete_murs_from_s3():
     """
@@ -345,11 +402,13 @@ def delete_murs_from_s3():
     for obj in bucket.objects.filter(Prefix="legal/murs"):
         obj.delete()
 
+
 def delete_current_murs_from_es():
     """
     Deletes all current MURs from Elasticsearch
     """
     delete_from_es('docs_index', 'murs')
+
 
 def delete_advisory_opinions_from_es():
     """
@@ -357,12 +416,16 @@ def delete_advisory_opinions_from_es():
     """
     delete_from_es('docs_index', 'advisory_opinions')
 
+
 def delete_from_es(index, doc_type):
     """
     Deletes all documents with the given `doc_type` from Elasticsearch
     """
     es = utils.get_elasticsearch_connection()
-    es.delete_by_query(index=index, body={'query': {'match_all': {}}}, doc_type=doc_type)
+    es.delete_by_query(
+        index=index, body={'query': {'match_all': {}}}, doc_type=doc_type
+    )
+
 
 def get_mur_names(mur_names={}):
     # Cache the mur names
@@ -379,7 +442,9 @@ def get_mur_names(mur_names={}):
 def get_documents(td_text, bucket):
 
     documents = []
-    for index, file_name in enumerate(re.findall(r"/disclosure_data/mur/([0-9_A-Z]+)\.pdf", td_text)):
+    for index, file_name in enumerate(
+        re.findall(r"/disclosure_data/mur/([0-9_A-Z]+)\.pdf", td_text)
+    ):
         logger.info("Loading file %s.pdf", file_name)
         pdf_key = 'legal/murs/%s.pdf' % file_name
         pdf_text, pdf_size, pdf_pages = process_mur_pdf(file_name, pdf_key, bucket)
@@ -394,17 +459,35 @@ def get_documents(td_text, bucket):
 
     return documents
 
+
 def process_murs(raw_mur_tr_element_list):
     es = utils.get_elasticsearch_connection()
     bucket = get_bucket()
     mur_names = get_mur_names()
 
     for index, raw_mur_tr_element in enumerate(raw_mur_tr_element_list):
-        (mur_no_td, open_date_td, close_date_td, parties_td, subject_td, citations_td)\
-            = re.findall("<td[^>]*>(.*?)</td>", raw_mur_tr_element, re.S)
-        mur_no = re.search("/disclosure_data/mur/([0-9]+)(?:_[A-H])*\.pdf", mur_no_td).group(1)
+        (
+            mur_no_td,
+            open_date_td,
+            close_date_td,
+            parties_td,
+            subject_td,
+            citations_td,
+        ) = re.findall(
+            "<td[^>]*>(.*?)</td>", raw_mur_tr_element, re.S
+        )  # noqa
+        mur_no = re.search(
+            "/disclosure_data/mur/([0-9]+)(?:_[A-H])*\.pdf", mur_no_td
+        ).group(
+            1
+        )  # noqa
 
-        logger.info("Loading archived MUR %s: %s of %s", mur_no, index + 1, len(raw_mur_tr_element_list))
+        logger.info(
+            "Loading archived MUR %s: %s of %s",
+            mur_no,
+            index + 1,
+            len(raw_mur_tr_element_list),
+        )
 
         open_date, close_date = (None, None)
         if open_date_td:
@@ -416,7 +499,7 @@ def process_murs(raw_mur_tr_element_list):
         complainants = []
         respondents = []
         for party in parties:
-            match = re.match("\(([RC])\) - (.*)", party)
+            match = re.match("\(([RC])\) - (.*)", party)  # noqa
             name = match.group(2).strip().title()
             if match.group(1) == 'C':
                 complainants.append(name)
@@ -433,7 +516,7 @@ def process_murs(raw_mur_tr_element_list):
             'close_date': close_date,
             'complainants': complainants,
             'respondents': respondents,
-            'url': '/legal/matter-under-review/{0}/'.format(mur_no)
+            'url': '/legal/matter-under-review/{0}/'.format(mur_no),
         }
         mur['subject'] = get_subject_tree(subject_td)
         mur['citations'] = get_citations(re.findall("(.*?)<br>", citations_td))
@@ -442,7 +525,9 @@ def process_murs(raw_mur_tr_element_list):
         es.index('archived_murs_index', 'murs', mur, id=mur['doc_id'])
 
 
-def load_archived_murs(from_mur_no=None, specific_mur_no=None, num_processes=1, tasks_per_child=None):
+def load_archived_murs(
+    from_mur_no=None, specific_mur_no=None, num_processes=1, tasks_per_child=None
+):
     """
     Reads data for archived MURs from http://classic.fec.gov/MUR/, assembles a JSON
     document corresponding to the MUR and indexes this document in Elasticsearch
@@ -453,10 +538,24 @@ def load_archived_murs(from_mur_no=None, specific_mur_no=None, num_processes=1, 
     table_text = requests.get('http://classic.fec.gov/MUR/MURData.do').text
     raw_mur_tr_element_list = re.findall("<tr [^>]*>(.*?)</tr>", table_text, re.S)[1:]
     if from_mur_no is not None:
-        raw_mur_tr_element_list = list(itertools.dropwhile(
-            lambda x: re.search('/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M).group(1) != from_mur_no, raw_mur_tr_element_list))
+        raw_mur_tr_element_list = list(
+            itertools.dropwhile(
+                lambda x: re.search(
+                    '/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
+                ).group(1)
+                != from_mur_no,
+                raw_mur_tr_element_list,
+            )
+        )  # noqa
     elif specific_mur_no is not None:
-        raw_mur_tr_element_list = list(filter(
-            lambda x: re.search('/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M).group(1) == specific_mur_no, raw_mur_tr_element_list))
+        raw_mur_tr_element_list = list(
+            filter(
+                lambda x: re.search(
+                    '/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
+                ).group(1)
+                == specific_mur_no,
+                raw_mur_tr_element_list,
+            )
+        )  # noqa
     process_murs(raw_mur_tr_element_list)
     logger.info("%d archived MURs loaded", len(raw_mur_tr_element_list))

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -56,8 +56,8 @@ def get_text(node):
 
 def index_regulations():
     """
-        Indexes the regulations relevant to the FEC in Elasticsearch.
-        The regulations are accessed from FEC_EREGS_API.
+    Indexes the regulations relevant to the FEC in Elasticsearch.
+    The regulations are accessed from FEC_EREGS_API.
     """
     eregs_api = env.get_credential('FEC_EREGS_API', '')
     if not eregs_api:
@@ -307,9 +307,9 @@ def get_subject_tree(html, tree=None):
     # get next token
     root = re.match("([^<]+)(?:<br>)?(.*)", html, re.S)
     list_item = re.match("<li>(.*?)</li>(.*)", html, re.S)
-    unordered_list = re.match("<ul\s+class='no-top-margin'>(.*)", html, re.S)  # noqa
+    unordered_list = re.match(r"<ul\s+class='no-top-margin'>(.*)", html, re.S)
     end_list = re.match("</ul>(.*)", html, re.S)
-    empty = re.match("\s*<br>\s*", html)  # noqa
+    empty = re.match(r"\s*<br>\s*", html)
 
     if empty:
         pass
@@ -332,11 +332,11 @@ def get_subject_tree(html, tree=None):
     elif list_item or root:
         # shift
         subject = (
-            re.sub('\s+', ' ', (list_item or root).group(1))
+            re.sub(r'\s+', ' ', (list_item or root).group(1))
             .strip()
             .lower()
             .capitalize()
-        )  # noqa
+        )
         tree.append({'text': subject})
     else:
         print(html)
@@ -360,13 +360,13 @@ def get_citations(citation_texts):
 
     for citation_text in citation_texts:
         us_code_match = re.match(
-            "(?P<title>[0-9]+) U\.S\.C\. (?P<section>[0-9a-z-]+)(?P<paragraphs>.*)",
+            r"(?P<title>[0-9]+) U\.S\.C\. (?P<section>[0-9a-z-]+)(?P<paragraphs>.*)",
             citation_text,
-        )  # noqa
+        )
         regulation_match = re.match(
-            "(?P<title>[0-9]+) C\.F\.R\. (?P<part>[0-9]+)(?:\.(?P<section>[0-9]+))?",
+            r"(?P<title>[0-9]+) C\.F\.R\. (?P<part>[0-9]+)(?:\.(?P<section>[0-9]+))?",
             citation_text,
-        )  # noqa
+        )
 
         if us_code_match:
             (
@@ -475,12 +475,12 @@ def process_murs(raw_mur_tr_element_list):
             citations_td,
         ) = re.findall(
             "<td[^>]*>(.*?)</td>", raw_mur_tr_element, re.S
-        )  # noqa
+        )
         mur_no = re.search(
-            "/disclosure_data/mur/([0-9]+)(?:_[A-H])*\.pdf", mur_no_td
+            r"/disclosure_data/mur/([0-9]+)(?:_[A-H])*\.pdf", mur_no_td
         ).group(
             1
-        )  # noqa
+        )
 
         logger.info(
             "Loading archived MUR %s: %s of %s",
@@ -499,7 +499,7 @@ def process_murs(raw_mur_tr_element_list):
         complainants = []
         respondents = []
         for party in parties:
-            match = re.match("\(([RC])\) - (.*)", party)  # noqa
+            match = re.match(r"\(([RC])\) - (.*)", party)
             name = match.group(2).strip().title()
             if match.group(1) == 'C':
                 complainants.append(name)
@@ -541,21 +541,21 @@ def load_archived_murs(
         raw_mur_tr_element_list = list(
             itertools.dropwhile(
                 lambda x: re.search(
-                    '/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
+                    r'/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
                 ).group(1)
                 != from_mur_no,
                 raw_mur_tr_element_list,
             )
-        )  # noqa
+        )
     elif specific_mur_no is not None:
         raw_mur_tr_element_list = list(
             filter(
                 lambda x: re.search(
-                    '/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
+                    r'/disclosure_data/mur/([0-9]+)(?:_[A-Z])*\.pdf', x, re.M
                 ).group(1)
                 == specific_mur_no,
                 raw_mur_tr_element_list,
             )
-        )  # noqa
+        )
     process_murs(raw_mur_tr_element_list)
     logger.info("%d archived MURs loaded", len(raw_mur_tr_element_list))

--- a/webservices/legal_docs/load_legal_docs.py
+++ b/webservices/legal_docs/load_legal_docs.py
@@ -171,8 +171,8 @@ def get_title_52_statutes():
     es = utils.get_elasticsearch_connection()
 
     title_parsed = get_xml_tree_from_url(
-        'http://uscode.house.gov/download/ \
-        releasepoints/us/pl/114/219/xml_usc52@114-219.zip'
+        'http://uscode.house.gov/download/'
+        'releasepoints/us/pl/114/219/xml_usc52@114-219.zip'
     )
     tag_name = '{{http://xml.house.gov/schemas/uslm/1.0}}{0}'
     section_count = 0
@@ -216,8 +216,8 @@ def get_title_26_statutes():
     es = utils.get_elasticsearch_connection()
 
     title_parsed = get_xml_tree_from_url(
-        'http://uscode.house.gov/download/\
-        releasepoints/us/pl/114/219/xml_usc26@114-219.zip'
+        'http://uscode.house.gov/download/'
+        'releasepoints/us/pl/114/219/xml_usc26@114-219.zip'
     )
     tag_name = '{{http://xml.house.gov/schemas/uslm/1.0}}{0}'
     section_count = 0

--- a/webservices/legal_docs/reclassify_statutory_citation.py
+++ b/webservices/legal_docs/reclassify_statutory_citation.py
@@ -47,6 +47,7 @@ CITATIONS_MAP = {
 # The new section numbers are 5 digit numbers starting with 30. e.g., 30106
 RECLASSIFIED_STATUTE_SECTION_REGEX = re.compile(r'30\d{3,}')
 
+
 def reclassify_statutory_citation(title, section):
     """
     Archived MURs and Advisory Opinions indicate the titles explicitly.
@@ -58,11 +59,15 @@ def reclassify_statutory_citation(title, section):
     if title == "2":
         mapped_section = CITATIONS_MAP.get(section)
         if mapped_section:
-            logger.debug('Mapping 2 U.S.C statute citation %s -> %s',
-                        (title, section), (MAPPED_TITLE, mapped_section))
+            logger.debug(
+                'Mapping 2 U.S.C statute citation %s -> %s',
+                (title, section),
+                (MAPPED_TITLE, mapped_section),
+            )
             return MAPPED_TITLE, mapped_section
         logger.debug('Unmapped 2 U.S.C citation: %s', (title, section))
     return title, section
+
 
 def reclassify_statutory_citation_without_title(section):
     """
@@ -76,8 +81,11 @@ def reclassify_statutory_citation_without_title(section):
     MAPPED_TITLE = "52"
     mapped_section = CITATIONS_MAP.get(section)
     if mapped_section:
-        logger.debug('Mapping current MUR statute citation %s -> %s',
-                    section, (MAPPED_TITLE, mapped_section))
+        logger.debug(
+            'Mapping current MUR statute citation %s -> %s',
+            section,
+            (MAPPED_TITLE, mapped_section),
+        )
         return ORIGINAL_TITLE, MAPPED_TITLE, mapped_section
     elif RECLASSIFIED_STATUTE_SECTION_REGEX.match(section):
         return MAPPED_TITLE, MAPPED_TITLE, section

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -396,6 +396,7 @@ class ECAggregatesView(AggregateResource):
         ('committee_id', model.committee_id),
     ]
 
+
 def join_cand_cmte_names(query):
     query = query.subquery()
     return models.db.session.query(

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -8,7 +8,6 @@ from webservices import utils
 from webservices import filters
 from webservices import schemas
 from webservices import exceptions
-from webservices.common import counts
 from webservices.common import models
 from webservices.common.views import ApiResource
 

--- a/webservices/resources/audit.py
+++ b/webservices/resources/audit.py
@@ -171,12 +171,13 @@ class AuditCandidateNameSearch(utils.Resource):
         ).limit(20)
         return {'results': query.all()}
 
-# endpoint audit/search/name/committees
+
 @doc(
     tags=['audit'],
     description=docs.NAME_SEARCH,
 )
 class AuditCommitteeNameSearch(utils.Resource):
+    """endpoint audit/search/name/committees"""
 
     filter_fulltext_fields = [
         ('q', models.AuditCommitteeSearch.fulltxt),

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -12,11 +12,11 @@ from webservices.common.views import ApiResource
 from webservices.common import models
 from webservices.common.models import (
     CandidateCommitteeLink,
-    CandidateElection,
     ScheduleABySize,
     ScheduleAByState,
-    db
+    db,
 )
+
 
 def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
     """
@@ -32,20 +32,29 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
     Aggregated data are calculated per fec_cycle only, no odd year
 
     """
-    rows = db.session.query(
-        CandidateCommitteeLink.candidate_id.label('candidate_id'),
-        CandidateCommitteeLink.committee_id.label('committee_id'),
-        CandidateCommitteeLink.fec_election_year.label('fec_election_year'),
-        CandidateCommitteeLink.election_yr_to_be_included.label('election_yr_to_be_included'),
-    ).filter(
-        (
-            CandidateCommitteeLink.fec_election_year.in_(kwargs['cycle'])
-            if not kwargs.get('election_full')
-            else CandidateCommitteeLink.election_yr_to_be_included.in_(kwargs['cycle'])
-        ),
-        CandidateCommitteeLink.candidate_id.in_(kwargs['candidate_id']),
-        CandidateCommitteeLink.committee_designation.in_(['P', 'A']),
-    ).distinct().subquery()
+    rows = (
+        db.session.query(
+            CandidateCommitteeLink.candidate_id.label('candidate_id'),
+            CandidateCommitteeLink.committee_id.label('committee_id'),
+            CandidateCommitteeLink.fec_election_year.label('fec_election_year'),
+            CandidateCommitteeLink.election_yr_to_be_included.label(
+                'election_yr_to_be_included'
+            ),
+        )
+        .filter(
+            (
+                CandidateCommitteeLink.fec_election_year.in_(kwargs['cycle'])
+                if not kwargs.get('election_full')
+                else CandidateCommitteeLink.election_yr_to_be_included.in_(
+                    kwargs['cycle']
+                )
+            ),
+            CandidateCommitteeLink.candidate_id.in_(kwargs['candidate_id']),
+            CandidateCommitteeLink.committee_designation.in_(['P', 'A']),
+        )
+        .distinct()
+        .subquery()
+    )
 
     cycle_column = (
         rows.c.election_yr_to_be_included
@@ -53,29 +62,24 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
         else rows.c.fec_election_year
     ).label('cycle')
 
-    aggregates = db.session.query(
-        rows.c.candidate_id,
-        cycle_column,
-        *label_columns
-    ).join(
-        aggregate_model,
-        sa.and_(
-            rows.c.committee_id == aggregate_model.committee_id,
-            rows.c.fec_election_year == aggregate_model.cycle,
+    aggregates = (
+        db.session.query(rows.c.candidate_id, cycle_column, *label_columns)
+        .join(
+            aggregate_model,
+            sa.and_(
+                rows.c.committee_id == aggregate_model.committee_id,
+                rows.c.fec_election_year == aggregate_model.cycle,
+            ),
         )
-    ).group_by(
-        rows.c.candidate_id,
-        cycle_column,
-        *group_columns
+        .group_by(rows.c.candidate_id, cycle_column, *group_columns)
     )
     return rows, aggregates
 
+
 @doc(
-    tags=['receipts'],
-    description=docs.SCHEDULE_A_SIZE_CANDIDATE_TAG,
+    tags=['receipts'], description=docs.SCHEDULE_A_SIZE_CANDIDATE_TAG,
 )
 class ScheduleABySizeCandidateView(utils.Resource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.make_sort_args())
     @use_kwargs(args.schedule_a_candidate_aggregate)
@@ -88,15 +92,16 @@ class ScheduleABySizeCandidateView(utils.Resource):
         ]
         group_columns = [ScheduleABySize.size]
 
-        _, query = candidate_aggregate(ScheduleABySize, label_columns, group_columns, kwargs)
+        _, query = candidate_aggregate(
+            ScheduleABySize, label_columns, group_columns, kwargs
+        )
         return utils.fetch_page(query, kwargs, cap=None)
 
+
 @doc(
-    tags=['receipts'],
-    description=docs.SCHEDULE_A_STATE_CANDIDATE_TOTAL_TAG,
+    tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TOTAL_TAG,
 )
 class ScheduleAByStateCandidateTotalsView(utils.Resource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.make_sort_args())
     @use_kwargs(args.schedule_a_candidate_aggregate)
@@ -110,9 +115,7 @@ class ScheduleAByStateCandidateTotalsView(utils.Resource):
                 sa.func.max(ScheduleAByState.state_full).label('state_full'),
                 ScheduleAByState.count,
             ],
-            [
-                ScheduleAByState.state, ScheduleAByState.count
-            ],
+            [ScheduleAByState.state, ScheduleAByState.count],
             kwargs,
         )
         q = query.subquery()
@@ -120,17 +123,16 @@ class ScheduleAByStateCandidateTotalsView(utils.Resource):
             sa.func.sum(q.c.total).label('total'),
             sa.func.sum(q.c.count).label('count'),
             q.c.candidate_id.label('candidate_id'),
-            q.c.cycle
+            q.c.cycle,
         ).group_by(q.c.candidate_id, q.c.cycle)
 
         return utils.fetch_page(query, kwargs, cap=0)
 
+
 @doc(
-    tags=['receipts'],
-    description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
+    tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
 )
 class ScheduleAByStateCandidateView(utils.Resource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.make_sort_args())
     @use_kwargs(args.schedule_a_candidate_aggregate)
@@ -149,9 +151,9 @@ class ScheduleAByStateCandidateView(utils.Resource):
         )
         return utils.fetch_page(query, kwargs, cap=0)
 
+
 @doc(
-    tags=['candidate'],
-    description=docs.TOTAL_CANDIDATE_TAG,
+    tags=['candidate'], description=docs.TOTAL_CANDIDATE_TAG,
 )
 class TotalsCandidateView(ApiResource):
 
@@ -160,11 +162,7 @@ class TotalsCandidateView(ApiResource):
 
     @property
     def args(self):
-        return utils.extend(
-            args.paging,
-            args.candidate_totals,
-            args.make_sort_args(),
-        )
+        return utils.extend(args.paging, args.candidate_totals, args.make_sort_args(),)
 
     def filter_multi_fields(self, history, total):
         return [
@@ -181,8 +179,14 @@ class TotalsCandidateView(ApiResource):
         return [
             (('min_receipts', 'max_receipts'), model.receipts),
             (('min_disbursements', 'max_disbursements'), model.disbursements),
-            (('min_cash_on_hand_end_period', 'max_cash_on_hand_end_period'), model.cash_on_hand_end_period),
-            (('min_debts_owed_by_committee', 'max_debts_owed_by_committee'), model.debts_owed_by_committee),
+            (
+                ('min_cash_on_hand_end_period', 'max_cash_on_hand_end_period'),
+                model.cash_on_hand_end_period,
+            ),
+            (
+                ('min_debts_owed_by_committee', 'max_debts_owed_by_committee'),
+                model.debts_owed_by_committee,
+            ),
         ]
 
     filter_fulltext_fields = [('q', models.CandidateSearch.fulltxt)]
@@ -195,18 +199,18 @@ class TotalsCandidateView(ApiResource):
 
     def build_query(self, **kwargs):
         history = models.CandidateHistoryWithFuture
-        query = db.session.query(
-            history.__table__,
-            models.CandidateTotal.__table__
-        ).join(
-            models.CandidateTotal,
-            sa.and_(
-                history.candidate_id == models.CandidateTotal.candidate_id,
-                history.two_year_period == models.CandidateTotal.cycle,
+        query = (
+            db.session.query(history.__table__, models.CandidateTotal.__table__)
+            .join(
+                models.CandidateTotal,
+                sa.and_(
+                    history.candidate_id == models.CandidateTotal.candidate_id,
+                    history.two_year_period == models.CandidateTotal.cycle,
+                ),
             )
-        ).join(
-            models.Candidate,
-            history.candidate_id == models.Candidate.candidate_id,
+            .join(
+                models.Candidate, history.candidate_id == models.Candidate.candidate_id,
+            )
         )
         if kwargs.get('q'):
             query = query.join(
@@ -214,26 +218,30 @@ class TotalsCandidateView(ApiResource):
                 history.candidate_id == models.CandidateSearch.id,
             )
 
-        if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):   # load active candidates only if True
-            query = query.filter(
-                history.candidate_inactive == False # noqa
-            )
-        elif 'is_active_candidate' in kwargs and not kwargs.get('is_active_candidate'):     # load inactive candidates only if False
-            query = query.filter(
-                history.candidate_inactive == True  # noqa
-            )
+        if 'is_active_candidate' in kwargs and kwargs.get(
+            'is_active_candidate'
+        ):  # load active candidates only if True
+            query = query.filter(history.candidate_inactive == False)  # noqa
+        elif 'is_active_candidate' in kwargs and not kwargs.get(
+            'is_active_candidate'
+        ):  # load inactive candidates only if False
+            query = query.filter(history.candidate_inactive == True)  # noqa
         else:  # load all candidates
             pass
 
-        query = filters.filter_multi(query, kwargs, self.filter_multi_fields(history, models.CandidateTotal))
-        query = filters.filter_range(query, kwargs, self.filter_range_fields(models.CandidateTotal))
+        query = filters.filter_multi(
+            query, kwargs, self.filter_multi_fields(history, models.CandidateTotal)
+        )
+        query = filters.filter_range(
+            query, kwargs, self.filter_range_fields(models.CandidateTotal)
+        )
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = filters.filter_match(query, kwargs, self.filter_match_fields)
         return query
 
+
 @doc(
-    tags=['candidate'],
-    description=docs.TOTAL_BY_OFFICE_TAG,
+    tags=['candidate'], description=docs.TOTAL_BY_OFFICE_TAG,
 )
 class AggregateByOfficeView(ApiResource):
 
@@ -242,29 +250,27 @@ class AggregateByOfficeView(ApiResource):
 
     @property
     def args(self):
-        return utils.extend(
-            args.paging,
-            args.totals_by_office,
-            args.make_sort_args(),
-        )
+        return utils.extend(args.paging, args.totals_by_office, args.make_sort_args(),)
 
     def build_query(self, **kwargs):
         history = models.CandidateHistoryWithFuture
         total = models.CandidateTotal
         # check to see if candidate is marked as inactive in history
-        check_cand_status = db.session.query(
-            history
-        ).filter(
-            history.candidate_id == total.candidate_id,
-            history.candidate_election_year == total.election_year,
-            history.candidate_inactive.is_(True)
-        ).exists()
+        check_cand_status = (
+            db.session.query(history)
+            .filter(
+                history.candidate_id == total.candidate_id,
+                history.candidate_election_year == total.election_year,
+                history.candidate_inactive.is_(True),
+            )
+            .exists()
+        )
 
         query = db.session.query(
             sa.func.substr(total.candidate_id, 1, 1).label('office'),
             total.election_year.label('election_year'),
             sa.func.sum(total.receipts).label('total_receipts'),
-            sa.func.sum(total.disbursements).label('total_disbursements')
+            sa.func.sum(total.disbursements).label('total_disbursements'),
         ).filter(
             total.is_election == True  # noqa
         )
@@ -274,23 +280,23 @@ class AggregateByOfficeView(ApiResource):
                 sa.func.substr(total.candidate_id, 1, 1) == kwargs['office']
             )
         if kwargs.get('election_year'):
-            query = query.filter(
-                total.election_year.in_(kwargs['election_year'])
-            )
+            query = query.filter(total.election_year.in_(kwargs['election_year']))
 
         if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):
             query = query.filter(~check_cand_status)
         elif 'is_active_candidate' in kwargs and not kwargs.get('is_active_candidate'):
             query = query.filter(check_cand_status)
-        else:   # load all candidates
+        else:  # load all candidates
             pass
 
-        query = query.group_by(sa.func.substr(total.candidate_id, 1, 1), total.election_year)
+        query = query.group_by(
+            sa.func.substr(total.candidate_id, 1, 1), total.election_year
+        )
         return query
 
+
 @doc(
-    tags=['candidate'],
-    description=docs.TOTAL_BY_OFFICE_BY_PARTY_TAG,
+    tags=['candidate'], description=docs.TOTAL_BY_OFFICE_BY_PARTY_TAG,
 )
 class AggregateByOfficeByPartyView(ApiResource):
 
@@ -300,9 +306,7 @@ class AggregateByOfficeByPartyView(ApiResource):
     @property
     def args(self):
         return utils.extend(
-            args.paging,
-            args.totals_by_office_by_party,
-            args.make_sort_args(),
+            args.paging, args.totals_by_office_by_party, args.make_sort_args(),
         )
 
     def build_query(self, **kwargs):
@@ -310,47 +314,45 @@ class AggregateByOfficeByPartyView(ApiResource):
 
         query = db.session.query(
             total.office.label('office'),
-            #total.party.label('party'),
+            # total.party.label('party'),
             sa.case(
                 [
-                (total.party=='DFL','DEM'),
-                (total.party=='DEM','DEM'),
-                (total.party=='REP','REP'),
-                ], else_='Other'
-                ).label('party'),
+                    (total.party == 'DFL', 'DEM'),
+                    (total.party == 'DEM', 'DEM'),
+                    (total.party == 'REP', 'REP'),
+                ],
+                else_='Other',
+            ).label('party'),
             total.election_year.label('election_year'),
             sa.func.sum(total.receipts).label('total_receipts'),
-            sa.func.sum(total.disbursements).label('total_disbursements')
+            sa.func.sum(total.disbursements).label('total_disbursements'),
         ).filter(
             total.is_election == True  # noqa
         )
 
         if kwargs.get('office') and kwargs['office'] is not None:
-            query = query.filter(
-                total.office == kwargs['office']
-            )
+            query = query.filter(total.office == kwargs['office'])
         if kwargs.get('election_year'):
-            query = query.filter(
-                total.election_year.in_(kwargs['election_year'])
-            )
+            query = query.filter(total.election_year.in_(kwargs['election_year']))
 
         if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):
-            query = query.filter(
-                total.candidate_inactive == 'False'
-            )
+            query = query.filter(total.candidate_inactive == 'False')
         elif 'is_active_candidate' in kwargs and not kwargs.get('is_active_candidate'):
-            query = query.filter(
-                total.candidate_inactive == 'True'
-            )
-        else:   # load all candidates
+            query = query.filter(total.candidate_inactive == 'True')
+        else:  # load all candidates
             pass
 
-        query = query.group_by(total.office, sa.case(
-            [
-                (total.party == 'DFL', 'DEM'),
-                (total.party == 'DEM', 'DEM'),
-                (total.party == 'REP', 'REP'),
-            ], else_='Other'
-        ), total.election_year)
+        query = query.group_by(
+            total.office,
+            sa.case(
+                [
+                    (total.party == 'DFL', 'DEM'),
+                    (total.party == 'DEM', 'DEM'),
+                    (total.party == 'REP', 'REP'),
+                ],
+                else_='Other',
+            ),
+            total.election_year,
+        )
 
         return query

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -4,11 +4,9 @@ from flask_apispec import doc
 from webservices import args
 from webservices import docs
 from webservices import utils
-from webservices import filters
 from webservices import schemas
 from webservices import exceptions
 from webservices.common import models
-from webservices.common.models import db
 from webservices.common.views import ApiResource
 
 

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -193,7 +193,7 @@ class CommitteeHistoryView(ApiResource):
         if candidate_id:
             # use for
             # '/candidate/<candidate_id>/committees/history/',
-            #'/candidate/<candidate_id>/committees/history/<int:cycle>/',
+            # '/candidate/<candidate_id>/committees/history/<int:cycle>/',
             query = query.join(
                 models.CandidateCommitteeLink,
                 sa.and_(

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -89,6 +89,7 @@ class CalendarDatesExport(CalendarDatesView):
             mimetype=mimetype,
         )
 
+
 @doc(
     tags=['dates'],
     description=docs.ELECTION_DATES,
@@ -127,6 +128,7 @@ class ElectionDatesView(ApiResource):
     def build_query(self, *args, **kwargs):
         query = super().build_query(*args, **kwargs)
         return query.filter_by(election_status_id=1)
+
 
 @doc(
     tags=['dates'],

--- a/webservices/resources/download.py
+++ b/webservices/resources/download.py
@@ -19,6 +19,7 @@ client = boto3.client('s3')
 MAX_RECORDS = 500000
 URL_EXPIRY = 7 * 24 * 60 * 60
 
+
 class DownloadView(utils.Resource):
 
     @use_kwargs_original({'filename': fields.Str(missing=None)})
@@ -44,6 +45,7 @@ class DownloadView(utils.Resource):
         )
         return {'status': 'queued'}
 
+
 def get_cached_file(path, qs, filename=None):
     key = download.get_s3_name(path, qs)
     obj = task_utils.get_object(key)
@@ -52,6 +54,7 @@ def get_cached_file(path, qs, filename=None):
         return get_download_url(obj, filename=filename)
     except ClientError:
         return None
+
 
 def get_download_url(obj, filename=None):
     params = {

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -12,10 +12,14 @@ from webservices.utils import use_kwargs
 from webservices.common import models
 from webservices.common.views import ApiResource
 from webservices.common.models import (
-    db, CandidateHistory, CandidateCommitteeLink,
-    CommitteeTotalsPresidential, CommitteeTotalsHouseSenate,
-    ElectionsList, ZipsDistricts, ScheduleEByCandidate,
-    StateElectionOfficeInfo, BaseConcreteCommittee,
+    db,
+    CandidateHistory,
+    CandidateCommitteeLink,
+    CommitteeTotalsHouseSenate,
+    ElectionsList,
+    ZipsDistricts,
+    ScheduleEByCandidate,
+    BaseConcreteCommittee,
     CommitteeTotalsCombined,
 )
 
@@ -44,10 +48,8 @@ def get_cycle_duration(kwargs):
         return election_durations.get(kwargs['office'], 2)
     return 2
 
-@doc(
-    description=docs.ELECTION_SEARCH,
-    tags=['financial']
-)
+
+@doc(description=docs.ELECTION_SEARCH, tags=['financial'])
 class ElectionsListView(utils.Resource):
 
     model = ElectionsList
@@ -60,7 +62,7 @@ class ElectionsListView(utils.Resource):
 
     @use_kwargs(args.paging)
     @use_kwargs(args.elections_list)
-    @use_kwargs(args.make_multi_sort_args(default=['sort_order', 'district',]))
+    @use_kwargs(args.make_multi_sort_args(default=['sort_order', 'district', ]))
     @marshal_with(schemas.ElectionsListPageSchema())
     def get(self, **kwargs):
         query = self._get_elections(kwargs)
@@ -93,10 +95,14 @@ class ElectionsListView(utils.Resource):
 
     def _filter_zip(self, query, kwargs):
         """Filter query by zip codes."""
-        districts = db.session.query(ZipsDistricts).filter(
-            cast(ZipsDistricts.zip_code, Integer).in_(kwargs['zip']),
-            ZipsDistricts.active == 'Y'
-        ).subquery()
+        districts = (
+            db.session.query(ZipsDistricts)
+            .filter(
+                cast(ZipsDistricts.zip_code, Integer).in_(kwargs['zip']),
+                ZipsDistricts.active == 'Y',
+            )
+            .subquery()
+        )
         return query.join(
             districts,
             sa.or_(
@@ -107,30 +113,24 @@ class ElectionsListView(utils.Resource):
                 ),
                 # Senate and presidential races from matching states
                 sa.and_(
-                    sa.or_(
-                        ElectionsList.district == '00'
-                    ),
-                    ElectionsList.state.in_([districts.c['state_abbrevation'], 'US'])
+                    sa.or_(ElectionsList.district == '00'),
+                    ElectionsList.state.in_([districts.c['state_abbrevation'], 'US']),
                 ),
-            )
+            ),
         )
 
 
-@doc(
-    description=docs.ELECTIONS,
-    tags=['financial']
-)
+@doc(description=docs.ELECTIONS, tags=['financial'])
 class ElectionView(ApiResource):
     schema = schemas.ElectionSchema
     page_schema = schemas.ElectionPageSchema
+
     @property
     def args(self):
         return utils.extend(
             args.paging,
             args.elections,
-            args.make_sort_args(
-                default='-total_receipts',
-            ),
+            args.make_sort_args(default='-total_receipts',),
         )
 
     def get(self, *args, **kwargs):
@@ -141,9 +141,15 @@ class ElectionView(ApiResource):
             multi = True
 
         return utils.fetch_page(
-            query, kwargs,
-            count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
-            index_column=self.index_column, cap=0, multi=multi,
+            query,
+            kwargs,
+            count=count,
+            model=self.model,
+            join_columns=self.join_columns,
+            aliases=self.aliases,
+            index_column=self.index_column,
+            cap=0,
+            multi=multi,
         )
 
     def build_query(self, **kwargs):
@@ -154,13 +160,16 @@ class ElectionView(ApiResource):
         aggregates = self._get_aggregates(pairs).subquery()
         candAggregates = self._get_candAggregates(aggregates).subquery()
 
-        final_query = db.session.query(
-            candAggregates,
-            BaseConcreteCommittee.name.label('candidate_pcc_name')
-        ).outerjoin(
-            BaseConcreteCommittee,
-            candAggregates.c.candidate_pcc_id == BaseConcreteCommittee.committee_id
-        ).distinct()
+        final_query = (
+            db.session.query(
+                candAggregates, BaseConcreteCommittee.name.label('candidate_pcc_name')
+            )
+            .outerjoin(
+                BaseConcreteCommittee,
+                candAggregates.c.candidate_pcc_id == BaseConcreteCommittee.committee_id,
+            )
+            .distinct()
+        )
         return final_query
 
     def _get_basicPairs(self, totals_model, kwargs):
@@ -172,35 +181,62 @@ class ElectionView(ApiResource):
             CandidateHistory.incumbent_challenge_full,
             CandidateHistory.office,
             CandidateHistory.two_year_period,
-            #CandidateHistory.candidate_election_year,
-            CandidateCommitteeLink.election_yr_to_be_included.label('candidate_election_year'),
+            # CandidateHistory.candidate_election_year,
+            CandidateCommitteeLink.election_yr_to_be_included.label(
+                'candidate_election_year'
+            ),
             CandidateCommitteeLink.committee_id.label('committee_id'),
             totals_model.receipts.label('receipts'),
             totals_model.disbursements.label('disbursements'),
-            totals_model.last_cash_on_hand_end_period.label('last_cash_on_hand_end_period'),
+            totals_model.last_cash_on_hand_end_period.label(
+                'last_cash_on_hand_end_period'
+            ),
             totals_model.coverage_end_date,
             sa.case(
-                [(CandidateCommitteeLink.committee_designation == 'P', CandidateCommitteeLink.committee_id)]  # noqa
-            ).label('candidate_pcc_id')
-        ).filter(
-            CandidateCommitteeLink.committee_designation.in_(['P', 'A'])
-        )
+                [
+                    (
+                        CandidateCommitteeLink.committee_designation == 'P',
+                        CandidateCommitteeLink.committee_id,
+                    )
+                ]  # noqa
+            ).label('candidate_pcc_id'),
+        ).filter(CandidateCommitteeLink.committee_designation.in_(['P', 'A']))
         basicPairs = join_candidate_totals(basicPairs, kwargs, totals_model)
         basicPairs = filter_candidate_totals(basicPairs, kwargs)
 
         return basicPairs
 
     def _get_pairs(self, basicPairs):
-        # get cash_on_hand_end_period info from the latest financial report
-        #   per candidate_id/candidate_election_year/cmte_id
-        # when newlest financial report not filed yet, the financial data columns will be null,
-        #   take the data from the previous filing for calculation.
-        # However, when the latest fincial report filed, but COH is null, the null (will be convert to 0 in final calculation) should be used.
+        """
+        get cash_on_hand_end_period info from the latest financial report
+        per candidate_id/candidate_election_year/cmte_id
+
+        When newlest financial report not filed yet, the financial data columns will be
+        null, take the data from the previous filing for calculation.
+
+        However, when the latest fincial report filed, but COH is null (the null will be
+        converted to 0 in final calculation) should be used.
+        """
 
         # Window params
         window_p = {
-        'partition_by': [basicPairs.c.candidate_id, basicPairs.c.candidate_election_year, basicPairs.c.committee_id],
-        'order_by': [sa.case([(basicPairs.c.coverage_end_date.isnot(None), basicPairs.c.two_year_period)]).desc().nullslast()]
+            'partition_by': [
+                basicPairs.c.candidate_id,
+                basicPairs.c.candidate_election_year,
+                basicPairs.c.committee_id,
+            ],
+            'order_by': [
+                sa.case(
+                    [
+                        (
+                            basicPairs.c.coverage_end_date.isnot(None),
+                            basicPairs.c.two_year_period,
+                        )
+                    ]
+                )
+                .desc()
+                .nullslast()
+            ],
         }
 
         pairs = db.session.query(
@@ -214,9 +250,13 @@ class ElectionView(ApiResource):
             basicPairs.c.committee_id,
             basicPairs.c.receipts.label('receipts'),
             basicPairs.c.disbursements.label('disbursements'),
-            sa.func.first_value(basicPairs.c.last_cash_on_hand_end_period).over(**window_p).label('last_cash_on_hand_end_period'),
-            sa.func.first_value(basicPairs.c.coverage_end_date).over(**window_p).label('coverage_end_date'),
-            basicPairs.c.candidate_pcc_id
+            sa.func.first_value(basicPairs.c.last_cash_on_hand_end_period)
+            .over(**window_p)
+            .label('last_cash_on_hand_end_period'),
+            sa.func.first_value(basicPairs.c.coverage_end_date)
+            .over(**window_p)
+            .label('coverage_end_date'),
+            basicPairs.c.candidate_pcc_id,
         )
         return pairs
 
@@ -228,17 +268,21 @@ class ElectionView(ApiResource):
             pairs.c.committee_id,
             sa.func.max(pairs.c.name).label('candidate_name'),
             sa.func.max(pairs.c.party_full).label('party_full'),
-            sa.func.max(pairs.c.incumbent_challenge_full).label('incumbent_challenge_full'),
+            sa.func.max(pairs.c.incumbent_challenge_full).label(
+                'incumbent_challenge_full'
+            ),
             sa.func.max(pairs.c.office).label('office'),
             sa.func.sum(sa.func.coalesce(pairs.c.receipts, 0.0)).label('receipts'),
-            sa.func.sum(sa.func.coalesce(pairs.c.disbursements, 0.0)).label('disbursements'),
-            sa.func.max(sa.func.coalesce(pairs.c.last_cash_on_hand_end_period, 0.0)).label('last_cash_on_hand_end_period'),
+            sa.func.sum(sa.func.coalesce(pairs.c.disbursements, 0.0)).label(
+                'disbursements'
+            ),
+            sa.func.max(
+                sa.func.coalesce(pairs.c.last_cash_on_hand_end_period, 0.0)
+            ).label('last_cash_on_hand_end_period'),
             sa.func.max(pairs.c.coverage_end_date).label('coverage_end_date'),
-            sa.func.max(pairs.c.candidate_pcc_id).label('candidate_pcc_id')
+            sa.func.max(pairs.c.candidate_pcc_id).label('candidate_pcc_id'),
         ).group_by(
-            pairs.c.candidate_id,
-            pairs.c.candidate_election_year,
-            pairs.c.committee_id
+            pairs.c.candidate_id, pairs.c.candidate_election_year, pairs.c.committee_id
         )
         return aggregates
 
@@ -249,37 +293,46 @@ class ElectionView(ApiResource):
             aggregates.c.candidate_election_year,
             sa.func.max(aggregates.c.candidate_name).label('candidate_name'),
             sa.func.max(aggregates.c.party_full).label('party_full'),
-            sa.func.max(aggregates.c.incumbent_challenge_full).label('incumbent_challenge_full'),
+            sa.func.max(aggregates.c.incumbent_challenge_full).label(
+                'incumbent_challenge_full'
+            ),
             sa.func.max(aggregates.c.office).label('office'),
-            sa.func.sum(sa.func.coalesce(aggregates.c.receipts, 0.0)).label('total_receipts'),
-            sa.func.sum(sa.func.coalesce(aggregates.c.disbursements, 0.0)).label('total_disbursements'),
-            sa.func.sum(sa.func.coalesce(aggregates.c.last_cash_on_hand_end_period, 0.0)).label('cash_on_hand_end_period'),
-            sa.func.array_agg(sa.distinct(aggregates.c. committee_id)).label('committee_ids'),
+            sa.func.sum(sa.func.coalesce(aggregates.c.receipts, 0.0)).label(
+                'total_receipts'
+            ),
+            sa.func.sum(sa.func.coalesce(aggregates.c.disbursements, 0.0)).label(
+                'total_disbursements'
+            ),
+            sa.func.sum(
+                sa.func.coalesce(aggregates.c.last_cash_on_hand_end_period, 0.0)
+            ).label('cash_on_hand_end_period'),
+            sa.func.array_agg(sa.distinct(aggregates.c.committee_id)).label(
+                'committee_ids'
+            ),
             sa.func.max(aggregates.c.coverage_end_date).label('coverage_end_date'),
-            sa.func.max(aggregates.c.candidate_pcc_id).label('candidate_pcc_id')
-        ).group_by(
-            aggregates.c.candidate_id,
-            aggregates.c.candidate_election_year
-        )
+            sa.func.max(aggregates.c.candidate_pcc_id).label('candidate_pcc_id'),
+        ).group_by(aggregates.c.candidate_id, aggregates.c.candidate_election_year)
         return candAggregates
-@doc(
-    description=docs.ELECTION_SEARCH,
-    tags=['financial']
-)
-class ElectionSummary(utils.Resource):
 
+
+@doc(description=docs.ELECTION_SEARCH, tags=['financial'])
+class ElectionSummary(utils.Resource):
     @use_kwargs(args.elections)
     @marshal_with(schemas.ElectionSummarySchema())
     def get(self, **kwargs):
         utils.check_election_arguments(kwargs)
         aggregates = self._get_aggregates(kwargs).subquery()
         expenditures = self._get_expenditures(kwargs).subquery()
-        return db.session.query(
-            aggregates.c.count,
-            aggregates.c.receipts,
-            aggregates.c.disbursements,
-            expenditures.c.independent_expenditures,
-        ).first()._asdict()
+        return (
+            db.session.query(
+                aggregates.c.count,
+                aggregates.c.receipts,
+                aggregates.c.disbursements,
+                expenditures.c.independent_expenditures,
+            )
+            .first()
+            ._asdict()
+        )
 
     def _get_aggregates(self, kwargs):
         totals_model = office_totals_map[kwargs['office']]
@@ -293,20 +346,23 @@ class ElectionSummary(utils.Resource):
         return aggregates
 
     def _get_expenditures(self, kwargs):
-        expenditures = db.session.query(
-            sa.func.sum(ScheduleEByCandidate.total).label('independent_expenditures'),
-        ).select_from(
-            CandidateHistory
-        ).join(
-            ScheduleEByCandidate,
-            sa.and_(
-                CandidateHistory.candidate_id == ScheduleEByCandidate.candidate_id,
-                ScheduleEByCandidate.cycle == kwargs['cycle'],
-            ),
+        expenditures = (
+            db.session.query(
+                sa.func.sum(ScheduleEByCandidate.total).label(
+                    'independent_expenditures'
+                ),
+            )
+            .select_from(CandidateHistory)
+            .join(
+                ScheduleEByCandidate,
+                sa.and_(
+                    CandidateHistory.candidate_id == ScheduleEByCandidate.candidate_id,
+                    ScheduleEByCandidate.cycle == kwargs['cycle'],
+                ),
+            )
         )
         expenditures = filter_candidate_totals(expenditures, kwargs)
         return expenditures
-
 
 
 def join_candidate_totals(query, kwargs, totals_model):
@@ -323,15 +379,16 @@ def join_candidate_totals(query, kwargs, totals_model):
         CandidateCommitteeLink,
         sa.and_(
             CandidateHistory.candidate_id == CandidateCommitteeLink.candidate_id,
-            CandidateHistory.two_year_period == CandidateCommitteeLink.fec_election_year,
-        )
+            CandidateHistory.two_year_period
+            == CandidateCommitteeLink.fec_election_year,
+        ),
     ).outerjoin(
         totals_model,
         sa.and_(
             CandidateCommitteeLink.committee_id == totals_model.committee_id,
             CandidateCommitteeLink.fec_election_year == totals_model.cycle,
             CandidateCommitteeLink.committee_designation.in_(['P', 'A']),
-        )
+        ),
     )
 
 
@@ -342,7 +399,6 @@ def filter_candidate_totals(query, kwargs):
         CandidateHistory.two_year_period > (kwargs['cycle'] - duration),
         CandidateCommitteeLink.election_yr_to_be_included == kwargs['cycle'],
         CandidateHistory.office == kwargs['office'][0].upper(),
-
     )
     if kwargs.get('state'):
         query = query.filter(CandidateHistory.state == kwargs['state'])
@@ -357,8 +413,7 @@ def filter_candidate_totals(query, kwargs):
 
 
 @doc(
-    tags=['filer resources'],
-    description=docs.STATE_ELECTION_OFFICES,
+    tags=['filer resources'], description=docs.STATE_ELECTION_OFFICES,
 )
 class StateElectionOfficeInfoView(ApiResource):
     model = models.StateElectionOfficeInfo
@@ -368,10 +423,7 @@ class StateElectionOfficeInfoView(ApiResource):
     @property
     def args(self):
         return utils.extend(
-            args.paging,
-            args.state_election_office_info,
-            args.make_sort_args(
-            ),
+            args.paging, args.state_election_office_info, args.make_sort_args(),
         )
 
     @property
@@ -380,5 +432,4 @@ class StateElectionOfficeInfoView(ApiResource):
 
     filter_match_fields = [
         ('state', models.StateElectionOfficeInfo.state),
-
     ]

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -53,8 +53,11 @@ class BaseFilings(views.ApiResource):
 
     @property
     def args(self):
-        #Place the sort argument in a list, as the api will return a 422 status code if it's not in a list
-        #list is needed because multisort is used
+        """
+        Place the sort argument in a list.
+        The api will return a 422 status code if it's not in a list
+        (list is needed because multisort is used)
+        """
         default_sort = ['-receipt_date']
         return utils.extend(
             args.paging,
@@ -67,7 +70,7 @@ class BaseFilings(views.ApiResource):
 
     def build_query(self, **kwargs):
         if 'RFAI' in kwargs.get('form_type', []):
-            #Adds FRQ types if RFAI was requested
+            # Add FRQ types if RFAI was requested
             kwargs.get('form_type').append('FRQ')
         query = super().build_query(**kwargs)
         return query

--- a/webservices/resources/large_aggregates.py
+++ b/webservices/resources/large_aggregates.py
@@ -29,7 +29,7 @@ class EntityReceiptDisbursementTotalsView(ApiResource):
             args.large_aggregates,
             args.make_sort_args(
                 default='end_date',
-                validator=args.OptionValidator(['end_date',]),
+                validator=args.OptionValidator(['end_date', ]),
             )
         )
 

--- a/webservices/resources/operations_log.py
+++ b/webservices/resources/operations_log.py
@@ -1,4 +1,3 @@
-
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
@@ -6,6 +5,7 @@ from webservices import utils
 from webservices import schemas
 from webservices.common import models
 from webservices.common.views import ApiResource
+
 
 @doc(tags=['filings'], description=docs.OPERATIONS_LOG)
 class OperationsLogView(ApiResource):
@@ -25,8 +25,17 @@ class OperationsLogView(ApiResource):
 
     filter_range_fields = [
         (('min_receipt_date', 'max_receipt_date'), models.OperationsLog.receipt_date),
-        (('min_coverage_end_date', 'max_coverage_end_date'), models.OperationsLog.coverage_end_date),
-        (('min_transaction_data_complete_date', 'max_transaction_data_complete_date'), models.OperationsLog.transaction_data_complete_date),
+        (
+            ('min_coverage_end_date', 'max_coverage_end_date'),
+            models.OperationsLog.coverage_end_date,
+        ),
+        (
+            (
+                'min_transaction_data_complete_date',
+                'max_transaction_data_complete_date',
+            ),
+            models.OperationsLog.transaction_data_complete_date,
+        ),
     ]
 
     @property
@@ -35,9 +44,7 @@ class OperationsLogView(ApiResource):
         return utils.extend(
             args.paging,
             args.operations_log,
-            args.make_multi_sort_args(
-                default=default_sort,
-            ),
+            args.make_multi_sort_args(default=default_sort,),
         )
 
     def build_query(self, *args, **kwargs):

--- a/webservices/resources/presidential.py
+++ b/webservices/resources/presidential.py
@@ -38,6 +38,7 @@ class PresidentialByCandidateView(ApiResource):
     def index_column(self):
         return self.model.idx
 
+
 @doc(
     tags=['presidential'],
     description=docs.PRESIDENTIAL_BY_SUMMERY,
@@ -67,6 +68,7 @@ class PresidentialSummaryView(ApiResource):
     @property
     def index_column(self):
         return self.model.idx
+
 
 @doc(
     tags=['presidential'],
@@ -99,6 +101,7 @@ class PresidentialBySizeView(ApiResource):
     def index_column(self):
         return self.model.idx
 
+
 @doc(
     tags=['presidential'],
     description=docs.PRESIDENTIAL_BY_STATE,
@@ -128,6 +131,7 @@ class PresidentialByStateView(ApiResource):
     @property
     def index_column(self):
         return self.model.idx
+
 
 @doc(
     tags=['presidential'],

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -12,20 +12,48 @@ from webservices.utils import use_kwargs
 
 
 reports_schema_map = {
-    'P': (models.CommitteeReportsPresidential, schemas.CommitteeReportsPresidentialPageSchema),
-    'H': (models.CommitteeReportsHouseSenate, schemas.CommitteeReportsHouseSenatePageSchema),
-    'S': (models.CommitteeReportsHouseSenate, schemas.CommitteeReportsHouseSenatePageSchema),
+    'P': (
+        models.CommitteeReportsPresidential,
+        schemas.CommitteeReportsPresidentialPageSchema,
+    ),
+    'H': (
+        models.CommitteeReportsHouseSenate,
+        schemas.CommitteeReportsHouseSenatePageSchema,
+    ),
+    'S': (
+        models.CommitteeReportsHouseSenate,
+        schemas.CommitteeReportsHouseSenatePageSchema,
+    ),
     'I': (models.CommitteeReportsIEOnly, schemas.CommitteeReportsIEOnlyPageSchema),
 }
 
 efile_reports_schema_map = {
-    'P': (models.BaseF3PFiling, schemas.BaseF3PFilingSchema, schemas.BaseF3PFilingPageSchema),
-    'H': (models.BaseF3Filing, schemas.BaseF3FilingSchema, schemas.BaseF3FilingPageSchema),
-    'S': (models.BaseF3Filing, schemas.BaseF3FilingSchema, schemas.BaseF3FilingPageSchema),
-    'X': (models.BaseF3XFiling, schemas.BaseF3XFilingSchema, schemas.BaseF3XFilingPageSchema),
+    'P': (
+        models.BaseF3PFiling,
+        schemas.BaseF3PFilingSchema,
+        schemas.BaseF3PFilingPageSchema,
+    ),
+    'H': (
+        models.BaseF3Filing,
+        schemas.BaseF3FilingSchema,
+        schemas.BaseF3FilingPageSchema,
+    ),
+    'S': (
+        models.BaseF3Filing,
+        schemas.BaseF3FilingSchema,
+        schemas.BaseF3FilingPageSchema,
+    ),
+    'X': (
+        models.BaseF3XFiling,
+        schemas.BaseF3XFilingSchema,
+        schemas.BaseF3XFilingPageSchema,
+    ),
 }
 # We don't have report data for C and E yet
-default_schemas = (models.CommitteeReportsPacParty, schemas.CommitteeReportsPacPartyPageSchema)
+default_schemas = (
+    models.CommitteeReportsPacParty,
+    schemas.CommitteeReportsPacPartyPageSchema,
+)
 
 reports_type_map = {
     'house-senate': 'H',
@@ -33,7 +61,7 @@ reports_type_map = {
     'ie-only': 'I',
     'pac-party': None,
     'pac': 'O',
-    'party': 'XY'
+    'party': 'XY',
 }
 
 form_type_map = {
@@ -45,18 +73,44 @@ form_type_map = {
 
 def get_range_filters():
     filter_range_fields = [
-        (('min_receipt_date', 'max_receipt_date'), models.CommitteeReports.receipt_date),
-        (('min_disbursements_amount', 'max_disbursements_amount'), models.CommitteeReports.total_disbursements_period),
-        (('min_receipts_amount', 'max_receipts_amount'), models.CommitteeReports.total_receipts_period),
-        (('min_cash_on_hand_end_period_amount', 'max_cash_on_hand_end_period_amount'),
-         models.CommitteeReports.cash_on_hand_end_period),
-        (('min_debts_owed_amount', 'max_debts_owed_amount'), models.CommitteeReports.debts_owed_by_committee),
-        (('min_independent_expenditures', 'max_independent_expenditures'),
-         models.CommitteeReportsPacParty.independent_expenditures_period),
-        (('min_party_coordinated_expenditures', 'max_party_coordinated_expenditures'),
-         models.CommitteeReportsPacParty.coordinated_expenditures_by_party_committee_period),
-        (('min_total_contributions', 'max_total_contributions'),
-         models.CommitteeReportsIEOnly.independent_contributions_period),
+        (
+            ('min_receipt_date', 'max_receipt_date'),
+            models.CommitteeReports.receipt_date,
+        ),
+        (
+            ('min_disbursements_amount', 'max_disbursements_amount'),
+            models.CommitteeReports.total_disbursements_period,
+        ),
+        (
+            ('min_receipts_amount', 'max_receipts_amount'),
+            models.CommitteeReports.total_receipts_period,
+        ),
+        (
+            (
+                'min_cash_on_hand_end_period_amount',
+                'max_cash_on_hand_end_period_amount',
+            ),
+            models.CommitteeReports.cash_on_hand_end_period,
+        ),
+        (
+            ('min_debts_owed_amount', 'max_debts_owed_amount'),
+            models.CommitteeReports.debts_owed_by_committee,
+        ),
+        (
+            ('min_independent_expenditures', 'max_independent_expenditures'),
+            models.CommitteeReportsPacParty.independent_expenditures_period,
+        ),
+        (
+            (
+                'min_party_coordinated_expenditures',
+                'max_party_coordinated_expenditures',
+            ),
+            models.CommitteeReportsPacParty.coordinated_expenditures_by_party_committee_period,
+        ),
+        (
+            ('min_total_contributions', 'max_total_contributions'),
+            models.CommitteeReportsIEOnly.independent_contributions_period,
+        ),
     ]
     return filter_range_fields
 
@@ -81,17 +135,13 @@ def get_match_filters():
     },
 )
 class ReportsView(views.ApiResource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.reports)
-    @use_kwargs(
-        args.make_multi_sort_args(default=['-coverage_end_date'])
-    )
+    @use_kwargs(args.make_multi_sort_args(default=['-coverage_end_date']))
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
-            committee_type=committee_type,
-            **kwargs
+            committee_type=committee_type, **kwargs
         )
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
@@ -100,10 +150,9 @@ class ReportsView(views.ApiResource):
         return reports_schema().dump(page).data
 
     def build_query(self, committee_type=None, **kwargs):
-        #For this endpoint we now enforce the enpoint specified to map the right model.
+        # For this endpoint we now enforce the enpoint specified to map the right model.
         reports_class, reports_schema = reports_schema_map.get(
-            reports_type_map.get(committee_type),
-            default_schemas,
+            reports_type_map.get(committee_type), default_schemas,
         )
         query = reports_class.query
 
@@ -117,12 +166,20 @@ class ReportsView(views.ApiResource):
         ]
 
         if hasattr(reports_class, 'committee'):
-            query = reports_class.query.outerjoin(reports_class.committee).options(sa.orm.contains_eager(reports_class.committee))
+            query = reports_class.query.outerjoin(reports_class.committee).options(
+                sa.orm.contains_eager(reports_class.committee)
+            )
 
         if kwargs.get('candidate_id'):
-            query = query.filter(models.CommitteeHistory.candidate_ids.overlap([kwargs.get('candidate_id')]))
+            query = query.filter(
+                models.CommitteeHistory.candidate_ids.overlap(
+                    [kwargs.get('candidate_id')]
+                )
+            )
         if kwargs.get('type'):
-            query = query.filter(models.CommitteeHistory.committee_type.in_(kwargs.get('type')))
+            query = query.filter(
+                models.CommitteeHistory.committee_type.in_(kwargs.get('type'))
+            )
 
         query = filters.filter_range(query, kwargs, get_range_filters())
         query = filters.filter_match(query, kwargs, get_match_filters())
@@ -133,21 +190,16 @@ class ReportsView(views.ApiResource):
 @doc(
     tags=['financial'],
     description=docs.REPORTS,
-    params={
-        'committee_id': {'description': docs.COMMITTEE_ID},
-    },
+    params={'committee_id': {'description': docs.COMMITTEE_ID}, },
 )
 class CommitteeReportsView(views.ApiResource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.committee_reports)
     @use_kwargs(args.make_multi_sort_args(default=['-coverage_end_date']))
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
-            committee_id=committee_id,
-            committee_type=committee_type,
-            **kwargs
+            committee_id=committee_id, committee_type=committee_type, **kwargs
         )
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
@@ -158,9 +210,7 @@ class CommitteeReportsView(views.ApiResource):
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         reports_class, reports_schema = reports_schema_map.get(
             self._resolve_committee_type(
-                committee_id=committee_id,
-                committee_type=committee_type,
-                **kwargs
+                committee_id=committee_id, committee_type=committee_type, **kwargs
             ),
             default_schemas,
         )
@@ -175,7 +225,9 @@ class CommitteeReportsView(views.ApiResource):
         ]
         # Eagerly load committees if applicable
         if hasattr(reports_class, 'committee'):
-            query = reports_class.query.options(sa.orm.joinedload(reports_class.committee))
+            query = reports_class.query.options(
+                sa.orm.joinedload(reports_class.committee)
+            )
         if committee_id is not None:
             query = query.filter_by(committee_id=committee_id)
 
@@ -202,8 +254,7 @@ class CommitteeReportsView(views.ApiResource):
 
 
 @doc(
-    tags=['efiling'],
-    description=docs.EFILE_REPORTS,
+    tags=['efiling'], description=docs.EFILE_REPORTS,
 )
 class EFilingHouseSenateSummaryView(views.ApiResource):
 
@@ -216,7 +267,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
     ]
     filter_multi_fields = [
         ('file_number', model.file_number),
-        ('committee_id', model.committee_id)
+        ('committee_id', model.committee_id),
     ]
 
     @property
@@ -225,8 +276,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
             args.paging,
             args.efilings,
             args.make_sort_args(
-                default='-receipt_date',
-                validator=args.IndexValidator(self.model),
+                default='-receipt_date', validator=args.IndexValidator(self.model),
             ),
         )
 
@@ -236,8 +286,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
 
 
 @doc(
-    tags=['efiling'],
-    description=docs.EFILE_REPORTS,
+    tags=['efiling'], description=docs.EFILE_REPORTS,
 )
 class EFilingPresidentialSummaryView(views.ApiResource):
 
@@ -250,7 +299,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
     ]
     filter_multi_fields = [
         ('file_number', model.file_number),
-        ('committee_id', model.committee_id)
+        ('committee_id', model.committee_id),
     ]
 
     @property
@@ -259,8 +308,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
             args.paging,
             args.efilings,
             args.make_sort_args(
-                default='-receipt_date',
-                validator=args.IndexValidator(self.model),
+                default='-receipt_date', validator=args.IndexValidator(self.model),
             ),
         )
 
@@ -270,8 +318,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
 
 
 @doc(
-    tags=['efiling'],
-    description=docs.EFILE_REPORTS,
+    tags=['efiling'], description=docs.EFILE_REPORTS,
 )
 class EFilingPacPartySummaryView(views.ApiResource):
 
@@ -284,7 +331,7 @@ class EFilingPacPartySummaryView(views.ApiResource):
     ]
     filter_multi_fields = [
         ('file_number', model.file_number),
-        ('committee_id', model.committee_id)
+        ('committee_id', model.committee_id),
     ]
 
     @property
@@ -293,8 +340,7 @@ class EFilingPacPartySummaryView(views.ApiResource):
             args.paging,
             args.efilings,
             args.make_sort_args(
-                default='-receipt_date',
-                validator=args.IndexValidator(self.model),
+                default='-receipt_date', validator=args.IndexValidator(self.model),
             ),
         )
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -17,9 +17,9 @@ two years restriction removed from schedule_a. For details, refer:
 https://github.com/fecgov/openFEC/issues/3595
 """
 
+
 @doc(
-    tags=['receipts'],
-    description=docs.SCHEDULE_A,
+    tags=['receipts'], description=docs.SCHEDULE_A,
 )
 class ScheduleAView(ItemizedResource):
 
@@ -30,12 +30,15 @@ class ScheduleAView(ItemizedResource):
     @property
     def year_column(self):
         return self.model.two_year_transaction_period
+
     @property
     def index_column(self):
         return self.model.sub_id
+
     @property
     def amount_column(self):
         return self.model.contribution_receipt_amount
+
     filter_multi_fields = [
         ('image_number', models.ScheduleA.image_number),
         ('committee_id', models.ScheduleA.committee_id),
@@ -44,7 +47,10 @@ class ScheduleAView(ItemizedResource):
         ('contributor_state', models.ScheduleA.contributor_state),
         ('recipient_committee_type', models.ScheduleA.recipient_committee_type),
         ('recipient_committee_org_type', models.ScheduleA.recipient_committee_org_type),
-        ('recipient_committee_designation', models.ScheduleA.recipient_committee_designation),
+        (
+            'recipient_committee_designation',
+            models.ScheduleA.recipient_committee_designation,
+        ),
         ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     filter_match_fields = [
@@ -76,13 +82,15 @@ class ScheduleAView(ItemizedResource):
             args.make_seek_args(),
             args.make_sort_args(
                 default='contribution_receipt_date',
-                validator=args.OptionValidator([
-                    'contribution_receipt_date',
-                    'contribution_receipt_amount',
-                    'contributor_aggregate_ytd',
-               ]),
+                validator=args.OptionValidator(
+                    [
+                        'contribution_receipt_date',
+                        'contribution_receipt_amount',
+                        'contributor_aggregate_ytd',
+                    ]
+                ),
                 show_nulls_last_arg=False,
-            )
+            ),
         )
 
     def build_query(self, **kwargs):
@@ -96,11 +104,16 @@ class ScheduleAView(ItemizedResource):
             'contributor_occupation',
             'image_number',
         ]
-        two_year_transaction_periods = set(kwargs.get('two_year_transaction_period', []))
+        two_year_transaction_periods = set(
+            kwargs.get('two_year_transaction_period', [])
+        )
         if len(two_year_transaction_periods) != 1:
             if not any(kwargs.get(field) for field in secondary_index_options):
                 raise exceptions.ApiError(
-                    "Please choose a single `two_year_transaction_period` or add one of the following filters to your query: `{}`".format("`, `".join(secondary_index_options)),
+                    "Please choose a single `two_year_transaction_period` or \
+                    add one of the following filters to your query: `{}`".format(
+                        "`, `".join(secondary_index_options)
+                    ),
                     status_code=400,
                 )
         query = super().build_query(**kwargs)
@@ -108,7 +121,7 @@ class ScheduleAView(ItemizedResource):
         zip_list = []
         if kwargs.get('contributor_zip'):
             for value in kwargs['contributor_zip']:
-                if re.search('[^a-zA-Z0-9-\s]', value):
+                if re.search('[^a-zA-Z0-9-\s]', value):  # noqa
                     raise exceptions.ApiError(
                         'Invalid zip code. It can not have special character',
                         status_code=400,
@@ -116,7 +129,9 @@ class ScheduleAView(ItemizedResource):
                 else:
                     zip_list.append(value[:5])
             contributor_zip_list = {'contributor_zip': zip_list}
-            query = filters.filter_multi_start_with(query, contributor_zip_list, self.filter_multi_start_with_fields)
+            query = filters.filter_multi_start_with(
+                query, contributor_zip_list, self.filter_multi_start_with_fields
+            )
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):
@@ -127,14 +142,13 @@ class ScheduleAView(ItemizedResource):
                 query = query.filter_by(line_number=line_no)
             else:
                 raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
+                    exceptions.LINE_NUMBER_ERROR, status_code=400,
                 )
         return query
 
+
 @doc(
-    tags=['receipts'],
-    description=docs.EFILING_TAG,
+    tags=['receipts'], description=docs.EFILING_TAG,
 )
 class ScheduleAEfileView(views.ApiResource):
     model = models.ScheduleAEfile
@@ -150,7 +164,10 @@ class ScheduleAEfileView(views.ApiResource):
 
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleAEfile.contribution_receipt_date),
-        (('min_amount', 'max_amount'), models.ScheduleAEfile.contribution_receipt_amount),
+        (
+            ('min_amount', 'max_amount'),
+            models.ScheduleAEfile.contribution_receipt_amount,
+        ),
         (('min_image_number', 'max_image_number'), models.ScheduleAEfile.image_number),
     ]
 
@@ -168,10 +185,12 @@ class ScheduleAEfileView(views.ApiResource):
             args.itemized,
             args.make_sort_args(
                 default='-contribution_receipt_date',
-                validator=args.OptionValidator([
-                    'contribution_receipt_date',
-                    'contribution_receipt_amount',
-                    'contributor_aggregate_ytd',
-                ]),
+                validator=args.OptionValidator(
+                    [
+                        'contribution_receipt_date',
+                        'contribution_receipt_amount',
+                        'contributor_aggregate_ytd',
+                    ]
+                ),
             ),
         )

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -75,7 +75,7 @@ class ScheduleBView(ItemizedResource):
         query = query.options(sa.orm.joinedload(models.ScheduleB.committee))
         query = query.options(
             sa.orm.joinedload(models.ScheduleB.recipient_committee))
-        #might be worth looking to factoring these out into the filter script
+        # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         if kwargs.get('line_number'):

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -56,6 +56,7 @@ class ScheduleCView(ApiResource):
             )
         )
 
+
 @doc(
     tags=['loans'],
     description=docs.SCHEDULE_C,
@@ -76,9 +77,11 @@ class ScheduleCViewBySubId(ApiResource):
 
     @property
     def args(self):
+        """
+        needed to attach a page, trivial since length is one,
+        but can't build this view without a pageschema
+        """
         return utils.extend(
-            #needed to attach a page, trivial since length is one, but can't build this view without a pageschema
             args.paging,
-            args.make_sort_args(
-            ),
+            args.make_sort_args(),
         )

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -57,7 +57,7 @@ class ScheduleDView(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         if kwargs.get('sub_id'):
-            query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
+            query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         return query
 
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -10,6 +10,7 @@ from webservices.common import models
 from webservices.common import views
 from webservices.common.views import ItemizedResource
 
+
 @doc(
     tags=['independent expenditures'],
     description=docs.SCHEDULE_E,
@@ -23,9 +24,11 @@ class ScheduleEView(ItemizedResource):
     @property
     def year_column(self):
         return self.model.report_year
+
     @property
     def index_column(self):
         return self.model.sub_id
+
     @property
     def amount_column(self):
         return self.model.expenditure_amount

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -5,7 +5,6 @@ from webservices import args
 from webservices import docs
 from webservices import utils
 from webservices import schemas
-from webservices import filters
 from sqlalchemy.orm import aliased, contains_eager
 from webservices.common import models
 from webservices.common import views
@@ -162,11 +161,11 @@ class ScheduleEEfileView(views.ApiResource):
         query = query.options(contains_eager(self.model.filing, alias=filing_alias))
 
         if kwargs.get('spender_name'):
-                spender_filter = [
-                    filing_alias.committee_name.like('%' + value.upper() + '%')
-                    for value in kwargs.get('spender_name')
-                ]
-                query = query.filter(sa.or_(*spender_filter))
+            spender_filter = [
+                filing_alias.committee_name.like('%' + value.upper() + '%')
+                for value in kwargs.get('spender_name')
+            ]
+            query = query.filter(sa.or_(*spender_filter))
 
         if kwargs.get('min_filed_date') is not None:
             query = query.filter(filing_alias.filed_date >= kwargs['min_filed_date'])

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -53,7 +53,7 @@ class ScheduleFView(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         if kwargs.get('sub_id'):
-            query = query.filter_by(sub_id= int(kwargs.get('sub_id')))
+            query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         return query
 
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -6,7 +6,6 @@ from webservices import docs
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
-from webservices.common import views
 from webservices.common.views import ItemizedResource
 from webservices import exceptions
 
@@ -34,7 +33,6 @@ class ScheduleH4View(ItemizedResource):
         ('committee_id', models.ScheduleH4.committee_id),
         ('cycle', models.ScheduleH4.cycle),
     ]
-
 
     @property
     def args(self):

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -16,27 +16,49 @@ committee_type_map = {
     'ie-only': 'I',
     'pac-party': None,
     'pac': 'O',
-    'party': 'X'
+    'party': 'X',
 }
 
 totals_schema_map = {
     'P': (models.CommitteeTotalsPerCycle, schemas.CommitteeTotalsPerCyclePageSchema),
-    'H': (models.CommitteeTotalsHouseSenate, schemas.CommitteeTotalsHouseSenatePageSchema),
-    'S': (models.CommitteeTotalsHouseSenate, schemas.CommitteeTotalsHouseSenatePageSchema),
+    'H': (
+        models.CommitteeTotalsHouseSenate,
+        schemas.CommitteeTotalsHouseSenatePageSchema,
+    ),
+    'S': (
+        models.CommitteeTotalsHouseSenate,
+        schemas.CommitteeTotalsHouseSenatePageSchema,
+    ),
     'I': (models.CommitteeTotalsIEOnly, schemas.CommitteeTotalsIEOnlyPageSchema),
 }
-default_schemas = (models.CommitteeTotalsPacParty, schemas.CommitteeTotalsPacPartyPageSchema)
+default_schemas = (
+    models.CommitteeTotalsPacParty,
+    schemas.CommitteeTotalsPacPartyPageSchema,
+)
 
 candidate_totals_schema_map = {
-    'P': (models.CandidateCommitteeTotalsPresidential, schemas.CandidateCommitteeTotalsPresidentialPageSchema),
-    'H': (models.CandidateCommitteeTotalsHouseSenate, schemas.CandidateCommitteeTotalsHouseSenatePageSchema),
-    'S': (models.CandidateCommitteeTotalsHouseSenate, schemas.CandidateCommitteeTotalsHouseSenatePageSchema),
+    'P': (
+        models.CandidateCommitteeTotalsPresidential,
+        schemas.CandidateCommitteeTotalsPresidentialPageSchema,
+    ),
+    'H': (
+        models.CandidateCommitteeTotalsHouseSenate,
+        schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+    ),
+    'S': (
+        models.CandidateCommitteeTotalsHouseSenate,
+        schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+    ),
 }
 pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
 
 party_cmte_list = {'X', 'Y'}
 
-default_candidate_schemas = (models.CandidateCommitteeTotalsHouseSenate, schemas.CandidateCommitteeTotalsHouseSenatePageSchema)
+default_candidate_schemas = (
+    models.CandidateCommitteeTotalsHouseSenate,
+    schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+)
+
 
 @doc(
     tags=['financial'],
@@ -44,21 +66,25 @@ default_candidate_schemas = (models.CandidateCommitteeTotalsHouseSenate, schemas
     params={
         'committee_type': {
             'description': 'House, Senate, presidential, independent expenditure only',
-            'enum': ['presidential', 'pac', 'party', 'pac-party', 'house-senate', 'ie-only'],
+            'enum': [
+                'presidential',
+                'pac',
+                'party',
+                'pac-party',
+                'house-senate',
+                'ie-only',
+            ],
         },
     },
 )
 class TotalsView(utils.Resource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.totals_all)
     @use_kwargs(args.make_sort_args(default='-cycle'))
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, totals_class, totals_schema = self.build_query(
-            committee_id=committee_id,
-            committee_type=committee_type,
-            **kwargs
+            committee_id=committee_id, committee_type=committee_type, **kwargs
         )
         page = utils.fetch_page(query, kwargs, model=totals_class)
         return totals_schema().dump(page).data
@@ -66,9 +92,7 @@ class TotalsView(utils.Resource):
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
             self._resolve_committee_type(
-                committee_id=committee_id,
-                committee_type=committee_type,
-                **kwargs
+                committee_id=committee_id, committee_type=committee_type, **kwargs
             ),
             default_schemas,
         )
@@ -87,7 +111,9 @@ class TotalsView(utils.Resource):
             )
         if committee_type == 'pac-party':
             query = query.filter(
-                models.CommitteeTotalsPacParty.committee_type.in_(pac_cmte_list.union(party_cmte_list))
+                models.CommitteeTotalsPacParty.committee_type.in_(
+                    pac_cmte_list.union(party_cmte_list)
+                )
             )
         return query, totals_class, totals_schema
 
@@ -102,6 +128,7 @@ class TotalsView(utils.Resource):
         elif committee_type is not None:
             return committee_type_map.get(committee_type)
 
+
 @doc(
     tags=['financial'],
     description=docs.TOTALS,
@@ -109,21 +136,25 @@ class TotalsView(utils.Resource):
         'committee_id': {'description': docs.COMMITTEE_ID},
         'committee_type': {
             'description': 'House, Senate, presidential, independent expenditure only',
-            'enum': ['presidential', 'pac-party', 'pac', 'party', 'house-senate', 'ie-only'],
+            'enum': [
+                'presidential',
+                'pac-party',
+                'pac',
+                'party',
+                'house-senate',
+                'ie-only',
+            ],
         },
     },
 )
 class TotalsCommitteeView(ApiResource):
-
     @use_kwargs(args.paging)
     @use_kwargs(args.totals)
     @use_kwargs(args.make_sort_args(default='-cycle'))
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, totals_class, totals_schema = self.build_query(
-            committee_id=committee_id,
-            committee_type=committee_type,
-            **kwargs
+            committee_id=committee_id, committee_type=committee_type, **kwargs
         )
         page = utils.fetch_page(query, kwargs, model=totals_class)
         return totals_schema().dump(page).data
@@ -131,9 +162,7 @@ class TotalsCommitteeView(ApiResource):
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
             self._resolve_committee_type(
-                committee_id=committee_id,
-                committee_type=committee_type,
-                **kwargs
+                committee_id=committee_id, committee_type=committee_type, **kwargs
             ),
             default_schemas,
         )
@@ -154,12 +183,11 @@ class TotalsCommitteeView(ApiResource):
             committee = query.first_or_404()
             return committee.committee_type
 
+
 @doc(
     tags=['candidate'],
     description=docs.TOTALS,
-    params={
-        'candidate_id': {'description': docs.CANDIDATE_ID},
-    },
+    params={'candidate_id': {'description': docs.CANDIDATE_ID}, },
 )
 class CandidateTotalsView(utils.Resource):
     @use_kwargs(args.paging)
@@ -169,8 +197,7 @@ class CandidateTotalsView(utils.Resource):
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, candidate_id, **kwargs):
         query, totals_class, totals_schema = self.build_query(
-            candidate_id=candidate_id,
-            **kwargs
+            candidate_id=candidate_id, **kwargs
         )
         if kwargs['sort']:
             validator = args.IndexValidator(totals_class)
@@ -180,10 +207,7 @@ class CandidateTotalsView(utils.Resource):
 
     def build_query(self, candidate_id=None, **kwargs):
         totals_class, totals_schema = candidate_totals_schema_map.get(
-            self._resolve_committee_type(
-                candidate_id=candidate_id,
-                **kwargs
-            ),
+            self._resolve_committee_type(candidate_id=candidate_id, **kwargs),
             default_schemas,
         )
         query = totals_class.query
@@ -192,8 +216,7 @@ class CandidateTotalsView(utils.Resource):
         if 'full_election' in kwargs.keys():
             # full_election is replaced by election_full.
             raise exceptions.ApiError(
-                exceptions.FULL_ELECTION_ERROR,
-                status_code=400,
+                exceptions.FULL_ELECTION_ERROR, status_code=400,
             )
 
         if kwargs.get('election_full') is None:
@@ -207,7 +230,9 @@ class CandidateTotalsView(utils.Resource):
             if kwargs.get('cycle'):
                 if kwargs.get('election_full'):
                     # if election_full = true, filter by candidate_election_year = cycle
-                    query = query.filter(totals_class.candidate_election_year.in_(kwargs['cycle']))
+                    query = query.filter(
+                        totals_class.candidate_election_year.in_(kwargs['cycle'])
+                    )
                 else:
                     # if election_full = false, filter by cycle = cycle
                     query = query.filter(totals_class.cycle.in_(kwargs['cycle']))
@@ -217,10 +242,8 @@ class CandidateTotalsView(utils.Resource):
         if candidate_id is not None:
             return candidate_id[0]
 
-@doc(
-    tags=['receipts'],
-    description=(docs.STATE_AGGREGATE_RECIPIENT_TOTALS)
-)
+
+@doc(tags=['receipts'], description=(docs.STATE_AGGREGATE_RECIPIENT_TOTALS))
 class ScheduleAByStateRecipientTotalsView(ApiResource):
     model = models.ScheduleAByStateRecipientTotals
     schema = schemas.ScheduleAByStateRecipientTotalsSchema
@@ -239,13 +262,10 @@ class ScheduleAByStateRecipientTotalsView(ApiResource):
             args.paging,
             args.make_sort_args(
                 default='cycle',
-                validator=args.OptionValidator([
-                    'cycle',
-                    'state',
-                    'committee_type',
-                    'total'
-                ]),
-            )
+                validator=args.OptionValidator(
+                    ['cycle', 'state', 'committee_type', 'total']
+                ),
+            ),
         )
 
     @property

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -70,7 +70,7 @@ def sqla_conn_string():
     return sqla_conn_string
 
 
-#app.debug = True
+# app.debug = True
 app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
 app.config['APISPEC_FORMAT_RESPONSE'] = None
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
@@ -137,6 +137,7 @@ FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
 # Search this key_id in the API umbrella admin interface to look up the API KEY
 DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
 RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS', False)
+
 
 @app.before_request
 def limit_remote_addr():
@@ -255,10 +256,12 @@ def handle_exception(exception):
     raise exceptions.ApiError('Could not process the request',
         status_code=http.client.NOT_FOUND)
 
+
 @app.errorhandler(404)
 def page_not_found(exception):
     wrapped = ResponseException(str(exception), exception.code, type(exception))
     return wrapped.wrappedException, wrapped.status
+
 
 @app.errorhandler(403)
 def forbidden(exception):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1,6 +1,5 @@
 import re
 import functools
-import json
 
 from collections import namedtuple
 
@@ -11,12 +10,9 @@ from marshmallow_pagination import schemas as paging_schemas
 from webservices import utils, decoders
 from webservices.spec import spec
 from webservices.common import models
-from webservices.common.models import db
 from webservices import __API_VERSION__
 from webservices.calendar import format_start_date, format_end_date
-from marshmallow import pre_dump, post_dump
-from sqlalchemy import func
-import sqlalchemy as sa
+from marshmallow import post_dump
 
 
 spec.definition('OffsetInfo', schema=paging_schemas.OffsetInfoSchema)
@@ -199,6 +195,7 @@ class EFilingF3XSchema(BaseEfileSchema):
         line_list['cash_on_hand_beginning_period'] = line_list.pop('coh_bop')
         return line_list
 
+
 schema_map = {}
 schema_map["BaseF3XFiling"] = EFilingF3XSchema
 schema_map["BaseF3Filing"] = EFilingF3Schema
@@ -325,6 +322,7 @@ class CommitteeSearchListSchema(ApiSchema):
         many=True,
     )
 
+
 register_schema(CandidateSearchSchema)
 register_schema(CandidateSearchListSchema)
 register_schema(CommitteeSearchSchema)
@@ -353,6 +351,7 @@ class AuditCommitteeSearchListSchema(ApiSchema):
         ref='#/definitions/AuditCommitteeSearch',
         many=True,
     )
+
 
 register_schema(AuditCandidateSearchSchema)
 register_schema(AuditCandidateSearchListSchema)
@@ -418,6 +417,7 @@ augment_models(
 class CandidateHistoryTotalSchema(schemas['CandidateHistorySchema'],
         schemas['CandidateTotalSchema'], schemas['CandidateFlagsSchema']):
     pass
+
 
 augment_schemas(CandidateHistoryTotalSchema)
 
@@ -812,6 +812,7 @@ class FilingsSchema(BaseFilingsSchema):
         if not obj.get('fec_url'):
             obj.pop('fec_url')
 
+
 augment_schemas(FilingsSchema)
 
 EfilingsAmendmentsSchema = make_schema(
@@ -972,7 +973,6 @@ CalendarDateSchema = make_schema(
 CalendarDatePageSchema = make_page_schema(CalendarDateSchema)
 augment_schemas(CalendarDateSchema)
 
-
 class ElectionSearchSchema(ma.Schema):
     state = ma.fields.Str()
     office = ma.fields.Str()
@@ -981,16 +981,18 @@ class ElectionSearchSchema(ma.Schema):
     cycle = ma.fields.Int(attribute='two_year_period')
     incumbent_id = ma.fields.Str(attribute='cand_id')
     incumbent_name = ma.fields.Str(attribute='cand_name')
-augment_schemas(ElectionSearchSchema)
 
+
+augment_schemas(ElectionSearchSchema)
 
 class ElectionSummarySchema(ApiSchema):
     count = ma.fields.Int()
     receipts = ma.fields.Decimal(places=2)
     disbursements = ma.fields.Decimal(places=2)
     independent_expenditures = ma.fields.Decimal(places=2)
-register_schema(ElectionSummarySchema)
 
+
+register_schema(ElectionSummarySchema)
 
 class ElectionSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -1005,6 +1007,8 @@ class ElectionSchema(ma.Schema):
     cash_on_hand_end_period = ma.fields.Decimal(places=2)
     candidate_election_year = ma.fields.Int()
     coverage_end_date = ma.fields.Date()
+
+
 augment_schemas(ElectionSchema)
 
 ElectionPageSchema = make_page_schema(ElectionSchema)
@@ -1016,6 +1020,7 @@ class ScheduleABySizeCandidateSchema(ma.Schema):
     total = ma.fields.Decimal(places=2)
     size = ma.fields.Int()
     count = ma.fields.Int()
+
 
 class ScheduleAByStateCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -1039,6 +1044,7 @@ class TotalsCommitteeSchema(schemas['CommitteeHistorySchema']):
     cash_on_hand_end_period = ma.fields.Decimal(places=2)
     debts_owed_by_committee = ma.fields.Decimal(places=2)
     independent_expenditures = ma.fields.Decimal(places=2)
+
 
 augment_schemas(
     ScheduleABySizeCandidateSchema,
@@ -1244,6 +1250,8 @@ class TotalByOfficeSchema(ma.Schema):
     election_year = ma.fields.Int()
     total_receipts = ma.fields.Decimal(places=2)
     total_disbursements = ma.fields.Decimal(places=2)
+
+
 augment_schemas(TotalByOfficeSchema)
 
 class TotalByOfficeByPartySchema(ma.Schema):
@@ -1252,12 +1260,16 @@ class TotalByOfficeByPartySchema(ma.Schema):
     election_year = ma.fields.Int()
     total_receipts = ma.fields.Decimal(places=2)
     total_disbursements = ma.fields.Decimal(places=2)
+
+
 augment_schemas(TotalByOfficeByPartySchema)
 
 class ECTotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
     total = ma.fields.Decimal(places=2)
+
+
 augment_schemas(ECTotalsByCandidateSchema)
 
 class IETotalsByCandidateSchema(ma.Schema):
@@ -1265,6 +1277,8 @@ class IETotalsByCandidateSchema(ma.Schema):
     cycle = ma.fields.Int()
     support_oppose_indicator = ma.fields.Str()
     total = ma.fields.Decimal(places=2)
+
+
 augment_schemas(IETotalsByCandidateSchema)
 
 class CCTotalsByCandidateSchema(ma.Schema):
@@ -1272,6 +1286,8 @@ class CCTotalsByCandidateSchema(ma.Schema):
     cycle = ma.fields.Int()
     support_oppose_indicator = ma.fields.Str()
     total = ma.fields.Decimal(places=2)
+
+
 augment_schemas(CCTotalsByCandidateSchema)
 
 # Presidential endpoints

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -77,7 +77,7 @@ class BaseEfileSchema(BaseSchema):
     def extract_summary_rows(self, obj):
         if obj.get('summary_lines'):
             for key, value in obj.get('summary_lines').items():
-                #may be a way to pull these out using pandas?
+                # may be a way to pull these out using pandas?
                 if key == 'nan':
                     continue
                 obj[key] = value
@@ -157,7 +157,7 @@ class EFilingF3Schema(BaseEfileSchema):
     def parse_summary_rows(self, obj):
         descriptions = decoders.f3_description
         line_list = extract_columns(obj, decoders.f3_col_a, decoders.f3_col_b, descriptions)
-        #final bit of data cleaning before json marshalling
+        # final bit of data cleaning before json marshalling
         # If values are None, fall back to 0 to prevent errors
         coh_cop_i = line_list.get('coh_cop_i') if line_list.get('coh_cop_i') else 0
         coh_cop_ii = line_list.get('coh_cop_ii') if line_list.get('coh_cop_ii') else 0
@@ -473,7 +473,7 @@ make_totals_schema = functools.partial(
     fields={
         'pdf_url': ma.fields.Str(),
         'report_form': ma.fields.Str(),
-        #'committee_type': ma.fields.Str(attribute='committee.committee_type'),
+        # 'committee_type': ma.fields.Str(attribute='committee.committee_type'),
         'last_cash_on_hand_end_period': ma.fields.Decimal(places=2),
         'last_beginning_image_number': ma.fields.Str(),
         'transaction_coverage_date': ma.fields.Date(
@@ -973,6 +973,7 @@ CalendarDateSchema = make_schema(
 CalendarDatePageSchema = make_page_schema(CalendarDateSchema)
 augment_schemas(CalendarDateSchema)
 
+
 class ElectionSearchSchema(ma.Schema):
     state = ma.fields.Str()
     office = ma.fields.Str()
@@ -985,6 +986,7 @@ class ElectionSearchSchema(ma.Schema):
 
 augment_schemas(ElectionSearchSchema)
 
+
 class ElectionSummarySchema(ApiSchema):
     count = ma.fields.Int()
     receipts = ma.fields.Decimal(places=2)
@@ -993,6 +995,7 @@ class ElectionSummarySchema(ApiSchema):
 
 
 register_schema(ElectionSummarySchema)
+
 
 class ElectionSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -1013,6 +1016,7 @@ augment_schemas(ElectionSchema)
 
 ElectionPageSchema = make_page_schema(ElectionSchema)
 register_schema(ElectionPageSchema)
+
 
 class ScheduleABySizeCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -1245,6 +1249,7 @@ OperationsLogPageSchema = make_page_schema(OperationsLogSchema)
 register_schema(OperationsLogSchema)
 register_schema(OperationsLogPageSchema)
 
+
 class TotalByOfficeSchema(ma.Schema):
     office = ma.fields.Str()
     election_year = ma.fields.Int()
@@ -1253,6 +1258,7 @@ class TotalByOfficeSchema(ma.Schema):
 
 
 augment_schemas(TotalByOfficeSchema)
+
 
 class TotalByOfficeByPartySchema(ma.Schema):
     office = ma.fields.Str()
@@ -1264,6 +1270,7 @@ class TotalByOfficeByPartySchema(ma.Schema):
 
 augment_schemas(TotalByOfficeByPartySchema)
 
+
 class ECTotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
@@ -1271,6 +1278,7 @@ class ECTotalsByCandidateSchema(ma.Schema):
 
 
 augment_schemas(ECTotalsByCandidateSchema)
+
 
 class IETotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
@@ -1280,6 +1288,7 @@ class IETotalsByCandidateSchema(ma.Schema):
 
 
 augment_schemas(IETotalsByCandidateSchema)
+
 
 class CCTotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()

--- a/webservices/sorting.py
+++ b/webservices/sorting.py
@@ -43,8 +43,8 @@ def parse_option(option, model=None, aliases=None, join_columns=None, query=None
 def multi_sort(query, keys, model, aliases=None, join_columns=None, clear=False,
          hide_null=False, index_column=None, nulls_last=False):
     for key in keys:
-        query,_ = sort(query, key, model, aliases, join_columns, clear, hide_null, index_column, nulls_last)
-    return query,_
+        query, _ = sort(query, key, model, aliases, join_columns, clear, hide_null, index_column, nulls_last)
+    return query, _
 
 
 def sort(query, key, model, aliases=None, join_columns=None, clear=False,

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -1,10 +1,10 @@
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 
-
 from webservices import docs
 from webservices import __API_VERSION__
 from webservices.env import env
+
 
 def format_docstring(docstring):
     if not docstring or not docstring.strip():

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -37,6 +37,7 @@ if env.app.get('space_name', 'unknown-space').lower() != 'feature':
 
     }
 
+
 def redis_url():
     """
     Retrieve the URL needed to connect to a Redis instance, depending on environment.
@@ -78,10 +79,12 @@ app.conf.ONCE = {
 
 context = {}
 
+
 @signals.task_prerun.connect
 def push_context(task_id, task, *args, **kwargs):
     context[task_id] = utils.get_app().app_context()
     context[task_id].push()
+
 
 @signals.task_postrun.connect
 def pop_context(task_id, task, *args, **kwargs):

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -145,7 +145,7 @@ def export_query(path, qs):
         logger.info('Download resource: {0}'.format(qs))
         make_bundle(resource)
         logger.info('Bundled: {0}'.format(qs))
-    except:
+    except Exception:
         logger.exception('Download failed: {0}'.format(qs))
 
 

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -102,9 +102,11 @@ def query_with_labels(query, schema, sort_columns=False):
 
     return query
 
+
 def unpack(values, size):
     values = values if isinstance(values, tuple) else (values, )
     return values + (None, ) * (size - len(values))
+
 
 def get_s3_name(path, qs):
     """
@@ -134,6 +136,7 @@ def make_bundle(resource):
             format='csv',
             header=True
         )
+
 
 @app.task(base=QueueOnce, once={'graceful': True})
 def export_query(path, qs):

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -38,11 +38,13 @@ RECENTLY_MODIFIED_CASES = """
     ORDER BY case_serial
 """
 
+
 @app.task(once={'graceful': True}, base=QueueOnce)
 def refresh():
     with db.engine.connect() as conn:
         refresh_aos(conn)
         refresh_cases(conn)
+
 
 @app.task(once={'graceful': True}, base=QueueOnce)
 def reload_all_aos_when_change():
@@ -64,6 +66,7 @@ def reload_all_aos_when_change():
                 'No modified AOs found for the day - Reload of all AOs skipped in {0} space'.format(get_app_name())
             utils.post_to_slack(slack_message, '#bots')
 
+
 @app.task(once={'graceful': True}, base=QueueOnce)
 def reload_all_aos():
     logger.info("Weekly (%s) reload of all AOs starting", datetime.date.today().strftime("%A"))
@@ -71,6 +74,7 @@ def reload_all_aos():
     logger.info("Weekly (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
     slack_message = 'Weekly reload of all AOs completed in {0} space'.format(get_app_name())
     utils.post_to_slack(slack_message, '#bots')
+
 
 @app.task(once={'graceful': True}, base=QueueOnce)
 def create_es_backup():
@@ -85,6 +89,7 @@ def create_es_backup():
         slack_message = '*ERROR* elasticsearch backup failed for {0}. Check logs.'.format(get_app_name())
         utils.post_to_slack(slack_message, '#bots')
 
+
 def refresh_aos(conn):
     row = conn.execute(RECENTLY_MODIFIED_STARTING_AO).first()
     if row:
@@ -92,6 +97,7 @@ def refresh_aos(conn):
         load_advisory_opinions(row["ao_no"])
     else:
         logger.info("No modified AOs found")
+
 
 def refresh_cases(conn):
     logger.info('Checking for modified cases')

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -1,14 +1,9 @@
-
-
 import json
 import logging
-import re
-
 import boto
+import boto3
 
 from boto.s3.key import Key
-
-import boto3
 
 from webservices.env import env
 

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -7,21 +7,24 @@ from boto.s3.key import Key
 
 from webservices.env import env
 
-
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('smart_open').setLevel(logging.CRITICAL)
+
 
 def get_app():
     from webservices.rest import app
     return app
+
 
 def get_bucket():
     session = boto3.Session()
     s3 = session.resource('s3')
     return s3.Bucket(env.get_credential('bucket'))
 
+
 def get_object(key):
     return get_bucket().Object(key=key)
+
 
 def get_s3_key(name):
     connection = boto.s3.connect_to_region(
@@ -31,10 +34,12 @@ def get_s3_key(name):
     key = Key(bucket=bucket, name=name)
     return key
 
+
 def get_json_data(response):
     # convert the response bytes data to a string
     python_str = json.dumps(response.data.decode('utf-8'))
     return python_str
+
 
 def get_app_name():
     return env.get_credential('APP_NAME')


### PR DESCRIPTION
## Summary (required)

Resolves #4257 

- Automate pep8 checking with `pytest-flake8` (See "how to test" for instructions for use)
- Fix presidential tests
- Update pytest, speed up tests, fix deprecation errors/warning

max line length = 120 chars

**Skipping**
- E128 continuation line under-indented for visual indent
- E127 continuation line over-indented for visual indent
- W503 line break before binary operator


## How to test the changes locally

- check out this branch 
- `pip install -r requirements.txt`
- `pytest` includes `pytest-flake8` PEP8 linting
- `pytest --no-linting` skips `pytest-flake8` PEP8 linting
- `pytest --linting` only runs `pytest-flake8` PEP8 linting
- `pytest --cache-clear --linting` to run without cached results https://github.com/tholo/pytest-flake8/issues/62
- You can still run one tests with `pytest tests/test_elections.py --no-linting` or `--linting` or don't specify either


