### PR TITLE
pinned vine 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ prance[osv]>=0.19
 cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3
+vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency of kombu
 psycopg2-binary==2.7.4
 werkzeug==0.16.1
 Flask==1.1.1


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/4608

We ran into a vine.five error below:

```
2020-09-09T09:00:23.12-0400 [APP/PROC/WEB/0] ERR ModuleNotFoundError: No module named 'vine.five'
```

Dependency changed and we needed to pin vine to 1.3.0. See vine release history: https://pypi.org/project/vine/#history

```
    - kombu [required: >=4.4.0,<5.0, installed: 4.6.3]
      - amqp [required: >=2.5.0,<3.0, installed: 2.6.1]
        - vine [required: >=1.1.3,<5.0.0a1, installed: 5.0.0]
```

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
release/public 20200908 | [link](https://github.com/fecgov/openFEC/pull/4598)
