### PR TITLE
Update prance to address deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apispec==0.39.0
-prance[osv]>=0.11
+prance[osv]>=0.19
 cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3


### PR DESCRIPTION
See https://github.com/jfinkhaeuser/prance/commit/e251bb201c17a9440de1bf8521f484b9646ab1d6

## Summary (required)

- Resolves issue found in testing

```
=============================== warnings summary ===============================
tests/test_swagger.py::TestSwagger::test_swagger_valid
  /Users/lbeaufort/.pyenv/versions/3.7.7/envs/api-env/lib/python3.7/site-packages/prance/__init__.py:180: DeprecationWarning: Function 'semver.format_version' is deprecated. Deprecated since version 2.10.0.  This function will be removed in semver 3. Use 'str(versionobject)' instead.
    self.semver = semver.format_version(*version)
```
- Also see https://app.circleci.com/pipelines/github/fecgov/openFEC/259/workflows/cc6c738b-02aa-4ed3-9cb1-8a893148661c/jobs/2635

## How to test the changes locally
**Before:** 
- `pytest tests/test_swagger.py` throws warnings
**After:**
- `pip install -r requirements.txt`
- `pytest tests/test_swagger.py`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Swagger validation

