### PR TITLE
Remove unused/extra return statement for 'join_cand_cmte_names' function

### DIFF
--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -418,4 +418,3 @@ def join_cand_cmte_names(query):
             query.c.cycle == models.CommitteeHistory.cycle,
         ),
     )
-    return query


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in testing

Remove unused/extra return

There’s a return on line 402 and another on line 421 that will never run, but it could cause problems if we change the code and don’t realize the behavior.

https://github.com/fecgov/openFEC/blob/85fb11a78246e51745f82a57896b5a602ea83cac/webservices/resources/aggregates.py#L400-L421