### PR TITLE
4766 bump lodash 4.17.20 > 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5057,9 +5057,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._arraypool": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.11",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "prettier": "^1.12.1",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^0.21.0",


### PR DESCRIPTION
## Summary

- Resolves #4766 

## Reviewers

Feel free to add/remove

## Impacted areas of the application

Bumped the version of lodash from 4.17.20 to 4.17.21, just a patch-level change

## Screenshots

None

## Related PRs

None

## How to test

- pull branch
- `npm i`
- `npm run build` will tell us if lodash failed as a devDependency
- `./manage.py runserver`
- [localhost](http://127.0.0.1:5000/) should work as expected
- Looking at the release notes for lodash, it looks like only `trim()` and `baseTrim()` were affected and they were used by `isNumber()`. It doesn't looks like swagger-tools is using any of the three


____
