### PR TITLE
Handle case sensitivity for /example/<string:>/urls

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -727,7 +727,7 @@ class TestCandidateAggregates(ApiBaseTest):
         results = self._results(
             api.url_for(
                 ScheduleAByStateCandidateTotalsView,
-                candidate_id=self.candidate.candidate_id,
+                candidate_id=self.candidate.candidate_id.lower(),
                 cycle=2012,
             )
         )

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -159,7 +159,7 @@ class CandidateFormatTest(ApiBaseTest):
             ('state', 'CA'),
             ('party', 'DEM'),
             ('cycle', '2006'),
-            ('candidate_id', ['BARTLET', 'RITCHIE']),
+            ('candidate_id', ['BARTLET', 'ritchie']),
             ('is_active_candidate', False),
         )
 
@@ -350,4 +350,27 @@ class TestCandidateHistory(ApiBaseTest):
         )
         assert len(results) == 1
         assert results[0]['two_year_period'] == 2012
+        assert results[0]['candidate_id'] == self.candidates[1].candidate_id
+
+    def test_case_insensitivity(self):
+        results = self._results(
+            api.url_for(
+                CandidateHistoryView,
+                committee_id=self.committee.committee_id.lower(),
+                cycle=2012,
+                election_full=False,
+            )
+        )
+        assert len(results) == 1
+        assert results[0]['candidate_id'] == self.candidates[1].candidate_id
+
+        results = self._results(
+            api.url_for(
+                CandidateHistoryView,
+                candidate_id=self.candidates[1].candidate_id.lower(),
+                cycle=2012,
+                election_full=False,
+            )
+        )
+        assert len(results) == 1
         assert results[0]['candidate_id'] == self.candidates[1].candidate_id

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -315,6 +315,23 @@ class TestReports(ApiBaseTest):
         ]:
             self.assertEqual(result[key], getattr(report, key))
 
+    def test_case_insensitivity(self):
+        committee = factories.CommitteeFactory()
+        committee_id = committee.committee_id
+        factories.CommitteeHistoryFactory(
+            committee_id=committee_id,
+        )
+        factories.ReportsIEOnlyFactory(
+            committee_id=committee_id,
+            independent_contributions_period=200,
+            independent_expenditures_period=100,
+        )
+        results = self._results(
+            api.url_for(CommitteeReportsView, committee_id=committee_id.lower(),)
+        )
+        for result in results:
+            self.assertEqual(result["committee_id"], committee_id)
+
     def _check_reports(self, committee_type, factory, schema):
         committee = factories.CommitteeFactory(committee_type=committee_type)
         factories.CommitteeHistoryFactory(

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -85,7 +85,7 @@ class TestTotals(ApiBaseTest):
         fields = utils.extend(fields, transaction_coverage_fields)
 
         results = self._results(
-            api.url_for(TotalsCommitteeView, committee_id=committee_id)
+            api.url_for(TotalsCommitteeView, committee_id=committee_id.lower())
         )
         self.assertEqual(results[0], fields)
 

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -181,12 +181,12 @@ class CandidateView(ApiResource):
         query = super().build_query(**kwargs)
 
         if candidate_id is not None:
-            query = query.filter_by(candidate_id=candidate_id)
+            query = query.filter_by(candidate_id=candidate_id.upper())
 
         if committee_id is not None:
             query = (
                 query.join(models.CandidateCommitteeLink)
-                .filter(models.CandidateCommitteeLink.committee_id == committee_id)
+                .filter(models.CandidateCommitteeLink.committee_id == committee_id.upper())
                 .distinct()
             )
 
@@ -249,7 +249,7 @@ class CandidateHistoryView(ApiResource):
             # use for
             # '/candidate/<string:candidate_id>/history/',
             # '/candidate/<string:candidate_id>/history/<int:cycle>/',
-            query = query.filter(models.CandidateHistory.candidate_id == candidate_id)
+            query = query.filter(models.CandidateHistory.candidate_id == candidate_id.upper())
 
         if committee_id:
             # use for
@@ -261,7 +261,7 @@ class CandidateHistoryView(ApiResource):
                     models.CandidateCommitteeLink.candidate_id
                     == models.CandidateHistory.candidate_id,
                 )
-                .filter(models.CandidateCommitteeLink.committee_id == committee_id)
+                .filter(models.CandidateCommitteeLink.committee_id == committee_id.upper())
                 .distinct()
             )
         if cycle:

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -133,13 +133,13 @@ class CommitteeView(ApiResource):
         query = super().build_query(**kwargs)
 
         if committee_id is not None:
-            query = query.filter_by(committee_id=committee_id)
+            query = query.filter_by(committee_id=committee_id.upper())
 
         if candidate_id is not None:
             query = query.join(
                 models.CandidateCommitteeLink
             ).filter(
-                models.CandidateCommitteeLink.candidate_id == candidate_id
+                models.CandidateCommitteeLink.candidate_id == candidate_id.upper()
             ).distinct()
 
         if kwargs.get('year'):
@@ -188,7 +188,7 @@ class CommitteeHistoryView(ApiResource):
             # use for
             # '/committee/<string:committee_id>/history/',
             # '/committee/<string:committee_id>/history/<int:cycle>/',
-            query = query.filter(models.CommitteeHistory.committee_id == committee_id)
+            query = query.filter(models.CommitteeHistory.committee_id == committee_id.upper())
 
         if candidate_id:
             # use for
