### PR TITLE
upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5513,9 +5513,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._arraypool": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.11",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.19",
     "prettier": "^1.12.1",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^0.21.0",


### PR DESCRIPTION
## Summary (required)
Upgrade lodash to v4.17.19 to resolve the `Prototype Pollution` snyk vulnerability

- Resolves https://github.com/fecgov/openFEC/issues/4337

_Include a summary of proposed changes._

- update lodash in `package.json` and `package-lock.json`
## How to test the changes locally

- checkout feature branch  
    - run `git checkout feature/upgrade-lodash`
- create a new python virtual env 
   - run - `pyenv virtualenv 3.7.7 api377`
- activate virtual env
  - run - pyenv activate api377
- run `rm -rf node_modules/`
- run `npm i`
- run `npm run build`
- run `snyk test` 
