### PR TITLE
Add new amount filters to debts

### DIFF
--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -49,31 +49,90 @@ class TestScheduleDView(ApiBaseTest):
 
     def test_filter_range(self):
         [
-            factories.ScheduleDViewFactory(load_date=datetime.date(2012, 1, 1)),
-            factories.ScheduleDViewFactory(load_date=datetime.date(2013, 1, 1)),
-            factories.ScheduleDViewFactory(load_date=datetime.date(2014, 1, 1)),
-            factories.ScheduleDViewFactory(load_date=datetime.date(2015, 1, 1)),
+            factories.ScheduleDViewFactory(
+                load_date=datetime.date(2012, 1, 1),
+                amount_incurred_period=1,
+                outstanding_balance_beginning_of_period=1,
+                outstanding_balance_close_of_period=1
+            ),
+            factories.ScheduleDViewFactory(
+                load_date=datetime.date(2013, 1, 1),
+                amount_incurred_period=2,
+                outstanding_balance_beginning_of_period=2,
+                outstanding_balance_close_of_period=2
+            ),
+            factories.ScheduleDViewFactory(
+                load_date=datetime.date(2014, 1, 1),
+                amount_incurred_period=3,
+                outstanding_balance_beginning_of_period=3,
+                outstanding_balance_close_of_period=3
+            ),
+            factories.ScheduleDViewFactory(
+                load_date=datetime.date(2015, 1, 1),
+                amount_incurred_period=4,
+                outstanding_balance_beginning_of_period=3,
+                outstanding_balance_close_of_period=4
+            ),
         ]
+        # load_date min, max
         min_date = datetime.date(2013, 1, 1)
-        results = self._results(api.url_for(ScheduleDView, min_load_date=min_date))
+        results = self._results(api.url_for(ScheduleDView, min_date=min_date))
         self.assertTrue(
-            all(each for each in results if each['load_date'] >= min_date.isoformat())
+            all(
+                each['load_date'] >= min_date.isoformat()
+                for each in results
+            )
         )
         max_date = datetime.date(2014, 1, 1)
-        results = self._results(api.url_for(ScheduleDView, max_load_date=max_date))
+        results = self._results(api.url_for(ScheduleDView, max_date=max_date))
         self.assertTrue(
-            all(each for each in results if each['load_date'] <= max_date.isoformat())
+            all(each['load_date'] <= max_date.isoformat() for each in results)
         )
         results = self._results(
-            api.url_for(ScheduleDView, min_load_date=min_date, max_load_date=max_date)
+            api.url_for(ScheduleDView, min_date=min_date, max_date=max_date)
         )
         self.assertTrue(
             all(
-                each
+                min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
                 for each in results
-                if min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
             )
         )
