### PR TITLE
Remove unnecessary filters for `/committee/committee_id/totals` 

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -412,10 +412,8 @@ committee_reports = {
     'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
 }
 
-totals = {
+committee_totals = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'type': fields.Str(description=docs.COMMITTEE_TYPE),
-    'designation': fields.Str(description=docs.DESIGNATION),
 }
 
 totals_by_committee_type = {

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -91,7 +91,7 @@ class TotalsByCommitteeTypeView(utils.Resource):
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
-            committee_type_map.get(committee_type), 
+            committee_type_map.get(committee_type),
             default_schemas,
         )
         query = totals_class.query
@@ -138,7 +138,7 @@ class TotalsByCommitteeTypeView(utils.Resource):
 )
 class TotalsCommitteeView(ApiResource):
     @use_kwargs(args.paging)
-    @use_kwargs(args.totals)
+    @use_kwargs(args.committee_totals)
     @use_kwargs(args.make_sort_args(default='-cycle'))
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, committee_type=None, **kwargs):


### PR DESCRIPTION
## Summary (required)

- Resolves #4462

Remove unnecessary filters for `/committee/committee_id/totals` 

## Reviewers
One requested, any others appreciated

## How to test the changes locally

- Run this branch
- Check out swagger (http://localhost:5000/developers/#/financial/get_committee__committee_id__totals_), make sure that `/committee/committee_id/totals` doesn't have type and designation filters
- Try a query with old filters (should be ignored): http://localhost:5000/v1/committee/C00703975/totals/?type=P&designation=P
- Try a query without filters (should still work): 
http://localhost:5000/v1/committee/C00703975/totals/
http://localhost:5000/v1/committee/C00703975/totals/?page=1&sort_hide_null=false&per_page=20&sort=-cycle&sort_nulls_last=false&sort_null_only=false


## Impacted areas of the application
List general components of the application that this PR will affect:

- No impact to user except removing filters from `/committee/committee_id/totals` that didn't work previously 
- According to API logs, doesn't look like they've been used in the past 2 months