### PR TITLE
Add message to change sched-a sort to DESC

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -98,7 +98,8 @@ class ScheduleAView(ItemizedResource):
                 default='contribution_receipt_date',
                 validator=args.OptionValidator(self.sort_options),
                 show_nulls_last_arg=False,
-                additional_description='The `contributor_aggregate_ytd` option is deprecated.'
+                additional_description="The `contributor_aggregate_ytd` option is deprecated. \n"
+                " `contribution_receipt_date` default sorting ASC will change to DESC."
             ),
         )
 


### PR DESCRIPTION
## Summary (required)
Remind API user we will change contribution_receipt_date default sort order from ASC to DESC.

- Resolves #4402

_Include a summary of proposed changes._
sche-a.py

## How to test the changes locally
1) checkout branch
2) pytest
3) ./manage.py runserver
4) http://127.0.0.1:5000/developers/#/receipts/get_schedules_schedule_a_

<img width="998" alt="Screen Shot 2020-06-23 at 5 46 45 PM" src="https://user-images.githubusercontent.com/24395751/85467734-95602d80-b579-11ea-99f5-834d1ddaab37.png">

