### PR TITLE
Remove "contributor_aggregate_ytd " sort option for Schedule A

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -508,12 +508,6 @@ schedule_a = {
         `contribution_receipt_amount` of the last result. However, you will need to pass the index \
         of that last result to `last_index` to get the next page.'
     ),
-    'last_contributor_aggregate_ytd': fields.Float(
-        missing=None,
-        description='When sorting by `contributor_aggregate_ytd`, this is populated with the \
-        `contributor_aggregate_ytd` of the last result. However, you will need to pass the index \
-        of that last result to `last_index` to get the next page.'
-    ),
     'is_individual': fields.Bool(missing=None, description=docs.IS_INDIVIDUAL),
     'contributor_type': fields.List(
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -88,7 +88,9 @@ class OptionValidator(object):
     def __call__(self, value):
         if value.lstrip('-') not in self.values:
             raise exceptions.ApiError(
-                'Cannot sort on value "{0}"'.format(value),
+                'Cannot sort on value "{0}". Instead choose one of: "{1}"'.format(
+                    value, '", "'.join(self.values)
+                ),
                 status_code=422,
             )
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -77,7 +77,6 @@ class ScheduleAView(ItemizedResource):
     sort_options = [
         'contribution_receipt_date',
         'contribution_receipt_amount',
-        'contributor_aggregate_ytd',
     ]
     filters_with_max_count = [
         'committee_id',
@@ -201,7 +200,6 @@ class ScheduleAEfileView(views.ApiResource):
                     [
                         'contribution_receipt_date',
                         'contribution_receipt_amount',
-                        'contributor_aggregate_ytd',
                     ]
                 ),
             ),


### PR DESCRIPTION
## Summary (required)

- Resolves #4381

- Remove "contributor_aggregate_ytd " sort option for Schedule A
- Provide a more helpful error message for invalid sort

## How to test the changes locally

- Run this branch, try http://localhost:5000/v1/schedules/schedule_a/?two_year_transaction_period=2010&sort=contributor_aggregate_ytd

```
{
message: "Cannot sort on value "contributor_aggregate_ytd". Instead choose one of: "contribution_receipt_date", "contribution_receipt_amount"",
status: 422
}
```

## Impacted areas of the application
List general components of the application that this PR will affect:

-  No front-end impact

