### PR TITLE
Use `UNION ALL` subqueries for 2-year-transaction-period for Schedules A and B

### DIFF
--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -425,11 +425,12 @@ class TriggerTestCase(common.BaseTestCase):
                 'contbr_employer': n,
                 'sub_id': 9999999959999999980 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_a "
-                + "(contbr_employer, sub_id, filing_form) "
-                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s)"
+                + "(contbr_employer, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(contbr_employer)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
@@ -466,18 +467,18 @@ class TriggerTestCase(common.BaseTestCase):
                 'recipient_nm': n,
                 'sub_id': 9999999999995699990 + i,
                 'filing_form': 'F3',
+                'two_year_transaction_period': 2020,
             }
             insert = (
                 "INSERT INTO disclosure.fec_fitem_sched_b "
-                + "(recipient_nm, sub_id, filing_form) "
-                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s)"
+                + "(recipient_nm, sub_id, filing_form, two_year_transaction_period) "
+                + " VALUES (%(recipient_nm)s, %(sub_id)s, %(filing_form)s, %(two_year_transaction_period)s)"
             )
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
         results = self._results(
             api.url_for(ScheduleBView, contributor_employer='ést-lou')
         )
-        print('results = ', results)
         contbr_employer_list = {r['recipient_name'] for r in results}
         assert names.issubset(contbr_employer_list)
         results = self._results(

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -238,6 +238,12 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_schedule_a_missing_secondary_index(self):
+        response = self.app.get(
+            api.url_for(ScheduleAView, contributor_state='WY')
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_schedule_a_recipient_committee_type_filter(self):
         [
             factories.ScheduleAFactory(recipient_committee_type='S'),

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -99,6 +99,82 @@ class TestScheduleA(ApiBaseTest):
         )
         self.assertEqual(len(response['results']), 2)
 
+    def test_schedule_a_multiple_cmte_id_and_two_year_transaction_period(self):
+        """
+        testing schedule_a api can take multiple cycles now
+        """
+        receipts = [  # noqa
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C001',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C002',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2014,
+                contribution_receipt_date=datetime.date(2014, 1, 1),
+                two_year_transaction_period=2014,
+                committee_id='C003',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2016,
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                committee_id='C003',
+            ),
+            factories.ScheduleAFactory(
+                report_year=2018,
+                contribution_receipt_date=datetime.date(2018, 1, 1),
+                two_year_transaction_period=2018,
+                committee_id='C003',
+            ),
+        ]
+        response = self._response(
+            api.url_for(
+                ScheduleAView,
+                two_year_transaction_period=[2016, 2018],
+                committee_id=['C001', 'C002'],
+            )
+        )
+        self.assertEqual(len(response['results']), 4)
+        response = self._response(
+            api.url_for(
+                ScheduleAView,
+                committee_id='C001',
+            )
+        )
+        self.assertEqual(len(response['results']), 3)
+
     def test_schedule_a_two_year_transaction_period_limits_results_per_cycle(self):
         receipts = [  # noqa
             factories.ScheduleAFactory(

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -86,6 +86,10 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
+    union_all_fields = [
+        'committee_id',
+        'two_year_transaction_period',
+    ]
     use_pk_for_count = True
 
     @property

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -90,6 +90,16 @@ class ScheduleAView(ItemizedResource):
         'committee_id',
         'two_year_transaction_period',
     ]
+    secondary_index_options = [
+        'committee_id',
+        'contributor_id',
+        'contributor_name',
+        'contributor_city',
+        'contributor_zip',
+        'contributor_employer',
+        'contributor_occupation',
+        'image_number',
+    ]
     use_pk_for_count = True
 
     @property
@@ -106,28 +116,6 @@ class ScheduleAView(ItemizedResource):
         )
 
     def build_query(self, **kwargs):
-        secondary_index_options = [
-            'committee_id',
-            'contributor_id',
-            'contributor_name',
-            'contributor_city',
-            'contributor_zip',
-            'contributor_employer',
-            'contributor_occupation',
-            'image_number',
-        ]
-        two_year_transaction_periods = set(
-            kwargs.get('two_year_transaction_period', [])
-        )
-        if len(two_year_transaction_periods) != 1:
-            if not any(kwargs.get(field) for field in secondary_index_options):
-                raise exceptions.ApiError(
-                    "Please choose a single `two_year_transaction_period` or "
-                    "add one of the following filters to your query: `{}`".format(
-                        "`, `".join(secondary_index_options)
-                    ),
-                    status_code=400,
-                )
         query = super().build_query(**kwargs)
         query = filters.filter_contributor_type(query, self.model.entity_type, kwargs)
         zip_list = []

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -65,6 +65,10 @@ class ScheduleBView(ItemizedResource):
         'recipient_city',
     ]
     use_pk_for_count = True
