### PR TITLE
Fix sort on candidate and committee name

### DIFF
--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -442,56 +442,56 @@ class TestCommunicationCostAggregates(ApiBaseTest):
 
     def test_filters_committee_candidate_id_cycle(self):
         factories.CandidateHistoryFactory(
-            candidate_id='C001', two_year_period=2000, candidate_election_year=2000, name='Apple Smith'
+            candidate_id='P001', two_year_period=2000, candidate_election_year=2000, name='Apple Smith'
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='C002', two_year_period=2000, candidate_election_year=2000, name='Snapple Smith'
+            candidate_id='P002', two_year_period=2000, candidate_election_year=2000, name='Snapple Smith'
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='C002', two_year_period=2004, candidate_election_year=2004, name='Zapple Smith'
+            candidate_id='P002', two_year_period=2004, candidate_election_year=2004, name='Zapple Smith'
         ),
 
         factories.CommitteeHistoryFactory(
-            committee_id='P001', cycle=2000, name='Acme Co'
+            committee_id='C001', cycle=2000, name='Acme Co'
         ),
         factories.CommitteeHistoryFactory(
-            committee_id='P002', cycle=2000, name='Tetris Corp'
+            committee_id='C002', cycle=2000, name='Tetris Corp'
         ),
         factories.CommitteeHistoryFactory(
-            committee_id='P002', cycle=2004, name='Winner PAC'
+            committee_id='C002', cycle=2004, name='Winner PAC'
         ),
 
         factories.CommunicationCostByCandidateFactory(
-            committee_id='P001', candidate_id='C001', cycle=2000
+            committee_id='C001', candidate_id='P001', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='P001', candidate_id='C002', cycle=2000
+            committee_id='C001', candidate_id='P002', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='P002', candidate_id='C001', cycle=2004
+            committee_id='C002', candidate_id='P001', cycle=2004
         )
         db.session.flush()
 
         # assert results filtered by committee_id sorted by candidate name in descending order
-        results = self._results(api.url_for(CCAggregatesView, committee_id='P001', sort='-candidate_name'))
+        results = self._results(api.url_for(CCAggregatesView, committee_id='C001', sort='-candidate_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['candidate_name'], 'Snapple Smith')
         self.assertEqual(results[1]['candidate_name'], 'Apple Smith')
 
         # assert results filtered by committee_id sorted by candidate name in ascending order
-        results = self._results(api.url_for(CCAggregatesView, committee_id='P001', sort='candidate_name'))
+        results = self._results(api.url_for(CCAggregatesView, committee_id='C001', sort='candidate_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['candidate_name'], 'Apple Smith')
         self.assertEqual(results[1]['candidate_name'], 'Snapple Smith')
 
         # assert results filtered by candidate_id sorted by committee name in descending order
-        results = self._results(api.url_for(CCAggregatesView, candidate_id='C001', sort='-committee_name'))
+        results = self._results(api.url_for(CCAggregatesView, candidate_id='P001', sort='-committee_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['committee_name'], 'Winner PAC')
         self.assertEqual(results[1]['committee_name'], 'Acme Co')
 
         # assert results filtered by candidate_id sorted by committee name in ascending order
-        results = self._results(api.url_for(CCAggregatesView, candidate_id='C001', sort='committee_name'))
+        results = self._results(api.url_for(CCAggregatesView, candidate_id='P001', sort='committee_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['committee_name'], 'Acme Co')
         self.assertEqual(results[1]['committee_name'], 'Winner PAC')

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -316,7 +316,7 @@ class CCAggregatesView(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate', 'committee'],
+                extra=['candidate_name', 'committee_name'],
             ),
         )
 
@@ -371,7 +371,7 @@ class ECAggregatesView(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate', 'committee'],
+                extra=['candidate_name', 'committee_name'],
             ),
         )
 

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -12,6 +12,10 @@ from webservices.common import models
 from webservices.common.views import ApiResource
 
 
+CANDIDATE_NAME_LABEL = 'candidate_name'
+COMMITTEE_NAME_LABEL = 'committee_name'
+
+
 class AggregateResource(ApiResource):
     query_args = {}
 
@@ -395,10 +399,7 @@ class ECAggregatesView(AggregateResource):
         ('candidate_id', model.candidate_id),
         ('committee_id', model.committee_id),
     ]
-
-
-CANDIDATE_NAME_LABEL = 'candidate_name'
-COMMITTEE_NAME_LABEL = 'committee_name'
+    
 
 def join_cand_cmte_names(query):
     query = query.subquery()

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -209,7 +209,7 @@ class CandidateAggregateResource(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate_name', 'committee_name', 'candidate_id', 'committee_id'],
+                extra=[CANDIDATE_NAME_LABEL, COMMITTEE_NAME_LABEL, 'candidate_id', 'committee_id'],
             ),
         )
 
@@ -316,7 +316,7 @@ class CCAggregatesView(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate_name', 'committee_name'],
+                extra=[CANDIDATE_NAME_LABEL, COMMITTEE_NAME_LABEL],
             ),
         )
 
@@ -371,7 +371,7 @@ class ECAggregatesView(AggregateResource):
         return args.make_sort_args(
             validator=args.IndexValidator(
                 self.model,
-                extra=['candidate_name', 'committee_name'],
+                extra=[CANDIDATE_NAME_LABEL, COMMITTEE_NAME_LABEL],
             ),
         )
 
@@ -397,14 +397,17 @@ class ECAggregatesView(AggregateResource):
     ]
 
 
+CANDIDATE_NAME_LABEL = 'candidate_name'
+COMMITTEE_NAME_LABEL = 'committee_name'
+
 def join_cand_cmte_names(query):
     query = query.subquery()
     return models.db.session.query(
         query,
         models.CandidateHistory.candidate_id.label('candidate_id'),
         models.CommitteeHistory.committee_id.label('committee_id'),
-        models.CandidateHistory.name.label('candidate_name'),
-        models.CommitteeHistory.name.label('committee_name'),
+        models.CandidateHistory.name.label(CANDIDATE_NAME_LABEL),
+        models.CommitteeHistory.name.label(COMMITTEE_NAME_LABEL),
     ).outerjoin(
         models.CandidateHistory,
         sa.and_(


### PR DESCRIPTION
## Summary

- Issue: https://github.com/fecgov/fec-cms/issues/3921
- Fixes API for candidate name and committee name sort

## How to test the changes locally

- Run this branch
- Make sure you can filter by `candidate_name`. Example: http://localhost:5000/v1/communication_costs/aggregates/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=candidate_name&per_page=30&page=1&election_full=false&cycle=2018&committee_id=C70001318
- Make sure you can filter by  `committee_name`. Example: http://localhost:5000/v1/communication_costs/aggregates/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&sort=committee_name&per_page=30&page=1&election_full=false&candidate_id=P80001571

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /communication_costs/aggregates/ endpoint
