### PR TITLE
add terms of service and acceptable use policy

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -143,6 +143,7 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/4511-add-TOS-and-AUP-to-api-key-signup'),
 )
 
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -17,14 +17,11 @@ interesting candidates and committees. Then, you can use their IDs to find repor
 item details with the other endpoints. If you are interested in individual donors, check
 out contributor information in schedule_a.
 
-If you would like to use the FEC's API programatically, you can sign up for
-your own API key below. But, you can still try out our API without
-an API key by using the web interface below and making use of a DEMO_KEY.
-Signing up for an API key will enable you to place up to 1,000 calls an hour.
-Each call is limited to 100 results per page. You can email questions, comments or
-a request to get a key for 120 calls per minute to [APIinfo@fec.gov](mailto:apiinfo@fec.gov). You can also
-ask questions and discuss the data in the [FEC data Google Group](https://groups.google.com/forum/#!forum/fec-data).
-API changes will also be added to this group in advance of the change.
+<b class="body" id="getting_started_head">Getting started with the openFEC API</b><br>
+If you would like to use the FEC's API programmatically, you can sign up for your own API key using our form. Alternatively, you can still try out our API without an API key by using the web interface and using DEMO_KEY. Note that when you use the openFEC API you are subject to the [Terms of Service](https://github.com/fecgov/FEC/blob/master/TERMS-OF-SERVICE.md) and [Acceptable Use policy](https://github.com/fecgov/FEC/blob/master/ACCEPTABLE-USE-POLICY.md).
+
+
+Signing up for an API key will enable you to place up to 1,000 calls an hour. Each call is limited to 100 results per page. You can email questions, comments or a request to get a key for 7,600 calls per hour (120 calls per minute) to <a href="mailto:APIinfo@fec.gov">APIinfo@fec.gov</a>. You can also ask questions and discuss the data in a community led [group](https://groups.google.com/forum/#!forum/fec-data).
 
 The model definitions and schema are available at [/swagger](/swagger/). This is useful for
 making wrappers and exploring the data.


### PR DESCRIPTION
## Summary (required)

- Resolves #4511

adds terms of service and acceptable use policy to the api key signup page (swagger-ui)

## How to test the changes locally
note to reviewers: 
required: @JonellaCulmer 
optional: @PaulClark2 @lbeaufort @johnnyporkchops 

- I'll [deploy to dev](https://fec-dev-api.app.cloud.gov/developers/) so @JonellaCulmer can review (as of 8/1/2020 1:30 p.m. it's available on dev)
- otherwise, run locally, review `localhost:5000`

Things to test:
- click links
- verify it looks as expected
- text was copy/paste other than formatting, but another read through may be good.