@@ -201,7 +201,7 @@ class CommitteeHistoryView(ApiResource):
                     models.CandidateCommitteeLink.fec_election_year == models.CommitteeHistory.cycle,
                 ),
             ).filter(
-                models.CandidateCommitteeLink.candidate_id == candidate_id,
+                models.CandidateCommitteeLink.candidate_id == candidate_id.upper(),
             )
         if cycle:
             # use for

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -199,7 +199,7 @@ class CommitteeReportsView(views.ApiResource):
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
-            committee_id=committee_id, committee_type=committee_type, **kwargs
+            committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
         )
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
@@ -210,7 +210,7 @@ class CommitteeReportsView(views.ApiResource):
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         reports_class, reports_schema = reports_schema_map.get(
             self._resolve_committee_type(
-                committee_id=committee_id, committee_type=committee_type, **kwargs
+                committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
             ),
             default_schemas,
         )
@@ -229,7 +229,7 @@ class CommitteeReportsView(views.ApiResource):
                 sa.orm.joinedload(reports_class.committee)
             )
         if committee_id is not None:
-            query = query.filter_by(committee_id=committee_id)
+            query = query.filter_by(committee_id=committee_id.upper())
 
         query = filters.filter_range(query, kwargs, get_range_filters())
         query = filters.filter_match(query, kwargs, get_match_filters())
@@ -238,7 +238,7 @@ class CommitteeReportsView(views.ApiResource):
 
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
-            query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
+            query = models.CommitteeHistory.query.filter_by(committee_id=committee_id.upper())
 
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -154,7 +154,7 @@ class TotalsCommitteeView(ApiResource):
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):
         query, totals_class, totals_schema = self.build_query(
-            committee_id=committee_id, committee_type=committee_type, **kwargs
+            committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
         )
         page = utils.fetch_page(query, kwargs, model=totals_class)
         return totals_schema().dump(page).data
@@ -162,13 +162,13 @@ class TotalsCommitteeView(ApiResource):
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
             self._resolve_committee_type(
-                committee_id=committee_id, committee_type=committee_type, **kwargs
+                committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
             ),
             default_schemas,
         )
         query = totals_class.query
         if committee_id is not None:
-            query = query.filter(totals_class.committee_id == committee_id)
+            query = query.filter(totals_class.committee_id == committee_id.upper())
         if kwargs.get('cycle'):
             query = query.filter(totals_class.cycle.in_(kwargs['cycle']))
 
@@ -197,7 +197,7 @@ class CandidateTotalsView(utils.Resource):
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, candidate_id, **kwargs):
         query, totals_class, totals_schema = self.build_query(
-            candidate_id=candidate_id, **kwargs
+            candidate_id=candidate_id.upper(), **kwargs
         )
         if kwargs['sort']:
             validator = args.IndexValidator(totals_class)
@@ -207,11 +207,11 @@ class CandidateTotalsView(utils.Resource):
 
     def build_query(self, candidate_id=None, **kwargs):
         totals_class, totals_schema = candidate_totals_schema_map.get(
-            self._resolve_committee_type(candidate_id=candidate_id, **kwargs),
+            self._resolve_committee_type(candidate_id=candidate_id.upper(), **kwargs),
             default_schemas,
         )
         query = totals_class.query
-        query = query.filter(totals_class.candidate_id == candidate_id)
+        query = query.filter(totals_class.candidate_id == candidate_id.upper())
 
         if 'full_election' in kwargs.keys():
             # full_election is replaced by election_full.


### PR DESCRIPTION
## Summary (required)

- Resolves #4355 

Handle case sensitivity for /example/<string:>/urls. Another issue found in testing: two endpoints aren't filtering for committee ID at all, but this PR is big enough (and solves a big front-end problem), so I split it off into another issue (https://github.com/fecgov/openFEC/issues/4357). 

## How to test the changes locally
Make sure candidate ID's and committee ID's return results when lower-cased.

candidates.CandidateView:
 - http://localhost:5000/v1/candidate/p00009621/
 - http://localhost:5000/v1/committee/c00693234/candidates/

candidates.CandidateHistoryView:
 - http://localhost:5000/v1/candidate/p00009621/history/
 - http://localhost:5000/v1/candidate/p00009621/history/2020/
 - http://localhost:5000/v1/committee/c00693234/candidates/history/
 - http://localhost:5000/v1/committee/c00693234/candidates/history/2020/

committees.CommitteeView:
 - http://localhost:5000/v1/committee/c00693234/
 - http://localhost:5000/v1/candidate/p00009621/committees/

committees.CommitteeHistoryView:
 - http://localhost:5000/v1/committee/c00693234/history/
 - http://localhost:5000/v1/committee/c00693234/history/2020/
 - http://localhost:5000/v1/candidate/p00009621/committees/history/
 - http://localhost:5000/v1/candidate/p00009621/committees/history/2020/

reports.CommitteeReportsView:
 - http://localhost:5000/v1/committee/c00693234/reports/

totals.TotalsCommitteeView:
 - http://localhost:5000/v1/committee/c00693234/totals/

totals.CandidateTotalsView:
 - http://localhost:5000/v1/candidate/p00009621/totals/


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Candidate profile page, committee profile page 500 errors




