### PR TITLE
Add leadership pac committee rows in return result

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,7 +27,7 @@ class CommitteeSearchFactory(BaseFactory):
 
 
 class BaseCandidateFactory(BaseFactory):
-    candidate_id = factory.Sequence(lambda n: 'ID{0}'.format(n))
+    candidate_id = factory.Sequence(lambda n: "ID{0}".format(n))
 
 
 class CandidateFactory(BaseCandidateFactory):
@@ -93,7 +93,7 @@ class CandidateFlagsFactory(BaseFactory):
 
 
 class BaseCommitteeFactory(BaseFactory):
-    committee_id = factory.Sequence(lambda n: 'ID{0}'.format(n))
+    committee_id = factory.Sequence(lambda n: "ID{0}".format(n))
 
 
 class CommitteeFactory(BaseCommitteeFactory):
@@ -133,6 +133,13 @@ class CandidateCommitteeLinkFactory(BaseFactory):
         model = models.CandidateCommitteeLink
 
     linkage_id = factory.Sequence(lambda n: n)
+
+
+class CandidateCommitteeAlternateLinkFactory(BaseFactory):
+    class Meta:
+        model = models.CandidateCommitteeAlternateLink
+
+    sub_id = factory.Sequence(lambda n: n)
 
 
 class BaseTotalsFactory(BaseFactory):
@@ -369,7 +376,7 @@ class ScheduleEByCandidateFactory(BaseAggregateFactory):
         model = models.ScheduleEByCandidate
 
     candidate_id = factory.Sequence(lambda n: str(n))
-    support_oppose_indicator = 'S'
+    support_oppose_indicator = "S"
 
 
 class CommunicationCostByCandidateFactory(BaseAggregateFactory):
@@ -377,7 +384,7 @@ class CommunicationCostByCandidateFactory(BaseAggregateFactory):
         model = models.CommunicationCostByCandidate
 
     candidate_id = factory.Sequence(lambda n: str(n))
-    support_oppose_indicator = 'S'
+    support_oppose_indicator = "S"
 
 
 class ElectioneeringByCandidateFactory(BaseAggregateFactory):
@@ -423,7 +430,7 @@ class ZipsDistrictsFactory(BaseFactory):
     class Meta:
         model = models.ZipsDistricts
 
-    active = 'Y'
+    active = "Y"
 
 
 class CommunicationCostFactory(BaseFactory):
@@ -456,7 +463,7 @@ class ElectioneeringFactory(BaseFactory):
         model = models.Electioneering
 
     idx = factory.Sequence(lambda n: n)
-    election_type_raw = 'G'
+    election_type_raw = "G"
 
     @factory.post_generation
     def update_fulltext(obj, create, extracted, **kwargs):
@@ -488,23 +495,23 @@ class AuditCaseFactory(BaseFactory):
     class Meta:
         model = models.AuditCase
 
-    audit_case_id = '2219'
-    primary_category_id = '3'
-    sub_category_id = '227'
+    audit_case_id = "2219"
+    primary_category_id = "3"
+    sub_category_id = "227"
 
 
 class AuditCategoryFactory(BaseFactory):
     class Meta:
         model = models.AuditCategory
 
-    primary_category_id = '3'
+    primary_category_id = "3"
 
 
 class AuditPrimaryCategoryFactory(BaseFactory):
     class Meta:
         model = models.AuditPrimaryCategory
 
-    primary_category_id = '3'
+    primary_category_id = "3"
 
 
 class AuditCandidateSearchFactory(BaseFactory):
@@ -525,8 +532,8 @@ class StateElectionOfficesFactory(BaseFactory):
     class Meta:
         model = models.StateElectionOfficeInfo
 
-    state = 'VA'
-    office_type = 'STATE CAMPAIGN FINANCE'
+    state = "VA"
+    office_type = "STATE CAMPAIGN FINANCE"
 
 
 class OperationsLogFactory(BaseFactory):

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -17,30 +17,30 @@ from webservices.resources.candidates import CandidateView
 class CommitteeFormatTest(ApiBaseTest):
     def test_committee_list_fields(self):
         committee = factories.CommitteeFactory(
-            first_file_date=datetime.date.fromisoformat('1982-12-31'),
-            committee_type='P',
-            treasurer_name='Robert J. Lipshutz',
-            party='DEM',
-            sponsor_candidate_ids=['P001']
+            first_file_date=datetime.date.fromisoformat("1982-12-31"),
+            committee_type="P",
+            treasurer_name="Robert J. Lipshutz",
+            party="DEM",
+            sponsor_candidate_ids=["P001"]
         )
         response = self._response(
             api.url_for(CommitteeView, committee_id=committee.committee_id)
         )
-        result = response['results'][0]
+        result = response["results"][0]
         # main fields
         # original registration date doesn't make sense in this example, need to look into this more
         self.assertEqual(
-            result['first_file_date'],
-            datetime.date.fromisoformat('1982-12-31').isoformat(),
+            result["first_file_date"],
+            datetime.date.fromisoformat("1982-12-31").isoformat(),
         )
-        self.assertEqual(result['committee_type'], committee.committee_type)
-        self.assertEqual(result['treasurer_name'], committee.treasurer_name)
-        self.assertEqual(result['party'], committee.party)
-        self.assertEqual(result['sponsor_candidate_ids'], committee.sponsor_candidate_ids)
+        self.assertEqual(result["committee_type"], committee.committee_type)
+        self.assertEqual(result["treasurer_name"], committee.treasurer_name)
+        self.assertEqual(result["party"], committee.party)
+        self.assertEqual(result["sponsor_candidate_ids"], committee.sponsor_candidate_ids)
 
     def test_fulltext_search(self):
         committee = factories.CommitteeFactory(
-            name='Americans for a Better Tomorrow, Tomorrow'
+            name="Americans for a Better Tomorrow, Tomorrow."
         )
         decoy_committee = factories.CommitteeFactory()
         factories.CommitteeSearchFactory(
@@ -49,30 +49,30 @@ class CommitteeFormatTest(ApiBaseTest):
             is_active=True,
         )
         queries = [
-            'america',
-            'tomorrow',
-            'america tomorrow',
-            'america & tomorrow',
+            "america",
+            "tomorrow",
+            "america tomorrow",
+            "america & tomorrow",
         ]
         for query in queries:
             results = self._results(api.url_for(CommitteeList, q=query))
             self.assertEqual(len(results), 1)
