### PR TITLE
Add validation for offset pagination (Schedule A, B, E)

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -314,7 +314,10 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(results[0]['contributor_occupation'], 'Doctor of Philosophy')
 
     def test_schedule_a_pagination(self):
-        filings = [factories.ScheduleAFactory() for _ in range(30)]
+        filings = [
+            factories.ScheduleAFactory(contribution_receipt_date=datetime.date(2016, 1, 1))
+            for _ in range(30)
+        ]
         page1 = self._results(api.url_for(ScheduleAView, **self.kwargs))
         self.assertEqual(len(page1), 20)
         self.assertEqual(
@@ -322,7 +325,12 @@ class TestScheduleA(ApiBaseTest):
             [each.sub_id for each in filings[:20]],
         )
         page2 = self._results(
-            api.url_for(ScheduleAView, last_index=page1[-1]['sub_id'], **self.kwargs)
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
+                **self.kwargs
+            )
         )
         self.assertEqual(len(page2), 10)
         self.assertEqual(
@@ -330,10 +338,70 @@ class TestScheduleA(ApiBaseTest):
             [each.sub_id for each in filings[20:]],
         )
 
-    def test_schedule_a_pagination_with_null_sort_column_values(self):
+    def test_schedule_a_pagination_with_null_sort_column_values_hidden(self):
+        # First 5 results [0:4] have missing receipt date
         filings = [
             factories.ScheduleAFactory(contribution_receipt_date=None) for _ in range(5)
         ]
+        # Results [5:30] have date
+        filings = filings + [
+            factories.ScheduleAFactory(
+                contribution_receipt_date=datetime.date(2016, 1, 1)
+            )
+            for _ in range(25)
+        ]
+        page1 = self._results(
+            api.url_for(
+                ScheduleAView,
+                sort='contribution_receipt_date',
+                sort_hide_null=True,
+                **self.kwargs)
+        )
+        self.assertEqual(len(page1), 20)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page1],
+            [each.sub_id for each in filings[5:25]],
+        )
+        self.assertEqual(
+            [each['contribution_receipt_date'] for each in page1],
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[5:25]
+            ],
+        )
+        page2 = self._results(
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
+                sort='contribution_receipt_date',
+                sort_hide_null=True,
+                **self.kwargs
+            )
+        )
+        self.assertEqual(len(page2), 5)
+        self.assertEqual(
+            [int(each['sub_id']) for each in page2],
+            [each.sub_id for each in filings[25:]],
+        )
+        self.assertEqual(
+            [each['contribution_receipt_date'] for each in page2],
+            [
+                each.contribution_receipt_date.strftime('%Y-%m-%d')
+                if each.contribution_receipt_date
+                else None
+                for each in filings[25:]
+            ],
+        )
+
+    def test_schedule_a_pagination_with_null_sort_column_values_showing(self):
+        # First 5 results [0:4] have missing receipt date
+        filings = [
+            factories.ScheduleAFactory(contribution_receipt_date=None) for _ in range(5)
+        ]
+        # Results [5:30] have date
         filings = filings + [
             factories.ScheduleAFactory(
                 contribution_receipt_date=datetime.date(2016, 1, 1)
@@ -357,7 +425,8 @@ class TestScheduleA(ApiBaseTest):
                 for each in filings[5:25]
             ],
         )
-        page2 = self._results(
+
+        page2_missing_last_contribution_receipt_date = self.app.get(
             api.url_for(
                 ScheduleAView,
                 last_index=page1[-1]['sub_id'],
@@ -365,10 +434,24 @@ class TestScheduleA(ApiBaseTest):
                 **self.kwargs
             )
         )
-        self.assertEqual(len(page2), 5)
+        self.assertEqual(page2_missing_last_contribution_receipt_date.status_code, 422)
+
+        page2 = self._results(
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
+                sort='contribution_receipt_date',
+                **self.kwargs
+            )
+        )
+        self.assertEqual(len(page2), 10)
+        last_date_results = filings[25:]
+        null_date_results = filings[:5]
+        last_date_results.extend(null_date_results)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
-            [each.sub_id for each in filings[25:]],
+            [each.sub_id for each in last_date_results],
         )
         self.assertEqual(
             [each['contribution_receipt_date'] for each in page2],
@@ -376,7 +459,7 @@ class TestScheduleA(ApiBaseTest):
                 each.contribution_receipt_date.strftime('%Y-%m-%d')
                 if each.contribution_receipt_date
                 else None
-                for each in filings[25:]
+                for each in last_date_results
             ],
         )
 
