### PR TITLE
Add flag ('use_pk_for_count') to only select primary key column for count query

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from webservices import rest
 from webservices.rest import api
 from webservices.resources.search import CandidateNameSearch, CommitteeNameSearch
 from webservices.resources.candidates import CandidateList
+from webservices.common.views import ApiResource
 
 
 class OverallTest(ApiBaseTest):
@@ -126,3 +127,9 @@ class OverallTest(ApiBaseTest):
         observed = [each['id'] for each in results]
         assert expected == observed
         assert all('bartlet' in each['name'].lower() for each in results)
+
+    def test_has_primary_key_if_using_pk_for_count(self):
+        for view in ApiResource.__subclasses__():
+            if view.use_pk_for_count:
+                assert view.model is not None
+                assert len(view.model.__mapper__.primary_key) > 0

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -27,7 +27,7 @@ class TestCounts(ApiBaseTest):
         ]
         resource = sched_e.ScheduleEEfileView()
         count, estimate = counts.get_count(
-            query, db.session, models.ScheduleEEfile, resource.use_estimated_counts
+            query, models.ScheduleEEfile, resource.use_estimated_counts
         )
         # Always use exact count for Schedule E efile
         self.assertEqual(count, 5)
@@ -51,7 +51,7 @@ class TestCounts(ApiBaseTest):
         get_query_plan_mock.return_value = [
             ('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)
         ]
-        count, estimate = counts.get_count(query, db.session, models.ScheduleA)
+        count, estimate = counts.get_count(query, models.ScheduleA)
         self.assertEqual(count, 2)
         self.assertEqual(estimate, False)
 
@@ -64,6 +64,6 @@ class TestCounts(ApiBaseTest):
             (cost=0.00..10.60 rows=2000000 width=1289)',
             )
         ]
-        count, estimate = counts.get_count(query, db.session, models.ScheduleA)
+        count, estimate = counts.get_count(query, models.ScheduleA)
         self.assertEqual(count, 2000000)
         self.assertEqual(estimate, True)

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -5,7 +5,7 @@ from unittest import mock
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.resources import sched_e
+from webservices.resources import sched_a, sched_e
 from webservices.rest import db
 from webservices.common import models, counts
 
@@ -27,7 +27,7 @@ class TestCounts(ApiBaseTest):
         ]
         resource = sched_e.ScheduleEEfileView()
         count, estimate = counts.get_count(
-            query, models.ScheduleEEfile, resource.use_estimated_counts
+            resource, query
         )
         # Always use exact count for Schedule E efile
         self.assertEqual(count, 5)
@@ -51,7 +51,8 @@ class TestCounts(ApiBaseTest):
         get_query_plan_mock.return_value = [
             ('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)
         ]
-        count, estimate = counts.get_count(query, models.ScheduleA)
+        resource = sched_a.ScheduleAView()
+        count, estimate = counts.get_count(resource, query)
         self.assertEqual(count, 2)
         self.assertEqual(estimate, False)
 
@@ -64,6 +65,7 @@ class TestCounts(ApiBaseTest):
             (cost=0.00..10.60 rows=2000000 width=1289)',
             )
         ]
-        count, estimate = counts.get_count(query, models.ScheduleA)
+        resource = sched_a.ScheduleAView()
+        count, estimate = counts.get_count(resource, query)
         self.assertEqual(count, 2000000)
         self.assertEqual(estimate, True)

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -27,7 +27,7 @@ class TestCounts(ApiBaseTest):
         ]
         resource = sched_e.ScheduleEEfileView()
         count, estimate = counts.get_count(
-            query, db.session, resource.use_estimated_counts
+            query, db.session, models.ScheduleEEfile, resource.use_estimated_counts
         )
         # Always use exact count for Schedule E efile
         self.assertEqual(count, 5)
@@ -51,7 +51,7 @@ class TestCounts(ApiBaseTest):
         get_query_plan_mock.return_value = [
             ('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)
         ]
-        count, estimate = counts.get_count(query, db.session)
+        count, estimate = counts.get_count(query, db.session, models.ScheduleA)
         self.assertEqual(count, 2)
         self.assertEqual(estimate, False)
 
@@ -64,6 +64,6 @@ class TestCounts(ApiBaseTest):
             (cost=0.00..10.60 rows=2000000 width=1289)',
             )
         ]
-        count, estimate = counts.get_count(query, db.session)
+        count, estimate = counts.get_count(query, db.session, models.ScheduleA)
         self.assertEqual(count, 2000000)
         self.assertEqual(estimate, True)

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -8,12 +8,13 @@ import re
 
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import Executable, ClauseElement, _literal_as_text
+from webservices.common import models
 
 
 count_pattern = re.compile(r'rows=(\d+)')
 
 
