### PR TITLE
Increase size of tres_nm column in f_rpt_or_form_sub table

### DIFF
--- a/data/migrations/V0203__ofec_filings_all_mv.sql
+++ b/data/migrations/V0203__ofec_filings_all_mv.sql
@@ -1,0 +1,338 @@
+/*
+This is migration file 1 of 3 to solve issue #4463
+As part of deploying the Informatica mappings to populate the tres_nm field 
+in f_rpt_or_form_sub table from tres_sign_nm field in nml form tables, 
+the size of tres_nm field in f_rpt_or_form_sub table 
+from varchar2(38) to varchar2(90) in FECP database. 
+The size of tres_nm column in f_rpt_or_form_sub table in Postgress databases 
+also need to be increased to accommodate this change.
+
+Currently there are MVs/VWs referencing f_rpt_or_form_sub table. 
+Two of them referencing this particular column 
+so these MVs/VWs need to be updated as well.
+
+The two MVs impacted are 
+ofec_filings_all_mv
+ofec_filings_mv
+
+Currently ofec_totals_combined_mv depends on ofec_filings_mv 
+but not using the tres_nm column.
+
+However, in order to drop the ofec_filings_mv/vw (since there is data type change),
+it is necessary to recreate ofec_totals_combined_mv to break the dependency. 
+
+Searching webservices folder, only one places has referring ofec_filings_all_mv, 
+(webservices/common/models/filings.py)
+nothing referencing ofec_filings_mv
+
+ofec_filings_mv is an older version of ofec_filings_all_mv 
+which we plan to drop and use ofec_filings_all_mv instead
+
+Since ofec_totals_combined_mv is the only child of ofec_filings_mv, 
+in this ticket we will do this step as well.
+
+
+Flow of the change:
+1. temporarily create a disclosure.f_rpt_or_form_sub_tmp table, with the desired
+tres_nm data type (varchar(90))
+
+2. rewrite ofec_filings_all_mv/vw to use this tmp table
+   since cureently ofec_filings_all_vw has no children, it can be dropped and recreated.
+
+3. rewrite ofec_totals_combined_mv to reference ofec_filings_all_vw instead of ofec_filings_vw  
+
+4. ofec_filings_mv/vw has no child and can be dropped
+
+5. now there is no dependency on tres_nm column in f_rpt_or_form_sub, the size can be increased
+
+6. rewrite ofec_filings_all_mv to use the real f_rpt_or_form_sub table, 
+     after the column size had been increased.
+
+7. drop the tmp f_rpt_or_form_sub table  
+
+Another layers of complexity is that once Informatica changes happened, 
+it will impact all databases (PRD/STG/DEV) at once.  
+So These migration files will be run in advance in all environments during off-peak time, 
+an "if" statment is added so these statements will not actually be executed again 
+in the PRD/STG/DEV databases.  However, it will be executed in test database during CircleCI run.
+This is used to 
+a. handle the difference in workflow between the FECP world and the website project
+b. decrese the time needed during deployment time
+
+NOTE:  ofec_filings_mv now has no children and can be dropped.  
+However, this will involve the code update in manage.py/flow.py.  
+Since the code strictly follow the website project workflow, 
+so it will be created with the same definition as the ofec_filings_all_mv for this Sprint.
+    -- It will be permantly dropped next Sprint
+    together with the  manage.py/flow.py change.
+
+*/
+DO $$
+DECLARE
+    execute_flg integer;
+BEGIN
+    execute 'SELECT count(*)
+    FROM pg_attribute a
+    JOIN pg_class t on a.attrelid = t.oid
+    JOIN pg_namespace s on t.relnamespace = s.oid
+    WHERE a.attnum > 0 
+    AND NOT a.attisdropped
+    and relname = ''f_rpt_or_form_sub''
+    and a.attname = ''tres_nm''
+    and pg_catalog.format_type(a.atttypid, a.atttypmod) = ''character varying(38)''
+    and s.nspname = ''disclosure'''
+    into execute_flg;
+
+    if execute_flg = 1 then
+
+	CREATE TABLE disclosure.f_rpt_or_form_sub_tmp 
+	as select * from disclosure.f_rpt_or_form_sub;
+
+	alter table disclosure.f_rpt_or_form_sub_tmp 
+	alter column tres_nm type varchar(90);
+
+	-- ----------
+	-- ofec_filings_all_mv_tmp
+	-- ----------
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+	CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp AS
+	SELECT row_number() OVER () AS idx,
+	    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	    END AS candidate_id,
+	    cand.name AS candidate_name,
+	    filing_history.cand_cmte_id AS committee_id,
+	    com.name AS committee_name,
+	    filing_history.sub_id,
+	    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+	    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+	    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+	    filing_history.election_yr AS election_year,
+	    filing_history.form_tp AS form_type,
+	    filing_history.rpt_yr AS report_year,
+	    get_cycle(filing_history.rpt_yr) AS cycle,
+	    filing_history.rpt_tp AS report_type,
+	    filing_history.to_from_ind AS document_type,
+	    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+	    filing_history.begin_image_num::bigint AS beginning_image_number,
+	    filing_history.end_image_num AS ending_image_number,
+	    filing_history.pages,
+	    filing_history.ttl_receipts AS total_receipts,
+	    filing_history.ttl_indt_contb AS total_individual_contributions,
+	    filing_history.net_dons AS net_donations,
+	    filing_history.ttl_disb AS total_disbursements,
+	    filing_history.ttl_indt_exp AS total_independent_expenditures,
+	    filing_history.ttl_communication_cost AS total_communication_cost,
+	    filing_history.coh_bop AS cash_on_hand_beginning_period,
+	    filing_history.coh_cop AS cash_on_hand_end_period,
+	    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+	    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+	    filing_history.hse_pers_funds_amt AS house_personal_funds,
+	    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+	    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+	    filing_history.tres_nm AS treasurer_name,
+	    filing_history.file_num AS file_number,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	    END AS previous_file_number,
+	    report.rpt_tp_desc AS report_type_full,
+	    filing_history.rpt_pgi AS primary_general_indicator,
+	    filing_history.request_tp AS request_type,
+	    filing_history.amndt_ind AS amendment_indicator,
+	    filing_history.lst_updt_dt AS update_date,
+	    report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.form_tp::text) AS pdf_url,
+	    means_filed(filing_history.begin_image_num::text) AS means_filed,
+	    report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	    report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	    amendments.amendment_chain,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	    END AS most_recent_file_number,
+	    is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+		    CASE 
+			WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+		    CASE 
+			WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	    END AS most_recent,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	    END AS amendment_version,
+	    cand.state,
+	    cand.office,
+	    cand.district,
+	    cand.party,
+	    cmte_valid_fec_yr.cmte_tp,
+	    get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	    CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	    END AS form_category
+	  FROM disclosure.f_rpt_or_form_sub_tmp filing_history
+	     LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+	     LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+	     LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+	     LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+	     LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+	     LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+	     LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+	  WHERE filing_history.rpt_yr >= 1979::numeric AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+	WITH DATA;
+
+	ALTER TABLE public.ofec_filings_all_mv_tmp
+	    OWNER TO fec;
+
+	GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+	GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (amendment_indicator);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (beginning_image_number);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (candidate_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (committee_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (coverage_end_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (coverage_start_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (cycle);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (cycle, committee_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (district );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (form_type );
+	CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (idx);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (office );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (office_cmte_tp );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (party );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (primary_general_indicator );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (receipt_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (request_type );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_type );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_type_full );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_year);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_disbursements);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_independent_expenditures);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_receipts);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (state );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (form_category);
+
+	-- Because the data type of tres_nm has been changed (even actually only increase in size), so the view has to be dropped and recreated
+	DROP VIEW public.ofec_filings_all_vw;
+
+	CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+	 SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+	ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+	GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+	GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+	-- drop old MV
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+	-- rename _tmp mv to mv
+	ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+	-- rename indexes
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;
+    else
+	null;
+    end if;
+
+EXCEPTION
+    WHEN others THEN
+        RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+

--- a/data/migrations/V0204__ofec_totals_combined_mv.sql
+++ b/data/migrations/V0204__ofec_totals_combined_mv.sql
@@ -1,0 +1,262 @@
+/*
+This is migration file 2 of 3 to solve issue #4463
+*/
+
+-- ---------------------------------------
+-- Now point the public.ofec_totals_combined_mv to the "new"/"tmp" ofec_fiings_all_mv, 
+--   which referencing a tmp table that has the new tres_nm length
+-- Please note, usually switch source MV need to update flow.py/manage.py
+-- But since ofec_filings_all_mv and ofec_filings_mv is in the same group in manage.py, this step is not needed
+-- ---------------------------------------
+DO $$
+DECLARE
+    execute_flg integer;
+BEGIN
+    execute 'SELECT count(*)
+    FROM pg_attribute a
+    JOIN pg_class t on a.attrelid = t.oid
+    JOIN pg_namespace s on t.relnamespace = s.oid
+    WHERE a.attnum > 0 
+    AND NOT a.attisdropped
+    and relname = ''f_rpt_or_form_sub''
+    and a.attname = ''tres_nm''
+    and pg_catalog.format_type(a.atttypid, a.atttypmod) = ''character varying(38)''
+    and s.nspname = ''disclosure'''
+    into execute_flg;
+
+    if execute_flg = 1 then
+
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_combined_mv_tmp;
+
+	CREATE MATERIALIZED VIEW ofec_totals_combined_mv_tmp AS
+	WITH last_subset AS (
+		 SELECT DISTINCT ON (v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr))) v_sum_and_det_sum_report.orig_sub_id,
+		    v_sum_and_det_sum_report.cmte_id,
+		    v_sum_and_det_sum_report.coh_cop,
+		    v_sum_and_det_sum_report.debts_owed_by_cmte,
+		    v_sum_and_det_sum_report.debts_owed_to_cmte,
+		    v_sum_and_det_sum_report.net_op_exp,
+		    v_sum_and_det_sum_report.net_contb,
+		    v_sum_and_det_sum_report.rpt_yr,
+		    get_cycle(v_sum_and_det_sum_report.rpt_yr) AS cycle
+		   FROM disclosure.v_sum_and_det_sum_report
+		  WHERE get_cycle(v_sum_and_det_sum_report.rpt_yr) >= 1979 AND (v_sum_and_det_sum_report.form_tp_cd::text <> 'F5'::text OR v_sum_and_det_sum_report.form_tp_cd::text = 'F5'::text AND (v_sum_and_det_sum_report.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text]))) AND v_sum_and_det_sum_report.form_tp_cd::text NOT IN ('F6','SL')
+		  ORDER BY v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr)), (to_timestamp(v_sum_and_det_sum_report.cvg_end_dt::double precision)) DESC NULLS LAST
+		), last AS (
+		 SELECT ls.cmte_id,
+		    ls.orig_sub_id,
+		    ls.coh_cop,
+		    ls.cycle,
+		    ls.debts_owed_by_cmte,
+		    ls.debts_owed_to_cmte,
+		    ls.net_op_exp,
+		    ls.net_contb,
+		    ls.rpt_yr,
+		    of.candidate_id,
+		    of.beginning_image_number,
+		    of.coverage_end_date,
+		    of.form_type,
+		    of.report_type_full,
+		    of.report_type,
+		    of.candidate_name,
+		    of.committee_name
+		   FROM last_subset ls
+		     LEFT JOIN ofec_filings_all_vw of ON ls.orig_sub_id = of.sub_id
+		), first AS (
+		 SELECT DISTINCT ON (v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr))) v_sum_and_det_sum_report.coh_bop AS cash_on_hand,
+		    v_sum_and_det_sum_report.cmte_id AS committee_id,
+			CASE
+			    WHEN v_sum_and_det_sum_report.cvg_start_dt = 99999999::numeric THEN NULL::timestamp without time zone
+			    ELSE v_sum_and_det_sum_report.cvg_start_dt::text::date::timestamp without time zone
+			END AS coverage_start_date,
+		    get_cycle(v_sum_and_det_sum_report.rpt_yr) AS cycle
+		   FROM disclosure.v_sum_and_det_sum_report
+		  WHERE get_cycle(v_sum_and_det_sum_report.rpt_yr) >= 1979 AND (v_sum_and_det_sum_report.form_tp_cd::text <> 'F5'::text OR v_sum_and_det_sum_report.form_tp_cd::text = 'F5'::text AND (v_sum_and_det_sum_report.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text]))) AND v_sum_and_det_sum_report.form_tp_cd::text NOT IN ('F6','SL')
+		  ORDER BY v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr)), (to_timestamp(v_sum_and_det_sum_report.cvg_end_dt::double precision))
+		), committee_info AS (
+		 SELECT DISTINCT ON (cmte_valid_fec_yr.cmte_id, cmte_valid_fec_yr.fec_election_yr) cmte_valid_fec_yr.cmte_id,
+		    cmte_valid_fec_yr.fec_election_yr,
+		    cmte_valid_fec_yr.cmte_nm,
+		    cmte_valid_fec_yr.cmte_tp,
+		    cmte_valid_fec_yr.cmte_dsgn,
+		    cmte_valid_fec_yr.cmte_pty_affiliation_desc
+		   FROM disclosure.cmte_valid_fec_yr
+		)
+	 SELECT get_cycle(vsd.rpt_yr) AS cycle,
+	    max(last.candidate_id::text) AS candidate_id,
+	    max(last.candidate_name::text) AS candidate_name,
+	    max(last.committee_name::text) AS committee_name,
+	    max(last.beginning_image_number) AS last_beginning_image_number,
+	    max(last.coh_cop) AS last_cash_on_hand_end_period,
+	    max(last.debts_owed_by_cmte) AS last_debts_owed_by_committee,
+	    max(last.debts_owed_to_cmte) AS last_debts_owed_to_committee,
+	    max(last.net_contb) AS last_net_contributions,
+	    max(last.net_op_exp) AS last_net_operating_expenditures,
+	    max(last.report_type::text) AS last_report_type,
+	    max(last.report_type_full::text) AS last_report_type_full,
+	    max(last.rpt_yr) AS last_report_year,
+	    max(last.coverage_end_date) AS coverage_end_date,
+	    max(vsd.orig_sub_id) AS sub_id,
+	    min(first.cash_on_hand) AS cash_on_hand_beginning_period,
+	    min(first.coverage_start_date) AS coverage_start_date,
+	    sum(vsd.all_loans_received_per) AS all_loans_received,
+	    sum(vsd.cand_cntb) AS candidate_contribution,
+	    sum(vsd.cand_loan_repymnt + vsd.oth_loan_repymts) AS loan_repayments_made,
+	    sum(vsd.cand_loan_repymnt) AS loan_repayments_candidate_loans,
+	    sum(vsd.cand_loan) AS loans_made_by_candidate,
+	    sum(vsd.cand_loan_repymnt) AS repayments_loans_made_by_candidate,
+	    sum(vsd.cand_loan) AS loans_received_from_candidate,
+	    sum(vsd.coord_exp_by_pty_cmte_per) AS coordinated_expenditures_by_party_committee,
+	    sum(vsd.exempt_legal_acctg_disb) AS exempt_legal_accounting_disbursement,
+	    sum(vsd.fed_cand_cmte_contb_per) AS fed_candidate_committee_contributions,
+	    sum(vsd.fed_cand_contb_ref_per) AS fed_candidate_contribution_refunds,
+	    sum(vsd.fed_funds_per) > 0::numeric AS federal_funds_flag,
+	    sum(vsd.ttl_fed_disb_per) AS fed_disbursements,
+	    sum(vsd.fed_funds_per) AS federal_funds,
+	    sum(vsd.fndrsg_disb) AS fundraising_disbursements,
+	    sum(vsd.indv_contb) AS individual_contributions,
+	    sum(vsd.indv_item_contb) AS individual_itemized_contributions,
+	    sum(vsd.indv_ref) AS refunded_individual_contributions,
+	    sum(vsd.indv_unitem_contb) AS individual_unitemized_contributions,
+	    sum(vsd.loan_repymts_received_per) AS loan_repayments_received,
+	    sum(vsd.loans_made_per) AS loans_made,
+	    sum(vsd.net_contb) AS net_contributions,
+	    sum(vsd.net_op_exp) AS net_operating_expenditures,
+	    sum(vsd.non_alloc_fed_elect_actvy_per) AS non_allocated_fed_election_activity,
+	    sum(vsd.offsets_to_fndrsg) AS offsets_to_fundraising_expenditures,
+	    sum(vsd.offsets_to_legal_acctg) AS offsets_to_legal_accounting,
+	    sum(vsd.offsets_to_op_exp + vsd.offsets_to_fndrsg + vsd.offsets_to_legal_acctg) AS total_offsets_to_operating_expenditures,
+	    sum(vsd.offsets_to_op_exp) AS offsets_to_operating_expenditures,
+	    sum(
+		CASE
+		    WHEN vsd.form_tp_cd::text = 'F3X'::text THEN vsd.ttl_op_exp_per
+		    ELSE vsd.op_exp_per
+		END) AS operating_expenditures,
+	    sum(vsd.oth_cmte_contb) AS other_political_committee_contributions,
+	    sum(vsd.oth_cmte_ref) AS refunded_other_political_committee_contributions,
+	    sum(vsd.oth_loan_repymts) AS loan_repayments_other_loans,
+	    sum(vsd.oth_loan_repymts) AS repayments_other_loans,
+	    sum(vsd.oth_loans) AS all_other_loans,
+	    sum(vsd.oth_loans) AS other_loans_received,
+	    sum(vsd.other_disb_per) AS other_disbursements,
+	    sum(vsd.other_fed_op_exp_per) AS other_fed_operating_expenditures,
+	    sum(vsd.other_receipts) AS other_fed_receipts,
+	    sum(vsd.other_receipts) AS other_receipts,
+	    sum(vsd.pol_pty_cmte_contb) AS refunded_political_party_committee_contributions,
+	    sum(vsd.pty_cmte_contb) AS political_party_committee_contributions,
+	    sum(vsd.shared_fed_actvy_fed_shr_per) AS shared_fed_activity,
+	    sum(vsd.shared_fed_actvy_nonfed_per) AS allocated_federal_election_levin_share,
+	    sum(vsd.shared_fed_actvy_nonfed_per) AS shared_fed_activity_nonfed,
+	    sum(vsd.shared_fed_op_exp_per) AS shared_fed_operating_expenditures,
+	    sum(vsd.shared_nonfed_op_exp_per) AS shared_nonfed_operating_expenditures,
+	    sum(vsd.tranf_from_nonfed_acct_per) AS transfers_from_nonfed_account,
+	    sum(vsd.tranf_from_nonfed_levin_per) AS transfers_from_nonfed_levin,
+	    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_affiliated_committee,
+	    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_affiliated_party,
+	    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_other_authorized_committee,
+	    sum(vsd.tranf_to_other_auth_cmte) AS transfers_to_affiliated_committee,
+	    sum(vsd.tranf_to_other_auth_cmte) AS transfers_to_other_authorized_committee,
+	    sum(vsd.ttl_contb_ref) AS contribution_refunds,
+	    sum(vsd.ttl_contb) AS contributions,
+	    sum(vsd.ttl_disb) AS disbursements,
+	    sum(vsd.ttl_fed_elect_actvy_per) AS fed_election_activity,
+	    sum(vsd.ttl_fed_receipts_per) AS fed_receipts,
+	    sum(vsd.ttl_loan_repymts) AS loan_repayments,
+	    sum(vsd.ttl_loans) AS loans_received,
+	    sum(vsd.ttl_loans) AS loans,
+	    sum(vsd.ttl_nonfed_tranf_per) AS total_transfers,
+	    sum(vsd.ttl_receipts) AS receipts,
+	    max(committee_info.cmte_tp::text) AS committee_type,
+	    max(expand_committee_type(committee_info.cmte_tp::text)) AS committee_type_full,
+	    max(committee_info.cmte_dsgn::text) AS committee_designation,
+	    max(expand_committee_designation(committee_info.cmte_dsgn::text)) AS committee_designation_full,
+	    max(committee_info.cmte_pty_affiliation_desc::text) AS party_full,
+	    vsd.cmte_id AS committee_id,
+	    vsd.form_tp_cd AS form_type,
+		CASE
+		    WHEN max(last.form_type::text) = ANY (ARRAY['F3'::text, 'F3P'::text]) THEN NULL::numeric
+		    ELSE sum(vsd.indt_exp_per)
+		END AS independent_expenditures,
+	    sum(vsd.exp_subject_limits_per) AS exp_subject_limits,
+	    sum(vsd.exp_prior_yrs_subject_lim_per) AS exp_prior_years_subject_limits,
+	    sum(vsd.ttl_exp_subject_limits) AS total_exp_subject_limits,
+	    sum(vsd.subttl_ref_reb_ret_per) AS refunds_relating_convention_exp,
+	    sum(vsd.item_ref_reb_ret_per) AS itemized_refunds_relating_convention_exp,
+	    sum(vsd.unitem_ref_reb_ret_per) AS unitemized_refunds_relating_convention_exp,
+	    sum(vsd.subttl_other_ref_reb_ret_per) AS other_refunds,
+	    sum(vsd.item_other_ref_reb_ret_per) AS itemized_other_refunds,
+	    sum(vsd.unitem_other_ref_reb_ret_per) AS unitemized_other_refunds,
+	    sum(vsd.item_other_income_per) AS itemized_other_income,
+	    sum(vsd.unitem_other_income_per) AS unitemized_other_income,
+	    sum(vsd.subttl_convn_exp_disb_per) AS convention_exp,
+	    sum(vsd.item_convn_exp_disb_per) AS itemized_convention_exp,
+	    sum(vsd.unitem_convn_exp_disb_per) AS unitemized_convention_exp,
+	    sum(vsd.item_other_disb_per) AS itemized_other_disb,
+	    sum(vsd.unitem_other_disb_per) AS unitemized_other_disb
+	   FROM disclosure.v_sum_and_det_sum_report vsd
+	     LEFT JOIN last ON vsd.cmte_id::text = last.cmte_id::text AND get_cycle(vsd.rpt_yr) = last.cycle
+	     LEFT JOIN first ON vsd.cmte_id::text = first.committee_id::text AND get_cycle(vsd.rpt_yr) = first.cycle
+	     LEFT JOIN committee_info ON vsd.cmte_id::text = committee_info.cmte_id::text AND get_cycle(vsd.rpt_yr)::numeric = committee_info.fec_election_yr
+	  WHERE get_cycle(vsd.rpt_yr) >= 1979 AND (vsd.form_tp_cd::text <> 'F5'::text OR vsd.form_tp_cd::text = 'F5'::text AND (vsd.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text]))) AND vsd.form_tp_cd::text NOT IN ('F6','SL')
+	  GROUP BY vsd.cmte_id, vsd.form_tp_cd, (get_cycle(vsd.rpt_yr))
+	  WITH DATA;
+
+	ALTER TABLE public.ofec_totals_combined_mv_tmp OWNER TO fec;
+
+	GRANT ALL ON TABLE public.ofec_totals_combined_mv_tmp TO fec;
+	GRANT SELECT ON TABLE public.ofec_totals_combined_mv_tmp TO fec_read;
+
+	CREATE UNIQUE INDEX idx_ofec_totals_combined_mv_tmp_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_dsgn_full_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (committee_designation_full COLLATE pg_catalog."default", sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_id_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (committee_id , sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_tp_full_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (committee_type_full, sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_cycle_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (cycle, sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_disb_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (disbursements, sub_id);
+	CREATE INDEX idx_ofec_totals_combined_mv_tmp_receipts_sub_id
+	    ON public.ofec_totals_combined_mv_tmp USING btree
+	    (receipts, sub_id);
+
+	-- recreate vw -> select all from new _tmp MV
+	CREATE OR REPLACE VIEW ofec_totals_combined_vw 
+	AS SELECT * FROM ofec_totals_combined_mv_tmp;
+
+	ALTER VIEW ofec_totals_combined_vw OWNER TO fec;
+	GRANT SELECT ON ofec_totals_combined_vw TO fec_read;
+
+	-- drop old `MV`
+	DROP MATERIALIZED VIEW public.ofec_totals_combined_mv;
+
+	-- rename _tmp mv to mv
+	ALTER MATERIALIZED VIEW IF EXISTS public.ofec_totals_combined_mv_tmp RENAME TO ofec_totals_combined_mv;
+
+	-- rename indexes
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_dsgn_full_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_dsgn_full_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_id_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_id_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_tp_full_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_tp_full_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cycle_sub_id RENAME TO idx_ofec_totals_combined_mv_cycle_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_disb_sub_id RENAME TO idx_ofec_totals_combined_mv_disb_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_receipts_sub_id RENAME TO idx_ofec_totals_combined_mv_receipts_sub_id;
+	ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_sub_id RENAME TO idx_ofec_totals_combined_mv_sub_id;
+
+    else
+	null;
+    end if;
+
+EXCEPTION
+    WHEN others THEN
+        RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+

--- a/data/migrations/V0205__tres_nm_ofec_filings_all_mv.sql
+++ b/data/migrations/V0205__tres_nm_ofec_filings_all_mv.sql
@@ -1,0 +1,414 @@
+/*
+This is migration file 3 of 3 to solve issue #4463
+*/
+
+DO $$
+DECLARE
+    execute_flg integer;
+BEGIN
+    execute 'SELECT count(*)
+    FROM pg_attribute a
+    JOIN pg_class t on a.attrelid = t.oid
+    JOIN pg_namespace s on t.relnamespace = s.oid
+    WHERE a.attnum > 0 
+    AND NOT a.attisdropped
+    and relname = ''f_rpt_or_form_sub''
+    and a.attname = ''tres_nm''
+    and pg_catalog.format_type(a.atttypid, a.atttypmod) = ''character varying(38)''
+    and s.nspname = ''disclosure'''
+    into execute_flg;
+
+    if execute_flg = 1 then
+
+	-- --------------------------------
+	-- public.ofec_filings_vw/public.ofec_filings_mv are not used anymore.  
+	-- So it can be dropped to remove the dependcy to disclosure.f_rpt_or_form_sub
+	-- But since this will involved in flow.py file change, need to be in sync with code build.
+	-- So at the end of this migration file it will be created with the same definition as the ofec_filings_all_mv for this Sprint.
+	-- It will be permantly dropped next Sprint.  
+	-- --------------------------------
+	DROP VIEW IF EXISTS public.ofec_filings_vw;
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_mv;
+	-- --------------------------------
+	-- Now all dependcy removed, the real table can be altered.
+	-- --------------------------------
+	alter table disclosure.f_rpt_or_form_sub 
+	alter column tres_nm type varchar(90);
+
+	-- ----------
+	-- ofec_filings_all_mv_tmp
+	-- ----------
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+	CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp AS
+	SELECT row_number() OVER () AS idx,
+	    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	    END AS candidate_id,
+	    cand.name AS candidate_name,
+	    filing_history.cand_cmte_id AS committee_id,
+	    com.name AS committee_name,
+	    filing_history.sub_id,
+	    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+	    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+	    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+	    filing_history.election_yr AS election_year,
+	    filing_history.form_tp AS form_type,
+	    filing_history.rpt_yr AS report_year,
+	    get_cycle(filing_history.rpt_yr) AS cycle,
+	    filing_history.rpt_tp AS report_type,
+	    filing_history.to_from_ind AS document_type,
+	    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+	    filing_history.begin_image_num::bigint AS beginning_image_number,
+	    filing_history.end_image_num AS ending_image_number,
+	    filing_history.pages,
+	    filing_history.ttl_receipts AS total_receipts,
+	    filing_history.ttl_indt_contb AS total_individual_contributions,
+	    filing_history.net_dons AS net_donations,
+	    filing_history.ttl_disb AS total_disbursements,
+	    filing_history.ttl_indt_exp AS total_independent_expenditures,
+	    filing_history.ttl_communication_cost AS total_communication_cost,
+	    filing_history.coh_bop AS cash_on_hand_beginning_period,
+	    filing_history.coh_cop AS cash_on_hand_end_period,
+	    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+	    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+	    filing_history.hse_pers_funds_amt AS house_personal_funds,
+	    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+	    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+	    filing_history.tres_nm AS treasurer_name,
+	    filing_history.file_num AS file_number,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	    END AS previous_file_number,
+	    report.rpt_tp_desc AS report_type_full,
+	    filing_history.rpt_pgi AS primary_general_indicator,
+	    filing_history.request_tp AS request_type,
+	    filing_history.amndt_ind AS amendment_indicator,
+	    filing_history.lst_updt_dt AS update_date,
+	    report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.form_tp::text) AS pdf_url,
+	    means_filed(filing_history.begin_image_num::text) AS means_filed,
+	    report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	    report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	    amendments.amendment_chain,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	    END AS most_recent_file_number,
+	    is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+		    CASE 
+			WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+		    CASE 
+			WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	    END AS most_recent,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	    END AS amendment_version,
+	    cand.state,
+	    cand.office,
+	    cand.district,
+	    cand.party,
+	    cmte_valid_fec_yr.cmte_tp,
+	    get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	    CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	    END AS form_category
+	  FROM disclosure.f_rpt_or_form_sub filing_history
+	     LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+	     LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+	     LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+	     LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+	     LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+	     LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+	     LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+	  WHERE filing_history.rpt_yr >= 1979::numeric AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+	WITH DATA;
+
+	ALTER TABLE public.ofec_filings_all_mv_tmp
+	    OWNER TO fec;
+
+	GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+	GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+	CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (idx);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (amendment_indicator);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (beginning_image_number);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (candidate_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (committee_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (coverage_end_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (coverage_start_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (cycle);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (cycle, committee_id );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (district );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (form_type );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (office );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (office_cmte_tp );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (party );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (primary_general_indicator );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (receipt_date);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (request_type );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_type );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_type_full );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (report_year);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_disbursements);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_independent_expenditures);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (total_receipts);
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (state );
+	CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+	    ON public.ofec_filings_all_mv_tmp USING btree
+	    (form_category);  
+
+	-- ------------
+	-- point the view to the _mv_tmp    
+	-- ------------
+	CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+	 SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+	ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+	GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+	GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+	-- drop old MV
+	DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+	-- rename _tmp mv to mv
+	ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+	-- rename indexes
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+	ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;
+
+	-- ------------------------
+	-- Now drop the tmp table
+	-- ------------------------
+	drop table disclosure.f_rpt_or_form_sub_tmp;
+
+	-- --------------------------------
+	-- public.ofec_filings_vw/public.ofec_filings_mv are not used anymore.  
+	-- So it can be dropped to remove the dependcy to disclosure.f_rpt_or_form_sub
+	-- But since this will involved in flow.py file change, need to be in sync with code build.
+	-- So at the end of this migration file it will be created with the same definition as the ofec_filings_all_mv for this Sprint.
+	-- It will be permantly dropped next Sprint.  
+	-- Here only has the bare miminum index for the MV refresh
+	-- --------------------------------
+	CREATE MATERIALIZED VIEW public.ofec_filings_mv AS
+	SELECT row_number() OVER () AS idx,
+	    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	    END AS candidate_id,
+	    cand.name AS candidate_name,
+	    filing_history.cand_cmte_id AS committee_id,
+	    com.name AS committee_name,
+	    filing_history.sub_id,
+	    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+	    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+	    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+	    filing_history.election_yr AS election_year,
+	    filing_history.form_tp AS form_type,
+	    filing_history.rpt_yr AS report_year,
+	    get_cycle(filing_history.rpt_yr) AS cycle,
+	    filing_history.rpt_tp AS report_type,
+	    filing_history.to_from_ind AS document_type,
+	    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+	    filing_history.begin_image_num::bigint AS beginning_image_number,
+	    filing_history.end_image_num AS ending_image_number,
+	    filing_history.pages,
+	    filing_history.ttl_receipts AS total_receipts,
+	    filing_history.ttl_indt_contb AS total_individual_contributions,
+	    filing_history.net_dons AS net_donations,
+	    filing_history.ttl_disb AS total_disbursements,
+	    filing_history.ttl_indt_exp AS total_independent_expenditures,
+	    filing_history.ttl_communication_cost AS total_communication_cost,
+	    filing_history.coh_bop AS cash_on_hand_beginning_period,
+	    filing_history.coh_cop AS cash_on_hand_end_period,
+	    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+	    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+	    filing_history.hse_pers_funds_amt AS house_personal_funds,
+	    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+	    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+	    filing_history.tres_nm AS treasurer_name,
+	    filing_history.file_num AS file_number,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	    END AS previous_file_number,
+	    report.rpt_tp_desc AS report_type_full,
+	    filing_history.rpt_pgi AS primary_general_indicator,
+	    filing_history.request_tp AS request_type,
+	    filing_history.amndt_ind AS amendment_indicator,
+	    filing_history.lst_updt_dt AS update_date,
+	    report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.form_tp::text) AS pdf_url,
+	    means_filed(filing_history.begin_image_num::text) AS means_filed,
+	    report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	    report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	    amendments.amendment_chain,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	    END AS most_recent_file_number,
+	    is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+		    CASE 
+			WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+		    CASE 
+			WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+			WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+			ELSE NULL
+		    END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	    END AS most_recent,
+	    CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	    END AS amendment_version,
+	    cand.state,
+	    cand.office,
+	    cand.district,
+	    cand.party,
+	    cmte_valid_fec_yr.cmte_tp,
+	    get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	    CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	    END AS form_category
+	  FROM disclosure.f_rpt_or_form_sub filing_history
+	     LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+	     LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+	     LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+	     LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+	     LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+	     LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+	     LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+	  WHERE filing_history.rpt_yr >= 1979::numeric AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+	WITH DATA;
+
+	ALTER TABLE public.ofec_filings_mv
+	    OWNER TO fec;
+
+	GRANT ALL ON TABLE public.ofec_filings_mv TO fec;
+	GRANT SELECT ON TABLE public.ofec_filings_mv TO fec_read;
+
+	CREATE UNIQUE INDEX idx_ofec_filings_mv_idx
+	    ON public.ofec_filings_mv USING btree
+	    (idx);
+	    
+    else
+      null;
+    end if;
+
+EXCEPTION
+    WHEN others THEN
+        RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+


### PR DESCRIPTION
## Summary (required)

- Resolves #4463 

As part of deploying the Informatica mappings to populate the tres_nm field 
in f_rpt_or_form_sub table from tres_sign_nm field in nml form tables, 
the size of tres_nm field in f_rpt_or_form_sub table 
from varchar2(38) to varchar2(90) in FECP database. 
The size of tres_nm column in f_rpt_or_form_sub table in Postgress databases 
also need to be increased to accommodate this change.

Currently there are MVs/VWs referencing f_rpt_or_form_sub table. 
Two of them referencing this particular column 
so these MVs/VWs need to be updated as well.

## How to test the changes locally
- Download the branch to local server, run flyway migration or run invoke create_sample_db, make sure migration files executed successfully
- Run pytest.
- log into local cfdm_test database, check the size of tres_nm column in f_rpt_or_form_sub table, it should be varchar(90)
- check ddl of ofec_totals_combined_mv, one of the source of this mv should be ofec_filings_all_vw, not ofec_filings_vw
- AFTER the migration files had executed, run the following statement in cfdm_test database
`delete from flyway_schema_history where version in ('0203', '0204', '0205');`
Then run flyway migrate again, make sure these migration files got executed again without error message.  This is to test the condition when these migration files merged into the AWS databases since these will be implement in the AWS databases already.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  No API impacted.



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
