### PR TITLE
Update deprecation notice

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1219,8 +1219,7 @@ or candidate election year
 COMMUNICATION_COST = '''
 <b>Deprecation notice: This endpoint will be replaced with a new endpoint \
  `/communication_costs/`, so that the pagination schema will be in line with \
-the other endpoints sharing the "communication cost" tag. Please note `/communication_costs/` \
- is not yet in place, and this notice will be updated once it is in service.</b>
+the other endpoints sharing the "communication cost" tag.</b>
 
 52 U.S.C. 30118 allows \
 "communications by a corporation to its stockholders and executive or administrative \


### PR DESCRIPTION
## Summary (required)

- Resolves #4591 

Removes "Please note /communication_costs/ is not yet in place, and this notice will be updated once it is in service." from deprecation notice since new endpoint will be in service with the 13.3 release.

## How to review
- any tagged reviewer who has the time may review and merge (this is easy)
- verify that sentence is removed