### PR TITLE
Add is_active column in names/committees/

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -42,7 +42,9 @@ class CommitteeFormatTest(ApiBaseTest):
         )
         decoy_committee = factories.CommitteeFactory()
         factories.CommitteeSearchFactory(
-            id=committee.committee_id, fulltxt=sa.func.to_tsvector(committee.name),
+            id=committee.committee_id,
+            fulltxt=sa.func.to_tsvector(committee.name),
+            is_active=True,
         )
         queries = [
             'america',

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -15,6 +15,7 @@ class CommitteeSearch(BaseModel):
     disbursements = db.Column(db.Numeric(30, 2))
     independent_expenditures = db.Column(db.Numeric(30, 2))
     total_activity = db.Column(db.Numeric(30, 2))
+    is_active = db.Column(db.Boolean, doc=docs.IS_COMMITTEE_ACTIVE)
 
 
 class BaseCommittee(BaseModel):

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -304,7 +304,7 @@ class CandidateSearchSchema(BaseSearchSchema):
 
 
 class CommitteeSearchSchema(BaseSearchSchema):
-    pass
+    is_active = ma.fields.Boolean()
 
 
 class CandidateSearchListSchema(ApiSchema):
@@ -317,7 +317,7 @@ class CandidateSearchListSchema(ApiSchema):
 
 class CommitteeSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
-        CandidateSearchSchema,
+        CommitteeSearchSchema,
         ref='#/definitions/CommitteeSearch',
         many=True,
     )


### PR DESCRIPTION
## Summary (required)
To make it more clear to our users what the status of a committee is, we want to add an indicator at the dropdown list of committee global search. 

- Resolves #[_4270_](https://github.com/fecgov/openFEC/issues/4270)

_Include a summary of proposed changes._
model: CommitteeSearch
test_committees.py

## How to test the changes locally
1)checkout branch
2)pytest
3)test url to see new field: is_avtive
on local:
http://127.0.0.1:5000/v1/names/committees/?q=tru

compare with production api:
https://api.open.fec.gov/v1/names/committees/?q=tru&api_key=DEMO_KEY