### PR TITLE
Use new aws-redis-elasticache service

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,13 @@ invoke deploy --space dev --migrate-database
 
 #### Setting up a service
 On Cloud Foundry, we use the aws-elasticache-redis
-service. The Redis service can be created as follows:
+service. For more information about plan names, see the
+[cloud.gov aws-elasticache-redis documentation](https://cloud.gov/docs/services/aws-elasticache/)
+
+The Redis service can be created as follows:
 
 ```
-cf create-service aws-elasticache-redis redis-3node fec-elasticache-redis
+cf create-service aws-elasticache-redis <plan_name> fec-elasticache-redis
 ```
 
 #### Setting up credentials

--- a/README.md
+++ b/README.md
@@ -347,11 +347,11 @@ invoke deploy --space dev --migrate-database
 
 
 #### Setting up a service
-On Cloud Foundry, we use the redis32
+On Cloud Foundry, we use the aws-elasticache-redis
 service. The Redis service can be created as follows:
 
 ```
-cf create-service redis32 standard-ha fec-redis
+cf create-service aws-elasticache-redis redis-3node fec-elasticache-redis
 ```
 
 #### Setting up credentials

--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -12,7 +12,7 @@ applications:
       - route: fec-dev-api.app.cloud.gov
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-dev
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_api_feature.yml
+++ b/manifests/manifest_api_feature.yml
@@ -12,7 +12,7 @@ applications:
       - route: fec-feature-api.app.cloud.gov
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-feature
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -12,7 +12,7 @@ applications:
       - route: fec-prod-api.app.cloud.gov
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-prod
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -12,7 +12,7 @@ applications:
       - route: fec-stage-api.app.cloud.gov
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-stage
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-dev
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_beat_feature.yml
+++ b/manifests/manifest_celery_beat_feature.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-feature
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-prod
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-stage
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-dev
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_worker_feature.yml
+++ b/manifests/manifest_celery_worker_feature.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-feature
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-prod
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -13,7 +13,7 @@ applications:
       - python_buildpack
     services:
       - fec-api-elasticsearch
-      - fec-redis
+      - fec-elasticache-redis
       - fec-creds-stage
       - fec-s3-api
       - fec-s3-snapshot

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -12,7 +12,7 @@ applications:
   health-check-type: process
   services:
     - fec-api-elasticsearch
-    - fec-redis
+    - fec-elasticache-redis
     - fec-creds-dev
     - fec-s3-api
     - fec-s3-snapshot

--- a/manifests/manifest_task_feature.yml.template
+++ b/manifests/manifest_task_feature.yml.template
@@ -12,7 +12,7 @@ applications:
   health-check-type: process
   services:
     - fec-api-elasticsearch
-    - fec-redis
+    - fec-elasticache-redis
     - fec-creds-feature
     - fec-s3-api
     - fec-s3-snapshot

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -12,7 +12,7 @@ applications:
   health-check-type: process
   services:
     - fec-api-elasticsearch
-    - fec-redis
+    - fec-elasticache-redis
     - fec-creds-prod
     - fec-s3-api
     - fec-s3-snapshot

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -12,7 +12,7 @@ applications:
   health-check-type: process
   services:
     - fec-api-elasticsearch
-    - fec-redis
+    - fec-elasticache-redis
     - fec-creds-stage
     - fec-s3-api
     - fec-s3-snapshot

--- a/webservices/config.py
+++ b/webservices/config.py
@@ -33,7 +33,7 @@ REQUIRED_CREDS = (
     "FEC_SLACK_TOKEN",
 )
 
-REQUIRED_SERVICES = ("redis32", "s3", "aws-elasticsearch")
+REQUIRED_SERVICES = ("aws-elasticache-redis", "s3", "aws-elasticsearch")
 
 REQUIRED_TABLES = tuple(db.Model.metadata.tables.keys()) + (
     "ofec_pacronyms",

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -42,12 +42,12 @@ def redis_url():
     """
     Retrieve the URL needed to connect to a Redis instance, depending on environment.
 
-    When running in a cloud.gov environment, retrieve the uri credential for the 'redis32' service.
+    When running in a cloud.gov environment, retrieve the uri credential for the 'aws-elasticache-redis' service.
     """
 
     # Is the app running in a cloud.gov environment
     if env.space is not None:
-        redis_env = env.get_service(label='redis32')
+        redis_env = env.get_service(label='aws-elasticache-redis')
         redis_url = redis_env.credentials.get('uri')
 
         return redis_url

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -4,7 +4,7 @@ from celery.schedules import crontab
 
 from webservices.env import env
 from webservices.tasks import utils
-
+import ssl
 
 # Feature and dev are sharing the same RDS box so we only want dev to update
 schedule = {}
@@ -58,6 +58,12 @@ def redis_url():
 app = celery.Celery('openfec')
 app.conf.update(
     broker_url=redis_url(),
+    broker_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
+    redis_backend_use_ssl={
+        'ssl_cert_reqs': ssl.CERT_NONE,
+    },
     imports=(
         'webservices.tasks.refresh',
         'webservices.tasks.download',
@@ -72,7 +78,7 @@ app.conf.update(
 app.conf.ONCE = {
     'backend': 'celery_once.backends.Redis',
     'settings': {
-        'url': redis_url(),
+        'url': redis_url() + "?ssl=true",
         'default_timeout': 60 * 60
     }
 }


### PR DESCRIPTION
## Summary (required)

Partial resolution for #4393: Use new `aws-redis-elasticache` service

Note: I deleted the old `redis32` service for testing in `dev` and it appears cloud.gov's deprecation process means creating new instances is no longer possible. I didn't realize this, so downloads won't work in the `dev` space if we rebuild the `develop` branch  

## Reviewers
One approval requested, other reviewers welcome

## How to test the changes locally

- Manually deploy this branch to the dev space
- Test a download

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Downloads
- Celery tasks - legal docs, MV refresh, elasticsearch backups

