### PR TITLE
Fix the broken sort by candidate_name, committee_name on IE, CC and EC by_candidate endpoint

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -372,6 +372,13 @@ class ScheduleEByCandidateFactory(BaseAggregateFactory):
     support_oppose_indicator = 'S'
 
 
+class ScheduleEByCandidateViewFactory(BaseAggregateFactory):
+    class Meta:
+        model = models.ScheduleEByCandidate
+
+    candidate_id = factory.Sequence(lambda n: str(n))
+
+
 class CommunicationCostByCandidateFactory(BaseAggregateFactory):
     class Meta:
         model = models.CommunicationCostByCandidate

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -372,13 +372,6 @@ class ScheduleEByCandidateFactory(BaseAggregateFactory):
     support_oppose_indicator = 'S'
 
 
-class ScheduleEByCandidateViewFactory(BaseAggregateFactory):
-    class Meta:
-        model = models.ScheduleEByCandidate
-
-    candidate_id = factory.Sequence(lambda n: str(n))
-
-
 class CommunicationCostByCandidateFactory(BaseAggregateFactory):
     class Meta:
         model = models.CommunicationCostByCandidate

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -6,6 +6,7 @@ from webservices.schemas import ScheduleEByCandidateSchema
 from webservices.resources.aggregates import ScheduleEByCandidateView
 
 
+# test /schedules/schedule_e/by_candidate/ under tag: independent expenditures
 class TestScheduleEByCandidateView(ApiBaseTest):
     def test_fields(self):
         candidate_id = 'S001'
@@ -145,7 +146,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             candidate_id='S005',
             support_oppose_indicator='S',
         ),
-        factories.ScheduleEByCandidateViewFactory(
+        factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
@@ -202,7 +203,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             support_oppose_indicator='S',
             committee_id='C005',
         ),
-        factories.ScheduleEByCandidateViewFactory(
+        factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
@@ -260,7 +261,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             support_oppose_indicator='S',
             committee_id='C005',
         ),
