### PR TITLE
fix-ao-data-load-issue

### DIFF
--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -129,6 +129,35 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "type": "Individual"}]
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
+    def test_ao_with_null_values_entity_individual(self, get_bucket):
+        expected_entity = {
+            "role": "Commenter",
+            "name": "Tom Dolan",
+            "type": "Individual",
+        }
+        expected_ao = {
+            "type": "advisory_opinions",
+            "no": "2020-01",
+            "name": "An AO name",
+            "summary": "An AO summary",
+            "request_date": datetime.date(2016, 6, 10),
+            "issue_date": datetime.date(2016, 12, 15),
+            "documents": [],
+            "requestor_names": [],
+            "requestor_types": [],
+            "entities": [expected_entity],
+        }
+        self.create_ao(2, expected_ao)
+        # create an individual entity by passing None in prefix and suffix columns
+        self.create_entity_individual(2, 456, "", 15, 2, None, "Tom", "Dolan", None)
+
+        actual_ao = next(get_advisory_opinions(None))
+        assert actual_ao["entities"] == [
+            {"role": "Commenter",
+            "name": " Tom Dolan ",
+            "type": "Individual"}]
+
+    @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     def test_completed_ao_with_docs(self, get_bucket):
         ao_no = "2017-01"
         filename = "Some File.pdf"

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -41,10 +41,10 @@ ALL_AOS = """
 
 AO_ENTITIES = """
     SELECT
-        e.prefix AS prefix,
-        e.first_name AS firstname,
-        e.last_name AS lastname,
-        e.suffix AS suffix,
+        COALESCE(e.prefix,'') AS prefix,
+        COALESCE(e.first_name,'') AS firstname,
+        COALESCE(e.last_name,'') AS lastname,
+        COALESCE(e.suffix,'') AS suffix,
         e.name,
         et.description AS entity_type_description,
         r.description AS role_description


### PR DESCRIPTION
## Summary (required)

Data reload tasks are failing - `python manage.py load_advisory_opinions` or `cf run-task api --command "python manage.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data` due to NULL values in prefix, suffix and firstname columns in the entity table. 
Use the COALESCE function and check for empty or null values on prefix, suffix, first and lastname columns on the entity table and replace with an empty string if found any. 

- ~Resolves~ Related #4443 

_Include a summary of proposed changes._

- In advisory_opinons.py,  AO_ENTITIES SQL:  check for empty or null values on prefix, suffix, first and lastname columns and replace with an empty string if found any.
- Add a test case with empty/null values in the prefix,suffix columns for individual enitity.

## How to test the changes locally

- checkout branch `feature/fix-ao-individual-entity-data-load-issue`
- export `$SQLA_CONN` to point to Dev DB
-  load AO's onto local elasticsearch service : run `python manage.py load_advisory_opinions` or `python manage.py load_advisory_opinions -f 1975-05` (Dont have to load all the AO's. Quit the process in the middle)
- Ex 1: 1975-05 (suffix is NULL)
- Ex 2: 2014-02 (prefix, suffix and firstname is NULL)
- What to expect: AO's should load onto local elasticsearch service without any errors in the terminal
- **Before the fix:** AO's reload task fails with an error. Screenshot attached below:
<img width="1274" alt="Screen Shot 2021-02-12 at 5 47 00 AM" src="https://user-images.githubusercontent.com/11650355/107759099-d3bb8000-6cf5-11eb-9d26-23114ed203d6.png">

- **After the fix**: AO's reload task run OK without any errors. Screenshot attached below:
<img width="1268" alt="Screen Shot 2021-02-12 at 5 47 33 AM" src="https://user-images.githubusercontent.com/11650355/107759124-d8803400-6cf5-11eb-8c30-aff36e868e7a.png">

## Impacted areas of the application
-  Legal Search/Advisory_Opinions
-  Data reload tasks are failing - `python manage.py load_advisory_opinions` or `cf run-task api --command "python manage.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data`
## Related PRs
#4760 