-            self.assertEqual(results[0]['committee_id'], committee.committee_id)
+            self.assertEqual(results[0]["committee_id"], committee.committee_id)
             self.assertNotEqual(
-                results[0]['committee_id'], decoy_committee.committee_id
+                results[0]["committee_id"], decoy_committee.committee_id
             )
 
     def test_filter_by_candidate_id(self):
-        candidate_id = 'ID0'
+        candidate_id = "ID0"
         candidate_committees = [
             factories.CommitteeFactory(candidate_ids=[candidate_id]) for _ in range(2)
         ]
         other_committees = [factories.CommitteeFactory() for _ in range(3)]  # noqa
         response = self._response(api.url_for(CommitteeList, candidate_id=candidate_id))
-        self.assertEqual(len(response['results']), len(candidate_committees))
+        self.assertEqual(len(response["results"]), len(candidate_committees))
 
     def test_filter_by_candidate_ids(self):
-        candidate_ids = ['ID0', 'ID1']
+        candidate_ids = ["ID0", "ID1"]
         candidate1_committees = [
             factories.CommitteeFactory(candidate_ids=[candidate_ids[0]])
             for _ in range(2)
@@ -86,55 +86,55 @@ class CommitteeFormatTest(ApiBaseTest):
             api.url_for(CommitteeList, candidate_id=candidate_ids)
         )
         self.assertEqual(
-            len(response['results']),
+            len(response["results"]),
             len(candidate1_committees) + len(candidate2_committees),
         )
 
     def test_committee_detail_fields(self):
         committee = factories.CommitteeDetailFactory(
-            first_file_date=datetime.date.fromisoformat('1982-12-31'),
-            committee_type='P',
-            treasurer_name='Robert J. Lipshutz',
-            party='DEM',
-            form_type='F1Z',
-            street_1='1795 Peachtree Road',
-            zip='30309',
+            first_file_date=datetime.date.fromisoformat("1982-12-31"),
+            committee_type="P",
+            treasurer_name="Robert J. Lipshutz",
+            party="DEM",
+            form_type="F1Z",
+            street_1="1795 Peachtree Road",
+            zip="30309",
         )
         response = self._response(
             api.url_for(CommitteeView, committee_id=committee.committee_id)
         )
-        result = response['results'][0]
+        result = response["results"][0]
         # main fields
         self.assertEqual(
-            result['first_file_date'], committee.first_file_date.isoformat()
+            result["first_file_date"], committee.first_file_date.isoformat()
         )
-        self.assertEqual(result['committee_type'], committee.committee_type)
-        self.assertEqual(result['treasurer_name'], committee.treasurer_name)
-        self.assertEqual(result['party'], committee.party)
+        self.assertEqual(result["committee_type"], committee.committee_type)
+        self.assertEqual(result["treasurer_name"], committee.treasurer_name)
+        self.assertEqual(result["party"], committee.party)
         # Things on the detailed view
-        self.assertEqual(result['form_type'], committee.form_type)
-        self.assertEqual(result['street_1'], committee.street_1)
-        self.assertEqual(result['zip'], committee.zip)
+        self.assertEqual(result["form_type"], committee.form_type)
+        self.assertEqual(result["street_1"], committee.street_1)
+        self.assertEqual(result["zip"], committee.zip)
 
     def test_committee_search_double_committee_id(self):
         committees = [factories.CommitteeFactory() for _ in range(2)]
         ids = [each.committee_id for each in committees]
         response = self._response(api.url_for(CommitteeList, committee_id=ids))
-        results = response['results']
+        results = response["results"]
         self.assertEqual(len(results), 2)
 
     def test_committee_party(self):
         factories.CommitteeFactory(
-            party='REP', party_full='Republican Party',
+            party="REP", party_full="Republican Party",
         )
-        response = self._results(api.url_for(CommitteeList, party='REP'))
-        self.assertEqual(response[0]['party'], 'REP')
-        self.assertEqual(response[0]['party_full'], 'Republican Party')
+        response = self._results(api.url_for(CommitteeList, party="REP"))
+        self.assertEqual(response[0]["party"], "REP")
+        self.assertEqual(response[0]["party_full"], "Republican Party")
 
     def test_filters_generic(self):
-        self._check_filter('designation', ['B', 'P'])
-        self._check_filter('organization_type', ['M', 'T'])
-        self._check_filter('committee_type', ['H', 'X'])
+        self._check_filter("designation", ["B", "P"])
+        self._check_filter("organization_type", ["M", "T"])
+        self._check_filter("committee_type", ["H", "X"])
 
     def _check_filter(self, field, values, alt=None, **attrs):
 
@@ -163,27 +163,27 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_filters(self):
         [
-            factories.CommitteeFactory(state='CA'),
-            factories.CommitteeFactory(name='Obama'),
-            factories.CommitteeFactory(committee_type='S'),
-            factories.CommitteeFactory(designation='P'),
-            factories.CommitteeFactory(party='DEM'),
-            factories.CommitteeFactory(organization_type='C'),
-            factories.CommitteeFactory(committee_id='C01'),
+            factories.CommitteeFactory(state="CA"),
+            factories.CommitteeFactory(name="Obama"),
+            factories.CommitteeFactory(committee_type="S"),
+            factories.CommitteeFactory(designation="P"),
+            factories.CommitteeFactory(party="DEM"),
+            factories.CommitteeFactory(organization_type="C"),
+            factories.CommitteeFactory(committee_id="C01"),
         ]
 
         # checking one example from each field
         filter_fields = (
-            ('committee_id', ['C01', 'C02']),
-            ('state', ['CA', 'DC']),
-            ('committee_type', 'S'),
-            ('designation', 'P'),
-            ('party', ['REP', 'DEM']),
-            ('organization_type', 'C'),
+            ("committee_id", ["C01", "C02"]),
+            ("state", ["CA", "DC"]),
+            ("committee_type", "S"),
+            ("designation", "P"),
+            ("party", ["REP", "DEM"]),
+            ("organization_type", "C"),
         )
 
         org_response = self._response(api.url_for(CommitteeList))
