### PR TITLE
Use primary-key only count for Schedules B and E

### DIFF
--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -64,6 +64,7 @@ class ScheduleBView(ItemizedResource):
         'recipient_name',
         'recipient_city',
     ]
+    use_pk_for_count = True
 
     @property
     def args(self):

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -67,6 +67,7 @@ class ScheduleEView(ItemizedResource):
         'committee_id',
         'candidate_id',
     ]
+    use_pk_for_count = True
 
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),


### PR DESCRIPTION
## Summary (required)

- Resolves #4429 

Use primary-key only count for Schedules B and E 

## Reviewers
- Two developers please

## How to test the changes locally

- Print out the query under `get_query_plan` in `webservices.common.counts.py` (Shortcut: `subl webservices/common/counts.py:38`)
- Do a Schedule B query, make sure it only selects `sub_id` column instead of many columns.
- Do a Schedule E query, make sure it only selects `sub_id` column instead of many columns.
**Example**
```
SELECT disclosure.fec_fitem_sched_b.sub_id AS disclosure_fec_fitem_sched_b_sub_id 
FROM disclosure.fec_fitem_sched_b
```

## Impacted areas of the application
List general components of the application that this PR will affect:

-  /schedules/schedule_b/ endpoint count
-  /schedules/schedule_e/ endpoint count


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
feature/4368-modify-count-logic | [Add flag ('use_pk_for_count') to only select primary key column for count query](https://github.com/fecgov/openFEC/pull/4380)

