### PR TITLE
Remove confusing brackets in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary (required)
 
-- Resolves #Issue number
+- Resolves #issue_number
 
 _Include a summary of proposed changes._
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary (required)
 
-- Resolves #[_Issue number_]
+- Resolves #Issue number
 
 _Include a summary of proposed changes._
 


### PR DESCRIPTION
See https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references

Remove confusing brackets in PR template

`Resolves #[Issue]` ends up looking like this (issue not undelined):
<img width="127" alt="Screen Shot 2020-06-24 at 11 05 15 AM" src="https://user-images.githubusercontent.com/31420082/85581612-bd4ba180-b60a-11ea-8d5b-13d33445194a.png">
 and will **not** close the linked issue

`Resolves #Issue` ends up looking like this (issue underlined): 
<img width="127" alt="Screen Shot 2020-06-24 at 11 05 23 AM" src="https://user-images.githubusercontent.com/31420082/85581632-c0df2880-b60a-11ea-92f3-7ed8217f3359.png">
and **will** close the linked issue