-        original_count = org_response['pagination']['count']
+        original_count = org_response["pagination"]["count"]
 
         for field, example in filter_fields:
             page = api.url_for(CommitteeList, **{field: example})
@@ -192,13 +192,13 @@ class CommitteeFormatTest(ApiBaseTest):
             self.assertGreater(len(results), 0)
             # doesn't return all results
             response = self._response(page)
-            self.assertGreater(original_count, response['pagination']['count'])
+            self.assertGreater(original_count, response["pagination"]["count"])
 
     def test_committee_year_filter_skips_null_first_file_date(self):
         # Build fixtures
         dates = [
-            datetime.date.fromisoformat('2012-01-01'),
-            datetime.date.fromisoformat('2015-01-01'),
+            datetime.date.fromisoformat("2012-01-01"),
+            datetime.date.fromisoformat("2015-01-01"),
         ]
         [
             factories.CommitteeFactory(first_file_date=None, last_file_date=None),
@@ -213,7 +213,7 @@ class CommitteeFormatTest(ApiBaseTest):
         results = self._results(api.url_for(CommitteeList, year=2013))
         self.assertEqual(len(results), 2)
         for each in results:
-            self.assertIsNotNone(each['first_file_date'])
+            self.assertIsNotNone(each["first_file_date"])
 
     def test_committees_by_cand_id(self):
         committees = [factories.CommitteeFactory() for _ in range(3)]
@@ -231,7 +231,7 @@ class CommitteeFormatTest(ApiBaseTest):
         )
 
         self.assertEqual(
-            set((each['committee_id'] for each in results)),
+            set((each["committee_id"] for each in results)),
             set((each.committee_id for each in committees)),
         )
 
@@ -252,11 +252,11 @@ class CommitteeFormatTest(ApiBaseTest):
         response = self._response(
             api.url_for(CommitteeView, candidate_id=candidate.candidate_id)
         )
-        self.assertEqual(response['pagination']['count'], 1)
-        self.assertEqual(len(response['results']), 1)
+        self.assertEqual(response["pagination"]["count"], 1)
+        self.assertEqual(len(response["results"]), 1)
 
     def test_committee_by_cand_filter(self):
-        committee = factories.CommitteeFactory(designation='P')
+        committee = factories.CommitteeFactory(designation="P")
         candidate = factories.CandidateFactory()
         db.session.flush()
         factories.CandidateCommitteeLinkFactory(
@@ -264,7 +264,7 @@ class CommitteeFormatTest(ApiBaseTest):
         )
         results = self._results(
             api.url_for(
-                CommitteeView, candidate_id=candidate.candidate_id, designation='P'
+                CommitteeView, candidate_id=candidate.candidate_id, designation="P"
             )
         )
         self.assertEqual(1, len(results))
@@ -283,147 +283,152 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_committee_sort(self):
         committees = [
-            factories.CommitteeFactory(designation='B'),
-            factories.CommitteeFactory(designation='U'),
+            factories.CommitteeFactory(designation="B"),
+            factories.CommitteeFactory(designation="U"),
         ]
         committee_ids = [each.committee_id for each in committees]
-        results = self._results(api.url_for(CommitteeList, sort='designation'))
-        self.assertEqual([each['committee_id'] for each in results], committee_ids)
-        results = self._results(api.url_for(CommitteeList, sort='-designation'))
+        results = self._results(api.url_for(CommitteeList, sort="designation"))
+        self.assertEqual([each["committee_id"] for each in results], committee_ids)
+        results = self._results(api.url_for(CommitteeList, sort="-designation"))
         self.assertEqual(
-            [each['committee_id'] for each in results], committee_ids[::-1]
+            [each["committee_id"] for each in results], committee_ids[::-1]
         )
 
     def test_committee_sort_default(self):
         committees = [
-            factories.CommitteeFactory(name='Zartlet for America'),
-            factories.CommitteeFactory(name='Bartlet for America'),
+            factories.CommitteeFactory(name="Zartlet for America"),
+            factories.CommitteeFactory(name="Bartlet for America"),
         ]
         committee_ids = [each.committee_id for each in committees]
         results = self._results(api.url_for(CommitteeList))
         self.assertEqual(
-            [each['committee_id'] for each in results], committee_ids[::-1]
+            [each["committee_id"] for each in results], committee_ids[::-1]
         )
 
     def test_treasurer_filter(self):
         committees = [
             factories.CommitteeFactory(
-                treasurer_text=sa.func.to_tsvector('uncle pennybags')
+                treasurer_text=sa.func.to_tsvector("uncle pennybags")
             ),
             factories.CommitteeFactory(
-                treasurer_text=sa.func.to_tsvector('eve moneypenny')
+                treasurer_text=sa.func.to_tsvector("eve moneypenny")
             ),
         ]
-        results = self._results(api.url_for(CommitteeList, treasurer_name='moneypenny'))
+        results = self._results(api.url_for(CommitteeList, treasurer_name="moneypenny"))
         assert len(results) == 1
