### PR TITLE
[WIP] Add more union fields to Schedule A

### DIFF
--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -425,11 +425,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'contbr_employer': n,
                 'sub_id': 9999999959999999980 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_a "
-                + "(contbr_employer, sub_id, filing_form) "
-                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                + "(contbr_employer, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
@@ -466,11 +467,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'recipient_nm': n,
                 'sub_id': 9999999999995699990 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_b "
-                + "(recipient_nm, sub_id, filing_form) "
-                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                + "(recipient_nm, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -477,7 +477,6 @@ class TriggerTestCase(common.BaseTestCase):
         results = self._results(
             api.url_for(ScheduleBView, contributor_employer='ést-lou')
         )
-        print('results = ', results)
         contbr_employer_list = {r['recipient_name'] for r in results}
         assert names.issubset(contbr_employer_list)
         results = self._results(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -288,7 +288,6 @@ class TestSort(ApiBaseTest):
             model=None,
         )
 
-        # print(str(query.statement.compile(dialect=postgresql.dialect())))
         self.assertEqual(len(query.all()), len(candidates))
         query, columns = sorting.sort(
             electionView.build_query(office='senate', cycle=2016, state='MO'),

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -62,9 +62,10 @@ class ItemizedResource(ApiResource):
     index_column = None
     filters_with_max_count = []
     max_count = 10
+    union_fields = ["committee_id"]
 
     def get(self, **kwargs):
-        """Get itemized resources. If multiple values are passed for `committee_id`,
+        """Get itemized resources. If multiple values are passed for any 'union_fields',
         create a subquery for each and combine with `UNION ALL`. This is necessary
         to avoid slow queries when one or more relevant committees has many
         records.
@@ -95,20 +96,21 @@ class ItemizedResource(ApiResource):
                 ),
                 status_code=422,
             )
-        if len(kwargs.get("committee_id", [])) > 1:
-            query, count = self.join_committee_queries(kwargs)
-            return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
+        for field in self.union_fields:
+            if len(kwargs.get(field, [])) > 1:
+                query, count = self.join_union_queries(kwargs, field)
+                return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
         count, _ = counts.get_count(self, query)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
-    def join_committee_queries(self, kwargs):
+    def join_union_queries(self, kwargs, field):
         """Build and compose per-committee subqueries using `UNION ALL`.
         """
         queries = []
         total = 0
