### PR TITLE
Upgraded flask-cors to v3.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency o
 psycopg2-binary==2.7.4
 werkzeug==0.16.1
 Flask==1.1.1
-Flask-Cors==3.0.8
+Flask-Cors==3.0.9
 Flask-Script==2.0.6
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.1


### PR DESCRIPTION
## Summary

- Resolves #4611 

_Upgraded flask-cors to v3.0.9._

flask_cors is imported into our rest.py. Tested the `@app.route` for swagger docs and it seems to still function ok.

## How to test the changes locally

- checkout this branch
- `pip install -r requirements.txt` 
- `./manage.py runserver`
