### PR TITLE
update circle config 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.4-buster
+      - image: circleci/python:3.7.8-buster
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,10 @@ jobs:
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:10.14
+      - image: circleci/postgres:10.11
         environment:
           POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: "trust"
           POSTGRES_DB: cfdm_unit_test
 
     working_directory: ~/repo
@@ -31,7 +32,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/9.6/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:9.6.8
+      - image: circleci/postgres:10.14
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: cfdm_unit_test


### PR DESCRIPTION
## Summary (required)

1. Update python docker image version to match the python version given in the runtime.txt file
2. Update Postgres docker image version to match the DB version in our govcloud environment
3. Set POSTGRES_HOST_AUTH_METHOD: "trust" environment variable. Builds fail without this env variable. 

 which is 10.11.

- Resolves https://github.com/fecgov/openFEC/issues/4425

_Include a summary of proposed changes._

- Update docker images in **circleci/config.yml file** : 

1. Python  from 3.7.4-buster to 3.7.8-buster
2. Postgres from 9.6 to 10.11

## Screenshots
- Before upgrade:

<img width="780" alt="Screen Shot 2020-09-30 at 5 48 42 PM" src="https://user-images.githubusercontent.com/11650355/94743361-3f9fdc00-0345-11eb-904c-a4f33fc7ea64.png">

<img width="946" alt="Screen Shot 2020-09-29 at 5 21 29 PM" src="https://user-images.githubusercontent.com/11650355/94743179-f51e5f80-0344-11eb-8b02-cc72368778aa.png">

- After upgrade:
<img width="961" alt="Screen Shot 2020-09-30 at 4 59 56 PM" src="https://user-images.githubusercontent.com/11650355/94742931-84774300-0344-11eb-919e-84e24eedc2a1.png">


<img width="425" alt="Screen Shot 2020-09-30 at 5 01 09 PM" src="https://user-images.githubusercontent.com/11650355/94742894-75909080-0344-11eb-8f58-903429ea1a87.png">


## How to test the changes ~locally~
 - Rebuild or Rerun _feature/4425-update-circle-config_ branch on circleci  and notice  **Spin up  environment** and **Container** circleci tasks downloading the upgraded python and postgres docker images.