### PR TITLE
Update pytest-flake8 to v1.0.6.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ redis==3.2.0
 pytest==5.2.0
 pytest-cov==2.5.1
 codecov==2.0.17
-pytest-flake8==1.0.4
+pytest-flake8==1.0.6
 nplusone==0.8.0
 webtest==2.0.34
 factory_boy==2.8.1


### PR DESCRIPTION
update pytest-flake8 to v1.0.6

## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/4373

_Include a summary of proposed changes._
- update the pytest-flake8 in requirements.txt

## How to test the changes locally

- checkout branch  `git checkout feature/upgrade-pytest-flake8`
- `pip install -r requirements.txt`
- run `pytest` 





