### PR TITLE
[Merge to release] Remove 2-year-transaction period from UNION ALL fields

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -88,7 +88,6 @@ class ScheduleAView(ItemizedResource):
     ]
     union_all_fields = [
         'committee_id',
-        'two_year_transaction_period',
     ]
     secondary_index_options = [
         'committee_id',

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -66,7 +66,6 @@ class ScheduleBView(ItemizedResource):
     ]
     union_all_fields = [
         'committee_id',
-        'two_year_transaction_period',
     ]
     use_pk_for_count = True
     query_options = [


### PR DESCRIPTION
## Summary (required)

- Resolves #4820

Remove 2-year-transaction period from UNION ALL fields

### Required reviewers

@dzhang-fec and @fec-jli please

## Impacted areas of the application

General components of the application that this PR will affect:

-  Schedule A and B query logic

## Related PRs

#4802

## How to test

See #4802 - this effectively reverts that change but keeps code improvements and automated tests

## System architecture updates (if applicable)

None