+    query_options = [
+        sa.orm.joinedload(models.ScheduleB.committee),
+        sa.orm.joinedload(models.ScheduleB.recipient_committee),
+    ]
 
     @property
     def args(self):
@@ -78,9 +82,6 @@ class ScheduleBView(ItemizedResource):
 
     def build_query(self, **kwargs):
         query = super(ScheduleBView, self).build_query(**kwargs)
-        query = query.options(sa.orm.joinedload(models.ScheduleB.committee))
-        query = query.options(
-            sa.orm.joinedload(models.ScheduleB.recipient_committee))
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -64,6 +64,10 @@ class ScheduleBView(ItemizedResource):
         'recipient_name',
         'recipient_city',
     ]
+    union_all_fields = [
+        'committee_id',
+        'two_year_transaction_period',
+    ]
     use_pk_for_count = True
     query_options = [
         sa.orm.joinedload(models.ScheduleB.committee),

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -67,8 +67,10 @@ class ScheduleEView(ItemizedResource):
         'committee_id',
         'candidate_id',
     ]
+    union_all_fields = [
+        'committee_id'
+    ]
     use_pk_for_count = True
-
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),
         sa.orm.joinedload(models.ScheduleE.committee),


### PR DESCRIPTION
## Summary (required)

- Resolves #4414 and resolves #4740: Use `UNION ALL` subqueries for either committee ID **or** two-year-transaction period for Schedules A & B

The `union_all_field` values are checked in the order they're specified in the resource file. The first `union_all_field` encountered is used to keep the number of subqueries manageable.

Example: For schedule A and B, if 1 or 0 committee ID's are passed to the query and more than one two-year transaction period is being searched, use `UNION ALL` the same way we currently do for multiple committeeIDs. Because we're only doing `UNION ALL` for either committee ID **or** two-year-transaction period, the most subqueries we would ever have is 10 committee IDs OR ~26 two-year-transaction-periods. The required secondary index for multiple two-year transaction periods should help keep the cost of these queries down. 

**To remove this feature** all you need to do is remove `two_year_transaction_period` from Schedule A and B's `union_all_fields` list.

## How to test the changes locally

- Run some test Sch A and B queries with:
- 1 or fewer committee ID
- either no 2-year period specified or more than one 2-year period specified
Examples: https://docs.google.com/spreadsheets/d/1rkVnmuMUzlBCgOE3ZsCDJC7AqXWI2VOhC57RvJcdasI/edit#gid=0
- Print out the query on line 94 https://github.com/fecgov/openFEC/blob/5892c7be3116736e0da4e5045e90bdb2c431e362/webservices/common/views.py#L93-L94
Print literal query:
```python
        from sqlalchemy.dialects import postgresql
        print(str(query.statement.compile(
            dialect=postgresql.dialect(),
            compile_kwargs={"literal_binds": True})))
```
- Note that subqueries are generated for 2-year period
- Comment out two year period from `union_all_fields`, example
- https://github.com/fecgov/openFEC/blob/5892c7be3116736e0da4e5045e90bdb2c431e362/webservices/resources/sched_a.py#L89-L92
- Run your query again, note that "traditional" `IN` logic is used.
**Optional** 
Run `EXPLAIN ANALYZE` on the "before" and "after" versions

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Schedule A and B queries across more than one 2-year period and with 1 or fewer committee IDs


