### PR TITLE
Add deprecation notice to /communication-cost/ endpoint

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1218,11 +1218,17 @@ or candidate election year
 '''
 
 COMMUNICATION_COST = '''
-52 U.S.C. 30118 allows "communications by a corporation to its stockholders and
-executive or administrative personnel and their families or by a labor organization
-to its members and their families on any subject," including the express advocacy of
-the election or defeat of any Federal candidate.  The costs of such communications
-must be reported to the Federal Election Commission under certain circumstances.
+<b>Deprecation notice: This endpoint will be replaced with a new endpoint \
+ `/communication_costs/`, so that the pagination schema will be in line with \
+the other endpoints sharing the "communication cost" tag. Please note `/communication_costs/` \
+ is not yet in place, and this notice will be updated once it is in service.</b>
+
+52 U.S.C. 30118 allows \
+"communications by a corporation to its stockholders and executive or administrative \
+personnel and their families or by a labor organization to its members and their families \
+on any subject," including the express advocacy of the election or defeat of any Federal \
+candidate.  The costs of such communications must be reported to the Federal Election \
+Commission under certain circumstances.
 '''
 
 COMMUNICATION_COST_AGGREGATE = 'Communication cost aggregated by candidate ID and committee ID.'


### PR DESCRIPTION
## Summary (required)

- Resolves #4508

_ adds deprecation notice to swagger-ui

## How to test the changes locally
- I would like both @fec-jli and  @lbeaufort to  review before merging
- check out branch and run locally. Check the `/communication-costs/` endpoint notice
- check  inbox for email announcing deprecation--went to  a total of 3 api users, only 1 external api user

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `/communication-costs/` endpoint



## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
#4203 |#4232