-        factories.ScheduleEByCandidateViewFactory(
+        factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -1,0 +1,276 @@
+
+from tests import factories
+from tests.common import ApiBaseTest
+from webservices.rest import api
+from webservices.schemas import ScheduleEByCandidateSchema
+from webservices.resources.aggregates import ScheduleEByCandidateView
+
+
+class TestScheduleEByCandidateView(ApiBaseTest):
+    def test_fields(self):
+        candidate_id = 'S001'
+        support_oppose_indicator = 'S'
+        factories.ScheduleEByCandidateFactory(candidate_id=candidate_id,
+            support_oppose_indicator=support_oppose_indicator, cycle=2018)
+        factories.CandidateElectionFactory(candidate_id=candidate_id,
+            cand_election_year=2018)
+        results = self._results(api.url_for(ScheduleEByCandidateView, candidate_id='S001'))
+        assert len(results) == 1
+        assert results[0].keys() == ScheduleEByCandidateSchema().fields.keys()
+
+    def test_sched_e_filter_match(self):
+        factories.CandidateElectionFactory(candidate_id='S002',
+            cand_election_year=2014)
+        factories.ScheduleEByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2008,
+            candidate_id='S001',
+            support_oppose_indicator='O',
+        ),
+        factories.ScheduleEByCandidateFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S002',
+            support_oppose_indicator='O',
+        ),
+
+        results = self._results(
+            api.url_for(ScheduleEByCandidateView, candidate_id='S002',
+            cycle=2014, support_oppose_indicator='S')
+        )
+        self.assertEqual(len(results), 1)
+
+    def test_sort_bad_column(self):
+        response = self.app.get(api.url_for(ScheduleEByCandidateView, sort='candidate'))
+        self.assertEqual(response.status_code, 422)
+        self.assertIn(b'Cannot sort on value', response.data)
+
+    def test_sort_by_candidate_id(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S001',
+            name='Robert Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S002',
+            name='FARLEY Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S003',
+            name='Robert Ritchie',
+            election_years=[2012],
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S001',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S002',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S003',
+            cand_election_year=2012)
+
+        factories.ScheduleEByCandidateFactory(
+            cycle=2012,
+            candidate_id='S001',
+            support_oppose_indicator='O',
+            total=700,
+            count=5,
+        ),
+        factories.ScheduleEByCandidateFactory(
+            cycle=2012,
+            candidate_id='S002',
+            support_oppose_indicator='O',
+            total=500,
+            count=3,
+        ),
+        factories.ScheduleEByCandidateFactory(
+            cycle=2012,
+            candidate_id='S003',
+            support_oppose_indicator='S',
+            total=100,
+            count=1,
+        ),
+        response = self._results(
+            api.url_for(ScheduleEByCandidateView, sort='-candidate_id',
+                office='senate', state='NY', cycle=2012))
+        self.assertEqual(len(response), 3)
+        self.assertEqual(response[0]['candidate_id'], 'S003')
+        self.assertEqual(response[0]['support_oppose_indicator'], 'S')
+        self.assertEqual(response[1]['candidate_id'], 'S002')
+        self.assertEqual(response[1]['support_oppose_indicator'], 'O')
+        self.assertEqual(response[2]['candidate_id'], 'S001')
+        self.assertEqual(response[2]['support_oppose_indicator'], 'O')
+
+    def test_sort_by_candidate_name_descending(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S005',
+            name='WARNER, MARK',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S006',
+            name='BALDWIN, ALISSA',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S005',
+            cand_election_year=2010)
+        factories.CandidateElectionFactory(
+            candidate_id='S006',
+            cand_election_year=2010)
+
+        factories.ScheduleEByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2010,
+            candidate_id='S005',
+            support_oppose_indicator='S',
+        ),
+        factories.ScheduleEByCandidateViewFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S006',
+            support_oppose_indicator='S',
+        ),
+
+        response = self._results(api.url_for(ScheduleEByCandidateView, cycle=2010,
+            office='senate', state='NY', sort='-candidate_name'))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
+        self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
+
+    def test_sort_by_committee_id(self):
+
+        factories.CommitteeHistoryFactory(
+            name='Warner for America', cycle=2010,
+            committee_id='C005'
+        )
+        factories.CommitteeHistoryFactory(
+            name='Ritche for America', cycle=2010,
+            committee_id='C006'
+        )
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S005',
+            name='WARNER, MARK',
+            election_years=[2010],
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S006',
+            name='BALDWIN, ALISSA',
+            election_years=[2010],
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S005',
+            cand_election_year=2010)
+        factories.CandidateElectionFactory(
+            candidate_id='S006',
+            cand_election_year=2010)
+
+        factories.ScheduleEByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2010,
+            candidate_id='S005',
+            support_oppose_indicator='S',
+            committee_id='C005',
+        ),
+        factories.ScheduleEByCandidateViewFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S005',
+            support_oppose_indicator='S',
+            committee_id='C006',
+        ),
+
+        response = self._results(api.url_for(ScheduleEByCandidateView, sort='-committee_id',
+            office='senate', cycle=2010, state='NY'))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['committee_id'], 'C006')
+        self.assertEqual(response[1]['committee_id'], 'C005')
+
+    def test_sort_by_committee_name(self):
+
+        factories.CommitteeHistoryFactory(
+            name='Warner for America', cycle=2010,
+            committee_id='C005'
+        )
+        factories.CommitteeHistoryFactory(
+            name='Ritche for America', cycle=2010,
+            committee_id='C006'
+        )
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S005',
+            name='WARNER, MARK',
+            election_years=[2010],
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S006',
+            name='BALDWIN, ALISSA',
+            election_years=[2010],
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S005',
+            cand_election_year=2010)
+        factories.CandidateElectionFactory(
+            candidate_id='S006',
+            cand_election_year=2010)
+
+        factories.ScheduleEByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2010,
+            candidate_id='S005',
+            support_oppose_indicator='S',
+            committee_id='C005',
+        ),
+        factories.ScheduleEByCandidateViewFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S005',
+            support_oppose_indicator='S',
+            committee_id='C006',
+        ),
+
+        response = self._results(api.url_for(ScheduleEByCandidateView, sort='-committee_name',
+            office='senate', cycle=2010, state='NY'))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['committee_name'], 'Warner for America')
+        self.assertEqual(response[1]['committee_name'], 'Ritche for America')

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -9,8 +9,118 @@ from webservices.resources.spending_by_others import (
 )
 from webservices.resources.aggregates import (
     CCAggregatesView,
+    CommunicationCostByCandidateView,
+    ElectioneeringByCandidateView,
     ECAggregatesView,
 )