-        assert results[0]['committee_id'] == committees[1].committee_id
+        assert results[0]["committee_id"] == committees[1].committee_id
 
     def test_committee_date_filters(self):
         [
             factories.CommitteeFactory(
-                first_file_date=datetime.date.fromisoformat('2015-01-01')
+                first_file_date=datetime.date.fromisoformat("2015-01-01")
             ),
             factories.CommitteeFactory(
-                first_file_date=datetime.date.fromisoformat('2015-02-01')
+                first_file_date=datetime.date.fromisoformat("2015-02-01")
             ),
             factories.CommitteeFactory(
-                first_file_date=datetime.date.fromisoformat('2015-03-01')
+                first_file_date=datetime.date.fromisoformat("2015-03-01")
             ),
             factories.CommitteeFactory(
-                first_file_date=datetime.date.fromisoformat('2015-04-01')
+                first_file_date=datetime.date.fromisoformat("2015-04-01")
             ),
         ]
         results = self._results(
             api.url_for(
                 CommitteeList,
-                min_first_file_date=datetime.date.fromisoformat('2015-02-01'),
+                min_first_file_date=datetime.date.fromisoformat("2015-02-01"),
             )
         )
         self.assertTrue(
             all(
-                each['first_file_date']
-                >= datetime.date.fromisoformat('2015-02-01').isoformat()
+                each["first_file_date"]
+                >= datetime.date.fromisoformat("2015-02-01").isoformat()
                 for each in results
             )
         )
         results = self._results(
             api.url_for(
                 CommitteeList,
-                max_first_file_date=datetime.date.fromisoformat('2015-02-03'),
+                max_first_file_date=datetime.date.fromisoformat("2015-02-03"),
             )
         )
         self.assertTrue(
             all(
-                each['first_file_date']
-                <= datetime.date.fromisoformat('2015-02-03').isoformat()
+                each["first_file_date"]
+                <= datetime.date.fromisoformat("2015-02-03").isoformat()
                 for each in results
             )
         )
         results = self._results(
             api.url_for(
                 CommitteeList,
-                min_first_file_date=datetime.date.fromisoformat('2015-02-01'),
-                max_first_file_date=datetime.date.fromisoformat('2015-03-01'),
+                min_first_file_date=datetime.date.fromisoformat("2015-02-01"),
+                max_first_file_date=datetime.date.fromisoformat("2015-03-01"),
             )
         )
         self.assertTrue(
             all(
-                datetime.date.fromisoformat('2015-02-01').isoformat()
-                <= each['first_file_date']
-                <= datetime.date.fromisoformat('2015-03-01').isoformat()
+                datetime.date.fromisoformat("2015-02-01").isoformat()
+                <= each["first_file_date"]
+                <= datetime.date.fromisoformat("2015-03-01").isoformat()
                 for each in results
             )
         )
 
     def test_filter_by_sponsor_candidate_ids(self):
-        sponsor_candidate_ids1 = ['H001']
-        sponsor_candidate_ids2 = ['S001']
+        sponsor_candidate_ids1 = ["H001"]
+        sponsor_candidate_ids2 = ["S001"]
         factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids1)
         factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids2)
 
         results = self._results(
-            api.url_for(CommitteeList, sponsor_candidate_id='H001')
+            api.url_for(CommitteeList, sponsor_candidate_id="H001")
         )
 
         assert len(results) == 1
-        assert results[0]['sponsor_candidate_ids'] == sponsor_candidate_ids1
+        assert results[0]["sponsor_candidate_ids"] == sponsor_candidate_ids1
 
         results = self._results(
-            api.url_for(CommitteeList, sponsor_candidate_id='-H001')
+            api.url_for(CommitteeList, sponsor_candidate_id="-H001")
         )
         assert len(results) == 1
-        assert results[0]['sponsor_candidate_ids'] == sponsor_candidate_ids2
+        assert results[0]["sponsor_candidate_ids"] == sponsor_candidate_ids2
 
 
+# test these endpoints:
+#  '/committee/<string:committee_id>/history/',
+#  '/committee/<string:committee_id>/history/<int:cycle>/',
+#  '/candidate/<string:candidate_id>/committees/history/',
+#  '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
 class TestCommitteeHistory(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
-        self.committees = [factories.CommitteeDetailFactory() for _ in range(6)]
+        self.committees = [factories.CommitteeDetailFactory() for _ in range(7)]
         self.histories = [
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[0].committee_id,
                 cycle=2010,
-                designation='P',
+                designation="P",
                 is_active=True,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[1].committee_id,
                 cycle=2012,
-                designation='P',
+                designation="P",
                 is_active=True,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
-                designation='P',
+                designation="P",
                 is_active=True,
             ),
             # Candidate PCC converted to PAC in 2016
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2016,
-                designation='P',
+                designation="P",
                 is_active=True,
                 # Needed to show conversion info
                 former_candidate_id=self.candidate.candidate_id,
@@ -433,21 +438,37 @@ class TestCommitteeHistory(ApiBaseTest):
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[3].committee_id,
                 cycle=2014,
-                designation='A',
+                designation="A",
                 is_active=False,
             ),
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
-                designation='J',
+                designation="J",
                 is_active=False,
             ),
+            # test leadership pac with same committees[5], different cycle.
             factories.CommitteeHistoryFactory(
                 committee_id=self.committees[5].committee_id,
-                cycle=2020,
-                designation='D',
+                cycle=2006,
+                committee_type="P",
+                designation="D",
                 is_active=True,
-                sponsor_candidate_ids=['H003']
+            ),
+            # test leadership pac with same committees[5], different cycle.
+            factories.CommitteeHistoryFactory(
+                committee_id=self.committees[5].committee_id,
+                cycle=2008,
+                committee_type="P",
+                designation="D",
+                is_active=True,
+            ),
+            factories.CommitteeHistoryFactory(
+                committee_id=self.committees[6].committee_id,
+                cycle=2020,
+                designation="D",
+                is_active=True,
+                sponsor_candidate_ids=["H003", "H004"]
             ),
         ]
 
@@ -458,37 +479,55 @@ class TestCommitteeHistory(ApiBaseTest):
                 committee_id=self.committees[0].committee_id,
                 fec_election_year=2010,
                 election_yr_to_be_included=2012,
-                committee_type='P',
-                committee_designation='P',
+                committee_type="P",
+                committee_designation="P",
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[1].committee_id,
                 fec_election_year=2012,
                 election_yr_to_be_included=2012,
-                committee_type='P',
-                committee_designation='P',
+                committee_type="P",
+                committee_designation="P",
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[2].committee_id,
                 fec_election_year=2014,
