### PR TITLE
Delete ofec_totals_pacs_parties_mv

### DIFF
--- a/data/migrations/V0191__drop_ofec_totals_pacs_parties.sql
+++ b/data/migrations/V0191__drop_ofec_totals_pacs_parties.sql
@@ -1,0 +1,12 @@
+/*
+This migration file is to solve issue #4245
+
+The below two database objects are replaced by 
+ofec_totals_pac_party_vw
+
+and we can drop the mv/view that are not being used anymore
+*/
+
+DROP VIEW IF EXISTS public.ofec_totals_pacs_parties_vw;
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_pacs_parties_mv; 

--- a/manage.py
+++ b/manage.py
@@ -129,7 +129,6 @@ def refresh_materialized(concurrent=True):
         'totals_combined': ['ofec_totals_combined_mv'],
         'totals_house_senate': ['ofec_totals_house_senate_mv'],
         'totals_ie': ['ofec_totals_ie_only_mv'],
-        # 'totals_pac_party': ['ofec_totals_pacs_parties_mv'],
         'totals_presidential': ['ofec_totals_presidential_mv'],
     }
 

--- a/manage.py
+++ b/manage.py
@@ -129,7 +129,7 @@ def refresh_materialized(concurrent=True):
         'totals_combined': ['ofec_totals_combined_mv'],
         'totals_house_senate': ['ofec_totals_house_senate_mv'],
         'totals_ie': ['ofec_totals_ie_only_mv'],
-        'totals_pac_party': ['ofec_totals_pacs_parties_mv'],
+        # 'totals_pac_party': ['ofec_totals_pacs_parties_mv'],
         'totals_presidential': ['ofec_totals_presidential_mv'],
     }
 

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -44,7 +44,6 @@ def get_graph():
         'totals_combined',
         'totals_house_senate',
         'totals_ie',
-        # 'totals_pac_party',
         'totals_presidential',
     ]
     graph.add_nodes_from(MATERIALIZED_VIEWS)
@@ -79,7 +78,6 @@ def get_graph():
     graph.add_edges_from([
         ('totals_combined', 'totals_house_senate'),
         ('totals_combined', 'totals_presidential'),
-        # ('totals_combined', 'totals_pac_party'),
         ('totals_combined', 'totals_ie'),
     ])
 
@@ -88,8 +86,7 @@ def get_graph():
         ('totals_combined', 'committee_fulltext'),
     ])
 
-    # graph.add_edge('committee_detail', 'totals_pac_party')
-
+    
     graph.add_edges_from([
         ('candidate_detail', 'candidate_fulltext'),
         ('totals_combined', 'candidate_fulltext'),

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -44,7 +44,7 @@ def get_graph():
         'totals_combined',
         'totals_house_senate',
         'totals_ie',
-        'totals_pac_party',
+        # 'totals_pac_party',
         'totals_presidential',
     ]
     graph.add_nodes_from(MATERIALIZED_VIEWS)
@@ -79,7 +79,7 @@ def get_graph():
     graph.add_edges_from([
         ('totals_combined', 'totals_house_senate'),
         ('totals_combined', 'totals_presidential'),
-        ('totals_combined', 'totals_pac_party'),
+        # ('totals_combined', 'totals_pac_party'),
         ('totals_combined', 'totals_ie'),
     ])
 
@@ -88,7 +88,7 @@ def get_graph():
         ('totals_combined', 'committee_fulltext'),
     ])
 
-    graph.add_edge('committee_detail', 'totals_pac_party')
+    # graph.add_edge('committee_detail', 'totals_pac_party')
 
     graph.add_edges_from([
         ('candidate_detail', 'candidate_fulltext'),


### PR DESCRIPTION
## Summary (required)

- Resolves #[_4245_](https://github.com/fecgov/openFEC/issues/4245)

_ofec_totals_pac_party_vw was created to provide totals for pac and party committees.  So ofec_totals_pacs_parties_mv and ofec_totals_pacs_parties_vw can be deleted_

## How to test the changes locally

- download branch to local
- run `pytest`
- test migration and refreshing job on cfdm_test.  After running the below steps, the two database 
   objects should not exist in cfdm_test, and the refreshing job does not include 
   ofec_totals_pacs_parties_mv

  `dropdb cfdm_test`
  `createdb cfdm_test`
  `invoke create_sample_db`
   


