### PR TITLE
[Before release] Fix public s3 bucket settings

### DIFF
--- a/webservices/env.py
+++ b/webservices/env.py
@@ -5,12 +5,14 @@ import cfenv
 
 env = cfenv.AppEnv()
 
-default_bucket = env.get_service(name="fec-s3-api")
+S3_PUBLIC_SERVICE_INSTANCE_NAME = "fec-s3-api"
 
-if default_bucket:
-    os.environ['AWS_DEFAULT_BUCKET'] = default_bucket.credentials.get('bucket')
-    os.environ['AWS_ACCESS_KEY_ID'] = default_bucket.credentials.get('access_key_id')
-    os.environ['AWS_SECRET_ACCESS_KEY'] = default_bucket.credentials.get('secret_access_key')
-    os.environ['AWS_DEFAULT_REGION'] = default_bucket.credentials.get('region')
+public_bucket = env.get_service(name=S3_PUBLIC_SERVICE_INSTANCE_NAME)
+
+if public_bucket:
+    os.environ['AWS_PUBLIC_BUCKET'] = public_bucket.credentials.get('bucket')
+    os.environ['AWS_ACCESS_KEY_ID'] = public_bucket.credentials.get('access_key_id')
+    os.environ['AWS_SECRET_ACCESS_KEY'] = public_bucket.credentials.get('secret_access_key')
+    os.environ['AWS_DEFAULT_REGION'] = public_bucket.credentials.get('region')
 
 __all__ = ['env']

--- a/webservices/env.py
+++ b/webservices/env.py
@@ -5,12 +5,12 @@ import cfenv
 
 env = cfenv.AppEnv()
 
+default_bucket = env.get_service(name="fec-s3-api")
 
-if env.get_credential('access_key_id'):
-    os.environ['AWS_ACCESS_KEY_ID'] = env.get_credential('access_key_id')
-if env.get_credential('secret_access_key'):
-    os.environ['AWS_SECRET_ACCESS_KEY'] = env.get_credential('secret_access_key')
-if env.get_credential('region'):
-    os.environ['AWS_DEFAULT_REGION'] = env.get_credential('region')
+if default_bucket:
+    os.environ['AWS_DEFAULT_BUCKET'] = default_bucket.credentials.get('bucket')
+    os.environ['AWS_ACCESS_KEY_ID'] = default_bucket.credentials.get('access_key_id')
+    os.environ['AWS_SECRET_ACCESS_KEY'] = default_bucket.credentials.get('secret_access_key')
+    os.environ['AWS_DEFAULT_REGION'] = default_bucket.credentials.get('region')
 
 __all__ = ['env']

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -20,7 +20,7 @@ def get_bucket():
     try:
         session = boto3.Session()
         s3 = session.resource("s3")
-        bucket = s3.Bucket(env.get_credential("AWS_DEFAULT_BUCKET"))
+        bucket = s3.Bucket(env.get_credential("AWS_PUBLIC_BUCKET"))
     except Exception as err:
         logging.error("An error occurred trying to connect to s3. Please disregard if running locally.{0}".format(err))
         return
@@ -33,9 +33,9 @@ def get_object(key):
 
 def get_s3_key(name):
     connection = boto.s3.connect_to_region(
-        env.get_credential("region"),
+        env.get_credential("AWS_DEFAULT_REGION"),
     )
-    bucket = connection.get_bucket(env.get_credential("AWS_DEFAULT_BUCKET"))
+    bucket = connection.get_bucket(env.get_credential("AWS_PUBLIC_BUCKET"))
     key = Key(bucket=bucket, name=name)
     return key
 

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -20,7 +20,7 @@ def get_bucket():
     try:
         session = boto3.Session()
         s3 = session.resource("s3")
-        bucket = s3.Bucket(env.get_credential("bucket"))
+        bucket = s3.Bucket(env.get_credential("AWS_DEFAULT_BUCKET"))
     except Exception as err:
         logging.error("An error occurred trying to connect to s3. Please disregard if running locally.{0}".format(err))
         return
@@ -35,7 +35,7 @@ def get_s3_key(name):
     connection = boto.s3.connect_to_region(
         env.get_credential("region"),
     )
-    bucket = connection.get_bucket(env.get_credential("bucket"))
+    bucket = connection.get_bucket(env.get_credential("AWS_DEFAULT_BUCKET"))
     key = Key(bucket=bucket, name=name)
     return key
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4719: Fix public s3 bucket

The `get_credential` code in `webservices.env` that retrieves s3 credentials for the API has always taken the first s3 service in the list, which never really mattered because we only had one s3 bucket. When a separate elasticsearch backup bucket was added, this changed the behavior in `webservices.env`  to be unpredictable and, if the repository backup bucket was first in the list, was putting user downloads and public legal docs in the private elasticsearch bucket. 

This PR  either looks for the credentials for the s3 service `fec-s3-api` in the cloud.gov environment, or defaults to what the user has saved in the `AWS_PUBLIC_BUCKET` and `AWS_DEFAULT_REGION` env vars locally.

## How to test the changes locally

**On cloud.gov**
- Deploy to `stage` space, test downloads, OR
- branch off `develop` and cherry-pick these commits over to test in `dev` (deploying this branch to `dev` will fail because it's still connecting to the old `redis32` service that is no longer in `dev`)
- Test a reload of a MUR or AO (https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-management-instruction)
- Test a download: https://dev.fec.gov/data/elections/senate/AK/2020/
- Check that the URL of the download file has the correct bucket name

**Locally**
- Take a look at API `env vars`: `cf target -s stage & cf env api`
- Export `AWS_PUBLIC_BUCKET` and `AWS_DEFAULT_REGION` `env vars` to the values for the `stage` `fec-s3-api` service s3 buckets, run locally
- test downloads (https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-downloads)
- Test reloading legal
- Check that the URL of the download file has the correct bucket name

## Impacted areas of the application
List general components of the application that this PR will affect:

- User downloads
- Loading legal docs



## Related PRs
List related PRs against other branches:

https://github.com/fecgov/openFEC/pull/4657: Upgrade es7 (elasticsearch) service