+
+
+# test /electioneering/by_candidate/ under tag: electioneering
+class TestElectionerringByCandidate(ApiBaseTest):
+
+    def test_sort_by_candidate_name_descending(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S001',
+            name='WARNER, MARK',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S002',
+            name='BALDWIN, ALISSA',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S001',
+            cand_election_year=2010)
+        factories.CandidateElectionFactory(
+            candidate_id='S002',
+            cand_election_year=2010)
+
+        factories.ElectioneeringByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2010,
+            candidate_id='S001',
+        ),
+        factories.ElectioneeringByCandidateFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S002',
+        ),
+
+        response = self._results(api.url_for(ElectioneeringByCandidateView, cycle=2010,
+            office='senate', state='NY', sort='-candidate_name'))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
+        self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
+
+    def test_sort_by_candidate_id(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S001',
+            name='Robert Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S002',
+            name='FARLEY Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S003',
+            name='Robert Ritchie',
+            election_years=[2012],
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S001',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S002',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S003',
+            cand_election_year=2012)
+
+        factories.ElectioneeringByCandidateFactory(
+            cycle=2012,
+            candidate_id='S001',
+            total=700,
+            count=5,
+        ),
+        factories.ElectioneeringByCandidateFactory(
+            cycle=2012,
+            candidate_id='S002',
+            total=500,
+            count=3,
+        ),
+        factories.ElectioneeringByCandidateFactory(
+            cycle=2012,
+            candidate_id='S003',
+            total=100,
+            count=1,
+        ),
+        response = self._results(
+            api.url_for(ElectioneeringByCandidateView, sort='-candidate_id',
+                office='senate', state='NY', cycle=2012))
+        self.assertEqual(len(response), 3)
+        self.assertEqual(response[0]['candidate_id'], 'S003')
+        self.assertEqual(response[1]['candidate_id'], 'S002')
+        self.assertEqual(response[2]['candidate_id'], 'S001')
 
 
 class TestTotalElectioneering(ApiBaseTest):
@@ -205,6 +315,122 @@ class TestTotalCommunicationsCosts(ApiBaseTest):
         assert len(results) == 2
         assert results[0]['total'] == 800
         assert results[1]['total'] == 600
+
+
+# test /communication_costs/by_candidate/ under tag: communication cost
+class TestCommunicationsCostsByCandidate(ApiBaseTest):
+
+    def test_sort_by_candidate_name_descending(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S001',
+            name='WARNER, MARK',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S002',
+            name='BALDWIN, ALISSA',
+            two_year_period=2010,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S001',
+            cand_election_year=2010)
+        factories.CandidateElectionFactory(
+            candidate_id='S002',
+            cand_election_year=2010)
+
+        factories.CommunicationCostByCandidateFactory(
+            total=50000,
+            count=10,
+            cycle=2010,
+            candidate_id='S001',
+            support_oppose_indicator='S',
+        ),
+        factories.CommunicationCostByCandidateFactory(
+            total=10000,
+            count=5,
+            cycle=2010,
+            candidate_id='S002',
+            support_oppose_indicator='S',
+        ),
+
+        response = self._results(api.url_for(CommunicationCostByCandidateView, cycle=2010,
+            office='senate', state='NY', sort='-candidate_name'))
+        self.assertEqual(len(response), 2)
+        self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
+        self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
+
+    def test_sort_by_candidate_id(self):
+
+        factories.CandidateHistoryFactory(
+            candidate_id='S001',
+            name='Robert Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S002',
+            name='FARLEY Ritchie',
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+        factories.CandidateHistoryFactory(
+            candidate_id='S003',
+            name='Robert Ritchie',
+            election_years=[2012],
+            two_year_period=2012,
+            office='S',
+            state='NY',
+        )
+
+        factories.CandidateElectionFactory(
+            candidate_id='S001',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S002',
+            cand_election_year=2012)
+        factories.CandidateElectionFactory(
+            candidate_id='S003',
+            cand_election_year=2012)
+
+        factories.CommunicationCostByCandidateFactory(
+            cycle=2012,
+            candidate_id='S001',
+            support_oppose_indicator='O',
+            total=700,
+            count=5,
+        ),
+        factories.CommunicationCostByCandidateFactory(
+            cycle=2012,
+            candidate_id='S002',
+            support_oppose_indicator='O',
+            total=500,
+            count=3,
+        ),
+        factories.CommunicationCostByCandidateFactory(
+            cycle=2012,
+            candidate_id='S003',
+            support_oppose_indicator='S',
+            total=100,
+            count=1,
+        ),
+        response = self._results(
+            api.url_for(CommunicationCostByCandidateView, sort='-candidate_id',
+                office='senate', state='NY', cycle=2012))
+        self.assertEqual(len(response), 3)
+        self.assertEqual(response[0]['candidate_id'], 'S003')
+        self.assertEqual(response[0]['support_oppose_indicator'], 'S')
+        self.assertEqual(response[1]['candidate_id'], 'S002')
+        self.assertEqual(response[1]['support_oppose_indicator'], 'O')
+        self.assertEqual(response[2]['candidate_id'], 'S001')
+        self.assertEqual(response[2]['support_oppose_indicator'], 'O')
 
 
 # test endpoint: /communication_costs/aggregates/ under tag:communication costs

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -209,7 +209,7 @@ class CandidateAggregateResource(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate', 'committee'],
+                extra=['candidate_name', 'committee_name', 'candidate_id', 'committee_id'],
             ),
         )
 


