### PR TITLE
Update cf cli to version 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
       - add_ssh_keys # add Bastion host private keys configured in the UI

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Incrementally-updated aggregates and materialized views are updated nightly; see
 ### Loading legal documents
 There are individual management commands for loading individual legal documents. More information is available by invoking each of these commands with a `--help` option. These commands can be run as [tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html) on `cloud.gov`, e.g.,
 ```
-cf run-task api  "python manage.py index_statutes" -m 2G --name index-statutes
+cf run-task api --command "python manage.py index_statutes" -m 2G --name index-statutes
 ```
 The progress of these tasks can be monitored using, e.g.,
 ```

--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ invoke dump postgresql://:@/cfdm_test data/subset.dump
 If you haven't used Cloud Foundry in other projects, you'll need to install the Cloud Foundry CLI and the autopilot plugin.
 
 #### Deploy
-Before deploying, install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) and the [autopilot plugin](https://github.com/concourse/autopilot):
+Before deploying, install version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) and the [autopilot plugin](https://github.com/concourse/autopilot):
 
-1. Read [Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) to install Cloud Foundry CLI.
+1. Read [Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) to install version 7 of the Cloud Foundry CLI.
 
 2. Install autopilot by running:
 

--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import git
+import sys
 
 from invoke import task, exceptions
 from jdbc_utils import get_jdbc_credentials, to_jdbc_url, remove_credentials
@@ -168,12 +169,11 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
     if space is None:
         return
 
-    # Set api
-    api = 'https://api.fr.cloud.gov'
-    ctx.run('cf api {0}'.format(api), echo=True)
-
-    # Log in if necessary
     if login == 'True':
+        # Set api
+        api = 'https://api.fr.cloud.gov'
+        ctx.run('cf api {0}'.format(api), echo=True)
+        # Authenticate
         login_command = 'cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(
             space.upper()
         )
@@ -226,6 +226,8 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
             space=space
         ), echo=True)
 
+    # Needed for CircleCI
+    return sys.exit(0)
 
 @task
 def create_sample_db(ctx):


### PR DESCRIPTION
## Summary (required)

- Resolves #4667 

**Deploy task changes**
- With cf cli version 7, `cf api <endpoint>` logs you out - this is a known issue: https://github.com/cloudfoundry/cli/issues/2075. Only set the endpoint if `deploy` task `--login True` (used for CircleCI)
- Cf cli doesn't exit with code 0 anymore, so I had to add it. (not sure where this is documented but you can read between the lines here: https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute)

**Other minor changes**
- Specify version in README because the `--command` change to `cf run-task` is backwards incompatible
- Update `cf run-task` in README to reflect new flag

## Reviewers
- One approval required

## How to test the changes locally

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch)
- Modify deploy task to deploy to a space of your choice
- Push to Github, make sure build works

**Locally:**
- Install cf cli version [following this guide](https://github.com/cloudfoundry/cli/wiki/Version-Switching-Guide) or:
```
# Install cf-cli@7. Complete commands
brew install cf-cli@7

# If you run across an error like this: Error: No such keg: /usr/local/Cellar/cf-cli@6, make sure you install cf-cli version 6 with brew
brew install cf-cli@6
 
# Unlink cf-cli version 6 and link cf-cli version 7
brew unlink cf-cli@6 && brew unlink cf-cli@7 && brew link cf-cli@7 && cf version
```
- Do a manual deploy with `invoke deploy --space dev`

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Deploy task only



