### PR TITLE
Update the AO task to include missing cites

### DIFF
--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -274,10 +274,14 @@ def fix_citations(ao_no, citation_type, citations):
 
     CITATION_EXCLUDE_LOOKUP = {
         '2017-03': {'ao': ['2010-11', '2011-12', '2015-16']},
+        '2019-11': {'statute': [(52, '301')]},
     }
 
     CITATION_INCLUDE_LOOKUP = {
         '1999-40': {'regulation': [(11, 110, 3)]},
+        '2019-14': {'regulation': [(11, 102, 1), (11, 102, 6), (11, 104, 1), (11, 300, 10)]},
+        '2019-11': {'regulation': [(11, 110, 11)]},
+        '2018-15': {'regulation': [(11, 112, 1), (11, 112, 5), (11, 113, 1), (11, 113, 2)]},
     }
 
     exclude_list = CITATION_EXCLUDE_LOOKUP.get(ao_no, {}).get(citation_type)


### PR DESCRIPTION
## Summary (required)
- update the AO python code to include and excludes the AO cites.

- Resolves https://github.com/fecgov/openFEC/issues/4333

## How to test the changes locally
- checkout branch `git checkout feature/4333-fix-missing-ao-cites`
- run local elastic search service instruction: https://github.com/fecgov/openFEC#run-locally
- set up local cms-->local api
- set local api --> to point to dev db
- get the dev s3 bucket creds from cf and export them in api terminal
- load AO : `python manage.py load_advisory_opinions -f 2018-15`
- on local cms  : http://localhost:8000/, verify that cites appear on AO's mentioned in issue #4333

## How to test the changes `dev` space:
- I have already deployed this feature branch to `dev` space and ran the api task that loads AO 
   from 2018-15(`cf run-task api  "python manage.py load_advisory_opinions -f 2018-15"`)
- Look up for AO's mentioned in issue #4333 in `dev` to see the cites appear 

**The following AO cites are updated in `dev`:**
1. AO 2018-15
Added regulations:
11 CFR 112.1
11 CFR 112.5
11 CFR 113.1
11 CFR 113.2

2. AO 2019-11
Added regulation: 11 CFR 110.11
Removed Statutes: 52 U.S.C. §301.

3. AO 2019-14
Added regulations:
11 CFR 102.1
11 CFR 102.6
11 CFR 104.1
11 CFR 300.10

## Impacted areas of the application
-  Legal Resources -->Advisory Opinions