@@ -484,11 +567,21 @@ class TestScheduleA(ApiBaseTest):
                 for each in top_reversed_from_middle
             ],
         )
+
+        page2_missing_sort_null_only = self.app.get(
+            api.url_for(
+                ScheduleAView,
+                last_index=page1[-1]['sub_id'],
+                sort='contribution_receipt_date',
+                **self.kwargs
+            )
+        )
+        self.assertEqual(page2_missing_sort_null_only.status_code, 422)
+
         page2 = self._results(
             api.url_for(
                 ScheduleAView,
                 last_index=page1[-1]['sub_id'],
-                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
                 sort_null_only=True,
                 sort='contribution_receipt_date',
                 **self.kwargs
@@ -687,8 +780,21 @@ class TestScheduleB(ApiBaseTest):
             [int(each['sub_id']) for each in page1],
             [each.sub_id for each in filings[:-21:-1]],
         )
+        page2_missing_sort_null_only = self.app.get(
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                **self.kwargs
+            )
+        )
+        self.assertEqual(page2_missing_sort_null_only.status_code, 422)
         page2 = self._results(
-            api.url_for(ScheduleBView, last_index=page1[-1]['sub_id'], **self.kwargs)
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                sort_null_only=True,
+                **self.kwargs
+            )
         )
         self.assertEqual(len(page2), 10)
         self.assertEqual(
@@ -725,7 +831,7 @@ class TestScheduleB(ApiBaseTest):
                 for each in filings[5:25]
             ],
         )
