### PR TITLE
add_pg_date_column_to_presidential_tables

### DIFF
--- a/data/migrations/V0192__add_pg_date_column_to_presidential_tables.sql
+++ b/data/migrations/V0192__add_pg_date_column_to_presidential_tables.sql
@@ -1,0 +1,201 @@
+/*
+Add column pg_date to presidential tables.
+This column will be added to all 3 cloud environment ahead of time at the same time since
+The python program that load the data 
+(which is the same program, just pass in different db as parameter) 
+will run to all environments
+
+However, the migration file still submitted to keep the version control.
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_a_join_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_a_join_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_link_sum_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_link_sum_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_state_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_ca_cm_sched_state_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_f3p_totals_ca_cm_link_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_f3p_totals_ca_cm_link_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_ca_cm_link_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_ca_cm_link_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_f3p_totals_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_f3p_totals_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_form_3p_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_form_3p_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_sched_a_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_sched_a_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_sched_b_16 ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE disclosure.pres_nml_sched_b_20d ADD COLUMN pg_date timestamp without time zone DEFAULT now()');
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+
+    EXCEPTION 
+             WHEN duplicate_column THEN 
+                null;
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+


### PR DESCRIPTION
## Summary (required)

- Resolves #[4265] 

Add pg_date column to presidential tables
The presidential tables were originally created without the pg_date column. It is not needed for the website presentation. However, it is decided later that this column will be useful for later internal maintenance.  The column had already been added to the tables.  This migration file serves to keep the version control of the database objects.

## How to test the changes locally

- download the branch and run flyway migration on the local machine.  Make sure the migration file executed successfully and the pg_date column created for these presidential tables.

(optional, to mimic the effect on AWS database, after the migration file run the first time, connect to the local repository, delete version = '0192' from flyway_schema_historty and executing the migration file again, make sure no 'duplicate_column' error message)

## Impacted areas of the application
List general components of the application that this PR will affect:
-  None

