### PR TITLE
remove manual deploy in tasks.py

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -143,7 +143,6 @@ DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
     ('dev', lambda _, branch: branch == 'develop'),
-    ('dev', lambda _, branch: branch == 'feature/4511-add-TOS-and-AUP-to-api-key-signup'),
 )
 
 


### PR DESCRIPTION
## Summary (required)

removes manual deploy line in tasks.py

## How to test the changes locally

- verify manual  deploy  line no longer in deploy rules

## Impacted areas of the application
List general components of the application that this PR will affect:

-  tasks.py
