### PR TITLE
drop MATERIALIZED VIEW ofec_filings_mv

### DIFF
--- a/data/migrations/V0207__drop_ofec_filings_mv.sql
+++ b/data/migrations/V0207__drop_ofec_filings_mv.sql
@@ -1,0 +1,16 @@
+/*
+This migration file is for issue #4478
+
+ofec_filings_mv is an older version of ofec_filings_all_mv 
+
+Searching webservices folder confirmed no code refrenecing this MV.
+
+Migration file V0204 for issue #4463 had removed the last usage of this MV 
+(ofec_totals_combined_mv). 
+
+Migration file V0205 had removed its counterpart ofec_filings_vw.
+
+It is ready to be dropped now.
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_mv;

--- a/manage.py
+++ b/manage.py
@@ -124,7 +124,6 @@ def refresh_materialized(concurrent=True):
         ],
         'filings': [
             'ofec_filings_amendments_all_mv',
-            'ofec_filings_mv',
             'ofec_filings_all_mv',
         ],
         'ofec_agg_coverage_date': ['ofec_agg_coverage_date_mv'],


### PR DESCRIPTION
## Summary (required)

- Resolves #4478 
ofec_filings_mv is an older version of ofec_filings_all_mv. PR for issue #4463 had removed the last usage of this MV. It will be dropped to avoid confusion and dual maintenance.

## How to test the changes locally
- Download the branch to local machine.  Run `invoke create_sample_db`
Make sure it runs successfully.  
Log in local cfdm_test database, make sure ofec_filings_mv does not exist.
Review the output from invoke create_sample_db, make sure ofec_filings_mv is not in the refreshing materialized view list.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  None



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()