-                committee_type='P',
-                committee_designation='P',
+                committee_type="P",
+                committee_designation="P",
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[3].committee_id,
                 fec_election_year=2014,
-                committee_type='P',
-                committee_designation='A',
+                committee_type="P",
+                committee_designation="A",
             ),
             factories.CandidateCommitteeLinkFactory(
                 candidate_id=self.candidate.candidate_id,
                 committee_id=self.committees[4].committee_id,
                 fec_election_year=2014,
-                committee_type='P',
-                committee_designation='J',
+                committee_type="P",
+                committee_designation="J",
+            ),
+            # test for leadership pac same committees[5], different fec_election_year.
+            factories.CandidateCommitteeAlternateLinkFactory(
+                candidate_id=self.candidate.candidate_id,
+                committee_id=self.committees[5].committee_id,
+                candidate_election_year=2008,
+                fec_election_year=2006,
+                committee_type="P",
+                committee_designation="D",
+            ),
+            # test for leadership pac same committees[5], different fec_election_year.
+            factories.CandidateCommitteeAlternateLinkFactory(
+                candidate_id=self.candidate.candidate_id,
+                committee_id=self.committees[5].committee_id,
+                candidate_election_year=2008,
+                fec_election_year=2008,
+                committee_type="P",
+                committee_designation="D",
             ),
         ]
         self.elections = [
@@ -537,8 +576,8 @@ class TestCommitteeHistory(ApiBaseTest):
             )
         )
         assert len(results) == 1
-        assert results[0]['cycle'] == 2012
-        assert results[0]['committee_id'] == self.committees[1].committee_id
+        assert results[0]["cycle"] == 2012
+        assert results[0]["committee_id"] == self.committees[1].committee_id
 
     def test_election_full(self):
         results = self._results(
@@ -551,21 +590,36 @@ class TestCommitteeHistory(ApiBaseTest):
         )
         assert len(results) == 2
         # Sort order isn't working properly - see #4012
-        assert results[0]['committee_id'] == self.committees[0].committee_id
-        assert results[0]['cycle'] == 2010
-        assert results[1]['committee_id'] == self.committees[1].committee_id
-        assert results[1]['cycle'] == 2012
+        assert results[0]["committee_id"] == self.committees[0].committee_id
+        assert results[0]["cycle"] == 2010
+        assert results[1]["committee_id"] == self.committees[1].committee_id
+        assert results[1]["cycle"] == 2012
 
     def test_designation(self):
         results = self._results(
             api.url_for(
                 CommitteeHistoryView,
                 candidate_id=self.candidate.candidate_id,
-                designation=['P', 'A'],
+                designation=["P", "A"],
             )
         )
         assert len(results) == 4
-        assert 'J' not in [committee.get('designation') for committee in results]
+        assert "J" not in [committee.get("designation") for committee in results]
+
+    def test_ledership_pac_committees(self):
+        results = self._results(
+            api.url_for(
+                CommitteeHistoryView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2008,
+                election_full=True,
+            )
+        )
+        # although there are two committees[5] (dsgn=D)in 2006 and 2008,
+        # candidate_election_year=2008 so the return will
+        # remove the duplicated committee, result = 1
+        assert len(results) == 1
+        assert results[0].get("designation") == "D"
 
     def test_converted_commtitee(self):
         """Where PCC converted to PAC in 2016, still show committee history."""
@@ -588,7 +642,7 @@ class TestCommitteeHistory(ApiBaseTest):
             factories.CommitteeHistoryFactory(
                 committee_id=lower_committee_1.committee_id,
                 cycle=2014,
-                designation='J',
+                designation="J",
                 is_active=False,
             ),
         ]
@@ -598,8 +652,8 @@ class TestCommitteeHistory(ApiBaseTest):
                 candidate_id=lower_candidate.candidate_id,
                 committee_id=lower_committee_1.committee_id,
                 fec_election_year=2014,
-                committee_type='P',
-                committee_designation='J',
+                committee_type="P",
+                committee_designation="J",
             ),
         ]
         [
@@ -637,12 +691,12 @@ class TestCommitteeHistory(ApiBaseTest):
         )
         assert len(results) == 1
 
-    def test_committee_history_fields(self):
+    def test_sponsor_candidate_ids(self):
         result = self._results(
             api.url_for(
                 CommitteeHistoryView,
-                committee_id=self.committees[5].committee_id,
+                committee_id=self.committees[6].committee_id,
             )
         )
         assert len(result) == 1
-        self.assertEqual(result[0]['sponsor_candidate_ids'], ['H003'])
+        self.assertEqual(result[0]["sponsor_candidate_ids"], ["H003", "H004"])

--- a/webservices/common/models/links.py
+++ b/webservices/common/models/links.py
@@ -1,14 +1,50 @@
 from .base import db
+from webservices import docs
 
 
 class CandidateCommitteeLink(db.Model):
-    __tablename__ = 'ofec_cand_cmte_linkage_mv'
+    __tablename__ = "ofec_cand_cmte_linkage_mv"
 
     linkage_id = db.Column(db.Integer, primary_key=True)
