### PR TITLE
add new transaction codes to the list to be included as individual

### DIFF
--- a/data/migrations/V0195__include_new_transaction_code_to_individual.sql
+++ b/data/migrations/V0195__include_new_transaction_code_to_individual.sql
@@ -1,0 +1,34 @@
+/*
+This is to resolve issue #4322: Update is_individual function to include the new transaction codes 30E, 31E, 32E
+
+Request from EFO to add new transaction code 30E, 31E, 32E:
+insert into STAGING.REF_TRAN_CODE (tran_code, tran_code_desc) VALUES ('30E', 'EARMARK – CONVENTION');
+insert into STAGING.REF_TRAN_CODE (tran_code, tran_code_desc) VALUES ('31E', 'EARMARKED – HEADQUARTERS');
+insert into STAGING.REF_TRAN_CODE (tran_code, tran_code_desc) VALUES ('32E', 'EARMARKED – RECOUNT');
+
+According to @PaulClark2 we need to add the new transaction codes to is_individual . They are considered individual contributions.
+
+There is no data using this three code yet so there is no need to reload fec_fitem_sched_a tables (resource intensive).  
+*/
+/*
+public.is_individual is calling function is_coded_individual(receipt_type) to to filter the coded individual.  Adds these 3 new codes in the list to be included.
+*/
+
+CREATE OR REPLACE FUNCTION public.is_coded_individual(receipt_type text)
+  RETURNS boolean AS
+$BODY$
+
+begin
+
+    return coalesce(receipt_type, '') in ('10', '15', '15E', '15J', '30', '30T', '31', '31T', '32', '10J', '11', '11J', '30J', '31J', '32T', '32J', '30E', '31E', '32E');
+
+end
+
+$BODY$
+  LANGUAGE plpgsql IMMUTABLE
+  COST 100;
+
+ALTER FUNCTION public.is_coded_individual(text)
+  OWNER TO fec;
+
+


### PR DESCRIPTION
## Summary (required)

- Resolves #4322 

Request from EFO to add new transaction code 30E, 31E, 32E.  
These 3 transaction codes are considered individual contributions and need be added to is_coded_individual

## How to test the changes locally

- download this feature branch to local server.  
Run flyway migration.  Make sure migration executed successfully.
Open the local database, 
- Verify the function public.is_coded_individual(text) to ensure it includes the transaction code 30E, 31E, 32E.
- The following queries will return true.
select public.is_coded_individual('30E');
select public.is_coded_individual('31E');
select public.is_coded_individual('32E');

## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
