### PR TITLE
[MERGE WITH GIT FLOW] [HOTFIX] [Migration V0219] Use https for docquery

### DIFF
--- a/data/migrations/V0219__update_docquery_https.sql
+++ b/data/migrations/V0219__update_docquery_https.sql
@@ -1,0 +1,101 @@
+/*
+This migration file is for #4458
+
+Use https instead of http for docquery URLs in these functions:
+
+image_pdf_url(text)
+report_fec_url(text, integer)
+report_html_url(text, text, text)
+report_pdf_url(text)
+
+*/
+
+
+--
+-- Name: image_pdf_url(text); Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION image_pdf_url(image_number text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+begin
+    return 'https://docquery.fec.gov/cgi-bin/fecimg/?' || image_number;
+end
+$$;
+
+
+ALTER FUNCTION public.image_pdf_url(image_number text) OWNER TO fec;
+
+--
+-- Name: report_fec_url(text, integer); Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_fec_url(image_number text, file_number integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+begin
+    return case
+        when file_number < 1 then null
+        when image_number is not null and not is_electronic(image_number) then format(
+            'https://docquery.fec.gov/paper/posted/%1$s.fec',
+            file_number
+        )
+        when image_number is not null and is_electronic(image_number) then format(
+            'https://docquery.fec.gov/dcdev/posted/%1$s.fec',
+            file_number
+        )
+    end;
+end
+$_$;
+
+
+ALTER FUNCTION public.report_fec_url(image_number text, file_number integer) OWNER TO fec;
+
+--
+-- Name: report_html_url(text, text, text); Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_html_url(means_filed text, cmte_id text, filing_id text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+BEGIN
+    return CASE
+       when means_filed = 'paper' and filing_id::int > 0 then format (
+           'https://docquery.fec.gov/cgi-bin/paper_forms/%1$s/%2$s/',
+            cmte_id,
+            filing_id
+       )
+       when means_filed = 'e-file' then format (
+           'https://docquery.fec.gov/cgi-bin/forms/%1$s/%2$s/',
+            cmte_id,
+            filing_id
+       )
+       else null
+    end;
+END
+$_$;
+
+
+ALTER FUNCTION public.report_html_url(means_filed text, cmte_id text, filing_id text) OWNER TO fec;
+
+--
+-- Name: report_pdf_url(text); Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_pdf_url(image_number text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+begin
+    return case
+        when image_number is not null then format(
+            'https://docquery.fec.gov/pdf/%1$s/%2$s/%2$s.pdf',
+            substr(image_number, length(image_number) - 2, length(image_number)),
+            image_number
+        )
+        else null
+    end;
+end
+$_$;
+
+
+ALTER FUNCTION public.report_pdf_url(image_number text) OWNER TO fec;

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -190,7 +190,7 @@ class TestReports(ApiBaseTest):
         )
         self.assertEqual(
             results[0]['pdf_url'],
-            'http://docquery.fec.gov/pdf/901/12345678901/12345678901.pdf',
+            'https://docquery.fec.gov/pdf/901/12345678901/12345678901.pdf',
         )
 
     def test_no_pdf_link(self):

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -152,11 +152,11 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     @property
     def pdf_url(self):
         image_number = str(self.beginning_image_number)
-        return 'http://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(image_number[-3:], image_number)
+        return 'https://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(image_number[-3:], image_number)
 
     @property
     def html_url(self):
-        return 'http://docquery.fec.gov/cgi-bin/forms/{0}/{1}/'.format(self.committee_id, self.file_number)
+        return 'https://docquery.fec.gov/cgi-bin/forms/{0}/{1}/'.format(self.committee_id, self.file_number)
 
 
 # TODO: add index on committee id and filed_date

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -41,9 +41,9 @@ API_KEY_ARG = fields.Str(
 if env.get_credential('PRODUCTION'):
     Resource = use_kwargs({'api_key': API_KEY_ARG})(Resource)
 
-fec_url_map = {'9': 'http://docquery.fec.gov/dcdev/posted/{0}.fec'}
+fec_url_map = {'9': 'https://docquery.fec.gov/dcdev/posted/{0}.fec'}
 fec_url_map = defaultdict(
-    lambda: 'http://docquery.fec.gov/paper/posted/{0}.fec', fec_url_map
+    lambda: 'https://docquery.fec.gov/paper/posted/{0}.fec', fec_url_map
 )
 
 
@@ -383,7 +383,7 @@ def document_description(
 
 def make_report_pdf_url(image_number):
     if image_number:
-        return 'http://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(
+        return 'https://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(
             str(image_number)[-3:], image_number,
         )
     else:
@@ -392,15 +392,15 @@ def make_report_pdf_url(image_number):
 
 def make_schedule_pdf_url(image_number):
     if image_number:
-        return 'http://docquery.fec.gov/cgi-bin/fecimg/?' + image_number
+        return 'https://docquery.fec.gov/cgi-bin/fecimg/?' + image_number
 
 
 def make_csv_url(file_num):
     file_number = str(file_num)
     if file_num > -1 and file_num < 100:
-        return 'http://docquery.fec.gov/csv/000/{0}.csv'.format(file_number)
+        return 'https://docquery.fec.gov/csv/000/{0}.csv'.format(file_number)
     elif file_num >= 100:
-        return 'http://docquery.fec.gov/csv/{0}/{1}.csv'.format(
+        return 'https://docquery.fec.gov/csv/{0}/{1}.csv'.format(
             file_number[-3:], file_number
         )
 


### PR DESCRIPTION
- [x] Will these changes modify the insert triggers for Schedule A and others that use `image_pdf_url()` or do the triggers need to be re-created to ingest the changes to `image_pdf_url()`? Per @fecjjeng no need to re-create the triggers.

## Summary (required)

- Resolves #4715: Use `https` for docquery links

- SQL changes: some endpoints use the SQL functions, which are used at the time of creating the MV's:
```
image_pdf_url(image_number text) RETURNS text
report_fec_url(image_number text, file_number integer) RETURNS text
report_html_url(means_filed text, cmte_id text, filing_id text) RETURNS text
report_pdf_url(image_number text) RETURNS text
```

- Python changes: some endpoints use the "`Mixin`" classes in the Python models. The "`Mixin`" use the `utils` functions.

`Mixin` code, for reference:

```python
class PdfMixin(object):
    @property
    def pdf_url(self):
        if self.has_pdf:
            return utils.make_report_pdf_url(self.beginning_image_number)
        return None

    @property
    def has_pdf(self):
        return self.report_year and self.report_year >= 1993


class CsvMixin(object):
    @property
    def csv_url(self):
        if self.file_number:
            return utils.make_csv_url(self.file_number)


class FecMixin(object):
    @property
    def fec_url(self):
        if self.file_number:
            return utils.make_fec_url(self.beginning_image_number, self.file_number)
```

## Reviewers
Required: @fecjjeng and one backend developer. Need to wait until the ActBlue M10 is finished processing. 
Additional reviewers appreciated


## How to test the changes locally

### Replicate the issue locally (optional - can also check in `dev` space)
- Make sure you're using Google Chrome and that you've updated to the latest version (87)
- Check out `develop` branch
- Point your `SQLA_CONN` to the `dev` database, run the API locally
- Check the URLs on some sample queries, see they have `http`
**URLs generated by the python functions:**
`pdf_url`, `fec_url`, `csv_url`, and `html_url` for http://localhost:5000/v1/efile/filings
**URLs generated by the SQL functions:**
`pdf_url` for http://localhost:5000/v1/schedules/schedule_e/
`pdf_url`, `fec_url`, `csv_url`, and `html_url` for http://localhost:5000/v1/filings (oddly, the `Mixin` is used for `csv_url` and the SQL functions are used for the rest)
- Run the `develop` branch for CMS, set `FEC_API_URL` to your local API
- Check datatables to see if you can download the .csv and .fec files:
URLs generated by the python functions:
URLs generated by the SQL functions:
- Page should flash and block downloads


### Test the fix

- Make sure you're using Google Chrome and that you've updated to the latest version (87)
- Check out this branch `hotfix/4715-use-https-for-docquery`
- Drop and recreate your local sample database (`dropdb cfdm_test` / `createdb cfdm_test`) and `invoke create_sample_db` to populate sample data, run migrations, and refresh MV's
- Unset `SQLA_CONN` or set to `postgresql://<username>:<password>@localhost:5432/cfdm_test` to use `cfdm_test`, run the API
- Check the URLs on some sample queries, see they have **`https`**
**URLs generated by the python functions:**
`pdf_url`, `fec_url`, `csv_url`, and `html_url` for http://localhost:5000/v1/efile/filings
**URLs generated by the SQL functions:**
`pdf_url` for http://localhost:5000/v1/schedules/schedule_e/
`pdf_url`, `fec_url`, `csv_url`, and `html_url` for http://localhost:5000/v1/filings (oddly, the `Mixin` is used for `csv_url` and the SQL functions are used for the rest)
- Run the `develop` branch for CMS, set `FEC_API_UR`L to your local API or the `dev 
- Check datatables to see if you can download the .csv and .fec files:
URLs generated by the python functions:
http://127.0.0.1:8000/data/filings/?data_type=efiling
http://127.0.0.1:8000/data/reports/presidential/?is_amended=false&data_type=processed
URLs generated by the SQL functions: 
http://127.0.0.1:8000/data/filings/?data_type=processed
http://127.0.0.1:8000/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true (can't download reports but can test the "open image" button in the flyout panel

## Other considerations
- [x] Will these changes modify the insert triggers for Schedule A and others that use `image_pdf_url()` or do the triggers need to be re-created to ingest the changes to `image_pdf_url()`?

## Impacted areas of the application
List general components of the application that this PR will affect:

- Datatables for filings, efilings, and reports
- Candidate and committee profile pages

