### PR TITLE
Increase API memory in production and stage, remove extra celery-worker instance (targets release)

### DIFF
--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -1,6 +1,6 @@
 ---
 path: ../
-memory: 1G
+memory: 1500M # 1.5G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -1,6 +1,6 @@
 ---
 path: ../
-memory: 1G
+memory: 1500M # 1.5G
 stack: cflinuxfs3
 buildpack: python_buildpack
 env:

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -12,7 +12,7 @@ services:
   - fec-s3-dev
 applications:
   - name: celery-worker
-    instances: 2
+    instances: 1
     memory: 1G
     disk_quota: 1G
     no-route: true


### PR DESCRIPTION
## Summary (required)

- Resolves #4578

Increase API memory in production and stage to 1.5G, remove extra celery-worker instance in `dev`.

Note: Memory is in MB (1500M instead of 1.5G) because the `cf cli` didn't take decimals until version 6.33.0 and we're on 6.32.0. When I tested 6.52.0 there were still issues - might be with the `zero-downtime-push` but it didn't seem worth it to muck around with things in there when a comment can address any confusion.

## Reviewers
- One developer (required) additional developers optional

## How to test the changes locally

- Test in stage with a manual deploy `invoke deploy --space stage`. Please don't commit to this branch, thanks!

## Impacted areas of the application
List general components of the application that this PR will affect:

-  API available memory

