### PR TITLE
Replace `xml.etree.ElementTree.parse` with its `defusedxml` equivalent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
 requests-aws4auth==1.0
 certifi==2020.11.8
+defusedxml==0.6.0
 
 # Marshalling
 flask-apispec==0.7.0

--- a/webservices/legal_docs/statutes.py
+++ b/webservices/legal_docs/statutes.py
@@ -2,7 +2,7 @@
 import re
 from zipfile import ZipFile
 from tempfile import NamedTemporaryFile
-from xml.etree import ElementTree as Et
+from defusedxml import ElementTree as Et
 import logging
 import requests
 from webservices.utils import create_es_client


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/fec-accounts/issues/339

Replace `xml.etree.ElementTree.parse` with its `defusedxml` equivalent

## How to test the changes locally

- `pip install -r requirements.txt`
- Run `pytest`
- Test loading statutes: https://github.com/fecgov/openFEC#loading-statutes

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Loading statutes