-    committee_id = db.Column('cmte_id', db.String, db.ForeignKey('ofec_committee_detail_mv.committee_id'))
-    candidate_id = db.Column('cand_id', db.String, db.ForeignKey('ofec_candidate_detail_mv.candidate_id'))
-    cand_election_year = db.Column('cand_election_yr', db.Integer)
-    fec_election_year = db.Column('fec_election_yr', db.Integer)
-    committee_designation = db.Column('cmte_dsgn', db.String)
-    committee_type = db.Column('cmte_tp', db.String)
-    election_yr_to_be_included = db.Column('election_yr_to_be_included', db.Integer)
+    committee_id = db.Column(
+        "cmte_id",
+        db.String,
+        db.ForeignKey("ofec_committee_detail_mv.committee_id"),
+        doc=docs.COMMITTEE_ID,
+    )
+    candidate_id = db.Column(
+        "cand_id",
+        db.String,
+        db.ForeignKey("ofec_candidate_detail_mv.candidate_id"),
+        doc=docs.CANDIDATE_ID,
+    )
+    cand_election_year = db.Column("cand_election_yr", db.Integer, doc=docs.CANDIDATE_ELECTION_YEARS)
+    fec_election_year = db.Column("fec_election_yr", db.Integer, doc=docs.FEC_CYCLES_IN_ELECTION)
+    committee_designation = db.Column("cmte_dsgn", db.String, doc=docs.DESIGNATION)
+    committee_type = db.Column("cmte_tp", db.String, doc=docs.COMMITTEE_TYPE)
+    election_yr_to_be_included = db.Column("election_yr_to_be_included", db.Integer)
+
+
+# Leadership PAC and sponsor candidate linkage
+class CandidateCommitteeAlternateLink(db.Model):
+    __table_args__ = {"schema": "disclosure"}
+    __tablename__ = "cand_cmte_linkage_alternate"
+
+    sub_id = db.Column(db.Integer, primary_key=True, doc=docs.SUB_ID)
+    candidate_id = db.Column(
+        "cand_id",
+        db.String,
+        db.ForeignKey("ofec_candidate_detail_mv.candidate_id"),
+        doc=docs.CANDIDATE_ID,
+    )
+    candidate_election_year = db.Column("cand_election_yr", db.Integer, doc=docs.CANDIDATE_ELECTION_YEARS)
+    fec_election_year = db.Column("fec_election_yr", db.Integer, doc=docs.FEC_CYCLES_IN_ELECTION)
+    committee_id = db.Column(
+        "cmte_id",
+        db.String,
+        db.ForeignKey("ofec_committee_detail_mv.committee_id"),
+        doc=docs.COMMITTEE_ID,
+    )
+    committee_type = db.Column("cmte_tp", db.String, doc=docs.COMMITTEE_TYPE)
+    committee_designation = db.Column("cmte_dsgn", db.String, doc=docs.DESIGNATION)
+    linkage_type = db.Column(db.String)

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -15,18 +15,20 @@ def filter_year(model, query, years):
         sa.or_(*[
             sa.and_(
                 sa.or_(
-                    sa.extract('year', model.last_file_date) >= year,
+                    sa.extract("year", model.last_file_date) >= year,
                     model.last_file_date == None,
                 ),
-                sa.extract('year', model.first_file_date) <= year,
+                sa.extract("year", model.first_file_date) <= year,
             )
             for year in years
         ])
     )  # noqa
 
 
+# use for this endpoint:(to get committee list)
+#  '/committees/'
 @doc(
-    tags=['committee'],
+    tags=["committee"],
     description=docs.COMMITTEE_LIST,
 )
 class CommitteeList(ApiResource):
@@ -34,28 +36,28 @@ class CommitteeList(ApiResource):
     model = models.Committee
     schema = schemas.CommitteeSchema
     page_schema = schemas.CommitteePageSchema
-    aliases = {'receipts': models.CommitteeSearch.receipts}
+    aliases = {"receipts": models.CommitteeSearch.receipts}
 
     filter_multi_fields = [
-        ('committee_id', models.Committee.committee_id),
-        ('filing_frequency', models.Committee.filing_frequency),
-        ('designation', models.Committee.designation),
-        ('organization_type', models.Committee.organization_type),
-        ('state', models.Committee.state),
-        ('party', models.Committee.party),
-        ('committee_type', models.Committee.committee_type),
+        ("committee_id", models.Committee.committee_id),
+        ("filing_frequency", models.Committee.filing_frequency),
+        ("designation", models.Committee.designation),
+        ("organization_type", models.Committee.organization_type),
+        ("state", models.Committee.state),
+        ("party", models.Committee.party),
+        ("committee_type", models.Committee.committee_type),
     ]
     filter_range_fields = [
-        (('min_first_file_date', 'max_first_file_date'), models.Committee.first_file_date),
-        (('min_last_f1_date', 'max_last_f1_date'), models.Committee.last_f1_date),
+        (("min_first_file_date", "max_first_file_date"), models.Committee.first_file_date),
+        (("min_last_f1_date", "max_last_f1_date"), models.Committee.last_f1_date),
     ]
     filter_fulltext_fields = [
-        ('q', models.CommitteeSearch.fulltxt),
-        ('treasurer_name', models.Committee.treasurer_text),
+        ("q", models.CommitteeSearch.fulltxt),
+        ("treasurer_name", models.Committee.treasurer_text),
     ]
 
     filter_overlap_fields = [
-        ('sponsor_candidate_id', models.Committee.sponsor_candidate_ids),
+        ("sponsor_candidate_id", models.Committee.sponsor_candidate_ids),
     ]
 
     @property
