### PR TITLE
Add filter by load_date in sched_a

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -711,6 +711,36 @@ class TestScheduleA(ApiBaseTest):
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
+    def test_schedule_a_load_date_filter(self):
+        [
+            factories.ScheduleAFactory(load_date=datetime.date(2020, 1, 2)),
+            factories.ScheduleAFactory(load_date=datetime.date(2020, 1, 3)),
+            factories.ScheduleAFactory(load_date=datetime.date(2020, 1, 1)),
+            factories.ScheduleAFactory(load_date=datetime.date(2019, 12, 31)),
+        ]
+
+        results = self._results(
+            api.url_for(ScheduleAView, min_load_date='2020-01-01', **self.kwargs)
+        )
+        self.assertTrue(
+            all(
+                datetime.datetime.strptime(each['load_date'][:10], '%Y-%m-%d').date()
+                >= datetime.date(2020, 1, 1)
+                for each in results
+            )
+        )
+
+        results = self._results(
+            api.url_for(ScheduleAView, max_load_date='2020-01-01', **self.kwargs)
+        )
+        self.assertTrue(
+            all(
+                datetime.datetime.strptime(each['load_date'][:10], '%Y-%m-%d').date()
+                <= datetime.date(2020, 1, 1)
+                for each in results
+            )
+        )
+
 
 class TestScheduleB(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -535,7 +535,8 @@ schedule_a = {
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
         description=docs.DESIGNATION,
     ),
-
+    'min_load_date': fields.Date(description=docs.MIN_LOAD_DATE),
+    'max_load_date': fields.Date(description=docs.MAX_LOAD_DATE),
 }
 
 schedule_a_e_file = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1360,6 +1360,8 @@ IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo c
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'
 MISSING_STATE = 'Exclude values with missing state'
+MIN_LOAD_DATE = 'Minimum load date'
+MAX_LOAD_DATE = 'Maximum load date'
 
 # schedule B
 DISBURSEMENT_DESCRIPTION = 'Description of disbursement'

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -60,6 +60,7 @@ class ScheduleAView(ItemizedResource):
         (('min_date', 'max_date'), models.ScheduleA.contribution_receipt_date),
         (('min_amount', 'max_amount'), models.ScheduleA.contribution_receipt_amount),
         (('min_image_number', 'max_image_number'), models.ScheduleA.image_number),
+        (('min_load_date', 'max_load_date'), models.ScheduleA.load_date),
     ]
     filter_fulltext_fields = [
         ('contributor_name', models.ScheduleA.contributor_name_text),


### PR DESCRIPTION
## Summary

Adds the ability to filter by `load_date` in `sched_a` views so users can search for contributions loaded in a specific day.

## How to test the changes locally

- `pytest tests/test_itemized.py::TestScheduleA::test_schedule_a_load_date_filter`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `ScheduleAView` 