+        min_amount = 2
+        max_amount = 3
+        filters = [
+            (
+                "amount_incurred_period",
+                "min_amount_incurred",
+                "max_amount_incurred"
+            ),
+            (
+                "outstanding_balance_beginning_of_period",
+                "min_amount_outstanding_beginning",
+                "max_amount_outstanding_beginning"),
+            (
+                "outstanding_balance_close_of_period",
+                "min_amount_outstanding_close",
+                "max_amount_outstanding_close"
+            ),
+        ]
+        for output_field, min_filter, max_filter in filters:
+            results = self._results(api.url_for(ScheduleDView, **{min_filter: min_amount}))
+            self.assertTrue(
+                all(each[output_field] >= min_amount for each in results)
+            )
+            results = self._results(api.url_for(ScheduleDView, **{max_filter: max_amount}))
+            self.assertTrue(
+                all(each[output_field] <= max_amount for each in results)
+            )
+            results = self._results(
+                api.url_for(ScheduleDView, **{min_filter: min_amount, max_filter: max_amount})
+            )
+            self.assertTrue(
+                all(
+                    min_amount <= each[output_field] <= max_amount
+                    for each in results
+                )
+            )
 
     def test_sort_ascending(self):
         [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -682,12 +682,23 @@ schedule_c = {
     'max_incurred_date': fields.Date(missing=None, description=docs.MAX_INCURRED_DATE),
 }
 
-# These arguments will evolve with updated filtering needs
 schedule_d = {
+    'image_number': fields.List(
+        fields.Str,
+        description='The image number of the page where the schedule item is reported',
+    ),
+    'min_image_number': fields.Str(),
+    'max_image_number': fields.Str(),
+    'min_date': fields.Date(description='Minimum load date'),
+    'max_date': fields.Date(description='Maximum load date'),
     'min_payment_period': fields.Float(),
     'max_payment_period': fields.Float(),
     'min_amount_incurred': fields.Float(),
     'max_amount_incurred': fields.Float(),
+    'min_amount_outstanding_beginning': fields.Float(),
+    'max_amount_outstanding_beginning': fields.Float(),
+    'min_amount_outstanding_close': fields.Float(),
+    'max_amount_outstanding_close': fields.Float(),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'creditor_debtor_name': fields.List(fields.Str),
     'nature_of_debt': fields.Str(),

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -31,8 +31,10 @@ class ScheduleDView(ApiResource):
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleD.load_date),
         (('min_payment_period', 'max_payment_period'), models.ScheduleD.payment_period),
-        (('min_amount_incurred_period', 'max_amount_incurred_period'), models.ScheduleD.amount_incurred_period),
+        (('min_amount_incurred', 'max_amount_incurred'), models.ScheduleD.amount_incurred_period),
         (('min_image_number', 'max_image_number'), models.ScheduleD.image_number),
+        (('min_amount_outstanding_beginning', 'max_amount_outstanding_beginning'), models.ScheduleD.outstanding_balance_beginning_of_period),
+        (('min_amount_outstanding_close', 'max_amount_outstanding_close'), models.ScheduleD.outstanding_balance_close_of_period),
     ]
 
     filter_match_fields = [
@@ -46,7 +48,6 @@ class ScheduleDView(ApiResource):
     @property
     def args(self):
         return utils.extend(
-            args.itemized,
             args.schedule_d,
             args.paging,
             args.make_sort_args(


### PR DESCRIPTION
## Summary (required)

Resolves #4755

- Add new filters to debts:
```
min_amount_outstanding_beginning
max_amount_outstanding_beginning
min_amount_outstanding_close
max_amount_outstanding_close
```
- Remove broken filters (formerly using `itemized` in `args.py`, copied over the working ones into `schedule_d` in `args.py`
```
min_amount
max_amount
line_number
```
- Rename `amount_incurred` filters to remove `_period` because including these in all the filters makes the names super long
```
min_amount_incurred_period -> min_amount_incurred
max_amount_incurred_period -> max_amount_incurred
```
- Fix broken tests
This style test will still be true, even if the results have extra items that shouldn't be there:
https://github.com/fecgov/openFEC/blob/ba5e5b62dabf0166d3d309878be727273ece4ef0/tests/test_sched_d.py#L70-L76
Instead of:
```python
        self.assertTrue(
            all(
                each
                for each in results
                if min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
            )
        )
```
we should do:
```python
        self.assertTrue(
            all(
                min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
                for each in results
            )
        )
```

## Reviewers
One backend developer, and @rfultz to make sure it has what you need please

## How to test the changes locally

- Deploy this branch to dev, or:
- Run this branch
- Test the new filters:
- http://localhost:5000/v1/schedules/schedule_d/?sort_null_only=false&sort=load_date&sort_hide_null=false&page=1&per_page=20&sort_nulls_last=false&min_amount_outstanding_beginning=1&max_amount_outstanding_beginning=200
http://localhost:5000/v1/schedules/schedule_d/?sort_null_only=false&sort=load_date&sort_hide_null=false&page=1&per_page=20&sort_nulls_last=false&min_amount_outstanding_close=1&max_amount_outstanding_close=200

## Impacted areas of the application
List general components of the application that this PR will affect:

-  New debt datatable

## Related PRs
New debt datable: https://github.com/fecgov/fec-cms/pull/4353