### PR TITLE
Set prod api instances to 10

### DIFF
--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -17,4 +17,4 @@ routes:
   - route: fec-prod-api.app.cloud.gov
 applications:
   - name: api
-    instances: 8
+    instances: 10


### PR DESCRIPTION
## Summary (required)

- Resolves #4315

Set prod api instances to 10

## How to test the changes locally

- Manifest file change equal to `cf scale api -i 10`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  API app instances


