### PR TITLE
Update requests to v2.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gunicorn==19.10.0
 gevent==1.4.0
 webargs==5.5.3
 ujson==1.33
-requests==2.21.0
+requests==2.22.0
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 git+https://github.com/18F/slate.git


### PR DESCRIPTION
## Summary (required)
Update requests package version to2.22.0 to resolve the ERROR that shows up in deploy script.

```ERROR: prance 0.18.2 has requirement requests~=2.22, but you'll have requests 2.21.0 which is incompatible```.

- Resolves https://github.com/fecgov/openFEC/issues/4295

_Include a summary of proposed changes._
 - update requests to v2.22.0 in `requirements.txt` file

## How to test the changes locally

- checkout branch `git checkout feature/upgrade-requests-pkg`
- install requirements`pip install -r requirements.txt`
- remove node modules: `rm -rf node_modules/`
- install node pkgs : `npm i`
- install python pkgs: `npm run build`
- run `pytest`
- run server : `python manage.py runserver`
- test endpoints here - `http://localhost:5000/`
- deploy this feature branch  to `dev` space and verify that the error (`ERROR: prance 0.18.2 has requirement requests~=2.22, but you'll have requests 2.21.0 which is incompatible`) no longer shows under circleci deploy task 

## Impacted areas of the application
List general components of the application that this PR will affect:

-  CircleCI deploy task

Screenshot of current circleci deploy script w/requests v2.21.0:
<img width="901" alt="Screen Shot 2020-05-26 at 5 40 27 PM" src="https://user-images.githubusercontent.com/11650355/82953498-de23c700-9f78-11ea-9984-0eaa75f296a2.png">


Screenshot of circleci deploy script after updating requests v2.22.0:
<img width="910" alt="Screen Shot 2020-05-26 at 5 40 02 PM" src="https://user-images.githubusercontent.com/11650355/82953305-84bb9800-9f78-11ea-924d-23dcc4375a89.png">
