### PR TITLE
4744-show-entity-names-for-individual-types

### DIFF
--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -101,6 +101,34 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         )
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
+    def test_ao_with_entity_individual(self, get_bucket):
+        expected_entity = {
+            "role": "Commenter",
+            "name": "Mr Dan Becker MD",
+            "type": "Individual",
+        }
+        expected_ao = {
+            "type": "advisory_opinions",
+            "no": "2017-01",
+            "name": "An AO name",
+            "summary": "An AO summary",
+            "request_date": datetime.date(2016, 6, 10),
+            "issue_date": datetime.date(2016, 12, 15),
+            "documents": [],
+            "requestor_names": [],
+            "requestor_types": [],
+            "entities": [expected_entity],
+        }
+        self.create_ao(1, expected_ao)
+        self.create_entity_individual(1, 123, "", 15, 2, "Mr", "Dan", "Becker", "MD")
+
+        actual_ao = next(get_advisory_opinions(None))
+        assert actual_ao["entities"] == [
+            {"role": "Commenter",
+            "name": "Mr Dan Becker MD",
+            "type": "Individual"}]
+
+    @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     def test_completed_ao_with_docs(self, get_bucket):
         ao_no = "2017-01"
         filename = "Some File.pdf"
@@ -377,6 +405,32 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             INSERT INTO aouser.entity
             (entity_id, name, type)
             VALUES (%s, %s, %s)""",
+            entity_id,
+            requestor_name,
+            entity_type_id,
+        )
+        self.connection.execute(
+            """
+            INSERT INTO aouser.players
+            (player_id, ao_id, entity_id, role_id)
+            VALUES (%s, %s, %s, %s)""",
+            entity_id,
+            ao_id,
+            entity_id,
+            role_id,
+        )
+
+    def create_entity_individual(self, ao_id, entity_id, requestor_name,
+            entity_type_id, role_id, prefix, first_name, last_name, suffix):
+        self.connection.execute(
+            """
+            INSERT INTO aouser.entity
+            (prefix, first_name, last_name, suffix, entity_id, name, type)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+            prefix,
+            first_name,
+            last_name,
+            suffix,
             entity_id,
             requestor_name,
             entity_type_id,

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -219,7 +219,7 @@ def get_entities(ao_id):
                 entities.append(
                     {
                         "role": row["role_description"],
-                        "name": row["prefix"] + "" + row["firstname"] + " " + row["lastname"] + " " + row["suffix"],
+                        "name": row["prefix"] + " " + row["firstname"] + " " + row["lastname"] + " " + row["suffix"],
                         "type": row["entity_type_description"],
                     }
                 )

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -41,6 +41,10 @@ ALL_AOS = """
 
 AO_ENTITIES = """
     SELECT
+        e.prefix AS prefix,
+        e.first_name AS firstname,
+        e.last_name AS lastname,
+        e.suffix AS suffix,
         e.name,
         et.description AS entity_type_description,
         r.description AS role_description
@@ -203,19 +207,34 @@ def get_entities(ao_id):
         rs = conn.execute(AO_ENTITIES, ao_id)
         for row in rs:
             if row["role_description"] == "Requestor":
+                print ("Inside Requestor if block...")
                 requestor_names.append(row["name"])
                 requestor_types.add(row["entity_type_description"])
             elif row["role_description"] == "Commenter":
+                print ("Inside Commenter if block...")
                 commenter_names.append(row["name"])
             elif row["role_description"] == "Counsel/Representative":
                 representative_names.append(row["name"])
-            entities.append(
-                {
-                    "role": row["role_description"],
-                    "name": row["name"],
-                    "type": row["entity_type_description"],
-                }
-            )
+
+            # For Individual entity types the name column is empty. In legacy
+            # system for individual types,  name is population by combining
+            # prefix, firstname, lastname and suffix.
+            if row["entity_type_description"] == "Individual":
+                entities.append(
+                    {
+                        "role": row["role_description"],
+                        "name": row["prefix"] + "" + row["firstname"] + " " + row["lastname"] + " " + row["suffix"],
+                        "type": row["entity_type_description"],
+                    }
+                )
+            else:
+                entities.append(
+                    {
+                        "role": row["role_description"],
+                        "name": row["name"],
+                        "type": row["entity_type_description"],
+                    }
+                )
     return (
         requestor_names,
         list(requestor_types),

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -207,17 +207,13 @@ def get_entities(ao_id):
         rs = conn.execute(AO_ENTITIES, ao_id)
         for row in rs:
             if row["role_description"] == "Requestor":
-                print ("Inside Requestor if block...")
                 requestor_names.append(row["name"])
                 requestor_types.add(row["entity_type_description"])
             elif row["role_description"] == "Commenter":
-                print ("Inside Commenter if block...")
                 commenter_names.append(row["name"])
             elif row["role_description"] == "Counsel/Representative":
                 representative_names.append(row["name"])
-
-            # For Individual entity types the name column is empty. In legacy
-            # system for individual types,  name is population by combining
+            # For entity type "individual" populate the name column by combining
             # prefix, firstname, lastname and suffix.
             if row["entity_type_description"] == "Individual":
                 entities.append(


### PR DESCRIPTION
## Summary (required)

In entity table, `name` for a individual  type could be empty . In such scenario, the `name`  is populated by concatenating the prefix, first & last names and suffix. 

- Resolves #4744 

## Reviewers
One developer required, @patphongs  is optional. 
(@patphongs i am not sure if you have ES setup on your local, that's why i put you as optional. if you have the setup already, please feel free to test this PR)

_Include a summary of proposed changes._
**In advisory_opinions.py:** 
- Update the AO_ENTITIES SQL to include the prefix, firstname, lastname and suffix columns. 
- Add logic to populate the name column for individual entity type. 

**Add  test_advisory_opinions.py :**
- Add a test case for individual entity type.
## Screenshots:

**Production (Before fix):**
<img width="1126" alt="Screen Shot 2021-02-08 at 9 59 26 AM" src="https://user-images.githubusercontent.com/11650355/107237719-09f6b800-69f5-11eb-9303-e3c10e698829.png">

**Local (After fix):**
<img width="1139" alt="Screen Shot 2021-02-08 at 9 59 15 AM" src="https://user-images.githubusercontent.com/11650355/107237717-095e2180-69f5-11eb-8d8c-3f070cb18282.png">

## How to test the changes locally

- checkout branch:  `feature/4744-show-entity-names-for-individual-types`
- run local elasticsearch service: [follow local ES service setup instructions ](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally)
- load ao 2020-03 onto your local elasticsearch service: run `python manage.py load_advisory_opinions -f 2020-03`
- Under entities section, `name` for the individual type shows now:  `http://localhost:9200/docs/_doc/2020-03` 

<img width="616" alt="Screen Shot 2021-02-08 at 9 26 57 AM" src="https://user-images.githubusercontent.com/11650355/107233123-3956f600-69f0-11eb-96a6-84b2d28b957e.png">

-  **Before fix (In Production)**:
<img width="647" alt="Screen Shot 2021-02-08 at 9 22 45 AM" src="https://user-images.githubusercontent.com/11650355/107234842-188fa000-69f2-11eb-8f38-5c1c63f58938.png">


## Impacted areas of the application
List general components of the application that this PR will affect:

-  Legal Search/ Advisory Opinions