-def get_count(query, session, model, estimate=True, use_pk_for_count=False, threshold=500000):
+def get_count(query, model, estimate=True, use_pk_for_count=False, threshold=500000):
     """
     Calculate either the estimated count or exact count.
     Indicate whether the count is an estimate.
@@ -22,7 +23,7 @@ def get_count(query, session, model, estimate=True, use_pk_for_count=False, thre
         primary_key = model.__mapper__.primary_key[0]
         query = query.with_entities(primary_key)
     if estimate:
-        rows = get_query_plan(query, session)
+        rows = get_query_plan(query)
         count = extract_analyze_count(rows)
         if count < threshold:
             estimate = False
@@ -32,8 +33,8 @@ def get_count(query, session, model, estimate=True, use_pk_for_count=False, thre
     return count, estimate
 
 
-def get_query_plan(query, session):
-    return session.execute(explain(query)).fetchall()
+def get_query_plan(query):
+    return models.db.session.execute(explain(query)).fetchall()
 
 
 def extract_analyze_count(rows):

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -18,7 +18,7 @@ def get_count(query, session, model, estimate=True, use_pk_for_count=False, thre
     Calculate either the estimated count or exact count.
     Indicate whether the count is an estimate.
     """
-    if use_pk_for_count:
+    if use_pk_for_count and model:
         primary_key = model.__mapper__.primary_key[0]
         query = query.with_entities(primary_key)
     if estimate:

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -13,13 +13,15 @@ from sqlalchemy.sql.expression import Executable, ClauseElement, _literal_as_tex
 count_pattern = re.compile(r'rows=(\d+)')
 
 
-def get_count(query, session, estimate=True, threshold=500000):
+def get_count(query, session, model, estimate=True, threshold=500000):
     """
     Calculate either the estimated count or exact count.
     Indicate whether the count is an estimate.
     """
+    # TODO: Move this to model.table_args? resource? I think table args can't be custom keys
     if estimate:
-        rows = get_query_plan(query, session)
+        # with_entities
+        rows = get_query_plan(query.with_entities(model.committee_id), session)
         count = extract_analyze_count(rows)
         if count < threshold:
             estimate = False
@@ -30,6 +32,7 @@ def get_count(query, session, estimate=True, threshold=500000):
 
 
 def get_query_plan(query, session):
+    print(query)
     return session.execute(explain(query)).fetchall()
 
 

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -254,6 +254,7 @@ class ScheduleAEfile(BaseRawItemized):
         return name
 
 
+
 class ScheduleB(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -27,12 +27,13 @@ class ApiResource(utils.Resource):
     aliases = {}
     cap = 100
     use_estimated_counts = True
+    use_pk_for_count = False
 
     @use_kwargs(Ref('args'))
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts)
+        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
@@ -97,7 +98,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.model)
+        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -124,5 +125,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count, _ = counts.get_count(query, models.db.session, self.model)
+        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
         return page_query, count

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -27,13 +27,14 @@ class ApiResource(utils.Resource):
     aliases = {}
     cap = 100
     use_estimated_counts = True
+    estimated_count_threshold = 500000
     use_pk_for_count = False
 
     @use_kwargs(Ref('args'))
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(self, query)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
@@ -98,7 +99,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(self, query)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -125,5 +126,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(self, query)
         return page_query, count

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -33,7 +33,7 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
@@ -98,7 +98,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -125,5 +125,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts, self.use_pk_for_count)
+        count, _ = counts.get_count(query, self.model, self.use_estimated_counts, self.use_pk_for_count)
         return page_query, count

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -32,7 +32,7 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.use_estimated_counts)
+        count, _ = counts.get_count(query, models.db.session, self.model, self.use_estimated_counts)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
@@ -97,7 +97,7 @@ class ItemizedResource(ApiResource):
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.db.session)
+        count, _ = counts.get_count(query, models.db.session, self.model)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
     def join_committee_queries(self, kwargs):
@@ -124,5 +124,5 @@ class ItemizedResource(ApiResource):
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
-        count, _ = counts.get_count(query, models.db.session)
+        count, _ = counts.get_count(query, models.db.session, self.model)
         return page_query, count

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -135,7 +135,7 @@ class ElectionView(ApiResource):
 
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, self.model)
+        count, _ = counts.get_count(self, query)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -135,7 +135,7 @@ class ElectionView(ApiResource):
 
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, models.db.session, self.model)
+        count, _ = counts.get_count(query, self.model)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -135,7 +135,7 @@ class ElectionView(ApiResource):
 
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(query, models.db.session)
+        count, _ = counts.get_count(query, models.db.session, self.model)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -130,7 +130,7 @@ class EFilingsView(views.ApiResource):
 
     def get(self, **kwargs):
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.EFilings)
+        count, _ = counts.get_count(self, query)
         return utils.fetch_page(query, kwargs, model=models.EFilings, count=count)
 
     @property

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -130,7 +130,7 @@ class EFilingsView(views.ApiResource):
 
     def get(self, **kwargs):
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.db.session, models.EFilings)
+        count, _ = counts.get_count(query, models.EFilings)
         return utils.fetch_page(query, kwargs, model=models.EFilings, count=count)
 
     @property

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -130,7 +130,7 @@ class EFilingsView(views.ApiResource):
 
     def get(self, **kwargs):
         query = self.build_query(**kwargs)
