### PR TITLE
[MERGE WITH GIT FLOW] Add feature flag to restrict API traffic

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -143,6 +143,8 @@ TRAFFIC_WHITELIST_API_KEY_IDS = env.get_credential('TRAFFIC_WHITELIST_API_KEY_ID
 # Settings to restrict traffic to certain API keys - only work with API umbrella
 RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS', False)
 RESTRICT_API_TRAFFIC = env.get_credential('RESTRICT_API_TRAFFIC', False)
+RESTRICT_API_MESSAGE = "We apologize for the inconvenience, but we are temporarily " \
+    "blocking API traffic. Please contact apiinfo@fec.gov if this is an urgent issue."
 
 @app.before_request
 def limit_remote_addr():
@@ -172,12 +174,8 @@ def limit_remote_addr():
             elif RESTRICT_API_TRAFFIC in true_values and '/v1/' in request.url:
                 request_api_key_id = request.headers.get('X-Api-User-Id')
                 if request_api_key_id not in TRAFFIC_WHITELIST_API_KEY_IDS:
-                    abort(
-                        503,  # Service unavailable
-                        "We apologize for the inconvenience, but we are temporarily "
-                        "blocking API traffic. "
-                        "Please contact apiinfo@fec.gov if this is an urgent issue.",
-                    )
+                    # Service unavailable
+                    abort(503, RESTRICT_API_MESSAGE)
 
 
 def get_cache_header(url):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -137,9 +137,12 @@ TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('TRUSTED_PROXY_IPS', 
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
-# Search this key_id in the API umbrella admin interface to look up the API KEY
+# Search these key_id's in the API umbrella admin interface to look up the API KEY
 DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
+TRAFFIC_WHITELIST_API_KEY_IDS = env.get_credential('TRAFFIC_WHITELIST_API_KEY_IDS')
+# Settings to restrict traffic to certain API keys - only work with API umbrella
 RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS', False)
+RESTRICT_API_TRAFFIC = env.get_credential('RESTRICT_API_TRAFFIC', False)
 
 @app.before_request
 def limit_remote_addr():
@@ -165,6 +168,16 @@ def limit_remote_addr():
                 request_api_key_id = request.headers.get('X-Api-User-Id')
                 if request_api_key_id != DOWNLOAD_WHITELIST_API_KEY_ID:
                     abort(403)
+            # We don't want to accidentally block downloads here, handled above
+            elif RESTRICT_API_TRAFFIC in true_values and '/v1/' in request.url:
+                request_api_key_id = request.headers.get('X-Api-User-Id')
+                if request_api_key_id not in TRAFFIC_WHITELIST_API_KEY_IDS:
+                    abort(
+                        503,  # Service unavailable
+                        "We apologize for the inconvenience, but we are temporarily "
+                        "blocking API traffic. "
+                        "Please contact apiinfo@fec.gov if this is an urgent issue.",
+                    )
 
 
 def get_cache_header(url):


### PR DESCRIPTION
## Summary (required)

- Resolves #4301

Add feature flag to restrict traffic to allowed keys
    
To turn on, env var `RESTRICT_API_TRAFFIC` needs to be `True`
To turn off, remove env var `RESTRICT_API_TRAFFIC`
    
To add allowed keys, update `TRAFFIC_WHITELIST_API_KEY_IDS`
 
Key ID's can be found in the API umbrella and at minimum should include:
- Private key ID
- Public key ID
- Pingdom key ID
- Demo key ID

## How to test the changes locally

- Manual deploy to `stage` (need API umbrella in place)
- Test server-side (candidate profile page) and client-side (data table) calls
- Test a download
- Test `DEMO_KEY` on https://api-stage.open.fec.gov/developers/
- Test another key (your own, or let me know if you want one) that isn't whitelisted