### PR TITLE
Add max ten (10) limits for additional fields

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -690,6 +690,22 @@ class TestScheduleA(ApiBaseTest):
             all(100 <= each['contribution_receipt_amount'] <= 150 for each in results)
         )
 
+    def test_schedule_a_max_filter_count(self):
+        max_count = 10
+        filters_with_max_count = [
+            ('committee_id', [str(number) for number in range(max_count + 1)]),
+            ('contributor_name', [str(number) for number in range(max_count + 1)]),
+            ('contributor_zip', [str(number) for number in range(max_count + 1)]),
+            ('contributor_city', [str(number) for number in range(max_count + 1)]),
+            ('contributor_employer', [str(number) for number in range(max_count + 1)]),
+            ('contributor_occupation', [str(number) for number in range(max_count + 1)]),
+        ]
+        for label, values in filters_with_max_count:
+            response = self.app.get(
+                api.url_for(ScheduleAView, **{label: values})
+            )
+            self.assertEqual(response.status_code, 422)
+
     def test_schedule_a_efile_filters(self):
         filters = [
             ('image_number', ScheduleAEfile.image_number, ['123', '456']),

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -59,6 +59,7 @@ class ItemizedResource(ApiResource):
     year_column = None
     index_column = None
     filters_with_max_count = []
+    max_count = 10
 
     def get(self, **kwargs):
         """Get itemized resources. If multiple values are passed for `committee_id`,
@@ -80,13 +81,18 @@ class ItemizedResource(ApiResource):
                     ),
                     status_code=422,
                 )
-        max_count = 10
-        for field in self.filters_with_max_count:
-            if len(kwargs.get(field, [])) > max_count:
-                raise exceptions.ApiError(
-                    'Can only specify up to {0} values for "{1}".'.format(max_count, field),
-                    status_code=422,
-                )
+        over_limit_fields = [
+            field
+            for field in self.filters_with_max_count
+            if len(kwargs.get(field, [])) > self.max_count
+        ]
+        if over_limit_fields:
+            raise exceptions.ApiError(
+                "Can only specify up to {0} values for `{1}`".format(
+                    self.max_count, "`, `".join(over_limit_fields)
+                ),
+                status_code=422,
+            )
         if len(kwargs.get("committee_id", [])) > 1:
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -117,8 +117,8 @@ class ScheduleAView(ItemizedResource):
         if len(two_year_transaction_periods) != 1:
             if not any(kwargs.get(field) for field in secondary_index_options):
                 raise exceptions.ApiError(
-                    "Please choose a single `two_year_transaction_period` or \
-                    add one of the following filters to your query: `{}`".format(
+                    "Please choose a single `two_year_transaction_period` or "
+                    "add one of the following filters to your query: `{}`".format(
                         "`, `".join(secondary_index_options)
                     ),
                     status_code=400,

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -78,6 +78,14 @@ class ScheduleAView(ItemizedResource):
         'contribution_receipt_amount',
         'contributor_aggregate_ytd',
     ]
+    filters_with_max_count = [
+        'committee_id',
+        'contributor_name',
+        'contributor_zip',
+        'contributor_city',
+        'contributor_employer',
+        'contributor_occupation',
+    ]
 
     @property
     def args(self):

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -59,6 +59,11 @@ class ScheduleBView(ItemizedResource):
          models.ScheduleB.image_number),
     ]
     sort_options = ['disbursement_date', 'disbursement_amount']
+    filters_with_max_count = [
+        'committee_id',
+        'recipient_name',
+        'recipient_city',
+    ]
 
     @property
     def args(self):

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -63,6 +63,10 @@ class ScheduleEView(ItemizedResource):
         'office_total_ytd',
         'support_oppose_indicator'
     ]
+    filters_with_max_count = [
+        'committee_id',
+        'candidate_id',
+    ]
 
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),


### PR DESCRIPTION
## Summary (required)

Resolves #3902
- Add max limits for additional fields (below)
- Add test coverage

**Schedule A endpoint (schedules/schedule_a/):** 
Limit 10 for:
- Name - `contributor_name`
- Zip - `contributor_zip`
- City - `contributor_city`
- Occupation - `contributor_employer`
- Employer - `contributor_occupation`

**Schedule B endpoint (schedules/schedule_b/):** 
Limit 10 for:
- Recipient name or ID - `recipient_name` (takes ID or name)
- City  - `recipient_city`

**Schedule E endpoint (schedules/schedule_e/):** 
Limit 10 for:
- Candidate name or ID (`candidate_id`)



## How to test the changes locally

## Schedule A
```
filters_with_max_count = [
    'committee_id',
    'contributor_name',
    'contributor_zip',
    'contributor_city',
    'contributor_employer',
    'contributor_occupation',
]
```
'committee_id',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&committee_id=C00223743&committee_id=C00223446&committee_id=C00223735&committee_id=C00222778&committee_id=C00222612&committee_id=C00224048&committee_id=C00222273&committee_id=C00222760&committee_id=C00223925&committee_id=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&committee_id=1&committee_id=2

'contributor_name',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_name=C00223743&contributor_name=C00223446&contributor_name=C00223735&contributor_name=C00222778&contributor_name=C00222612&contributor_name=C00224048&contributor_name=C00222273&contributor_name=C00222760&contributor_name=C00223925&contributor_name=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_name=1&contributor_name=2

'contributor_zip',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_zip=C00223743&contributor_zip=C00223446&contributor_zip=C00223735&contributor_zip=C00222778&contributor_zip=C00222612&contributor_zip=C00224048&contributor_zip=C00222273&contributor_zip=C00222760&contributor_zip=C00223925&contributor_zip=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_zip=1&contributor_zip=2

'contributor_city',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_city=C00223743&contributor_city=C00223446&contributor_city=C00223735&contributor_city=C00222778&contributor_city=C00222612&contributor_city=C00224048&contributor_city=C00222273&contributor_city=C00222760&contributor_city=C00223925&contributor_city=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_city=1&contributor_city=2

'contributor_employer',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_employer=C00223743&contributor_employer=C00223446&contributor_employer=C00223735&contributor_employer=C00222778&contributor_employer=C00222612&contributor_employer=C00224048&contributor_employer=C00222273&contributor_employer=C00222760&contributor_employer=C00223925&contributor_employer=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_employer=1&contributor_employer=2

'contributor_occupation',


http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_occupation=C00223743&contributor_occupation=C00223446&contributor_occupation=C00223735&contributor_occupation=C00222778&contributor_occupation=C00222612&contributor_occupation=C00224048&contributor_occupation=C00222273&contributor_occupation=C00222760&contributor_occupation=C00223925&contributor_occupation=C00213850&two_year_transaction_period=1996&two_year_transaction_period=1994&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_occupation=1&contributor_occupation=2

## Schedule B

```
    filters_with_max_count = [
        'committee_id',
        'recipient_name',
        'recipient_city',
    ]

```

 'committee_id',

http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00139998&committee_id=C00172189&committee_id=C00221820&committee_id=C00412304&committee_id=C00427526&committee_id=C00500975&committee_id=C00511055&committee_id=C00547679&committee_id=C00547828&committee_id=C00549972&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&sort=-disbursement_date&per_page=30&committee_id=2

'recipient_name',

http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&recipient_name=C00139998&recipient_name=C00172189&recipient_name=C00221820&recipient_name=C00412304&recipient_name=C00427526&recipient_name=C00500975&recipient_name=C00511055&recipient_name=C00547679&recipient_name=C00547828&recipient_name=C00549972&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&sort=-disbursement_date&per_page=30&recipient_name=2

'recipient_city',

http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&recipient_city=C00139998&recipient_city=C00172189&recipient_city=C00221820&recipient_city=C00412304&recipient_city=C00427526&recipient_city=C00500975&recipient_city=C00511055&recipient_city=C00547679&recipient_city=C00547828&recipient_city=C00549972&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&sort=-disbursement_date&per_page=30&recipient_city=2

## Schedule E
```
    filters_with_max_count = [
        'committee_id',
        'candidate_id',
    ]
```

'committee_id',

http://localhost:5000/v1/schedules/schedule_e/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00139998&committee_id=C00172189&committee_id=C00221820&committee_id=C00412304&committee_id=C00427526&committee_id=C00500975&committee_id=C00511055&committee_id=C00547679&committee_id=C00547828&committee_id=C00549972&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&per_page=30&committee_id=2

'candidate_id',

http://localhost:5000/v1/schedules/schedule_e/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&candidate_id=C00139998&candidate_id=C00172189&candidate_id=C00221820&candidate_id=C00412304&candidate_id=C00427526&candidate_id=C00500975&candidate_id=C00511055&candidate_id=C00547679&candidate_id=C00547828&candidate_id=C00549972&two_year_transaction_period=2020&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&per_page=30&candidate_id=2

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Schedule A, B, E  endpoints. Front-end is adding client-side validation.



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/3996-max-10-cmte-ids | https://github.com/fecgov/openFEC/pull/4014

