### PR TITLE
Snyk High - Bump Lodash from 4.17.17 to 4.17.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4951,9 +4951,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-/B2DjOphAoqi5BX4Gg2oh4UR0Gy/A7xYAMh3aSECEKzwS3eCDEpS0Cals1Ktvxwlal3bBJNc+5W9kNIcADdw5Q=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._arraypool": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.11",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.17",
+    "lodash": "^4.17.20",
     "prettier": "^1.12.1",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^0.21.0",


### PR DESCRIPTION
## Summary

- Resolves #4570 

Bumping the version of Lodash to 4.17.20 to address a [Snyk vulnerability ](https://app.snyk.io/vuln/SNYK-JS-LODASH-590103)

## How to test the changes locally

- pull the branch
- `npm i`
- `npm run build`
- check for errors
- check that Swagger works as expected

## Impacted areas of the application

We only upgraded Lodash so changes should be minimal. Lodash is a devDependency so errors should happen on build. If build runs fine and front-end functionality is the same, yay!

## Related PRs

None

