### PR TITLE
Add deprecation notice to Schedule A for 'contributor_aggregate_ytd'

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -138,12 +138,15 @@ class IndicesValidator(IndexValidator):
 
 
 def make_sort_args(default=None, validator=None, default_hide_null=False,
-        default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True):
+        default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True,
+        additional_description=''):
     args = {
         'sort': fields.Str(
             missing=default,
             validate=validator,
-            description='Provide a field to sort by. Use - for descending order.',
+            description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
+                additional_description
+            ),
         ),
         'sort_hide_null': fields.Bool(
             missing=default_hide_null,

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -98,6 +98,7 @@ class ScheduleAView(ItemizedResource):
                 default='contribution_receipt_date',
                 validator=args.OptionValidator(self.sort_options),
                 show_nulls_last_arg=False,
+                additional_description='The `contributor_aggregate_ytd` option is deprecated.'
             ),
         )
 


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #4381 
Add deprecation notice to Schedule A for `contributor_aggregate_ytd`

## How to test the changes locally

- http://localhost:5000/developers/#/receipts/get_schedules_schedule_a_
<img width="932" alt="Screen Shot 2020-06-19 at 4 15 14 PM" src="https://user-images.githubusercontent.com/31420082/85176618-38e2d280-b248-11ea-9547-de92078ba8b3.png">


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Swagger docs

