### PR TITLE
[Demo only] Feature/4414 union 2 year period

### DIFF
--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -62,9 +62,10 @@ class ItemizedResource(ApiResource):
     index_column = None
     filters_with_max_count = []
     max_count = 10
+    union_fields = ["committee_id"]
 
     def get(self, **kwargs):
-        """Get itemized resources. If multiple values are passed for `committee_id`,
+        """Get itemized resources. If multiple values are passed for any 'union_fields',
         create a subquery for each and combine with `UNION ALL`. This is necessary
         to avoid slow queries when one or more relevant committees has many
         records.
@@ -95,20 +96,21 @@ class ItemizedResource(ApiResource):
                 ),
                 status_code=422,
             )
-        if len(kwargs.get("committee_id", [])) > 1:
-            query, count = self.join_committee_queries(kwargs)
-            return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
+        for field in self.union_fields:
+            if len(kwargs.get(field, [])) > 1:
+                query, count = self.join_union_queries(kwargs, field)
+                return utils.fetch_seek_page(query, kwargs, self.index_column, count=count)
         query = self.build_query(**kwargs)
         count, _ = counts.get_count(self, query)
         return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
 
-    def join_committee_queries(self, kwargs):
+    def join_union_queries(self, kwargs, field):
         """Build and compose per-committee subqueries using `UNION ALL`.
         """
         queries = []
         total = 0
-        for committee_id in kwargs.get('committee_id', []):
-            query, count = self.build_committee_query(kwargs, committee_id)
+        for argument in kwargs.get(field, []):
+            query, count = self.build_union_query(kwargs, field, argument)
             queries.append(query.subquery().select())
             total += count
         query = models.db.session.query(
@@ -119,10 +121,10 @@ class ItemizedResource(ApiResource):
         query = query.options(*self.query_options)
         return query, total
 
-    def build_committee_query(self, kwargs, committee_id):
-        """Build a subquery by committee.
+    def build_union_query(self, kwargs, field, argument):
+        """Build a subquery by specified `field` arguments.
         """
-        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {'committee_id': [committee_id]}))
+        query = self.build_query(_apply_options=False, **utils.extend(kwargs, {field: [argument]}))
         sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
         query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -8,6 +8,9 @@ from webservices import exceptions
 from webservices.common import counts
 from webservices.common import models
 from webservices.utils import use_kwargs
+from webservices.config import SQL_CONFIG
+
+ALL_TWO_YEAR_PERIODS = range(1976, SQL_CONFIG["END_YEAR_ITEMIZED"] + 2, 2)
 
 
 class ApiResource(utils.Resource):
@@ -96,6 +99,9 @@ class ItemizedResource(ApiResource):
                 ),
                 status_code=422,
             )
+        if type(self).__name__ == "ScheduleAView":
+            if not kwargs.get("two_year_transaction_period"):
+                kwargs["two_year_transaction_period"] = ALL_TWO_YEAR_PERIODS
         for field in self.union_fields:
             if len(kwargs.get(field, [])) > 1:
                 query, count = self.join_union_queries(kwargs, field)

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -87,8 +87,11 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
-    use_pk_for_count=True
-
+    use_pk_for_count = True
+    union_fields = [
+        "committee_id",
+        "two_year_transaction_period",
+    ]
 
     @property
     def args(self):

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -153,6 +153,11 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
             cursor = cursor.filter(filter)
 
         query = cursor.order_by(direction(self.index_column)).limit(limit)
+        from sqlalchemy.dialects import postgresql
+
+        print(str(query.statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True})))
         return query.all() if eager else query
 
     def _get_index_values(self, result):


### PR DESCRIPTION
It's not just the overlap that makes us need to break the dependency - the logic only does one union at a time and uses "OR" for everything else: example
http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&data_type=processed&committee_id=C00589309&committee_id=C00703975&sort=-contribution_receipt_date&per_page=30

```
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00703975') AND disclosure.fec_fitem_sched_a.two_year_transaction_period IN (1976, 1978, 1980, 1982, 1984, 1986, 1988, 1990, 1992, 1994, 1996, 1998, 2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018, 2020) 
...
```