### PR TITLE
Pin greenlet@0.4.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ icalendar==4.0.2
 GitPython==3.1.0
 gunicorn==19.10.0
 gevent==1.4.0
+greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
 webargs==5.5.3
 ujson==1.33
 requests==2.22.0


### PR DESCRIPTION
## Summary (required)

Pins greenlet@0.4.16 since 0.4.17 causes api to go down.

``` 
2020-09-23T11:34:53.41-0400 [APP/PROC/WEB/0] ERR /home/vcap/deps/0/python/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 144 from C header, got 152 from PyObject
   2020-09-23T11:34:53.46-0400 [APP/PROC/WEB/0] ERR [2020-09-23 15:34:53 +0000] [6884] [INFO] Booting worker with pid: 6
```

```
TODAY:
       Collecting greenlet>=0.4.14; platform_python_implementation == "CPython"
         Downloading greenlet-0.4.17-cp37-cp37m-manylinux1_x86_64.whl (45 kB)

YESTERDAY:
       Collecting greenlet>=0.4.14; platform_python_implementation == "CPython"
         Downloading greenlet-0.4.16-cp37-cp37m-manylinux1_x86_64.whl (45 kB)
```