@@ -65,7 +67,7 @@ class CommitteeList(ApiResource):
             args.committee,
             args.committee_list,
             args.make_sort_args(
-                default='name',
+                default="name",
                 validator=args.IndexValidator(
                     models.Committee,
                     extra=list(self.aliases.keys()),
@@ -76,38 +78,41 @@ class CommitteeList(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
 
-        if {'receipts', '-receipts'}.intersection(kwargs.get('sort', [])) and 'q' not in kwargs:
+        if {"receipts", "-receipts"}.intersection(kwargs.get("sort", [])) and "q" not in kwargs:
             raise exceptions.ApiError(
-                'Cannot sort on receipts when parameter "q" is not set',
+                "Cannot sort on receipts when parameter 'q' is not set",
                 status_code=422,
             )
 
-        if kwargs.get('candidate_id'):
+        if kwargs.get("candidate_id"):
             query = query.filter(
-                models.Committee.candidate_ids.overlap(kwargs['candidate_id'])
+                models.Committee.candidate_ids.overlap(kwargs["candidate_id"])
             )
 
-        if kwargs.get('q'):
+        if kwargs.get("q"):
             query = query.join(
                 models.CommitteeSearch,
                 models.Committee.committee_id == models.CommitteeSearch.id,
             ).distinct()
 
-        if kwargs.get('year'):
-            query = filter_year(models.Committee, query, kwargs['year'])
+        if kwargs.get("year"):
+            query = filter_year(models.Committee, query, kwargs["year"])
 
-        if kwargs.get('cycle'):
-            query = query.filter(models.Committee.cycles.overlap(kwargs['cycle']))
+        if kwargs.get("cycle"):
+            query = query.filter(models.Committee.cycles.overlap(kwargs["cycle"]))
 
         return query
 
 
+# use for these endpoints:(return committee detail information)
+#  '/committee/<string:committee_id>/',
+#  '/candidate/<string:candidate_id>/committees/',
 @doc(
-    tags=['committee'],
+    tags=["committee"],
     description=docs.COMMITTEE_DETAIL,
     params={
-        'candidate_id': {'description': docs.CANDIDATE_ID},
-        'committee_id': {'description': docs.COMMITTEE_ID},
+        "candidate_id": {"description": docs.CANDIDATE_ID},
+        "committee_id": {"description": docs.COMMITTEE_ID},
     },
 )
 class CommitteeView(ApiResource):
@@ -117,9 +122,9 @@ class CommitteeView(ApiResource):
     page_schema = schemas.CommitteeDetailPageSchema
 
     filter_multi_fields = [
-        ('designation', models.CommitteeDetail.designation),
-        ('organization_type', models.CommitteeDetail.organization_type),
-        ('committee_type', models.CommitteeDetail.committee_type),
+        ("designation", models.CommitteeDetail.designation),
+        ("organization_type", models.CommitteeDetail.organization_type),
+        ("committee_type", models.CommitteeDetail.committee_type),
     ]
 
     @property
@@ -128,7 +133,7 @@ class CommitteeView(ApiResource):
             args.paging,
             args.committee,
             args.make_sort_args(
-                default='name',
+                default="name",
                 validator=args.IndexValidator(self.model),
             ),
         )
@@ -146,21 +151,27 @@ class CommitteeView(ApiResource):
                 models.CandidateCommitteeLink.candidate_id == candidate_id.upper()
             ).distinct()
 
-        if kwargs.get('year'):
-            query = filter_year(models.CommitteeDetail, query, kwargs['year'])
+        if kwargs.get("year"):
+            query = filter_year(models.CommitteeDetail, query, kwargs["year"])
 
-        if kwargs.get('cycle'):
-            query = query.filter(models.CommitteeDetail.cycles.overlap(kwargs['cycle']))
+        if kwargs.get("cycle"):
+            query = query.filter(models.CommitteeDetail.cycles.overlap(kwargs["cycle"]))
 
         return query
 
+
+# use for these endpoints:(return committee history)
+#  '/committee/<string:committee_id>/history/',
+#  '/committee/<string:committee_id>/history/<int:cycle>/',
+#  '/candidate/<string:candidate_id>/committees/history/',
+#  '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
 @doc(
-    tags=['committee'],
+    tags=["committee"],
     description=docs.COMMITTEE_HISTORY,
     params={
-        'candidate_id': {'description': docs.CANDIDATE_ID},
-        'committee_id': {'description': docs.COMMITTEE_ID},
-        'cycle': {'description': docs.COMMITTEE_CYCLE},
+        "candidate_id": {"description": docs.CANDIDATE_ID},
+        "committee_id": {"description": docs.COMMITTEE_ID},
+        "cycle": {"description": docs.COMMITTEE_CYCLE},
     },
 )
 class CommitteeHistoryView(ApiResource):
@@ -170,7 +181,7 @@ class CommitteeHistoryView(ApiResource):
     page_schema = schemas.CommitteeHistoryPageSchema
 
     filter_multi_fields = [
-        ('designation', models.CommitteeHistory.designation),
+        ("designation", models.CommitteeHistory.designation),
     ]
 
     @property
@@ -179,7 +190,7 @@ class CommitteeHistoryView(ApiResource):
             args.paging,
             args.committee_history,
             args.make_sort_args(
-                default='-cycle',
+                default="-cycle",
                 validator=args.IndexValidator(self.model),
             ),
         )
@@ -193,13 +204,13 @@ class CommitteeHistoryView(ApiResource):
             # '/committee/<string:committee_id>/history/<int:cycle>/',
             query = query.filter(models.CommitteeHistory.committee_id == committee_id.upper())
 
-        if candidate_id:
+        elif candidate_id:
             # use for
             # '/candidate/<candidate_id>/committees/history/',
             # '/candidate/<candidate_id>/committees/history/<int:cycle>/',
-            query_converted = query.filter(models.CommitteeHistory.former_candidate_id == candidate_id.upper())
 
