### PR TITLE
refine api key signup page

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -3,22 +3,25 @@ from webservices.env import env
 api_key_signup_feature_flag = bool(env.get_credential('API_UMBRELLA_SIGNUP_KEY_FEATURE_FLAG', ''))
 
 """Narrative API documentation."""
-
 API_DESCRIPTION = '''
-This API allows you to explore the way candidates and committees fund their campaigns.
+This application programming interface (API) allows you to explore the way
+candidates and committees fund their campaigns.
 
 The FEC API is a RESTful web service supporting full-text and field-specific searches on
 FEC data. [Bulk downloads](https://www.fec.gov/data/advanced/?tab=bulk-data) are available on the current
 site. Information is tied to the underlying forms by file ID and image ID. Data is updated
 nightly.
 
-There is a lot of data, but a good place to start is to use search to find
+There are a lot of data, and a good place to start is to use search to find
 interesting candidates and committees. Then, you can use their IDs to find report or line
 item details with the other endpoints. If you are interested in individual donors, check
 out contributor information in schedule_a.
 
-Get an [API key here](https://api.data.gov/signup/). That will enable you to place up to 1,000
-calls an hour. Each call is limited to 100 results per page. You can email questions, comments or
+If you would like to use the FEC's API programatically, you can sign up for
+your own API key below. But, you can still try out our API without
+an API key by using the web interface below and making use of a DEMO_KEY.
+Signing up for an API key will enable you to place up to 1,000 calls an hour.
+Each call is limited to 100 results per page. You can email questions, comments or
 a request to get a key for 120 calls per minute to [APIinfo@fec.gov](mailto:apiinfo@fec.gov). You can also
 ask questions and discuss the data in the [FEC data Google Group](https://groups.google.com/forum/#!forum/fec-data).
 API changes will also be added to this group in advance of the change.

--- a/webservices/templates/swagger-ui.html
+++ b/webservices/templates/swagger-ui.html
@@ -23,9 +23,39 @@
 
       body
       {
-        margin:0;
-        background: #fafafa;
+      margin: 0;
+      background: #fafafa;
       }
+      
+      label[for=user_first_name]:before
+      {
+      content: " *";
+      color: #E87723;
+      font-weight: 1000;
+      font-family: "Verdana";
+      }
+
+      label[for=user_last_name]:before
+      {
+      content: " *";
+      color: #E87723;
+      font-weight: 1000;
+      font-family: "Verdana";
+      }
+      
+      label[for=user_email]:before
+      {
+      content: " *";
+      color: #E87723;
+      font-weight: 1000;
+      font-family: "Verdana";
+      }
+
+      #signup_head
+      {
+      font-size: 24px;
+      }
+
     </style>
 </head>
 

--- a/webservices/templates/swagger-ui.html
+++ b/webservices/templates/swagger-ui.html
@@ -42,7 +42,6 @@
      // Enter the API key you signed up for and specially configured for this
      // API key signup embed form.
      apiKey: "{{ api_key_signup_key }}",
-     // document.write(apiKey.toLocaleString( ));
      // Provide a URL or e-mail address to be used for customer support.
      //
      // The format for e-mail addresses can be given as either
@@ -63,7 +62,7 @@
      // This can be any API endpoint on your server, and you can use the
      // special {{api_key}} variable to automatically substitute in the API
      // key the user just signed up for.
-     exampleApiUrl: 'https://api.open.fec.gov/v1/legal/search/?api_key={{api_key}}',
+     exampleApiUrl: 'https://api.open.fec.gov/v1/legal/search/?api_key={{ '{{api_key}}' }}',
 
      // OPTIONAL: Provide extra content to display on the signup confirmation
      // page. This will be displayed below the user's API key and the example
@@ -78,18 +77,6 @@
      // OPTIONAL: Set to false to disable sending a welcome e-mail to the
      // user after signing up. Defaults to true.
      sendWelcomeEmail: true,
-
-     // OPTIONAL: Provide an extra input field to ask for the user's website.
-     // Defaults to false.
-     // websiteInput: true,
-
-     // OPTIONAL: Provide an extra checkbox asking the user to agree to terms
-     // and conditions before signing up. Defaults to false.
-     // termsCheckbox: true,
-
-     // OPTIONAL: If the terms & conditions checkbox is enabled, link to this
-     // URL for your API's terms & conditions. Defaults to "".
-     // termsUrl: "https://agency.gov/api-terms/",
    };
  </script>
  <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>


### PR DESCRIPTION
## Summary (required)

- Resolves #4363
- hard coding "required fields" addressed under #4447

refine API key signup elements per completion criteria in #4363 

## How to test the changes locally
for non developers: 
- https://fec-dev-api.app.cloud.gov/developers/

for developers:
- check out branch
- pytest
- run local api
- verify that api signup looks correct per #4363 completion criteria.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  swagger-ui.html
- docs.py

