### PR TITLE
Revert "Upgraded flask-cors to v3.0.9"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency o
 psycopg2-binary==2.7.4
 werkzeug==0.16.1
 Flask==1.1.1
-Flask-Cors==3.0.9
+Flask-Cors==3.0.8
 Flask-Script==2.0.6
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.1


### PR DESCRIPTION
Reverts fecgov/openFEC#4622 until we can figure out what's going on

```
/home/vcap/deps/0/python/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
```