### PR TITLE
Bump sqlalchemy to 1.3.19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-SQLAlchemy==2.4.1
 python-dateutil==2.8.1
 sqlalchemy-postgres-copy==0.3.0
 networkx==1.11
-SQLAlchemy==1.3.1
+SQLAlchemy==1.3.19
 icalendar==4.0.2
 GitPython==3.1.0
 gunicorn==19.10.0


### PR DESCRIPTION
## Summary (required)

- Resolves #4588

- updates sqlalchemy to 1.3.19 from 1.3.1 (changelog: https://docs.sqlalchemy.org/en/13/changelog/changelog_13.html#change-1.3.19)

## How to test the changes (at least 2 reviewers out of 3)
- check out branch, run `pytest`
- branch was also deployed to dev space with successful build/deploy
- please feel free to "poke around" at endpoints of interest to see that results are as you expect them
- I have also written a cross-environment `pytest` which you can add to and run (run when branch is deployed to dev):
  - https://github.com/jason-upchurch/fec_util/blob/master/compare_endpoints.py
  - recommend having an upgraded api key as an environmental variable named 'FEC_ENV_TEST_API_KEY'
  - usage: cd to wherever you checked out script and run `pytest compare_endpoints.py`
  - please feel free to add endpoints to this script--the basic premise is that it is necessary for pagination to be identical between endoints to claim not adverse effects from package upgrade. It is not sufficient however. 
- reviewing the changelog, I don't see breaking changes that would affect us in our present state
  - In particular:
    >Fixed bug where the detection for many-to-one or one-to-one use with a “dynamic” relationship, which is an invalid configuration, would fail to raise if the relationship were configured with uselist=True. The current fix is that it warns, instead of raises, as this would otherwise be backwards incompatible, however in a future release it will be a raise. References: #[4772](https://github.com/sqlalchemy/sqlalchemy/issues/4772)
   - We don't appear to use `lazy='dynamic'` anwhere (re: https://github.com/sqlalchemy/sqlalchemy/issues/4772#issuecomment-512851217) so I don't think the bug fix is currently relevant to our application
- use snyk cli to verify vulnerability is resolved.
      
## Impacted areas of the application
List general components of the application that this PR will affect:

-  sqlalchemy package
