### PR TITLE
Add sponsor_candidate_id to endpoint: /committees/

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -373,6 +373,20 @@ class CommitteeFormatTest(ApiBaseTest):
             )
         )
 
+    def test_filter_by_sponsor_candidate_ids(self):
+        sponsor_candidate_ids = ['H001']
+        factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids)
+
+        response = self._response(
+            api.url_for(CommitteeList, sponsor_candidate_id='H001')
+        )
+        assert len(response['results']) == 1
+
+        response = self._response(
+            api.url_for(CommitteeList, sponsor_candidate_id='-H001')
+        )
+        assert len(response['results']) == 0
+
 
 class TestCommitteeHistory(ApiBaseTest):
     def setUp(self):

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -374,18 +374,23 @@ class CommitteeFormatTest(ApiBaseTest):
         )
 
     def test_filter_by_sponsor_candidate_ids(self):
-        sponsor_candidate_ids = ['H001']
-        factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids)
+        sponsor_candidate_ids1 = ['H001']
+        sponsor_candidate_ids2 = ['S001']
+        factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids1)
+        factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids2)
 
-        response = self._response(
+        results = self._results(
             api.url_for(CommitteeList, sponsor_candidate_id='H001')
         )
-        assert len(response['results']) == 1
 
-        response = self._response(
+        assert len(results) == 1
+        assert results[0]['sponsor_candidate_ids'] == sponsor_candidate_ids1
+
+        results = self._results(
             api.url_for(CommitteeList, sponsor_candidate_id='-H001')
         )
-        assert len(response['results']) == 0
+        assert len(results) == 1
+        assert results[0]['sponsor_candidate_ids'] == sponsor_candidate_ids2
 
 
 class TestCommitteeHistory(ApiBaseTest):
@@ -554,7 +559,7 @@ class TestCommitteeHistory(ApiBaseTest):
         assert 'J' not in [committee.get('designation') for committee in results]
 
     def test_converted_commtitee(self):
-        """Where PCC converted to PAC in 2016, still show committee history"""
+        """Where PCC converted to PAC in 2016, still show committee history."""
         results = self._results(
             api.url_for(
                 CommitteeHistoryView,

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -305,6 +305,7 @@ committee_list = {
     'min_last_f1_date': fields.Date(description=docs.MIN_LAST_F1_DATE),
     'max_last_f1_date': fields.Date(description=docs.MAX_LAST_F1_DATE),
     'treasurer_name': fields.List(fields.Str, description=docs.TREASURER_NAME),
+    'sponsor_candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
 }
 
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -305,7 +305,7 @@ committee_list = {
     'min_last_f1_date': fields.Date(description=docs.MIN_LAST_F1_DATE),
     'max_last_f1_date': fields.Date(description=docs.MAX_LAST_F1_DATE),
     'treasurer_name': fields.List(fields.Str, description=docs.TREASURER_NAME),
-    'sponsor_candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'sponsor_candidate_id': fields.List(IStr, description=docs.SPONSOR_CANDIDATE_ID),
 }
 
 

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -44,7 +44,7 @@ class BaseConcreteCommittee(BaseCommittee):
 
     committee_id = db.Column(db.String, primary_key=True, unique=True, index=True, doc=docs.COMMITTEE_ID)
     candidate_ids = db.Column(ARRAY(db.Text), doc=docs.CANDIDATE_ID)
-    sponsor_candidate_ids = db.Column(ARRAY(db.Text), doc=docs.CANDIDATE_ID)
+    sponsor_candidate_ids = db.Column(ARRAY(db.Text), doc=docs.SPONSOR_CANDIDATE_ID)
 
 
 class Committee(BaseConcreteCommittee):

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -44,6 +44,7 @@ class BaseConcreteCommittee(BaseCommittee):
 
     committee_id = db.Column(db.String, primary_key=True, unique=True, index=True, doc=docs.COMMITTEE_ID)
     candidate_ids = db.Column(ARRAY(db.Text), doc=docs.CANDIDATE_ID)
+    sponsor_candidate_ids = db.Column(ARRAY(db.Text), doc=docs.CANDIDATE_ID)
 
 
 class Committee(BaseConcreteCommittee):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -22,6 +22,7 @@ class ApiResource(utils.Resource):
     filter_multi_fields = []
     filter_range_fields = []
     filter_fulltext_fields = []
+    filter_overlap_fields = []
     query_options = []
     join_columns = {}
     aliases = {}
@@ -51,6 +52,7 @@ class ApiResource(utils.Resource):
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields)
         query = filters.filter_range(query, kwargs, self.filter_range_fields)
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
+        query = filters.filter_overlap(query, kwargs, self.filter_overlap_fields)
         if _apply_options:
             query = query.options(*self.query_options)
         return query

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -134,7 +134,6 @@ to provide context.
 CANDIDATE_DETAIL = '''
 This endpoint is useful for finding detailed information about a particular candidate. Use the
 `candidate_id` to find the most recent information about that candidate.
-
 '''
 
 CANDIDATE_NAME = 'Name of candidate running for office'
@@ -531,6 +530,11 @@ Affiliated committee or connected organization
 
 IS_COMMITTEE_ACTIVE = '''
 True indicates that a committee is active.
+'''
+
+SPONSOR_CANDIDATE_ID = '''
+A unique identifier assigned to each candidate registered with the FEC.
+If a person runs for several offices, that person will have separate candidate IDs for each office. This is a filter for Leadership PAC sponsor.
 '''
 # ======== committee end ===========
 

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -63,6 +63,10 @@ def filter_range(query, kwargs, fields):
 
 
 def filter_overlap(query, kwargs, fields):
+    """The purpose of this filter is to compare whether two arrays have elements in common.
+
+    It returns a Boolean value.
+    """
     for key, column in fields:
         if kwargs.get(key):
             # handle combination exclude/include lists

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -62,6 +62,19 @@ def filter_range(query, kwargs, fields):
     return query
 
 
+def filter_overlap(query, kwargs, fields):
+    for key, column in fields:
+        if kwargs.get(key):
+            # handle combination exclude/include lists
+            exclude_list = build_exclude_list(kwargs.get(key))
+            include_list = build_include_list(kwargs.get(key))
+            if exclude_list:
+                query = query.filter(~column.overlap(exclude_list))
+            if include_list:
+                query = query.filter(column.overlap(include_list))
+    return query
+
+
 def filter_fulltext(query, kwargs, fields):
     for key, column in fields:
         if kwargs.get(key):

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -9,6 +9,7 @@ from webservices import exceptions
 from webservices.common import models
 from webservices.common.views import ApiResource
 
+
 def filter_year(model, query, years):
     return query.filter(
         sa.or_(*[
@@ -51,6 +52,10 @@ class CommitteeList(ApiResource):
     filter_fulltext_fields = [
         ('q', models.CommitteeSearch.fulltxt),
         ('treasurer_name', models.Committee.treasurer_text),
+    ]
+
+    filter_overlap_fields = [
+        ('sponsor_candidate_id', models.Committee.sponsor_candidate_ids),
     ]
 
     @property
@@ -232,7 +237,7 @@ class CommitteeHistoryView(ApiResource):
                 query = query_regular.union(query_converted).order_by(
                     models.CommitteeHistory.committee_id,
                     sa.desc(models.CommitteeHistory.cycle),
-                    )
+                )
 
             else:
                 query = query.filter(models.CommitteeHistory.cycle == cycle)


### PR DESCRIPTION
## Summary (required)

- Resolves #4613

_Add filter sponsor_candidate_id to endpoint: /committees/_

## Reviewers
- Two developers (required) additional developer optional

## How to test the changes locally

- Download feature branch
- Run `pytest`
- Set SQLA_CONN to dev database and start endpoint on local
- Compare these endpoints, and sponsor_candidate_ids can be found in endpoint output.

Before change:
https://api.open.fec.gov/v1/committees/?page=1&per_page=20&sort=name&sort_nulls_last=false&api_key=DEMO_KEY&committee_id=C00692715&sort_hide_null=false&sort_null_only=false

After change:
http://127.0.0.1:5000/v1/committees/?per_page=20&page=1&sort_null_only=false&committee_id=C00692715&sort_nulls_last=false&sort=name&sort_hide_null=false

<img width="250" alt="Screen Shot 2020-10-20 at 11 32 04 AM" src="https://user-images.githubusercontent.com/24396726/96609032-10d3b080-12c8-11eb-9e4a-7ad0101b7b33.png">

- Run this endpoint to test filter

http://127.0.0.1:5000/v1/committees/?sort_null_only=false&page=1&sort_nulls_last=false&sort_hide_null=false&sort=name&sponsor_candidate_id=H2NV02395&per_page=20

http://127.0.0.1:5000/v1/committees/?sort_null_only=false&page=1&sort_nulls_last=false&sort_hide_null=false&sort=name&sponsor_candidate_id=H8OK01157&per_page=20

## Impacted areas of the application
These endpoints will have sponsor_candidate_ids in the output:
/committee/{committee_id}/
/committees/
/candidate/{candidate_id}/committees/

