### PR TITLE
Add is_active to committee history endpoint

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -382,26 +382,31 @@ class TestCommitteeHistory(ApiBaseTest):
                 committee_id=self.committees[0].committee_id,
                 cycle=2010,
                 designation='P',
+                is_active=True,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[1].committee_id,
                 cycle=2012,
                 designation='P',
+                is_active=True,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
                 designation='P',
+                is_active=True,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[3].committee_id,
                 cycle=2014,
                 designation='A',
+                is_active=False,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
                 designation='J',
+                is_active=False,
             ),
         ]
 
@@ -457,6 +462,29 @@ class TestCommitteeHistory(ApiBaseTest):
                 prev_election_year=2012,
             ),
         ]
+
+    def test_is_active(self):
+        results = self._results(
+            api.url_for(
+                CommitteeHistoryView,
+                committee_id=self.committees[4].committee_id,
+                cycle=2014,
+                election_full=False,
+                is_active=False,
+            )
+        )
+        assert len(results) == 1
+
+        results = self._results(
+            api.url_for(
+                CommitteeHistoryView,
+                committee_id=self.committees[2].committee_id,
+                cycle=2014,
+                election_full=False,
+                is_active=True,
+            )
+        )
+        assert len(results) == 1
 
     def test_candidate_cycle(self):
         results = self._results(

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -68,6 +68,7 @@ class CommitteeHistory(BaseCommittee):
     last_cycle_has_financial = db.Column(db.Integer, doc=docs.COMMITTEE_LAST_CYCLE_HAS_FINANCIAL)
     cycles_has_activity = db.Column(ARRAY(db.Integer), doc=docs.COMMITTEE_CYCLES_HAS_ACTIVITY)
     last_cycle_has_activity = db.Column(db.Integer, doc=docs.COMMITTEE_LAST_CYCLE_HAS_ACTIVITY)
+    is_active = db.Column(db.Boolean, doc=docs.IS_COMMITTEE_ACTIVE)
 
 
 class CommitteeDetail(BaseConcreteCommittee):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -510,6 +510,10 @@ MAX_LAST_F1_DATE = 'Filter for committees whose latest Form 1 was received on or
 AFFILIATED_COMMITTEE_NAME = '''
 Affiliated committee or connected organization
 '''
+
+IS_COMMITTEE_ACTIVE = '''
+True indicates that a committee is active.
+'''
 # ======== committee end ===========
 
 


### PR DESCRIPTION
## Summary (required)
To make it more clear to our users what the status of a committee is, we want to add an indicator at the top of the committee profile page.

- Resolves #[_4284_](https://github.com/fecgov/openFEC/issues/4284)

_Include a summary of proposed changes._
model: CommitteeHistory
test_committees.py

## How to test the changes locally
1)checkout branch
2)pytest
3)test url to see new field: is_avtive
on local:
a) is_active=true
http://127.0.0.1:5000/v1/committee/C00693234/history

b) is_active=false:
http://127.0.0.1:5000/v1/committee/C00000141/history/
