### PR TITLE
Decrease celery worker disk quota, specify quota for other apps

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -15,3 +15,4 @@ routes:
 applications:
   - name: api
     instances: 1
+    disk_quota: 1G

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -18,3 +18,4 @@ routes:
 applications:
   - name: api
     instances: 10
+    disk_quota: 1G

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -17,3 +17,4 @@ routes:
 applications:
   - name: api
     instances: 1
+    disk_quota: 1G

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -14,6 +14,7 @@ applications:
   - name: celery-beat
     instances: 1
     memory: 256M
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -17,6 +17,7 @@ applications:
   - name: celery-beat
     instances: 1
     memory: 500M
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -16,6 +16,7 @@ applications:
   - name: celery-beat
     instances: 1
     memory: 256M
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -14,6 +14,7 @@ applications:
   - name: celery-worker
     instances: 2
     memory: 1G
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -17,7 +17,7 @@ applications:
   - name: celery-worker
     instances: 6
     memory: 1G
-    disk_quota: 2G
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 3

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -16,6 +16,7 @@ applications:
   - name: celery-worker
     instances: 1
     memory: 1G
+    disk_quota: 1G
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2


### PR DESCRIPTION
## Summary (required)

- Resolves #4579 

Decrease celery worker disk quota, specify quota for other apps. Disk is only used for the storage of the app itself and won't impact performance - therefore we can reduce the disk for `celery-worker` to 1G to match other applications.

## How to test the changes locally

- Only one backend dev approval required to merge
- Celery-worker disk isn't really test-able since it's only changed for `prod` but to test the other `disk_quota` settings you can do a manual deploy with `invoke deploy --space dev` and make sure it successfully deploys

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Disk size allocation for `celery-worker` -  Disk is only used for the storage of the app itself and won't impact performance - therefore we can reduce the disk to 1G to match other applications. 

