### PR TITLE
Implement rolling deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ jobs:
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
-            cf install-plugin autopilot -f -r CF-Community
 
       - add_ssh_keys # add Bastion host private keys configured in the UI
       - run: echo $FEC_BASTION_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts # copy Bastion host public key

--- a/README.md
+++ b/README.md
@@ -306,22 +306,14 @@ invoke dump postgresql://:@/cfdm_test data/subset.dump
 ## Deployment (FEC team only)
 
 ### Deployment prerequisites
-If you haven't used Cloud Foundry in other projects, you'll need to install the Cloud Foundry CLI and the autopilot plugin.
+If you haven't used Cloud Foundry in other projects, you'll need to install the Cloud Foundry CLI.
 
 #### Deploy
-Before deploying, install version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) and the [autopilot plugin](https://github.com/concourse/autopilot):
+Before deploying, install version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html):
 
 1. Read [Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) to install version 7 of the Cloud Foundry CLI.
 
-2. Install autopilot by running:
-
-   ```
-   cf install-plugin autopilot -r CF-Community
-   ```
-
-   [Learn more about autopilot](https://github.com/concourse/autopilot).
-
-3. Set environment variables used by the deploy script:
+2. Set environment variables used by the deploy script:
 
    ```
    export FEC_CF_USERNAME=<your_cf_username>

--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -1,18 +1,20 @@
 ---
-path: ../
-memory: 1500M # 1.5G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  APP_NAME: fec | api | dev
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-dev
-  - fec-s3-dev
-routes:
-  - route: fec-dev-api.app.cloud.gov
 applications:
   - name: api
     instances: 1
+    memory: 1.5G
     disk_quota: 1G
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    path: ../
+    routes:
+      - route: fec-dev-api.app.cloud.gov
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-dev
+      - fec-s3-dev
+      - test-aws-glue-etl
+    env:
+      APP_NAME: fec | api | dev

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -1,21 +1,22 @@
 ---
-path: ../
-memory: 1500M # 1.5G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | prod
-  PRODUCTION: True
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-prod
-  - fec-s3-prod
-routes:
-  - route: fec-prod-api.app.cloud.gov
 applications:
   - name: api
     instances: 10
+    memory: 1.5G
     disk_quota: 1G
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    path: ../
+    routes:
+      - route: fec-prod-api.app.cloud.gov
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-prod
+      - fec-s3-prod
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | prod
+      PRODUCTION: True

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -1,20 +1,21 @@
 ---
-path: ../
-memory: 1500M # 1.5G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | stage
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-stage
-  - fec-s3-stage
-routes:
-  - route: fec-stage-api.app.cloud.gov
 applications:
   - name: api
     instances: 1
+    memory: 1.5G
     disk_quota: 1G
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    path: ../
+    routes:
+      - route: fec-stage-api.app.cloud.gov
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-stage
+      - fec-s3-stage
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | stage

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -1,15 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  APP_NAME: fec | api | dev
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-dev
-  - fec-s3-dev
 applications:
   - name: celery-beat
     instances: 1
@@ -18,3 +7,14 @@ applications:
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-dev
+      - fec-s3-dev
+    env:
+      APP_NAME: fec | api | dev

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -1,18 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | prod
-  PRODUCTION: True
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-prod
-  - fec-s3-prod
 applications:
   - name: celery-beat
     instances: 1
@@ -21,3 +7,17 @@ applications:
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-prod
+      - fec-s3-prod
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | prod
+      PRODUCTION: True

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -1,17 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | stage
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-stage
-  - fec-s3-stage
 applications:
   - name: celery-beat
     instances: 1
@@ -20,3 +7,16 @@ applications:
     no-route: true
     health-check-type: process
     command: celery beat --app webservices.tasks --loglevel INFO
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-stage
+      - fec-s3-stage
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | stage

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -1,15 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  APP_NAME: fec | api | dev
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-dev
-  - fec-s3-dev
 applications:
   - name: celery-worker
     instances: 1
@@ -18,3 +7,14 @@ applications:
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-dev
+      - fec-s3-dev
+    env:
+      APP_NAME: fec | api | dev

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -1,18 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | prod
-  PRODUCTION: True
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-prod
-  - fec-s3-prod
 applications:
   - name: celery-worker
     instances: 6
@@ -21,3 +7,17 @@ applications:
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 3
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-prod
+      - fec-s3-prod
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | prod
+      PRODUCTION: True

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -1,17 +1,4 @@
 ---
-path: ../
-memory: 1G
-stack: cflinuxfs3
-buildpack: python_buildpack
-env:
-  FEC_API_USE_PROXY: true
-  FEC_API_RESTRICT_DOWNLOADS: true
-  APP_NAME: fec | api | stage
-services:
-  - fec-api-search56
-  - fec-redis
-  - fec-creds-stage
-  - fec-s3-stage
 applications:
   - name: celery-worker
     instances: 1
@@ -20,3 +7,16 @@ applications:
     no-route: true
     health-check-type: process
     command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    path: ../
+    stack: cflinuxfs3
+    buildpacks:
+      - python_buildpack
+    services:
+      - fec-api-search56
+      - fec-redis
+      - fec-creds-stage
+      - fec-s3-stage
+    env:
+      FEC_API_USE_PROXY: true
+      FEC_API_RESTRICT_DOWNLOADS: true
+      APP_NAME: fec | api | stage

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -1,19 +1,21 @@
-path: ../
+---
 applications:
 - name: <name>-kill-<date>
   memory: 1024M
   disk_quota: 1024M
   command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python manage.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
-  buildpack: python_buildpack
+  no-route: true
+  path: ../
+  stack: cflinuxfs3
+  buildpacks:
+    - python_buildpack
+  health-check-type: process
+  services:
+    - fec-s3-dev
+    - fec-api-search56
+    - fec-creds-dev
+    - fec-redis
   env:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | dev
     PRODUCTION: True
-  no-route: true
-  services:
-  - fec-s3-dev
-  - fec-api-search56
-  - fec-creds-dev
-  - fec-redis
-  stack: cflinuxfs3
-  health-check-type: process

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -1,19 +1,21 @@
-path: ../
+---
 applications:
 - name: <name>-kill-<date>
   memory: 1024M
   disk_quota: 1024M
   command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"
-  buildpack: python_buildpack
+  no-route: true
+  path: ../
+  stack: cflinuxfs3
+  buildpacks:
+    - python_buildpack
   health-check-type: process
+  services:
+    - fec-s3-prod
+    - fec-api-search56
+    - fec-creds-prod
+    - fec-redis
   env:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | prod
     PRODUCTION: True
-  no-route: true
-  services:
-  - fec-s3-prod
-  - fec-api-search56
-  - fec-creds-prod
-  - fec-redis
-  stack: cflinuxfs3

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -1,19 +1,21 @@
-path: ../
+---
 applications:
 - name: <name>-kill-<date>
   memory: 1024M
   disk_quota: 1024M
   command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"
-  buildpack: python_buildpack
+  no-route: true
+  path: ../
+  stack: cflinuxfs3
+  buildpacks:
+    - python_buildpack
+  health-check-type: process
+  services:
+    - fec-s3-stage
+    - fec-api-search56
+    - fec-creds-stage
+    - fec-redis
   env:
     FEC_API_USE_PROXY: true
     APP_NAME: fec | api | stage
     PRODUCTION: True
-  no-route: true
-  services:
-  - fec-s3-stage
-  - fec-api-search56
-  - fec-creds-stage
-  - fec-redis
-  stack: cflinuxfs3
-  health-check-type: process

--- a/tasks.py
+++ b/tasks.py
@@ -218,6 +218,7 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
     # Deploy API and worker applications
     for app in ('api', 'celery-worker', 'celery-beat'):
         existing_deploy = ctx.run('cf app {0}'.format(app), echo=True, warn=True)
+        print("\n")
         cmd = 'push --strategy rolling' if existing_deploy.ok else 'push'
         new_deploy = ctx.run('cf {cmd} {app} -f manifests/manifest_{file}_{space}.yml'.format(
             cmd=cmd,
@@ -245,6 +246,9 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
                     print("Unable to cancel deploy. Check logs.")
 
             return sys.exit(1)
+
+        print("\nA new version of your application '{}' has been successfully pushed!".format(app))
+        ctx.run('cf apps', echo=True, warn=True)
 
     # Needed for CircleCI
     return sys.exit(0)

--- a/tasks.py
+++ b/tasks.py
@@ -241,7 +241,6 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False, migrate_database
                 cancel_deploy = ctx.run('cf cancel-deployment {}'.format(app), echo=True, warn=True)
                 if cancel_deploy.ok:
                     print("Successfully cancelled deploy. Check logs.")
-                    ctx.run('cf app {}'.format(app), echo=True, warn=True)
                 else:
                     print("Unable to cancel deploy. Check logs.")
 


### PR DESCRIPTION
## Summary (required)

Resolves #4668
Resolves #3950 

- Reformat manifests with newer format
- Implement rolling deployments, remove references to `autopilot` and `zero-downtime-push`


## Reviewers
- At least two reviewers please

## How to test the changes locally

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch)
- Modify deploy task to deploy to a space of your choice
- Push to Github, make sure build works

**Locally:**
- Install cf cli version [following this guide](https://github.com/cloudfoundry/cli/wiki/Version-Switching-Guide) or:
```
# Install cf-cli@7. Complete commands
brew install cf-cli@7

# If you run across an error like this: Error: No such keg: /usr/local/Cellar/cf-cli@6, make sure you install cf-cli version 6 with brew
brew install cf-cli@6
 
# Unlink cf-cli version 6 and link cf-cli version 7
brew unlink cf-cli@6 && brew unlink cf-cli@7 && brew link cf-cli@7 && cf version
```
- Do a manual deploy with `invoke deploy --space dev`

##  Testing failed builds
- Test with bad requirements.txt, like `Flask=2222`, make sure build fails
- Test with crashing app - add 5 instances,  at the top of `run.sh`, add:
```
rand_mod=$(expr $RANDOM % 5)
if [ $rand_mod -eq 0 ]; then
    echo "Starting divisible by five app"
else
    echo "Crashing non-divisible by five app";
    exit 1
fi
```
make sure build fails and is cancelled

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Deploy task only