-        count, _ = counts.get_count(query, models.db.session)
+        count, _ = counts.get_count(query, models.db.session, models.EFilings)
         return utils.fetch_page(query, kwargs, model=models.EFilings, count=count)
 
     @property

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -87,6 +87,8 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
+    use_pk_for_count=True
+
 
     @property
     def args(self):

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -34,6 +34,8 @@ def call_resource(path, qs):
         kwargs.pop(field, None)
 
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
+    if not model:
+        model = resource.model
     count, _ = counts.get_count(query, db.session, model, resource.use_estimated_counts, resource.use_pk_for_count)
     return {
         'path': path,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -34,7 +34,7 @@ def call_resource(path, qs):
         kwargs.pop(field, None)
 
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
-    count, _ = counts.get_count(query, db.session, resource.use_estimated_counts)
+    count, _ = counts.get_count(query, db.session, model, resource.use_estimated_counts, resource.use_pk_for_count)
     return {
         'path': path,
         'qs': qs,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -36,7 +36,7 @@ def call_resource(path, qs):
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
     if not model:
         model = resource.model
-    count, _ = counts.get_count(query, db.session, model, resource.use_estimated_counts, resource.use_pk_for_count)
+    count, _ = counts.get_count(query, model, resource.use_estimated_counts, resource.use_pk_for_count)
     return {
         'path': path,
         'qs': qs,

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -34,9 +34,7 @@ def call_resource(path, qs):
         kwargs.pop(field, None)
 
     query, model, schema = unpack(resource.build_query(**kwargs), 3)
-    if not model:
-        model = resource.model
-    count, _ = counts.get_count(query, model, resource.use_estimated_counts, resource.use_pk_for_count)
+    count, _ = counts.get_count(resource, query)
     return {
         'path': path,
         'qs': qs,


### PR DESCRIPTION
## Summary (required)

Resolves #4368

- Add option to only pass primary key column to count query
- Refactor `get_count` to have fewer parameters


[Locust tests](https://docs.google.com/spreadsheets/d/1VKjqaPdnf8GAU6znXHTwbMVQKBzIbbjFk2MKVXSUWy4/edit#gid=0)

Note: SQLAlchemy [requires a primary key](https://docs.sqlalchemy.org/en/13/faq/ormconfiguration.html), and should throw an error like this without one:
```
E   sqlalchemy.exc.ArgumentError: Mapper mapped class ScheduleA->fec_fitem_sched_a could not assemble any primary key columns for mapped table 'fec_fitem_sched_a'
```
So, this test `assert len(view.model.__mapper__.primary_key) > 0` would be a superfluous. However, it's possible we'd have a resource without a `model` attribute so I added both tests for more clarity on expected behavior.

```
<class 'webservices.common.views.ItemizedResource'> has no model
<class 'webservices.resources.totals.TotalsCommitteeView'> has no model
<class 'webservices.resources.reports.ReportsView'> has no model
<class 'webservices.resources.reports.CommitteeReportsView'> has no model
<class 'webservices.resources.aggregates.AggregateResource'> has no model
<class 'webservices.resources.candidate_aggregates.TotalsCandidateView'> has no model
<class 'webservices.resources.candidate_aggregates.AggregateByOfficeView'> has no model
<class 'webservices.resources.candidate_aggregates.AggregateByOfficeByPartyView'> has no model
<class 'webservices.resources.elections.ElectionView'> has no model
<class 'webservices.resources.spending_by_others.ECTotalsByCandidateView'> has no model
<class 'webservices.resources.spending_by_others.IETotalsByCandidateView'> has no model
<class 'webservices.resources.spending_by_others.CCTotalsByCandidateView'> has no model
```

## How to test the changes locally

- print out the query under `get_query_plan` in `webservices.common.counts.py`, do a Schedule A query, make sure it only selects `sub_id` column instead of 80 columns.
**Example**
```
SELECT disclosure.fec_fitem_sched_a.sub_id 
FROM disclosure.fec_fitem_sched_a 
WHERE disclosure.fec_fitem_sched_a.two_year_transaction_period IN (2010)
```

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /schedules/schedule_a/ endpoint

