### PR TITLE
Remove sort expression for Schedule B

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -371,20 +371,6 @@ class ScheduleB(BaseItemized):
     spender_committee_org_type = db.Column('org_tp', db.String(1), index=True)
     spender_committee_designation = db.Column('cmte_dsgn', db.String(1), index=True)
 
-    @hybrid_property
-    def sort_expressions(self):
-        return {
-            'disbursement_date': {
-                'expression': sa.func.coalesce(
-                    self.disbursement_date,
-                    sa.cast('9999-12-31', sa.Date)
-                ),
-                'field': ma.fields.Date,
-                'type': 'date',
-                'null_sort': self.disbursement_date,
-            },
-        }
-
 
 class ScheduleBEfile(BaseRawItemized):
     __tablename__ = 'real_efile_sb4'

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -670,7 +670,6 @@ ScheduleBSchema = make_schema(
             'disbursement_description_text',
             'recipient_street_1',
             'recipient_street_2',
-            'sort_expressions',
         ),
         'relationships': [
             Relationship(


### PR DESCRIPTION
## To Do
- [x] Add composite index (date, sub_id) for "default load" of 2020 (#4531), consider removing and other `coalesce` indexes (See #2923)
- [x] One more possible index needed (See https://github.com/fecgov/openFEC/issues/4531#issuecomment-668288075)
- [x] Test before/after manually ([results](https://docs.google.com/spreadsheets/d/1J5QK4mw7HXbMnaDV_ClCGWEgbbI3VZZhXDqmjIFwBqI/edit#gid=0)), including pagination, see #2791



## Summary (required)

- Resolves #4491

Remove sort expression for Schedule B

## How to test the changes locally
- Check out develop branch
- Run any Schedule B query, or choose one from this list https://docs.google.com/spreadsheets/d/1J5QK4mw7HXbMnaDV_ClCGWEgbbI3VZZhXDqmjIFwBqI/edit#gid=0
- Print out query here: https://github.com/fecgov/openFEC/blob/b849152b2dd1f1bc6836fc57a464b029c62f3974/webservices/utils.py#L155
- Note that the `ORDER BY` has `COALESCE` in it
- Check out this branch
- Run any Schedule B query
- Note that the `ORDER BY` no longer has `COALESCE` in it

## Impacted areas of the application
List general components of the application that this PR will affect:

- Schedule B query internals  


