### PR TITLE
[MERGE WITH GIT FLOW] Hotfix: Fix downloads while using Schedule A routing setting

### DIFF
--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -50,7 +50,8 @@ class RoutingSession(SignallingSession):
 
     def get_bind(self, mapper=None, clause=None):
         if self.use_follower:
-            if self.route_schedule_a:
+            # Celery worker doesn't have request context
+            if request and self.route_schedule_a:
                 if '/schedule_a/' not in request.path:
                     # Route all non-schedule A traffic to replica 1
                     return self.followers[0]


### PR DESCRIPTION
## Summary (required)

- Resolves #4273: Fix downloads while using Schedule A routing setting 

The purpose of this change is to allow us to re-enable the setting to protect the rest of the website from Schedule A queries. If we’re getting hit hard on schedule A, we can serve up candidate profile pages, presidential map data, etc

**Technical implementation**

Only do request-based routing when there's request context. In other words, only do request-based routing for API calls, not celery-worker tasks. Sending flask request context to celery-worker is really complex (I spent a while trying to get this to work and it could introduce more bugs), so instead if we don't have request context, fall back to non-request based routing and just choose a random replica.

Some commonly cited resources on passing application context from Flask to celery worker:

Request context
- http://xion.io/post/code/celery-include-flask-request-context.html

Application context
- https://blog.miguelgrinberg.com/post/celery-and-the-flask-application-factory-pattern



## How to test the changes locally

- This fixes a bug with celery-worker combined with flask application configuration, which we don't currently have automated tests for. This has been tech debt for a while (https://github.com/fecgov/openFEC/issues/3176) so for now we need to test manually.

**Locally**
- Get downloads set up locally (see wiki https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads)
- Set your `SQLA_FOLLOWERS` to those of `prod` or just copy/paste your local `cfdm_test` many times like this `'connection_string,connection_string,connection_string'` so you mimic having three replicas
- set `SQLA_ROUTE_SCHEDULE_A` to true
- Test on the master branch, see that downloads fail
- Check out this branch
- Test downloads, see that they succeed

**In cloud.gov**
- Alternately or in addition to local testing, you can test in cloud.gov:
- Hook up the `stage` API to the `prod` replicas and set `SQLA_ROUTE_SCHEDULE_A` to `true` https://github.com/fecgov/openFEC/wiki/Switch-out-cf-environment-variables
- Push up this branch to the `stage` space (I used `invoke deploy --space stage` because it's faster and doesn't require making commits)
- be sure to put the `stage` `env vars` back

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Downloads (celery-worker)


## Related PRs
List related PRs against other branches:


- https://github.com/fecgov/openFEC/pull/4269