-        page2 = self._results(
+        page2_missing_last_disbursement_date = self.app.get(
             api.url_for(
                 ScheduleBView,
                 last_index=page1[-1]['sub_id'],
@@ -733,10 +839,24 @@ class TestScheduleB(ApiBaseTest):
                 **self.kwargs
             )
         )
-        self.assertEqual(len(page2), 5)
+        self.assertEqual(page2_missing_last_disbursement_date.status_code, 422)
+
+        page2 = self._results(
+            api.url_for(
+                ScheduleBView,
+                last_index=page1[-1]['sub_id'],
+                last_disbursement_date=page1[-1]['disbursement_date'],
+                sort='disbursement_date',
+                **self.kwargs
+            )
+        )
+        self.assertEqual(len(page2), 10)
+        last_date_results = filings[25:]
+        null_date_results = filings[:5]
+        last_date_results.extend(null_date_results)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
-            [each.sub_id for each in filings[25:]],
+            [each.sub_id for each in last_date_results],
         )
         self.assertEqual(
             [each['disbursement_date'] for each in page2],
@@ -744,7 +864,7 @@ class TestScheduleB(ApiBaseTest):
                 each.disbursement_date.strftime('%Y-%m-%d')
                 if each.disbursement_date
                 else None
-                for each in filings[25:]
+                for each in last_date_results
             ],
         )
 

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -488,6 +488,7 @@ class TestScheduleA(ApiBaseTest):
             api.url_for(
                 ScheduleAView,
                 last_index=page1[-1]['sub_id'],
+                last_contribution_receipt_date=page1[-1]['contribution_receipt_date'],
                 sort_null_only=True,
                 sort='contribution_receipt_date',
                 **self.kwargs

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -65,6 +65,18 @@ class ItemizedResource(ApiResource):
         to avoid slow queries when one or more relevant committees has many
         records.
         """
+        if kwargs.get("last_index"):
+            if not any(kwargs.get("last_{}".format(option)) for option in self.sort_options):
+                print(kwargs)
+                for option in self.sort_options:
+                    print("last_{}".format(option))
+                    print(kwargs.get("last_{}".format(option)))
+                raise exceptions.ApiError(
+                    "Please add one of the following filters to your query: `last_{}`".format(
+                        "`, `".join(self.sort_options)
+                    ),
+                    status_code=400,
+                )
         committee_ids = kwargs.get('committee_id', [])
         if len(committee_ids) > 10:
             raise exceptions.ApiError(

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -72,10 +72,10 @@ class ItemizedResource(ApiResource):
             ) and not kwargs.get("sort_null_only"):
                 raise exceptions.ApiError(
                     "When paginating through results, both values from the \
-                    previous page's `last_index` object are needed. For more information, \
+                    previous page's `last_indexes` object are needed. For more information, \
                     see https://api.open.fec.gov/developers/. Please add one of the following \
-                    filters to your query: `sort_null_only`=True, `last_{}`".format(
-                        "`, `".join(self.sort_options)
+                    filters to your query: `sort_null_only`=True, {}".format(
+                        ", ".join("`last_" + option + "`" for option in self.sort_options)
                     ),
                     status_code=422,
                 )

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -66,16 +66,18 @@ class ItemizedResource(ApiResource):
         records.
         """
         if kwargs.get("last_index"):
-            if not any(kwargs.get("last_{}".format(option)) for option in self.sort_options):
-                print(kwargs)
-                for option in self.sort_options:
-                    print("last_{}".format(option))
-                    print(kwargs.get("last_{}".format(option)))
+            if all(
+                kwargs.get("last_{}".format(option)) is None
+                for option in self.sort_options
+            ) and not kwargs.get("sort_null_only"):
                 raise exceptions.ApiError(
-                    "Please add one of the following filters to your query: `last_{}`".format(
+                    "When paginating through results, both values from the \
+                    previous page's `last_index` object are needed. For more information, \
+                    see https://api.open.fec.gov/developers/. Please add one of the following \
+                    filters to your query: `sort_null_only`=True, `last_{}`".format(
                         "`, `".join(self.sort_options)
                     ),
-                    status_code=400,
+                    status_code=422,
                 )
         committee_ids = kwargs.get('committee_id', [])
         if len(committee_ids) > 10:

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -93,14 +93,6 @@ class ScheduleAView(ItemizedResource):
         )
 
     def build_query(self, **kwargs):
-        if kwargs.get("last_index"):
-            if not any(kwargs.get("last_{}".format(option)) for option in self.sort_options):
-                raise exceptions.ApiError(
-                    "Please add one of the following filters to your query: `last_{}`".format(
-                        "`, `".join(self.sort_options)
-                    ),
-                    status_code=400,
-                )
         secondary_index_options = [
             'committee_id',
             'contributor_id',

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -58,6 +58,7 @@ class ScheduleBView(ItemizedResource):
         (('min_image_number', 'max_image_number'),
          models.ScheduleB.image_number),
     ]
+    sort_options = ['disbursement_date', 'disbursement_amount']
 
     @property
     def args(self):
@@ -65,8 +66,7 @@ class ScheduleBView(ItemizedResource):
             args.itemized, args.schedule_b, args.make_seek_args(),
             args.make_sort_args(
                 default='-disbursement_date',
-                validator=args.OptionValidator(
-                    ['disbursement_date', 'disbursement_amount']),
+                validator=args.OptionValidator(self.sort_options),
                 show_nulls_last_arg=False,
             ))
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -57,6 +57,12 @@ class ScheduleEView(ItemizedResource):
         (('min_filing_date', 'max_filing_date'), models.ScheduleE.filing_date),
 
     ]
+    sort_options = [
+        'expenditure_date',
+        'expenditure_amount',
+        'office_total_ytd',
+        'support_oppose_indicator'
+    ]
 
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),
@@ -71,12 +77,7 @@ class ScheduleEView(ItemizedResource):
             args.make_seek_args(),
             args.make_sort_args(
                 default='-expenditure_date',
-                validator=args.OptionValidator([
-                    'expenditure_date',
-                    'expenditure_amount',
-                    'office_total_ytd',
-                    'support_oppose_indicator'
-                ]),
+                validator=args.OptionValidator(self.sort_options),
             ),
         )
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -33,6 +33,7 @@ class ScheduleH4View(ItemizedResource):
         ('committee_id', models.ScheduleH4.committee_id),
         ('cycle', models.ScheduleH4.cycle),
     ]
