### PR TITLE
Modernize repository language

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ This section covers a few topics we think might help developers after setup.
 ### API umbrella
 The staging and production environments use the [API Umbrella](https://apiumbrella.io) for
 rate limiting, authentication, caching, and HTTPS termination and redirection. Both
-environments use the `FEC_API_WHITELIST_IPS` flag to reject requests that are not routed
+environments use the `FEC_API_USE_PROXY` flag to reject requests that are not routed
 through the API Umbrella.
 
 ### Caching

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ Sorting fields include a compound index on on the filed to sort and a unique fie
 ### Database mirrors/replicas
 Database mirrors/replicas are supported by the API if the `SQLA_FOLLOWERS` is set to one or more valid connection strings.  By default, setting this environment variable will shift all `read` operations to any mirrors/replicas that are available (and randomly choose one to target per request if there are more than one).
 
-You can optionally choose to restrict traffic that goes to the mirrors/replicas to be the asynchronous tasks only by setting the `SQLA_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS` environment variable to something that will evaluate to `True` in Python (simply using `True` as the value is fine).  If you do this, you can also restrict which tasks are supported on the mirrors/replicas.  Supported tasks are configured by adding their fully qualified names to the `app.config['SQLALCHEMY_FOLLOWER_TASKS']` list in order to whitelist them.  By default, only the `download` task is enabled.
+You can optionally choose to restrict traffic that goes to the mirrors/replicas to be the asynchronous tasks only by setting the `SQLA_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS` environment variable to something that will evaluate to `True` in Python (simply using `True` as the value is fine).  If you do this, you can also restrict which tasks are supported on the mirrors/replicas.  Supported tasks are configured by adding their fully qualified names to the `app.config['SQLALCHEMY_FOLLOWER_TASKS']` list in order to allow them.  By default, only the `download` task is enabled.
 
 ### Database migration
 `flyway` is the tool used for database migration.

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
   WEB_CONCURRENCY: 4

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -4,7 +4,7 @@ memory: 1G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:
-  FEC_API_WHITELIST_IPS: true
+  FEC_API_USE_PROXY: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -5,6 +5,7 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   FEC_API_USE_PROXY: true
+  FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
   WEB_CONCURRENCY: 4
 services:

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -6,7 +6,7 @@ applications:
   command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python manage.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
   buildpack: python_buildpack
   env:
-    FEC_API_WHITELIST_IPS: true
+    FEC_API_USE_PROXY: true
     APP_NAME: fec | api | dev
     PRODUCTION: True
     WEB_CONCURRENCY: 4

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -7,7 +7,7 @@ applications:
   buildpack: python_buildpack
   health-check-type: process
   env:
-    FEC_API_WHITELIST_IPS: true
+    FEC_API_USE_PROXY: true
     APP_NAME: fec | api | prod
     PRODUCTION: True
     WEB_CONCURRENCY: 4

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -6,7 +6,7 @@ applications:
   command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"
   buildpack: python_buildpack
   env:
-    FEC_API_WHITELIST_IPS: true
+    FEC_API_USE_PROXY: true
     APP_NAME: fec | api | stage
     PRODUCTION: True
     WEB_CONCURRENCY: 4

--- a/tests/common.py
+++ b/tests/common.py
@@ -78,7 +78,7 @@ class ApiBaseTest(BaseTestCase):
                 stdout=null,
             )
 
-        whitelist = [
+        tables_to_skip = [
             models.CandidateCommitteeTotalsPresidential,
             models.CandidateCommitteeTotalsHouseSenate,
         ]
@@ -87,7 +87,7 @@ class ApiBaseTest(BaseTestCase):
             tables=[
                 each.__table__
                 for each in rest.db.Model._decl_class_registry.values()
-                if hasattr(each, '__table__') and each not in whitelist
+                if hasattr(each, '__table__') and each not in tables_to_skip
             ],
         )
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -80,7 +80,7 @@ class TestDownloadTask(ApiBaseTest):
         db.session.commit()
 
         # these are the major downloadable resources, we may want to add more later
