### PR TITLE
[ON HOLD] Use 'UNION ALL' for 'two_year_transaction_period' for Schedules A and B

### DIFF
--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -425,11 +425,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'contbr_employer': n,
                 'sub_id': 9999999959999999980 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_a "
-                + "(contbr_employer, sub_id, filing_form) "
-                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                + "(contbr_employer, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
@@ -466,18 +467,18 @@ class TriggerTestCase(common.BaseTestCase):
                 'recipient_nm': n,
                 'sub_id': 9999999999995699990 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_b "
-                + "(recipient_nm, sub_id, filing_form) "
-                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                + "(recipient_nm, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
         results = self._results(
             api.url_for(ScheduleBView, contributor_employer='ést-lou')
         )
-        print('results = ', results)
         contbr_employer_list = {r['recipient_name'] for r in results}
         assert names.issubset(contbr_employer_list)
         results = self._results(

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -99,6 +99,82 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(len(response['results']), 2)
 
+    def test_schedule_a_multiple_cmte_id_and_two_year_transaction_period(self):
+        """
+        testing schedule_a api can take multiple cycles now
+        """
+        receipts = [  # noqa
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C003',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C003',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C003',
+            ),
+        ]
+        response = self._response(
+            api.url_for(
+                ScheduleAView,
+                two_year_transaction_period=[2016, 2018],
+                committee_id=['C001', 'C002'],
+            )
+        )
+        self.assertEqual(len(response['results']), 4)
+        response = self._response(
+            api.url_for(
+                ScheduleAView,
+                committee_id='C001',
+            )
+        )
+        self.assertEqual(len(response['results']), 3)
+
     def test_schedule_a_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [  # noqa
             factories.ScheduleAFactory(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -327,14 +327,21 @@ class TestEnvVarSplit(TestCase):
 
 class TestDecadeRange(TestCase):
     def test_get_decade_range(self):
+
+        start_year = 2000
+        current_year = 2018
+        expected = [(None, 2000), (2000, 2010), (2010, 2020)]
+        result = utils.get_decade_range(start_year, current_year)
+        self.assertEqual(result, expected)
+
         start_year = 2000
         current_year = 2020
-        expected = [(None, 2000), (2000, 2010), (2010, None)]
+        expected = [(None, 2000), (2000, 2010), (2010, 2020)]
         result = utils.get_decade_range(start_year, current_year)
         self.assertEqual(result, expected)
 
         start_year = 2000
         current_year = 2022
-        expected = [(None, 2000), (2000, 2010), (2010, 2020), (2020, None)]
+        expected = [(None, 2000), (2000, 2010), (2010, 2020), (2020, 2030)]
         result = utils.get_decade_range(start_year, current_year)
         self.assertEqual(result, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,3 +323,18 @@ class TestEnvVarSplit(TestCase):
         for test_case in test_cases:
             result = utils.split_env_var(test_case)
             self.assertEqual(result, expected)
+
+
+class TestDecadeRange(TestCase):
+    def test_get_decade_range(self):
+        start_year = 2000
+        current_year = 2020
+        expected = [(None, 2000), (2000, 2010), (2010, None)]
+        result = utils.get_decade_range(start_year, current_year)
+        self.assertEqual(result, expected)
+
+        start_year = 2000
+        current_year = 2022
+        expected = [(None, 2000), (2000, 2010), (2010, 2020), (2020, None)]
+        result = utils.get_decade_range(start_year, current_year)
+        self.assertEqual(result, expected)

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -78,26 +78,23 @@ class ItemizedResource(ApiResource):
             kwargs["two_year_transaction_period"] = range(
                 1976, utils.get_current_cycle() + 2, 2
             )
-        # Generate subqueries for multiple committee ID's and 2-year periods
+        # Generate traditional "IN" query and counts for all
+        query = self.build_query(**kwargs)
+        count, _ = counts.get_count(self, query)
+
+        # Generate "UNION ALL" subqueries for multiple committee ID's and 2-year periods
         if len(kwargs.get("committee_id", [])) > 1:
-            query_for_count = self.build_query(**kwargs)
-            count, _ = counts.get_count(self, query_for_count)
             query = self.join_sub_queries(
                 kwargs,
                 primary_field="committee_id",
                 secondary_field="two_year_transaction_period",
             )
-        # Generate subqueries for multiple 2-year periods
+        # Generate subqueries for only multiple 2-year periods
         elif len(kwargs.get("two_year_transaction_period", [])) > 1:
-            query_for_count = self.build_query(**kwargs)
-            count, _ = counts.get_count(self, query_for_count)
             query = self.join_sub_queries(
                 kwargs,
                 primary_field="two_year_transaction_period"
             )
-        else:
-            query = self.build_query(**kwargs)
-            count, _ = counts.get_count(self, query)
 
         return utils.fetch_seek_page(
             query, kwargs, self.index_column, count=count, cap=self.cap

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -62,6 +62,8 @@ class ItemizedResource(ApiResource):
     index_column = None
     filters_with_max_count = []
     max_count = 10
+    union_all_fields = ["committee_id"]
+
 
     def get(self, **kwargs):
         """Get itemized resources. If multiple values are passed for `committee_id`,
@@ -71,7 +73,7 @@ class ItemizedResource(ApiResource):
         """
         self.validate_kwargs(kwargs)
         # Add all 2-year transaction periods where not specified
-        if (type(self).__name__ in ("ScheduleAView", "ScheduleBView")
+        if ("two_year_transaction_period" in self.union_all_fields
             and not kwargs.get("two_year_transaction_period")):
             kwargs["two_year_transaction_period"] = range(1976, utils.get_current_cycle() + 2, 2)
         if len(kwargs.get("committee_id", [])) > 1:

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -152,10 +152,8 @@ class ItemizedResource(ApiResource):
         return query
 
     def build_union_subquery(self, kwargs, temp_kwargs):
-        """Build a subquery by committee.
+        """Build a subquery by specified arguments.
         """
         query = self.build_query(_apply_options=False, **utils.extend(kwargs, temp_kwargs))
-        sort, hide_null = kwargs['sort'], kwargs['sort_hide_null']
-        query, _ = sorting.sort(query, sort, model=self.model, hide_null=hide_null)
         page_query = utils.fetch_seek_page(query, kwargs, self.index_column, count=-1, eager=False).results
         return page_query

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -70,10 +70,6 @@ class ScheduleAView(ItemizedResource):
     filter_multi_start_with_fields = [
         ('contributor_zip', models.ScheduleA.contributor_zip),
     ]
-    query_options = [
-        sa.orm.joinedload(models.ScheduleA.committee),
-        sa.orm.joinedload(models.ScheduleA.contributor),
-    ]
     sort_options = [
         'contribution_receipt_date',
         'contribution_receipt_amount',
@@ -87,6 +83,11 @@ class ScheduleAView(ItemizedResource):
         'contributor_occupation',
     ]
     use_pk_for_count = True
+    union_all_fields = ["committee_id", "two_year_transaction_period"]
+    query_options = [
+        sa.orm.joinedload(models.ScheduleA.committee),
+        sa.orm.joinedload(models.ScheduleA.contributor),
+    ]
 
     @property
     def args(self):

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -64,6 +64,7 @@ class ScheduleBView(ItemizedResource):
         'recipient_name',
         'recipient_city',
     ]
+    union_all_fields = ["committee_id", "two_year_transaction_period"]
     query_options = [
         sa.orm.joinedload(models.ScheduleB.committee),
         sa.orm.joinedload(models.ScheduleB.recipient_committee),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -64,6 +64,10 @@ class ScheduleBView(ItemizedResource):
         'recipient_name',
         'recipient_city',
     ]
+    query_options = [
+        sa.orm.joinedload(models.ScheduleB.committee),
+        sa.orm.joinedload(models.ScheduleB.recipient_committee),
+    ]
 
     @property
     def args(self):
@@ -77,9 +81,6 @@ class ScheduleBView(ItemizedResource):
 
     def build_query(self, **kwargs):
         query = super(ScheduleBView, self).build_query(**kwargs)
-        query = query.options(sa.orm.joinedload(models.ScheduleB.committee))
-        query = query.options(
-            sa.orm.joinedload(models.ScheduleB.recipient_committee))
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -490,3 +490,22 @@ def post_to_slack(message, channel):
 def split_env_var(env_var):
     """ Remove whitespace and split to a list based of comma delimiter"""
     return env_var.replace(" ", "").split(',')
+
+
+def get_decade_range(start_year, current_year):
+    """Get a list of tuples representing min, max decades
+    between start_year and current_year.
+
+    Used with > min_year and <= max_year
+    2020 will end with (2010, None) and 2022 will end with (2020, None)
+    because max_year is inclusive
+    """
+
+    min_year = None
+    decade_ranges = []
+    for max_year in range(start_year, current_year, 10):
+        decade_ranges.append((min_year, max_year))
+        min_year = max_year
+    # Add current decade forward
+    decade_ranges.append((max_year, None))
+    return decade_ranges

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -494,18 +494,12 @@ def split_env_var(env_var):
 
 def get_decade_range(start_year, current_year):
     """Get a list of tuples representing min, max decades
-    between start_year and current_year.
-
-    Used with > min_year and <= max_year
-    2020 will end with (2010, None) and 2022 will end with (2020, None)
-    because max_year is inclusive
+    between start_year and current_year. Used with > min_year and <= max_year
     """
 
     min_year = None
     decade_ranges = []
-    for max_year in range(start_year, current_year, 10):
+    for max_year in range(start_year, current_year + 10, 10):
         decade_ranges.append((min_year, max_year))
         min_year = max_year
-    # Add current decade forward
-    decade_ranges.append((max_year, None))
     return decade_ranges


### PR DESCRIPTION
Thoughts: 
- Decoupling counts from query generation is risky when query generation logic is complex like this. What's our confidence in our test coverage? We're not testing the structure of the SQL in the tests, we're testing the result.
- Debugging the query is getting more difficult
- Brief performance testing (need to locust) didn't have huge difference 

## Additional changes
Thank you @fecjjeng @fec-jli @hcaofec and @dzhang-fec for your careful review!

- [ ] Per @dzhang-fec do every 10 years as a batch:
Updated after talking: 

- all time 

:arrow_right: 10-year chunks starting in 2000 (<=2000, >2000, <=2010 etc)

- consecutive or non-consecutive 2-year periods: 1990, 1992, 1994, 1996, etc

:arrow_right: 1: IN, 2 to 15 UNION ALL , over 15 IN

```
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00139998')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period <=2000
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00139998')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2000 
ANd disclosure.fec_fitem_sched_a.two_year_transaction_period <=2010
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00139998')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2010 
ANd disclosure.fec_fitem_sched_a.two_year_transaction_period <=2020
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00139998')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2020 
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00172189')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period <=2000
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00172189')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2000 
ANd disclosure.fec_fitem_sched_a.two_year_transaction_period <=2010
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00172189')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2010 
ANd disclosure.fec_fitem_sched_a.two_year_transaction_period <=2020
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
UNION ALL
(SELECT * FROM disclosure.fec_fitem_sched_a LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_1 ON disclosure.fec_fitem_sched_a.cmte_id = ofec_committee_history_mv_1.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_1.cycle LEFT OUTER JOIN ofec_committee_history_mv AS ofec_committee_history_mv_2 ON disclosure.fec_fitem_sched_a.clean_contbr_id = ofec_committee_history_mv_2.committee_id AND disclosure.fec_fitem_sched_a.two_year_transaction_period = ofec_committee_history_mv_2.cycle
WHERE disclosure.fec_fitem_sched_a.cmte_id IN ('C00172189')
and disclosure.fec_fitem_sched_a.is_individual = true
and disclosure.fec_fitem_sched_a.two_year_transaction_period >2020 
ORDER BY disclosure.fec_fitem_sched_a.contb_receipt_dt DESC, disclosure.fec_fitem_sched_a.sub_id DESC
LIMIT 30)
ORDER BY  contb_receipt_dt DESC,  sub_id DESC
LIMIT 30
```


## Summary (required)

- Resolves #4414

Use `UNION ALL` for `two_year_transaction_period` for Schedules A and B. Max complexity is 10 committee ID's * 23 two-year-periods (will go up one every two years) = 230 subqueries.

Locust tests: pushed to Stage, did a [few tests](https://docs.google.com/spreadsheets/d/1X9VKafFuRrP6RNL73bLmHvILkLMOB4wkLSQP7glOO4s/edit#gid=0), compared it to recent [load testing](https://docs.google.com/spreadsheets/d/1RDghse7ILJDbizCikNSeVPfTd8XYWmmWosjYFDSR14w/edit#gid=0) and it seemed slightly faster but per @dzhang-fec the SQL will be faster.

## Required reviewers
- At least @dzhang-fec as the original ticket-maker and one python developer (@hcaofec, @fec-jli, @pkfec or @jason-upchurch)
- Any other review/comments appreciated!

## How to test the changes locally

- Either uncomment this (make sure not to check this in):
https://github.com/fecgov/openFEC/blob/e22bdf7a9f203057a7793b128e44a70b2ab7a6ea/webservices/rest.py#L96
OR
- Print out count query generated here https://github.com/fecgov/openFEC/blob/853e1aaa0a38ddb1c438b89355a912b81a9fa4ad/webservices/common/counts.py#L25
- and print out query generated here 
https://github.com/fecgov/openFEC/blob/8a0bc3f71a3c04c706311e04ee7e6552844b8e2a/webservices/common/views.py#L101-L104
- Run some example Schedule A and B queries: https://docs.google.com/spreadsheets/d/1rkVnmuMUzlBCgOE3ZsCDJC7AqXWI2VOhC57RvJcdasI/edit#gid=0 and make sure where there is more than one `committee_id` and/or more than one `two_year_transaction_period` (or none, which is the same as all) the query is generated using `UNION ALL` subqueries
- Take a look at the test cases to see if you think there's sufficient coverage
- Example SQL: https://drive.google.com/drive/folders/1DAzx3sAe5QheJVGP-xipp_YPFkWKjAC1?ths=true

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Schedule A and B performance

## Related PRs
List related PRs against other branches:

- Initial WIP PR when trying to add more `UNION ALL` fields: https://github.com/fecgov/openFEC/pull/4437
- WIP PR that shows my workflow for this approach: https://github.com/fecgov/openFEC/pull/4620
