### PR TITLE
Add bulk schedule A data dump information to API documentation

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -754,11 +754,10 @@ If you are interested in our "is_individual" methodology visit
 our [methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/).\n
 
 
-Schedule A is also available as a database dump file, updated weekly on Sunday.
-We cannot provide help with restoring these database dump files.
-You can refer to this community led [group](https://groups.google.com/forum/#!forum/fec-data) for discussion.
-Those files are here: https://www.fec.gov/files/bulk-downloads/index.html?prefix=bulk-downloads/data-dump/schedules/.
-The instructions are here: https://www.fec.gov/files//bulk-downloads/data-dump/schedules/README.txt
+Schedule A is also available as a database dump file that is updated weekly on Sunday.
+The database dump files are here: https://www.fec.gov/files/bulk-downloads/index.html?prefix=bulk-downloads/data-dump/schedules/.
+The instructions are here: https://www.fec.gov/files//bulk-downloads/data-dump/schedules/README.txt.
+We cannot provide help with restoring the database dump files, but you can refer to this community led [group](https://groups.google.com/forum/#!forum/fec-data) for discussion.
 '''
 
 SCHEDULE_A = '''

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -748,8 +748,17 @@ SCHEDULE_A_TAG = '''
 This collection of endpoints includes Schedule A records reported by a committee. \
 Schedule A records describe itemized receipts, including contributions from individuals. \
 If you are interested in contributions from individuals, use the /schedules/schedule_a/ endpoint. \
-For a more complete description of all Schedule A records visit [About receipts data](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/). \
-If you are interested in our "is_individual" methodology visit our [methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/).
+For a more complete description of all Schedule A records visit
+[About receipts data](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/). \
+If you are interested in our "is_individual" methodology visit
+our [methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/).\n
+
+
+Schedule A is also available as a database dump file, updated weekly on Sunday.
+We cannot provide help with restoring these database dump files.
+You can refer to this community led [group](https://groups.google.com/forum/#!forum/fec-data) for discussion.
+Those files are here: https://www.fec.gov/files/bulk-downloads/index.html?prefix=bulk-downloads/data-dump/schedules/.
+The instructions are here: https://www.fec.gov/files//bulk-downloads/data-dump/schedules/README.txt
 '''
 
 SCHEDULE_A = '''


### PR DESCRIPTION
## Summary (required)

- Resolves #4772

-  Add bulk schedule A data dump information to the API documentation

## How to test the changes locally
- Bulk schedule A data dump information has been added to the "receipts" section on API swagger page

**Before:**
<img width="1223" alt="Screen Shot 2021-03-02 at 4 00 38 PM" src="https://user-images.githubusercontent.com/24396726/109714769-cf55ea80-7b70-11eb-9c54-35a16295fea0.png">


**After:**
<img width="1298" alt="Screen Shot 2021-03-05 at 10 40 51 AM" src="https://user-images.githubusercontent.com/24396726/110137941-6902df00-7d9f-11eb-8d4c-54f647022abc.png">



Or Download feature branch and ran api on local to see the change: http://127.0.0.1:5000/developers/#/receipts

