### PR TITLE
API key signup page

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1,3 +1,7 @@
+from webservices.env import env
+
+api_key_signup_feature_flag = bool(env.get_credential('API_UMBRELLA_SIGNUP_KEY_FEATURE_FLAG', ''))
+
 """Narrative API documentation."""
 
 API_DESCRIPTION = '''
@@ -27,13 +31,17 @@ lists for commercial purposes or to solicit donations.
 [Learn more here](https://www.fec.gov/updates/sale-or-use-contributor-information/).
 
 [View our source code](https://github.com/fecgov/openFEC). We welcome issues and pull requests!
-
-
-<p><br></p>
-<h2 class="title" id="signup_head">Sign up for an API key</h2>
-<div id="apidatagov_signup">Loading signup form...</div>
-
 '''
+
+if api_key_signup_feature_flag:
+    API_DESCRIPTION += \
+        '''
+        
+        <p><br></p>
+        <h2 class="title" id="signup_head">Sign up for an API key</h2>
+        <div id="apidatagov_signup">Loading signup form...</div>
+
+        '''
 
 PAGES = '''
 Number of pages in the document

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -27,6 +27,12 @@ lists for commercial purposes or to solicit donations.
 [Learn more here](https://www.fec.gov/updates/sale-or-use-contributor-information/).
 
 [View our source code](https://github.com/fecgov/openFEC). We welcome issues and pull requests!
+
+
+<p><br></p>
+<h2 class="title" id="signup_head">Sign up for an API key</h2>
+<div id="apidatagov_signup">Loading signup form...</div>
+
 '''
 
 PAGES = '''

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -236,10 +236,10 @@ def add_secure_headers(response):
     content_security_policy = {
         "default-src": "'self' *.fec.gov *.app.cloud.gov",
         "img-src": "'self' data:",
-        "script-src": "'self' 'unsafe-inline'",
-        "style-src": "'self' https://fonts.googleapis.com 'unsafe-inline'",
-        "font-src": "'self' https://fonts.gstatic.com data:",
-        "connect-src": "*.fec.gov *.cloud.gov",
+        "script-src": "'self' https://api.data.gov 'unsafe-inline'",
+        "style-src": "'self' https://fonts.googleapis.com https://api.data.gov 'unsafe-inline'",
+        "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
+        "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov",
         "object-src": "'none'",
         "report-uri": "/report-csp-violation/",
     }
@@ -563,6 +563,7 @@ def api_ui():
         'swagger-ui.html',
         specs_url=url_for('docs.api_spec'),
         PRODUCTION=env.get_credential('PRODUCTION'),
+        api_key_signup_key=env.get_credential('API_UMBRELLA_SIGNUP_KEY'),
     )
 
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -564,6 +564,7 @@ def api_ui():
         specs_url=url_for('docs.api_spec'),
         PRODUCTION=env.get_credential('PRODUCTION'),
         api_key_signup_key=env.get_credential('API_UMBRELLA_SIGNUP_KEY'),
+        api_key_signup_feature_flag=bool(env.get_credential('API_UMBRELLA_SIGNUP_KEY_FEATURE_FLAG', '')),
     )
 
 

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -117,7 +117,23 @@ spec = APISpec(
             'name': 'api_key',
             'in': 'query',
         },
+        'ApiKeyQueryAuth': {
+            'type': 'apiKey',
+            'name': 'api_key',
+            'in': 'query',
+        },
+        'ApiKeyHeaderAuth': {
+            'type': 'apiKey',
+            'name': 'X-Api-Key',
+            'in': 'header',
+        }
     },
-    security=[{'apiKey': []}],
+    security=[
+        {
+            'apiKey': [],
+            'ApiKeyQueryAuth': [],
+            'ApiKeyHeaderAuth': []
+        }
+    ],
     tags=TAGS,
 )

--- a/webservices/templates/swagger-ui.html
+++ b/webservices/templates/swagger-ui.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>OpenFEC API Documentation</title>
-
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{ swagger_static('dist/main.css') }}" >
     <link rel="icon" type="image/png" href="{{ swagger_static('favicon.ico') }}" />
@@ -30,7 +29,70 @@
 </head>
 
 <body>
-    <div id="swagger-ui"></div>
+
+<div id="swagger-ui"></div>
+ <script type="text/javascript">
+   /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+   var apiUmbrellaSignupOptions = {
+     // Pick a short, unique name to identify your site, like 'gsa-auctions'
+     // in this example.
+     registrationSource: 'fec-api',
+
+     // Enter the API key you signed up for and specially configured for this
+     // API key signup embed form.
+     apiKey: "{{ api_key_signup_key }}",
+     // document.write(apiKey.toLocaleString( ));
+     // Provide a URL or e-mail address to be used for customer support.
+     //
+     // The format for e-mail addresses can be given as either
+     // 'example@example.com' or 'mailto:example@example.com'.
+     contactUrl: 'APIinfo@fec.gov',
+
+     // Provide the name of your developer site. This will appear in the
+     // subject of the welcome e-mail as "Your {{siteName}} API key".
+     siteName: 'openFEC',
+
+     // Provide a sender name for who the welcome email appears from. The
+     // actual address will be "noreply@api.data.gov", but this will
+     // change the name of the displayed sender in this fashion:
+     // "{{emailFromName}} <noreply@api.data.gov>".
+     emailFromName: 'openFEC',
+
+     // Provide an example URL you want to show to users after they signup.
+     // This can be any API endpoint on your server, and you can use the
+     // special {{api_key_signup_key}} variable to automatically substitute in the API
+     // key the user just signed up for.
+     // exampleApiUrl: 'https://api.open.fec.gov/v1/legal/search/?api_key_signup_key={{api_key_signup_key}}',
+
+     // OPTIONAL: Provide extra content to display on the signup confirmation
+     // page. This will be displayed below the user's API key and the example
+     // API URL are shown. HTML is allowed. Defaults to ""
+     // signupConfirmationMessage: '',
+
+     // OPTIONAL: Set to true to verify the user's e-mail address by only
+     // sending them their API key via e-mail, and not displaying it on the
+     // signup confirmation web page. Defaults to false.
+     verifyEmail: true,
+
+     // OPTIONAL: Set to false to disable sending a welcome e-mail to the
+     // user after signing up. Defaults to true.
+     sendWelcomeEmail: true,
+
+     // OPTIONAL: Provide an extra input field to ask for the user's website.
+     // Defaults to false.
+     // websiteInput: true,
+
+     // OPTIONAL: Provide an extra checkbox asking the user to agree to terms
+     // and conditions before signing up. Defaults to false.
+     // termsCheckbox: true,
+
+     // OPTIONAL: If the terms & conditions checkbox is enabled, link to this
+     // URL for your API's terms & conditions. Defaults to "".
+     // termsUrl: "https://agency.gov/api-terms/",
+   };
+ </script>
+ <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
+
     <script src="{{ swagger_static('dist/swagger-layout.js') }}"> </script>
     <script>
       window.onload = function() {
@@ -38,6 +100,14 @@
           "{{ specs_url }}",
           document.getElementById("swagger-ui")
         );
+        
+         var apiUmbrella = document.createElement('script'); 
+         apiUmbrella.type = 'text/javascript'; 
+         apiUmbrella.async = true;
+         apiUmbrella.src = 'https://api.data.gov/static/javascripts/signup_embed.js';
+         (document.getElementsByTagName('head')[0] || 
+          document.getElementsByTagName('body')[0])
+         .appendChild(apiUmbrella);
       };
     </script>
 
@@ -54,6 +124,9 @@
         ga('send', 'pageview');
     </script>
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
-  {% endif %}
-  </body>
+{% endif %}
+
+
+</body>
+
 </html>

--- a/webservices/templates/swagger-ui.html
+++ b/webservices/templates/swagger-ui.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+
 <html>
 <head>
   <title>OpenFEC API Documentation</title>
@@ -29,8 +30,8 @@
 </head>
 
 <body>
-
 <div id="swagger-ui"></div>
+
  <script type="text/javascript">
    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
    var apiUmbrellaSignupOptions = {
@@ -46,7 +47,7 @@
      //
      // The format for e-mail addresses can be given as either
      // 'example@example.com' or 'mailto:example@example.com'.
-     contactUrl: 'APIinfo@fec.gov',
+     contactUrl: 'mailto:APIinfo@fec.gov',
 
      // Provide the name of your developer site. This will appear in the
      // subject of the welcome e-mail as "Your {{siteName}} API key".
@@ -56,13 +57,13 @@
      // actual address will be "noreply@api.data.gov", but this will
      // change the name of the displayed sender in this fashion:
      // "{{emailFromName}} <noreply@api.data.gov>".
-     emailFromName: 'openFEC',
+     emailFromName: 'FEC',
 
      // Provide an example URL you want to show to users after they signup.
      // This can be any API endpoint on your server, and you can use the
-     // special {{api_key_signup_key}} variable to automatically substitute in the API
+     // special {{api_key}} variable to automatically substitute in the API
      // key the user just signed up for.
-     // exampleApiUrl: 'https://api.open.fec.gov/v1/legal/search/?api_key_signup_key={{api_key_signup_key}}',
+     exampleApiUrl: 'https://api.open.fec.gov/v1/legal/search/?api_key={{api_key}}',
 
      // OPTIONAL: Provide extra content to display on the signup confirmation
      // page. This will be displayed below the user's API key and the example
@@ -93,7 +94,11 @@
  </script>
  <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
 
-    <script src="{{ swagger_static('dist/swagger-layout.js') }}"> </script>
+    <script src="{{ swagger_static('dist/swagger-layout.js') }}">
+</script>
+
+{% if api_key_signup_feature_flag %}
+
     <script>
       window.onload = function() {
         SwaggerLayout(
@@ -109,7 +114,18 @@
           document.getElementsByTagName('body')[0])
          .appendChild(apiUmbrella);
       };
-    </script>
+</script>
+{% else %}
+    <script>
+      window.onload = function() {
+        SwaggerLayout(
+          "{{ specs_url }}",
+          document.getElementById("swagger-ui")
+        );
+      };
+</script>
+{% endif %}
+
 
   {% if PRODUCTION %}
     <script>
@@ -125,7 +141,6 @@
     </script>
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
 {% endif %}
-
 
 </body>
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4323
- add plain vanilla API Key Signup page to our swagger-ui in advance of heavier lift https://github.com/fecgov/openFEC/issues/3947

## How to test the changes locally
Reviewers can either do a manual deploy to dev if desired, or run locally. The following are the steps for running locally:
- checkout this branch
- locally `export` the `API_UMBRELLA_SIGNUP_KEY` envar value located in `cf env api` (`cf target -s dev`)
- locally `export API_UMBRELLA_SIGNUP_KEY_FEATURE_FLAG="True"`
- run local api
- (please test functionality/correctness)

## Impacted areas of the application
List general components of the application that this PR will affect:
-  swagger-ui, rest.py, docs.py, spec.py