+    sort_options = ['event_purpose_date', 'disbursement_amount']
 
     @property
     def args(self):
@@ -40,8 +41,7 @@ class ScheduleH4View(ItemizedResource):
             args.itemized, args.schedule_h4, args.make_seek_args(),
             args.make_sort_args(
                 default='-event_purpose_date',
-                validator=args.OptionValidator(
-                    ['event_purpose_date', 'disbursement_amount']),
+                validator=args.OptionValidator(self.sort_options),
                 show_nulls_last_arg=False,
             ))
 


### PR DESCRIPTION
## Summary (required)

Resolves #4343

- **Add pagination validation:** For Schedules A, B, and E, if only `last_index` and not any of the sort options or `sort_hide_null=True` is chosen, throw a 422 error. Add test coverage.
- **Fix some Schedule A and Schedule B tests**: Make sure they pass both index values. For some tests, passing only `last_index` was hiding null values, which doesn't really make sense. Passing just `last_index` won't be valid behavior anymore, so for those tests, I explicitly added the `sort_hide_null=True` filter.

**Pagination basics** 
(from https://api.open.fec.gov/developers/#/receipts/get_schedules_schedule_a_):
> The `/schedules​/schedule_a​/` endpoint is not paginated by page number. This endpoint uses keyset pagination to improve query performance and these indices are required to properly page through this large dataset. To request the next page, you should append the values found in the last_indexes object from pagination to the URL of your last request as additional parameters. For example, when sorting by `contribution_receipt_date`, you might receive a page of results with the following pagination information:
```
pagination: {
    pages: 2152643,
    per_page: 20,
    count: 43052850,
    last_indexes: {
        last_index: "230880619",
        last_contribution_receipt_date: "2014-01-01"
    }
}
```
>To fetch the next page of sorted results, append `last_index=230880619` and `last_contribution_receipt_date=2014-01-01` to the URL. We strongly advise paging through these results using sort indices. The default sort is ascending by contribution_receipt_date. If you do not page using sort indices, some transactions may be unintentionally filtered out.

## How to test the changes locally

- Paginate through Schedule A, B, and E. This is tough to give exact links for because the data is changing all the time - the easiest way is to start with these queries and then copy/paste `last_index` and `last_contribution_receipt_date` or `sort_null_only=True` from the `pagination. last_indexes` object into new queries.
- Schedule A ascending: http://localhost:5000/v1/schedules/schedule_a/?two_year_transaction_period=2020&sort=contribution_receipt_date
- Schedule A descending: http://localhost:5000/v1/schedules/schedule_a/?two_year_transaction_period=2020&sort=-contribution_receipt_date
- Schedule B ascending: http://localhost:5000/v1/schedules/schedule_b/?sort=disbursement_date
- Schedule B ascending: http://localhost:5000/v1/schedules/schedule_b/?sort=-disbursement_date
- Schedule E ascending: http://localhost:5000/v1/schedules/schedule_e/?sort=expenditure_date
- Schedule E descending: http://localhost:5000/v1/schedules/schedule_e/?sort=-expenditure_date
- Try sorting/paginating by other `sort_options` as defined in the resource class
- Missing `last_contribution_receipt date` should throw 422 error: http://localhost:5000/v1/schedules/schedule_a/?sort_hide_null=false&sort_nulls_last=false&data_type=processed&min_date=05%2F06%2F2019&max_date=05%2F12%2F2020&sort=-contribution_receipt_date&per_page=100&contributor_name=Jeffrey+Allen&contributor_state=CA&last_index=4030220201231984113
- Test out some Schedule A, B, E queries in Swagger

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Pagination for Schedules A, B, E. Communication costs

