### PR TITLE
Add sponsor id to committee history endpoint

### DIFF
--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -21,6 +21,7 @@ class CommitteeFormatTest(ApiBaseTest):
             committee_type='P',
             treasurer_name='Robert J. Lipshutz',
             party='DEM',
+            sponsor_candidate_ids=['P001']
         )
         response = self._response(
             api.url_for(CommitteeView, committee_id=committee.committee_id)
@@ -35,6 +36,7 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEqual(result['committee_type'], committee.committee_type)
         self.assertEqual(result['treasurer_name'], committee.treasurer_name)
         self.assertEqual(result['party'], committee.party)
+        self.assertEqual(result['sponsor_candidate_ids'], committee.sponsor_candidate_ids)
 
     def test_fulltext_search(self):
         committee = factories.CommitteeFactory(
@@ -397,7 +399,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
-        self.committees = [factories.CommitteeDetailFactory() for _ in range(5)]
+        self.committees = [factories.CommitteeDetailFactory() for _ in range(6)]
         self.histories = [
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[0].committee_id,
@@ -439,6 +441,13 @@ class TestCommitteeHistory(ApiBaseTest):
                 cycle=2014,
                 designation='J',
                 is_active=False,
+            ),
+            factories.CommitteeHistoryFactory(
+                committee_id=self.committees[5].committee_id,
+                cycle=2020,
+                designation='D',
+                is_active=True,
+                sponsor_candidate_ids=['H003']
             ),
         ]
 
@@ -627,3 +636,13 @@ class TestCommitteeHistory(ApiBaseTest):
             )
         )
         assert len(results) == 1
+
+    def test_committee_history_fields(self):
+        result = self._results(
+            api.url_for(
+                CommitteeHistoryView,
+                committee_id=self.committees[5].committee_id,
+            )
+        )
+        assert len(result) == 1
+        self.assertEqual(result[0]['sponsor_candidate_ids'], ['H003'])

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -278,3 +278,35 @@ class TestFilterOther(ApiBaseTest):
                 if 'Report' in each.summary and 'IE' not in each.summary
             ),
         )
+
+
+class TestFilterOverlap(ApiBaseTest):
+    def setUp(self):
+        super(TestFilterOverlap, self).setUp()
+        self.committees = [
+            factories.CommitteeFactory(committee_id='C001', sponsor_candidate_ids=['S001']),
+            factories.CommitteeFactory(committee_id='C002', sponsor_candidate_ids=['H001']),
+        ]
+
+    def test_filter_overlap(self):
+        """Test the filter that compares whether two arrays have elements in common."""
+        query_committees = filters.filter_overlap(
+            models.Committee.query,
+            {'sponsor_candidate_id': ['H001']},
+            CommitteeList.filter_overlap_fields,
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.sponsor_candidate_ids == ['H001']),
+        )
+
+    def test_filter_overlap_exclude(self):
+        query_committees = filters.filter_overlap(
+            models.Committee.query,
+            {'sponsor_candidate_id': ['-H001']},
+            CommitteeList.filter_overlap_fields,
+        )
+        self.assertEqual(
+            set(query_committees.all()),
+            set(each for each in self.committees if each.sponsor_candidate_ids == ['S001']),
+        )

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -72,10 +72,11 @@ class CommitteeHistory(BaseCommittee):
     last_cycle_has_activity = db.Column(db.Integer, doc=docs.COMMITTEE_LAST_CYCLE_HAS_ACTIVITY)
     is_active = db.Column(db.Boolean, doc=docs.IS_COMMITTEE_ACTIVE)
     former_committee_name = db.Column(db.String(200), doc=docs.COMMITTEE_NAME)
-    former_candidate_id  = db.Column(db.String(9), doc=docs.CANDIDATE_ID)
+    former_candidate_id = db.Column(db.String(9), doc=docs.CANDIDATE_ID)
     former_candidate_name = db.Column(db.String(90), doc=docs.CANDIDATE_NAME)
     former_candidate_election_year = db.Column(db.Integer, doc=docs.CANDIDATE_ELECTION_YEAR)
     convert_to_pac_flag = db.Column(db.Boolean, doc=docs.CONVERT_TO_PAC_FLAG)
+    sponsor_candidate_ids = db.Column(ARRAY(db.Text), doc=docs.SPONSOR_CANDIDATE_ID)
 
 
 class CommitteeDetail(BaseConcreteCommittee):


### PR DESCRIPTION
## Summary (required)

- Resolves #4612 

_Updated these endpoints to include sponsor_candidate_id_

'/committee/<committee_id>/history/',
'/committee/<committee_id>/history/cycle/',
'/candidate/<candidate_id>/committees/history/',
'/candidate/<candidate_id>/committees/history/cycle/'

## Reviewers
Two developers (required), additional developer optional

## How to test the changes locally

- Download feature branch
- run `pytest` to make sure all tests pass
- Set SQLA_CONN to dev database, and run `./manage.py runserver`
- Check these endpoints and make sure sponsor_candidate_ids is in the output

http://127.0.0.1:5000/v1/committee/C00432104/history/?election_full=true&sort_null_only=false&sort_hide_null=false&sort=-cycle&per_page=20&page=1&sort_nulls_last=false


http://127.0.0.1:5000/v1/committee/C00497677/history/2016/?election_full=true&sort_null_only=false&sort_hide_null=false&sort=-cycle&per_page=20&page=1&sort_nulls_last=false






