### PR TITLE
Increase number of gunicorn workers

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
 python manage.py cf_startup
-gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 4 webservices.rest:app
+gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 9 webservices.rest:app

--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -5,7 +5,6 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   APP_NAME: fec | api | dev
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -8,7 +8,6 @@ env:
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -7,7 +7,6 @@ env:
   FEC_API_USE_PROXY: true
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -5,7 +5,6 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   APP_NAME: fec | api | dev
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -8,7 +8,6 @@ env:
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -7,7 +7,6 @@ env:
   FEC_API_USE_PROXY: true
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -5,7 +5,6 @@ stack: cflinuxfs3
 buildpack: python_buildpack
 env:
   APP_NAME: fec | api | dev
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -8,7 +8,6 @@ env:
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | prod
   PRODUCTION: True
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -7,7 +7,6 @@ env:
   FEC_API_USE_PROXY: true
   FEC_API_RESTRICT_DOWNLOADS: true
   APP_NAME: fec | api | stage
-  WEB_CONCURRENCY: 4
 services:
   - fec-api-search56
   - fec-redis

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -9,7 +9,6 @@ applications:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | dev
     PRODUCTION: True
-    WEB_CONCURRENCY: 4
   no-route: true
   services:
   - fec-s3-dev

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -10,7 +10,6 @@ applications:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | prod
     PRODUCTION: True
-    WEB_CONCURRENCY: 4
   no-route: true
   services:
   - fec-s3-prod

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -9,7 +9,6 @@ applications:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | stage
     PRODUCTION: True
-    WEB_CONCURRENCY: 4
   no-route: true
   services:
   - fec-s3-stage


### PR DESCRIPTION
## Summary (required)

Resolves #4489

- Update number of `gunicorn` workers to `9` (2*CPU+1) per https://docs.gunicorn.org/en/stable/design.html#how-many-workers
- Remove unused env var `WEB_CONCURRENCY` (gunicorn ignores this - can't figure out why we can't use this env var but it's not being used, so removed it)

## How to test the changes locally

Load testing results show improved speed: https://docs.google.com/spreadsheets/d/1DNs0O1YiL7AgHptYd9de-iuUv1c6tZ8ZtFA4Soym9cQ/edit#gid=0

- Manually deploy this branch with `invoke deploy --space dev` (please don't commit to this branch)
- ssh into instance 0 of the api app with `cf ssh api -0` 
- Check number of CPU cores with `cat /proc/cpuinfo`
- Check number of workers with `ps aux | grep gunicorn | grep -v grep | wc -l` (subtract one) per https://stackoverflow.com/a/33107962

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Concurrency/speed should be less impacted when the database is slow