-        RESOURCE_WHITELIST = {
+        DOWNLOADABLE_RESOURCES = {
             aggregates.ScheduleABySizeView,
             aggregates.ScheduleAByStateView,
             aggregates.ScheduleAByZipView,
@@ -112,7 +112,7 @@ class TestDownloadTask(ApiBaseTest):
             sched_f.ScheduleFView,
         }
 
-        for view in RESOURCE_WHITELIST:
+        for view in DOWNLOADABLE_RESOURCES:
             if view.endpoint in ['reportsview']:
                 url = api.url_for(view, committee_type=committee.committee_type)
             elif view.endpoint in [

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -150,7 +150,7 @@ RESTRICT_MESSAGE = "We apologize for the inconvenience, but we are temporarily "
 @app.before_request
 def limit_remote_addr():
     """
-    If `USE_PROXY` is set:
+    If `FEC_API_USE_PROXY` is set:
     - Reject all requests that are not routed through the API Umbrella
     - Block any flagged IPs
     - If we're restricting downloads, only allow requests from specified key

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -136,7 +136,7 @@ def handle_error(error):
 TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('TRUSTED_PROXY_IPS', ''))
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
-FEC_API_WHITELIST_IPS = env.get_credential('FEC_API_WHITELIST_IPS', False)
+FEC_API_USE_PROXY = env.get_credential('FEC_API_USE_PROXY', False)
 # Search these key_id's in the API umbrella admin interface to look up the API KEY
 DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
 TRAFFIC_WHITELIST_API_KEY_IDS = env.get_credential('TRAFFIC_WHITELIST_API_KEY_IDS')
@@ -150,13 +150,13 @@ RESTRICT_API_MESSAGE = "We apologize for the inconvenience, but we are temporari
 @app.before_request
 def limit_remote_addr():
     """
-    If `FEC_API_WHITELIST_IPS` is set:
+    If `FEC_API_USE_PROXY` is set:
     - Reject all requests that are not routed through the API Umbrella
     - Block any flagged IPs
-    - If we're restricting downloads, only allow requests from whitelisted key
+    - If we're restricting downloads, only allow requests from specified key
     """
     true_values = (True, 'True', 'true', 't')
-    if FEC_API_WHITELIST_IPS in true_values:
+    if FEC_API_USE_PROXY in true_values:
         try:
             *_, source_ip, api_data_route, cf_route = request.access_route
         except ValueError:  # Not enough routes

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -133,30 +133,30 @@ def handle_error(error):
 
 
 # api.data.gov
-TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('TRUSTED_PROXY_IPS', ''))
+TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('FEC_API_TRUSTED_PROXY_IPS', ''))
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
-BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
-FEC_API_USE_PROXY = env.get_credential('FEC_API_USE_PROXY', False)
+BLOCKED_IPS = env.get_credential('FEC_API_BLOCKED_IPS', '')
+USE_PROXY = env.get_credential('FEC_API_USE_PROXY', False)
 # Search these key_id's in the API umbrella admin interface to look up the API KEY
-FEC_API_DOWNLOAD_KEY_ID = env.get_credential('FEC_API_DOWNLOAD_KEY_ID')
-FEC_API_THROTTLE_BYPASS_API_KEY_IDS = env.get_credential('FEC_API_THROTTLE_BYPASS_API_KEY_IDS')
+DOWNLOAD_KEY_ID = env.get_credential('FEC_API_DOWNLOAD_KEY_ID')
+BYPASS_RESTRICTION_API_KEY_IDS = env.get_credential('FEC_API_BYPASS_RESTRICTION_API_KEY_IDS')
 # Settings to restrict traffic to certain API keys - only work with API umbrella
-RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS', False)
-RESTRICT_API_TRAFFIC = env.get_credential('RESTRICT_API_TRAFFIC', False)
-RESTRICT_API_MESSAGE = "We apologize for the inconvenience, but we are temporarily " \
+RESTRICT_DOWNLOADS = env.get_credential('FEC_API_RESTRICT_DOWNLOADS', False)
+RESTRICT_TRAFFIC = env.get_credential('FEC_API_RESTRICT_TRAFFIC', False)
+RESTRICT_MESSAGE = "We apologize for the inconvenience, but we are temporarily " \
     "blocking API traffic. Please contact apiinfo@fec.gov if this is an urgent issue."
 
 
 @app.before_request
 def limit_remote_addr():
     """
-    If `FEC_API_USE_PROXY` is set:
+    If `USE_PROXY` is set:
     - Reject all requests that are not routed through the API Umbrella
     - Block any flagged IPs
     - If we're restricting downloads, only allow requests from specified key
     """
     true_values = (True, 'True', 'true', 't')
-    if FEC_API_USE_PROXY in true_values:
+    if USE_PROXY in true_values:
         try:
             *_, source_ip, api_data_route, cf_route = request.access_route
         except ValueError:  # Not enough routes
@@ -169,12 +169,12 @@ def limit_remote_addr():
             if RESTRICT_DOWNLOADS in true_values and '/download/' in request.url:
                 # 'X-Api-User-Id' header is passed through by the API umbrella
                 request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id != FEC_API_DOWNLOAD_KEY_ID:
+                if request_api_key_id != DOWNLOAD_KEY_ID:
                     abort(403)
             # We don't want to accidentally block downloads here, handled above
-            elif RESTRICT_API_TRAFFIC in true_values and '/v1/' in request.url:
+            elif RESTRICT_TRAFFIC in true_values and '/v1/' in request.url:
                 request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id not in FEC_API_THROTTLE_BYPASS_API_KEY_IDS:
+                if request_api_key_id not in BYPASS_RESTRICTION_API_KEY_IDS:
                     # Service unavailable
                     abort(503, RESTRICT_API_MESSAGE)
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -138,8 +138,8 @@ TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('TRUSTED_PROXY_IPS', 
 BLOCKED_IPS = env.get_credential('BLOCKED_IPS', '')
 FEC_API_USE_PROXY = env.get_credential('FEC_API_USE_PROXY', False)
 # Search these key_id's in the API umbrella admin interface to look up the API KEY
-DOWNLOAD_WHITELIST_API_KEY_ID = env.get_credential('DOWNLOAD_WHITELIST_API_KEY_ID')
-TRAFFIC_WHITELIST_API_KEY_IDS = env.get_credential('TRAFFIC_WHITELIST_API_KEY_IDS')
+FEC_API_DOWNLOAD_KEY_ID = env.get_credential('FEC_API_DOWNLOAD_KEY_ID')
+FEC_API_THROTTLE_BYPASS_API_KEY_IDS = env.get_credential('FEC_API_THROTTLE_BYPASS_API_KEY_IDS')
 # Settings to restrict traffic to certain API keys - only work with API umbrella
 RESTRICT_DOWNLOADS = env.get_credential('RESTRICT_DOWNLOADS', False)
 RESTRICT_API_TRAFFIC = env.get_credential('RESTRICT_API_TRAFFIC', False)
@@ -169,12 +169,12 @@ def limit_remote_addr():
             if RESTRICT_DOWNLOADS in true_values and '/download/' in request.url:
                 # 'X-Api-User-Id' header is passed through by the API umbrella
                 request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id != DOWNLOAD_WHITELIST_API_KEY_ID:
+                if request_api_key_id != FEC_API_DOWNLOAD_KEY_ID:
                     abort(403)
             # We don't want to accidentally block downloads here, handled above
             elif RESTRICT_API_TRAFFIC in true_values and '/v1/' in request.url:
                 request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id not in TRAFFIC_WHITELIST_API_KEY_IDS:
+                if request_api_key_id not in FEC_API_THROTTLE_BYPASS_API_KEY_IDS:
                     # Service unavailable
                     abort(503, RESTRICT_API_MESSAGE)
 


### PR DESCRIPTION
### Summary (required)

- Partial resolution for #4417

Replace whitelist/blacklist with more descriptive language

- [x] Create these six (6) **new** env vars in all three spaces where their old equivalent value exist. (**Don't** rename or things will break) ([Instructions](https://github.com/fecgov/openFEC/wiki/Switch-out-cf-environment-variables))

- [x] dev
- [x] stage
- [x] prod

|old|new|
|-|-|
|`TRUSTED_PROXY_IPS`| `FEC_API_TRUSTED_PROXY_IPS`|
|`BLOCKED_IPS`| `FEC_API_BLOCKED_IPS `|
|`DOWNLOAD_WHITELIST_API_KEY_ID `| `FEC_API_DOWNLOAD_KEY_ID`|
|`TRAFFIC_WHITELIST_API_KEY_IDS `| `FEC_API_BYPASS_RESTRICTION_API_KEY_IDS`|
|`RESTRICT_DOWNLOADS `| `FEC_API_RESTRICT_DOWNLOADS `|
|`RESTRICT_TRAFFIC`|`FEC_API_RESTRICT_TRAFFIC`|

Note: these are taken care of in the manifest files
|~`FEC_API_WHITELIST_IPS `~|~`FEC_API_USE_PROXY`~|
**Template** 
```
                            ...,
     "FEC_API_TRUSTED_PROXY_IPS":"",
     "FEC_API_BLOCKED_IPS":"",
     "FEC_API_DOWNLOAD_KEY_ID":"",
     "FEC_API_BYPASS_RESTRICTION_API_KEY_IDS":"",
     "FEC_API_RESTRICT_DOWNLOADS":"",
     "FEC_API_RESTRICT_TRAFFIC":""
```
- [x] Move non-sensitive, unlikely to change env var `FEC_API_RESTRICT_DOWNLOADS` to manifests
- [x] Update wiki
- [x] Enter a follow-up issue to test in staging environment (need API umbrella in place) and clean up old env vars after code change goes live: #4468

## How to test the changes locally

- Run `pytest`
- Need to test in `stage` after release is cut: https://github.com/fecgov/openFEC/issues/4468

## Impacted areas of the application
List general components of the application that this PR will affect:

-  API umbrella IPs, download restrictions, blocked IPs, API throttling 



