### PR TITLE
Tell user why 'create_sample_db' task fails without 'SQLA_SAMPLE_DB_CONN'

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -235,6 +235,9 @@ def create_sample_db(ctx):
 
     print("Loading schema...")
     db_conn = os.getenv('SQLA_SAMPLE_DB_CONN')
+    if not db_conn:
+        print("Error: SQLA_SAMPLE_DB_CONN env var must be set")
+        return
     jdbc_url = to_jdbc_url(db_conn)
     result = run_migrations(ctx, jdbc_url)
     if result.failed:


### PR DESCRIPTION
## Summary (required)

- Resolves issue found in local setup

When running `invoke create_sample_db` tell the user if `SQLA_SAMPLE_DB_CONN` is unset instead of throwing a cryptic exception.

## Reviewers

- One approval required to merge, thanks!

## How to test the changes locally

### Reproduce the issue
- Check out `develop`
- `echo SQLA_SAMPLE_DB_CONN` so you can reset it later
- `unset SQLA_SAMPLE_DB_CONN`
- Run `invoke create_sample_db`
- ➡️ get cryptic exception 😞 
```
Traceback (most recent call last):
  File "/Users/lbeaufort/.pyenv/versions/api-env/bin/invoke", line 10, in <module>
    sys.exit(program.run())
  File "/Users/lbeaufort/.pyenv/versions/3.7.7/envs/api-env/lib/python3.7/site-packages/invoke/program.py", line 293, in run
    self.execute()
  File "/Users/lbeaufort/.pyenv/versions/3.7.7/envs/api-env/lib/python3.7/site-packages/invoke/program.py", line 408, in execute
    executor.execute(*self.tasks)
  File "/Users/lbeaufort/.pyenv/versions/3.7.7/envs/api-env/lib/python3.7/site-packages/invoke/executor.py", line 114, in execute
    result = call.task(*args, **call.kwargs)
  File "/Users/lbeaufort/.pyenv/versions/3.7.7/envs/api-env/lib/python3.7/site-packages/invoke/tasks.py", line 114, in __call__
    result = self.body(*args, **kwargs)
  File "/Users/lbeaufort/dev/API/openFEC/tasks.py", line 238, in create_sample_db
    jdbc_url = to_jdbc_url(db_conn)
  File "/Users/lbeaufort/dev/API/openFEC/jdbc_utils.py", line 20, in to_jdbc_url
    jdbc_url, username, password = get_jdbc_credentials(dbi_url)
  File "/Users/lbeaufort/dev/API/openFEC/jdbc_utils.py", line 9, in get_jdbc_credentials
    match = DB_URL_REGEX.match(dbi_url)
TypeError: expected string or bytes-like object
```
### Verify the fix
- Check out this branch 
- `unset SQLA_SAMPLE_DB_CONN`
- Run `invoke create_sample_db`
- ➡️ get helpful error 😄 
```
Error: SQLA_SAMPLE_DB_CONN env var must be set
```
- Remember to reset the `SQLA_SAMPLE_DB_CONN`
https://github.com/fecgov/openFEC#create-a-development-database

## Impacted areas of the application
List general components of the application that this PR will affect:

-  `invoke create_sample_db` task


