### PR TITLE
Change sched-a default sort by DESC

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -322,7 +322,7 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(len(page1), 20)
         self.assertEqual(
             [int(each['sub_id']) for each in page1],
-            [each.sub_id for each in filings[:20]],
+            [each.sub_id for each in filings[29:9:-1]],
         )
         page2 = self._results(
             api.url_for(
@@ -335,7 +335,7 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(len(page2), 10)
         self.assertEqual(
             [int(each['sub_id']) for each in page2],
-            [each.sub_id for each in filings[20:]],
+            [each.sub_id for each in filings[9::-1]],
         )
 
     def test_schedule_a_pagination_with_null_sort_column_values_hidden(self):

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -86,8 +86,7 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
-    use_pk_for_count=True
-
+    use_pk_for_count = True
 
     @property
     def args(self):
@@ -96,11 +95,9 @@ class ScheduleAView(ItemizedResource):
             args.schedule_a,
             args.make_seek_args(),
             args.make_sort_args(
-                default='contribution_receipt_date',
+                default='-contribution_receipt_date',
                 validator=args.OptionValidator(self.sort_options),
                 show_nulls_last_arg=False,
-                additional_description="The `contributor_aggregate_ytd` option is deprecated. \n"
-                " `contribution_receipt_date` default sorting ASC will change to DESC."
             ),
         )
 


### PR DESCRIPTION
## Summary (required)
Currently for /schedules​/schedule_a​/ endpoint, the default sorting "contribution_receipt_date ASC". But SB and SE are sorted DESC by default. 

- Resolves #4402 
Ref : [https://github.com/fecgov/openFEC/pull/4427](https://github.com/fecgov/openFEC/pull/4427)

_Include a summary of proposed changes._
sched_a.py

## How to test the changes locally
1)checkout branch
2)pytest
3)./manage.py runsever

Test URL:
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2008&sort_null_only=false&sort=-contribution_receipt_date&per_page=20&sort_hide_null=true

## Impacted areas of the application
/schedules​/schedule_a​/  api user