-        for committee_id in kwargs.get('committee_id', []):
-            query, count = self.build_committee_query(kwargs, committee_id)
+        for argument in kwargs.get(field, []):
+            query, count = self.build_union_query(kwargs, field, argument)
             queries.append(query.subquery().select())
             total += count
         query = models.db.session.query(
@@ -119,10 +121,10 @@ class ItemizedResource(ApiResource):
         query = query.options(*self.query_options)
         return query, total
 
-    def build_committee_query(self, kwargs, committee_id):
-        """Build a subquery by committee.
+    def build_union_query(self, kwargs, field, argument):
+        """Build a subquery by specified `field` arguments.
         """
-        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {'committee_id': [committee_id]}))
+        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {field: [argument]}))
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -25,7 +25,7 @@ CURRENT_YEAR = datetime.datetime.now().year
 SQL_CONFIG = {
     'START_YEAR': get_cycle_start(1980),
     'START_YEAR_AGGREGATE': get_cycle_start(2008),
-    'END_YEAR_ITEMIZED': get_cycle_start(CURRENT_YEAR),
+    'END_YEAR_ITEMIZED': get_cycle_end(CURRENT_YEAR),
 }
 
 REQUIRED_CREDS = (

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -72,9 +72,6 @@ class ScheduleAView(ItemizedResource):
     ]
     filter_union_fields = [
         ('committee_id', models.ScheduleA.committee_id),
-        ('contributor_name', models.ScheduleA.contributor_name_text),
-        ('contributor_employer', models.ScheduleA.contributor_employer_text),
-        ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
         ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     query_options = [

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -70,6 +70,12 @@ class ScheduleAView(ItemizedResource):
     filter_multi_start_with_fields = [
         ('contributor_zip', models.ScheduleA.contributor_zip),
     ]
+    filter_union_fields = [
+        ('committee_id', models.ScheduleA.committee_id),
+        ('contributor_name', models.ScheduleA.contributor_name_text),
+        ('contributor_employer', models.ScheduleA.contributor_employer_text),
+        ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
+    ]
     query_options = [
         sa.orm.joinedload(models.ScheduleA.committee),
         sa.orm.joinedload(models.ScheduleA.contributor),
@@ -87,7 +93,7 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
-    use_pk_for_count=True
+    use_pk_for_count = True
 
 
     @property
@@ -119,7 +125,7 @@ class ScheduleAView(ItemizedResource):
         two_year_transaction_periods = set(
             kwargs.get('two_year_transaction_period', [])
         )
-        if len(two_year_transaction_periods) != 1:
+        if len(two_year_transaction_periods) != 1 and kwargs.get("check_secondary_index", True):
             if not any(kwargs.get(field) for field in secondary_index_options):
                 raise exceptions.ApiError(
                     "Please choose a single `two_year_transaction_period` or "

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -75,6 +75,7 @@ class ScheduleAView(ItemizedResource):
         ('contributor_name', models.ScheduleA.contributor_name_text),
         ('contributor_employer', models.ScheduleA.contributor_employer_text),
         ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
+        ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
     ]
     query_options = [
         sa.orm.joinedload(models.ScheduleA.committee),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -58,6 +58,10 @@ class ScheduleBView(ItemizedResource):
         (('min_image_number', 'max_image_number'),
          models.ScheduleB.image_number),
     ]
+    filter_union_fields = [
+        ('committee_id', models.ScheduleA.committee_id),
+        ('two_year_transaction_period', models.ScheduleB.two_year_transaction_period),
+    ]
     sort_options = ['disbursement_date', 'disbursement_amount']
     filters_with_max_count = [
         'committee_id',

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -58,7 +58,6 @@ class ScheduleEView(ItemizedResource):
     ]
     filter_union_fields = [
         ('committee_id', models.ScheduleA.committee_id),
-        ('cycle', sa.func.get_cycle(models.ScheduleE.report_year)),
     ]
     sort_options = [
         'expenditure_date',

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -55,7 +55,9 @@ class ScheduleEView(ItemizedResource):
         (('min_image_number', 'max_image_number'), models.ScheduleE.image_number),
         (('min_dissemination_date', 'max_dissemination_date'), models.ScheduleE.dissemination_date),
         (('min_filing_date', 'max_filing_date'), models.ScheduleE.filing_date),
-
+    ]
+    filter_union_fields = [
+        ('committee_id', models.ScheduleA.committee_id),
     ]
     sort_options = [
         'expenditure_date',

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -58,6 +58,7 @@ class ScheduleEView(ItemizedResource):
     ]
     filter_union_fields = [
         ('committee_id', models.ScheduleA.committee_id),
+        ('cycle', sa.func.get_cycle(models.ScheduleE.report_year)),
     ]
     sort_options = [
         'expenditure_date',

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -153,6 +153,7 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
             cursor = cursor.filter(filter)
 
         query = cursor.order_by(direction(self.index_column)).limit(limit)
+
         return query.all() if eager else query
 
     def _get_index_values(self, result):


### PR DESCRIPTION
Tracking example queries: https://docs.google.com/spreadsheets/d/1rkVnmuMUzlBCgOE3ZsCDJC7AqXWI2VOhC57RvJcdasI/edit#gid=0

Idea: What if we only did this when there was exactly one "union all" eligible field? This would fix our counts issue, and might address a large number of the example queries. What if we did this for just committee ID and two year transaction period? They can't overlap in the subqueries like name can.

### Problems
- Results sometimes incorrect? Dangerous to separate counts from actual query. Estimates might be different, which is ok - need to verify counts under 500,000
- Results seem slower than current logic at times
- Very difficult to look at/debug queries because they're over 50,000 lines even for shorter query parameters. 
- Downloads `/download/` call `build_query` and not `get` so this logic is skipped for downloads. This means different query logic for downloads and regular API calls.
```
23 2-year periods
x 10 committee ID’s = 230 subqueries
x contributor name (now union?) * 10 = 2,300 subqueries?
x contributor employer (now union?) * 10 = 23,000 subqueries?
x contributor occupation (now union?) * 10 = 230,000 subqueries?
```

### Todos
- [ ] Separate UNION ALL for 2-year period into different PR - can address counts issue because there isn't overlap. Max number of queries will be 230 (10 committee IDs x 23 2-year periods)
- [ ] Add more helpful output while building the query - too hard to validate the query as-is because it's so long
- [ ] Test with manual deploy
- [ ] Check counts. Before when we were UNION ALL-ing only by committee ID, the results couldn't be in both subqueries. When we add other fields, there could be some overlap, so we have to break the dependency between counts and the actual query (actual query uses `limit` and won't have the correct counts). It's not just the overlap that makes us need to break the dependency - the logic only does one union at a time and uses "OR" for everything else: example
http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00589309&committee_id=C00703975&sort=-contribution_receipt_date&per_page=30

```
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00703975') AND disclosure.fec_fitem_sched_a.two_year_transaction_period IN (1976, 1978, 1980, 1982, 1984, 1986, 1988, 1990, 1992, 1994, 1996, 1998, 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018, 2020) 
...
```
https://github.com/fecgov/openFEC/pull/4488
- [ ] Out of memory? 

```
psycopg2.OperationalError: SSL SYSCALL error: EOF detected
```
- [ ] Add more automated tests - 10 committee ID's and no 2-year transaction period, data in multiple 2-year transaction periods
- [ ] Validate queries with David
- [ ] Format code
- [ ] Test pagination
- [ ] Load test - make sure we have enough examples
- [ ] App is timing out when running locally and connected to `cfdm_test` - does it time out when connected to `dev`?  http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&committee_id=C00703975&contributor_occupation=teacher&contributor_occupation=retired&contributor_employer=teacher&contributor_employer=retired&contributor_employer=google&contributor_employer=amazon&min_date=03%2F01%2F2020&max_date=12%2F31%2F2020&sort=-contribution_receipt_date&per_page=30&is_individual=true
- [ ] Doesn't always seem faster - test this out. what if the app generated both queries and looked at the explain plan and then decided what to do based on that? Does the explain plan always look better for the better UNION ALL queries?
## Summary (required)

- Resolves #4389

_Include a summary of proposed changes._

## How to test the changes locally

-

## Impacted areas of the application
List general components of the application that this PR will affect:

-  



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