-            query = query.join(
+            # 1) query for regular committees
+            query_regular = query.join(
                 models.CandidateCommitteeLink,
                 sa.and_(
                     models.CandidateCommitteeLink.committee_id == models.CommitteeHistory.committee_id,
@@ -209,37 +220,71 @@ class CommitteeHistoryView(ApiResource):
                 models.CandidateCommitteeLink.candidate_id == candidate_id.upper(),
             )
 
+            # 2) query for PCC to PAC conversion
+            query_pcc_converted = query.filter(models.CommitteeHistory.former_candidate_id == candidate_id.upper())
+
+            # 3) query for Leadership PAC committees
+            query_leadership_pac = query.join(
+                models.CandidateCommitteeAlternateLink,
+                sa.and_(
+                    models.CandidateCommitteeAlternateLink.committee_id == models.CommitteeHistory.committee_id,
+                    models.CandidateCommitteeAlternateLink.fec_election_year == models.CommitteeHistory.cycle,
+                ),
+            ).filter(
+                models.CandidateCommitteeAlternateLink.candidate_id == candidate_id.upper(),
+            )
+
+            # query for election_full=false
+            query = query_regular
         if cycle:
             # use for
-            # '/committee/<string:committee_id>/history/<int:cycle>/',
             # '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
-            if kwargs.get('election_full') and candidate_id:
-                query_regular = query.filter(
+            if kwargs.get("election_full") and candidate_id:
+                # ====build query_regular
+                # When election_full = true, the parameter "cycle" means candidate election year.
+                # to get regular committee(s) we use the value in "election_yr_to_be_included"
+                query_regular = query_regular.filter(
                     models.CandidateCommitteeLink.election_yr_to_be_included == cycle,
                 ).order_by(
                     models.CommitteeHistory.committee_id,
                     sa.desc(models.CommitteeHistory.cycle),
                 ).distinct(
-                    # in same election_yr_to_be_included, remove duplicate committee
+                    # inside one candidate election year (election_yr_to_be_included),
+                    # remove duplicate committee(s), mostly for Presidental and Senate candidate.
                     models.CommitteeHistory.committee_id,
                 )
 
-                query_converted = query_converted.filter(
+                # ====build query_leadership_pac
+                query_leadership_pac = query_leadership_pac.filter(
+                    models.CandidateCommitteeAlternateLink.candidate_election_year == cycle,
+                ).order_by(
+                    models.CommitteeHistory.committee_id,
+                    sa.desc(models.CommitteeHistory.cycle),
+                ).distinct(
+                    # inside one candidate election year,
+                    # remove duplicate committee(s), mostly for Presidental and Senate candidate.
+                    models.CommitteeHistory.committee_id,
+                )
+
+                # ====build query_pcc_converted
+                query_pcc_converted = query_pcc_converted.filter(
                     models.CommitteeHistory.former_candidate_election_year == cycle,
                 ).order_by(
                     models.CommitteeHistory.committee_id,
                     sa.desc(models.CommitteeHistory.cycle),
                 ).distinct(
-                    # in same election_yr_to_be_included, remove duplicate committee
+                    # inside one candidate election year,
+                    # remove duplicate committee(s), mostly for Presidental and Senate candidate.
                     models.CommitteeHistory.committee_id,
                 )
 
-                query = query_regular.union(query_converted).order_by(
+                # union three queries: query_regular + query_leadership_pac + query_pcc_converted
+                query = query_regular.union(query_leadership_pac, query_pcc_converted).order_by(
                     models.CommitteeHistory.committee_id,
                     sa.desc(models.CommitteeHistory.cycle),
                 )
-
             else:
+                # for election_full=false
                 query = query.filter(models.CommitteeHistory.cycle == cycle)
 
         return query


### PR DESCRIPTION
## Summary (required)
To display leadership PAC names on candidate profile page, we need add leadership PACs committee rows in endpoint: /candidate/<string:candidate_id>/committees/history/<int:cycle>/

- Resolves #4738

_Include a summary of proposed changes._
[https://docs.google.com/drawings/d/1eROcEyNgXaKsRC39gQC9AUMfnd2EvYWKGWQqD_T1j9E/edit](https://docs.google.com/drawings/d/1eROcEyNgXaKsRC39gQC9AUMfnd2EvYWKGWQqD_T1j9E/edit)
<img width="700" alt="Screen Shot 2021-01-24 at 11 29 03 PM" src="https://user-images.githubusercontent.com/24395751/105663407-25fc4480-5ea0-11eb-9df2-47f9b2f7f580.png">



## How to test the changes locally
1) checkout branch, point to dev db
2) pytest
3) test / compare example endpoints on both local and prod:
[https://docs.google.com/spreadsheets/d/1cxZ1kFQP72Yi88cfjbJmV5A0s0UYD_jV/edit#gid=758020012](https://docs.google.com/spreadsheets/d/1cxZ1kFQP72Yi88cfjbJmV5A0s0UYD_jV/edit#gid=758020012)

example 1:
local: http://127.0.0.1:5000/v1/candidate/S4AR00103/committees/history/2020/	
prod: https://api.open.fec.gov/v1/candidate/S4AR00103/committees/history/2020?election_full=true&api_key=DEMO_KEY
<img width="587" alt="Screen Shot 2021-01-25 at 12 09 36 AM" src="https://user-images.githubusercontent.com/24395751/105664017-a3748480-5ea1-11eb-9b51-8f6d8ee79152.png">

example 2:
local: http://127.0.0.1:5000/v1/candidate/P00009092/committees/history/2020/
prod: https://api.open.fec.gov/v1/candidate/P00009092/committees/history/2020/?election_full=true&api_key=DEMO_KEY
<img width="780" alt="Screen Shot 2021-01-25 at 10 03 06 AM" src="https://user-images.githubusercontent.com/24395751/105723519-e14ec880-5ef4-11eb-8b21-6da068dc6c9d.png">
	
example 3:
local: http://127.0.0.1:5000/v1/candidate/H0MI08042/committees/history/2014/
prod: https://api.open.fec.gov/v1/candidate/H0MI08042/committees/history/2014/?election_full=true&api_key=DEMO_KEY
<img width="778" alt="Screen Shot 2021-01-25 at 10 03 18 AM" src="https://user-images.githubusercontent.com/24395751/105723846-3ee31500-5ef5-11eb-8cd9-18bf4b3f8b05.png">

example 4:
local: http://127.0.0.1:5000/v1/candidate/P00009183/committees/history/2020/
prod: https://api.open.fec.gov/v1/candidate/P00009183/committees/history/2020/?election_full=true&api_key=DEMO_KEY
<img width="781" alt="Screen Shot 2021-01-25 at 10 03 30 AM" src="https://user-images.githubusercontent.com/24395751/105723957-5ae6b680-5ef5-11eb-859a-62f287289149.png">

example 5:
local: http://127.0.0.1:5000/v1/candidate/H0OH08029/committees/history/2016/
prod: https://api.open.fec.gov/v1/candidate/H0OH08029/committees/history/2016/?election_full=true&api_key=DEMO_KEY
<img width="777" alt="Screen Shot 2021-01-25 at 10 03 46 AM" src="https://user-images.githubusercontent.com/24395751/105724071-7782ee80-5ef5-11eb-9293-cc49e1b10008.png">



-

## Impacted areas of the application
List general components of the application that this PR will affect:
endpoints:
'/candidate/<candidate_id>/committees/history/', '/candidate/<candidate_id>/committees/history/<int:cycle>/',
 
## Reviewer
one backend developer and one database developer

