### PR TITLE
Add validation for page=0

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -217,6 +217,12 @@ class CandidateFormatTest(ApiBaseTest):
         )
         self.assertEqual([each['candidate_id'] for each in results], ['2', '3', '1'])
 
+    def test_page_validation(self):
+        response = self.app.get(
+            api.url_for(CandidateList, page=0)
+        )
+        self.assertEqual(response.status_code, 422)
+
 
 class TestCandidateHistory(ApiBaseTest):
     def setUp(self):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -10,9 +10,9 @@ from webservices.common.models import db
 
 
 def _validate_natural(value):
-    if value < 0:
+    if value <= 0:
         raise exceptions.ApiError(
-            'Must be a natural number',
+            'Must be greater than zero',
             status_code=422
         )
 


### PR DESCRIPTION
## Summary (required)

Resolves #4486

- Add validation for `page=0` (should throw 422 instead of 500)
- Make error message friendlier 
- Add test coverage

## How to test the changes locally

- On production: https://api.open.fec.gov/v1/committees/?api_key=DEMO_KEY&committee_id=C00431445&page=0 throws 500 error
- Local: http://localhost:5000/v1/committees/?api_key=DEMO_KEY&committee_id=C00431445&page=0
```
{
message: "Must be greater than zero",
status: 422
}
```
## Impacted areas of the application
List general components of the application that this PR will affect:

-  No known front-end symptoms - saw this in logs from API users

