### PR TITLE
Add user_downloads prefix to downloads bucket

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -33,7 +33,8 @@ class TestDownloadTask(ApiBaseTest):
     def test_get_filename(self):
         path = '/v1/candidates/'
         qs = '?office=H&sort=name'
-        expected = hashlib.sha224((path + qs).encode('utf-8')).hexdigest() + '.csv'
+        prefix = 'user-downloads/'
+        expected = prefix + hashlib.sha224((path + qs).encode('utf-8')).hexdigest() + '.csv'
         assert tasks.get_s3_name(path, qs) == expected
 
     def test_download_url(self):

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -119,7 +119,8 @@ def get_s3_name(path, qs):
     # TODO: consider base64 vs hash
     raw = '{}{}'.format(path, qs)
     hashed = hashlib.sha224(raw.encode('utf-8')).hexdigest()
-    return '{}.csv'.format(hashed)
+    prefix = 'user-downloads/'
+    return '{}{}.csv'.format(prefix, hashed)
 
 
 def make_bundle(resource):


### PR DESCRIPTION
## Summary

- Resolves #4502 

_Adds the `user_downloads` prefix to the API's user generated downloads path. The name is unaffected.

## How to test the changes

- Deploy to the dev or stage environment to test that downloads are writing into the stage downloads bucket under the `user_downloads` prefix.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /downloads/ endpoint