### PR DESCRIPTION
## Summary (required)
Fix the broken sort by candidate_name, committee_name on the following endpoints:

1.  Independent Expenditures  - ` /schedules/schedule_e/by_candidate/` 
2. Communication Cost  -  `/communication_costs/by_candidate/`
3. Electioneering - `/electioneering/by_candidate/`

- Resolves #4360

_Include a summary of proposed changes._

- In resources/aggregates.py : Modify the sort_args in the `CandidateAggregateResource` to include `candidate_name` and `committee_name`
- Also added candidate_id and committee_id to sort_args function. While writing additional tests that sorts by those two parameters, pytests are failing with a 422 error. Reason being, these two columns are not found in the views(SE, CC and EC) and they are inherited from the parent class(BaseAggregates). pytests are unable to identify `sort` columns that are not in the views. 
- Add tests on `/schedules/schedule_e/by_candidate/` endpoint - sort by candidate_name, candidate_id, committee_id, committee_name
- Add tests on `electioneering/by_candidate` endpoint -  sort by candidate_name, candidate_id
- Add tests to `communication_costs/by_candidate` endpoint - sort by candidate_name, candidate_id

## How to test the changes locally

- checkout branch
   - run `git checkout feature/4360-fix-schedule_e-sort`
- make sure all pytests pass
   - run `pytest`
- export SQLA_CONN to DEV or STAGE db
- start server 
   - run - `./manage.py runserver`
- Test **sort by candidate_name, committee_name** on `/schedules/schedule_e/by_candidate/`, `electioneering/by_candidate`, `communication_costs/by_candidate` endpoints.

## Screenshots:

**_`/schedules/schedule_e/by_candidate/` sort by candidate_name in Production_**:

**URL:** https://api.open.fec.gov/v1/schedules/schedule_e/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

<img width="946" alt="Screen Shot 2020-07-17 at 12 26 43 AM" src="https://user-images.githubusercontent.com/11650355/87748560-38e0de80-c7c4-11ea-880e-6b45d5cb5dc9.png">


_**`/schedules/schedule_e/by_candidate/` sort by candidate_name in local:**_

**URL:** http://localhost:5000/v1/schedules/schedule_e/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

<img width="1012" alt="Screen Shot 2020-07-17 at 12 28 34 AM" src="https://user-images.githubusercontent.com/11650355/87748651-7c3b4d00-c7c4-11ea-8d60-df0ac6068627.png">
#############################################################################################
#############################################################################################

**_`/schedules/schedule_e/by_candidate/` sort by committee_name in Production_**:

**URL:** https://api.open.fec.gov/v1/schedules/schedule_e/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=committee_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

<img width="887" alt="Screen Shot 2020-07-17 at 12 33 57 AM" src="https://user-images.githubusercontent.com/11650355/87748937-4a76b600-c7c5-11ea-8834-2fb294667ab1.png">

**_`/schedules/schedule_e/by_candidate/` sort by committee_name in local**:
**URL:** http://localhost:5000/v1/schedules/schedule_e/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=committee_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

<img width="922" alt="Screen Shot 2020-07-17 at 12 35 37 AM" src="https://user-images.githubusercontent.com/11650355/87749014-81e56280-c7c5-11ea-9981-4552b4627b68.png">

#############################################################################################
#############################################################################################

**`electioneering/by_candidate` sort by candidate_name in Production_:**
**URL:** https://api.open.fec.gov/v1/electioneering/by_candidate/?sort_nulls_last=false&state=CO&api_key=DEMO_KEY&office=senate&per_page=20&sort=-candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

**`electioneering/by_candidate` sort by committee_name in local_:**
**URL:** http://localhost:5000/v1/electioneering/by_candidate/?sort_nulls_last=false&state=CO&api_key=DEMO_KEY&office=senate&per_page=20&sort=-candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

#############################################################################################
#############################################################################################

**`communication_costs/by_candidate` sort by candidate_name in Production_:**

**URL:** https://api.open.fec.gov/v1/communication_costs/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=-candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false

**`communication_costs/by_candidate` sort by committee_name in local_:**

**URL:**  http://localhost:5000/v1/communication_costs/by_candidate/?sort_nulls_last=false&state=tx&api_key=DEMO_KEY&office=senate&per_page=20&sort=-candidate_name&election_full=true&cycle=2020&sort_hide_null=false&page=1&sort_null_only=false
## Impacted areas of the application
List general components of the application that this PR will affect:

-  sort by candidate_name and committee_name on `/schedules/schedule_e/by_candidate/`, `electioneering/by_candidate`, `communication_costs/by_candidate` endpoints.
- On election pages, sort by candidate and spent by columns on IE, CC and EC sections
- On IE pages,  sort by candidate and spent by columns on IE section