### PR TITLE
[WIP] Add all 'two_year_transaction_period' values if not specified

### DIFF
--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -60,11 +60,12 @@ class TriggerTestCase(common.BaseTestCase):
                     'recipient_nm': n,
                     'sub_id': 9999999999999999990 + i,
                     'filing_form': 'F3',
+                    'two_year_transaction_period': 2020,
                 }
                 insert = (
                     "INSERT INTO disclosure.fec_fitem_sched_b "
-                    + "(recipient_nm, sub_id, filing_form) "
-                    + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                    + "(recipient_nm, sub_id, filing_form, two_year_transaction_period) "
+                    + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
                 )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
@@ -106,11 +107,12 @@ class TriggerTestCase(common.BaseTestCase):
                     'contbr_nm': n,
                     'sub_id': 9999999999999999990 + i,
                     'filing_form': 'F3',
+                    'two_year_transaction_period': 2020,
                 }
                 insert = (
                     "INSERT INTO disclosure.fec_fitem_sched_a "
-                    + "(contbr_nm, sub_id, filing_form) "
-                    + " VALUES (%(contbr_nm)s, %(sub_id)s, %(filing_form)s)"
+                    + "(contbr_nm, sub_id, filing_form, two_year_transaction_period) "
+                    + " VALUES (%(contbr_nm)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
                 )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
@@ -150,11 +152,12 @@ class TriggerTestCase(common.BaseTestCase):
                     'contbr_employer': n,
                     'sub_id': 9999999999999999980 + i,
                     'filing_form': 'F3',
+                    'two_year_transaction_period': 2020,
                 }
                 insert = (
                     "INSERT INTO disclosure.fec_fitem_sched_a "
-                    + "(contbr_employer, sub_id, filing_form) "
-                    + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                    + "(contbr_employer, sub_id, filing_form, two_year_transaction_period) "
+                    + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
                 )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
@@ -196,11 +199,12 @@ class TriggerTestCase(common.BaseTestCase):
                     'contbr_occupation': n,
                     'sub_id': 9999999999999999970 + i,
                     'filing_form': 'F3',
+                    'two_year_transaction_period': 2020,
                 }
                 insert = (
                     "INSERT INTO disclosure.fec_fitem_sched_a "
-                    + "(contbr_occupation, sub_id, filing_form) "
-                    + " VALUES (%(contbr_occupation)s, %(sub_id)s, %(filing_form)s)"
+                    + "(contbr_occupation, sub_id, filing_form, two_year_transaction_period) "
+                    + " VALUES (%(contbr_occupation)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
                 )
                 connection.execute(insert, data)
             manage.refresh_materialized(concurrent=False)
@@ -425,11 +429,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'contbr_employer': n,
                 'sub_id': 9999999959999999980 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_a "
-                + "(contbr_employer, sub_id, filing_form) "
-                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                + "(contbr_employer, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
@@ -466,11 +471,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'recipient_nm': n,
                 'sub_id': 9999999999995699990 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_b "
-                + "(recipient_nm, sub_id, filing_form) "
-                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                + "(recipient_nm, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s,  %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -8,7 +8,9 @@ from webservices import exceptions
 from webservices.common import counts
 from webservices.common import models
 from webservices.utils import use_kwargs
+from webservices.config import SQL_CONFIG
 
+ALL_TWO_YEAR_PERIODS = range(1976, SQL_CONFIG["END_YEAR_ITEMIZED"] + 2, 2)
 
 class ApiResource(utils.Resource):
 
@@ -95,6 +97,8 @@ class ItemizedResource(ApiResource):
                 ),
                 status_code=422,
             )
+        if not kwargs.get("two_year_transaction_period"):
+            kwargs["two_year_transaction_period"] = ALL_TWO_YEAR_PERIODS
         if len(kwargs.get("committee_id", [])) > 1:
             query, count = self.join_committee_queries(kwargs)
             return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -25,7 +25,7 @@ CURRENT_YEAR = datetime.datetime.now().year
 SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
-    'END_YEAR_ITEMIZED': get_cycle_start(CURRENT_YEAR),
+    'END_YEAR_ITEMIZED': get_cycle_end(CURRENT_YEAR),
 }
 
 REQUIRED_CREDS = (


### PR DESCRIPTION
- [ ] How to handle? for fec_fitem_sched_e table, the column contains this information is `election_cycle` (`cycle`)? Maybe just for Schedule A and B?

## Summary (required)

- Resolves #4414

Add all 'two_year_transaction_period' values if not specified

## How to test the changes locally

- Run any Itemized schedule endpoint without specifying two-year period, print out query - should include 
```
AND disclosure.fec_fitem_sched_a.two_year_transaction_period IN (1976, 1978, 1980, 1982, 1984, 1986, 1988, 1990, 1992, 1994, 1996, 1998, 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018, 2020)
```
- Examples: 

# Schedule A
'committee_id',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&committee_id=C00223743&committee_id=C00223446&committee_id=C00223735&committee_id=C00222778&committee_id=C00222612&committee_id=C00224048&committee_id=C00222273&committee_id=C00222760&committee_id=C00223925&committee_id=C00213850&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&committee_id=1&committee_id=2

'contributor_name',

http://localhost:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_name=C00223743&contributor_name=C00223446&contributor_name=C00223735&contributor_name=C00222778&contributor_name=C00222612&contributor_name=C00224048&contributor_name=C00222273&contributor_name=C00222760&contributor_name=C00223925&contributor_name=C00213850&contributor_state=CA&sort=-contribution_receipt_date&per_page=30&is_individual=true&contributor_name=1&contributor_name=2



## Schedule B



 'committee_id',

http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00139998&committee_id=C00172189&committee_id=C00221820&committee_id=C00412304&committee_id=C00427526&committee_id=C00500975&committee_id=C00511055&committee_id=C00547679&committee_id=C00547828&committee_id=C00549972&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&sort=-disbursement_date&per_page=30&committee_id=2

'recipient_name',

http://localhost:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&recipient_name=C00139998&recipient_name=C00172189&recipient_name=C00221820&recipient_name=C00412304&recipient_name=C00427526&recipient_name=C00500975&recipient_name=C00511055&recipient_name=C00547679&recipient_name=C00547828&recipient_name=C00549972&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&sort=-disbursement_date&per_page=30&recipient_name=2



## Schedule E


'committee_id',

http://localhost:5000/v1/schedules/schedule_e/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00139998&committee_id=C00172189&committee_id=C00221820&committee_id=C00412304&committee_id=C00427526&committee_id=C00500975&committee_id=C00511055&committee_id=C00547679&committee_id=C00547828&committee_id=C00549972&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&per_page=30&committee_id=2

'candidate_id',

http://localhost:5000/v1/schedules/schedule_e/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&candidate_id=C00139998&candidate_id=C00172189&candidate_id=C00221820&candidate_id=C00412304&candidate_id=C00427526&candidate_id=C00500975&candidate_id=C00511055&candidate_id=C00547679&candidate_id=C00547828&candidate_id=C00549972&min_date=01%2F01%2F2019&max_date=12%2F31%2F2020&per_page=30&candidate_id=2

## Impacted areas of the application
List general components of the application that this PR will affect:

-  No user impact other than speed improvement



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
