### PR TITLE
Modify report_pdf_url_or_null to generate image links

### DIFF
--- a/data/migrations/V0223__update_report_pdf_url_or_null.sql
+++ b/data/migrations/V0223__update_report_pdf_url_or_null.sql
@@ -1,0 +1,29 @@
+/*
+This migration file is for #4821
+Modify function: report_pdf_url_or_null to include more historic records
+*/
+
+--
+-- Name: report_pdf_url_or_null(text, numeric, text, text,  text); 
+-- Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_pdf_url_or_null(image_number text, report_year numeric, committee_type text, cand_id text, form_type text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+begin
+    return case
+        when image_number is not null and (
+             report_year >= 2000 or
+             (committee_type not in ('S','H') and report_year >= 1993) or
+             (committee_type = 'H' and report_year >= 1996) or
+             (form_type = 'F2' and substr(cand_id,1,1) = 'H' and report_year >= 1996) or
+             (form_type = 'F2' and substr(cand_id,1,1) = 'P' and report_year >= 1993) 
+        ) then report_pdf_url(image_number)
+        else null
+        end;
+end
+$$;
+
+
+ALTER FUNCTION public.report_pdf_url_or_null(text, numeric, text, text, text) OWNER TO fec;

--- a/data/migrations/V0224__ofec_filings_all_mv_pdfurl.sql
+++ b/data/migrations/V0224__ofec_filings_all_mv_pdfurl.sql
@@ -1,0 +1,255 @@
+/*
+This is migration is for issue #4821
+Because function report_pdf_url_or_null(text, numeric, text, text, text) has been refactored,
+this mv needs to be refactored too
+*/
+-- ----------
+-- ofec_filings_all_mv_tmp
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp 
+AS
+SELECT row_number() OVER () AS idx,
+    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	END AS candidate_id,
+	cand.name AS candidate_name,
+    filing_history.cand_cmte_id AS committee_id,
+    com.name AS committee_name,
+    filing_history.sub_id,
+    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+    filing_history.election_yr AS election_year,
+    filing_history.form_tp AS form_type,
+    filing_history.rpt_yr AS report_year,
+    get_cycle(filing_history.rpt_yr) AS cycle,
+    filing_history.rpt_tp AS report_type,
+    filing_history.to_from_ind AS document_type,
+    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+    filing_history.begin_image_num::bigint AS beginning_image_number,
+    filing_history.end_image_num AS ending_image_number,
+    filing_history.pages,
+    filing_history.ttl_receipts AS total_receipts,
+    filing_history.ttl_indt_contb AS total_individual_contributions,
+    filing_history.net_dons AS net_donations,
+    filing_history.ttl_disb AS total_disbursements,
+    filing_history.ttl_indt_exp AS total_independent_expenditures,
+    filing_history.ttl_communication_cost AS total_communication_cost,
+    filing_history.coh_bop AS cash_on_hand_beginning_period,
+    filing_history.coh_cop AS cash_on_hand_end_period,
+    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+    filing_history.hse_pers_funds_amt AS house_personal_funds,
+    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+    filing_history.tres_nm AS treasurer_name,
+    filing_history.file_num AS file_number,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	END AS previous_file_number,
+	report.rpt_tp_desc AS report_type_full,
+	filing_history.rpt_pgi AS primary_general_indicator,
+	filing_history.request_tp AS request_type,
+	filing_history.amndt_ind AS amendment_indicator,
+	filing_history.lst_updt_dt AS update_date,
+	report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.cand_cmte_id::text, filing_history.form_tp::text) AS pdf_url,
+	means_filed(filing_history.begin_image_num::text) AS means_filed,
+	report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	amendments.amendment_chain,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	END AS most_recent_file_number,
+	is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+	    	CASE 
+				WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+	    	CASE 
+				WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	END AS most_recent,
+	CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	END AS amendment_version,
+	cand.state,
+	cand.office,
+	cand.district,
+	cand.party,
+	cmte_valid_fec_yr.cmte_tp,
+	get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	END AS form_category,
+	cb.bank_depository_nm,
+    cb.bank_depository_st1,
+    cb.bank_depository_st2,
+    cb.bank_depository_city,
+    cb.bank_depository_st,
+    cb.bank_depository_zip,
+    cb.additional_bank_names
+FROM disclosure.f_rpt_or_form_sub filing_history
+LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+LEFT JOIN ofec_committee_bank_vw cb ON filing_history.sub_id = cb.sub_id
+WHERE filing_history.rpt_yr >= 1979::numeric AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+WITH DATA;
+
+
+
+ALTER TABLE public.ofec_filings_all_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (idx);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (amendment_indicator);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (beginning_image_number);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (candidate_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_end_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_start_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle, committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (district );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office_cmte_tp );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (party );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (primary_general_indicator );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (receipt_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (request_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type_full );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_year);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_disbursements);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_independent_expenditures);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_receipts);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (state );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_category);  
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+-- drop old MV
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;
+
+-- Drop old function
+DROP FUNCTION public.report_pdf_url_or_null(text, numeric, text, text);

--- a/tests/integration/test_filings.py
+++ b/tests/integration/test_filings.py
@@ -1,0 +1,152 @@
+import pytest
+import codecs
+import json
+
+import manage
+from tests.common import BaseTestCase
+from webservices import rest, __API_VERSION__
+from webservices.resources.filings import FilingsView, FilingsList
+
+
+@pytest.mark.usefixtures("migrate_db")
+class TestFilings(BaseTestCase):
+
+    committee = {
+        'valid_fec_yr_id': 1,
+        'committee_id': 'C001',
+        'fec_election_yr': 1996,
+        'committee_type': 'H',
+        'date_entered': 'now()',
+    }
+
+    FIRST_FILING = {
+        'cand_cmte_id': 'C001',
+        'report_year': 1996,
+        'form_type': 'F1',
+        'begin_image_num': '95039770818',
+        'pdf_url': 'https://docquery.fec.gov/pdf/818/95039770818/95039770818.pdf'
+    }
+
+    SECOND_FILING = {
+        'cand_cmte_id': 'P001',
+        'report_year': 1994,
+        'form_type': 'F2',
+        'begin_image_num': '95030061615',
+        'pdf_url': 'https://docquery.fec.gov/pdf/615/95030061615/95030061615.pdf'
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.longMessage = True
+        self.maxDiff = None
+        self.request_context = rest.app.test_request_context()
+        self.request_context.push()
+        self.connection = rest.db.engine.connect()
+
+    def tearDown(self):
+        rest.db.session.remove()
+        self.request_context.pop()
+        self.clear_test_data()
+        super().tearDown()
+
+    # _response and _results from APIBaseCase
+    def _response(self, qry):
+        response = self.app.get(qry)
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(codecs.decode(response.data))
+        self.assertNotEqual(result, [], "Empty response!")
+        self.assertEqual(result['api_version'], __API_VERSION__)
+        return result
+
+    def _results(self, qry):
+        response = self._response(qry)
+        return response['results']
+
+    def test_f1_pdf_url(self):
+        expected_filing = self.FIRST_FILING
+        self.insert_committee(self.committee)
+        self.insert_filing(100, expected_filing)
+
+        # Refresh `ofec_filings_all_mv`
+        manage.refresh_materialized(concurrent=False)
+
+        # FilingsList view
+        # /filings/ endpoint
+        results = self._results(
+            rest.api.url_for(FilingsList, committee_id=expected_filing['cand_cmte_id'])
+        )
+        assert len(results) == 1
+        list_result = results[0]
+
+        self.assert_filings_equal(list_result, expected_filing)
+
+        # FilingsView view
+        # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
+        results = self._results(
+            rest.api.url_for(FilingsView, committee_id=expected_filing['cand_cmte_id'])
+        )
+        assert len(results) == 1
+        view_result = results[0]
+
+        self.assert_filings_equal(view_result, expected_filing)
+
+    def test_f2_pdf_url(self):
+        expected_filing = self.SECOND_FILING
+        self.insert_filing(101, expected_filing)
+
+        # Refresh `ofec_filings_all_mv`
+        manage.refresh_materialized(concurrent=False)
+
+        # FilingsList view
+        # /filings/ endpoint
+        results = self._results(
+            rest.api.url_for(FilingsList, candidate_id=expected_filing['cand_cmte_id'])
+        )
+        assert len(results) == 1
+        list_result = results[0]
+
+        self.assert_filings_equal(list_result, expected_filing)
+
+        # FilingsView view
+        # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
+        results = self._results(
+            rest.api.url_for(FilingsView, candidate_id=expected_filing['cand_cmte_id'])
+        )
+        assert len(results) == 1
+        view_result = results[0]
+
+        self.assert_filings_equal(view_result, expected_filing)
+
+    def insert_committee(self, committee):
+        self.connection.execute(
+            "INSERT INTO disclosure.cmte_valid_fec_yr \
+            (valid_fec_yr_id, cmte_id, fec_election_yr, cmte_tp, date_entered) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            committee['valid_fec_yr_id'],
+            committee['committee_id'],
+            committee['fec_election_yr'],
+            committee['committee_type'],
+            committee['date_entered'],
+        )
+
+    def insert_filing(self, sub_id, expected_filing):
+        self.connection.execute(
+            "INSERT INTO disclosure.f_rpt_or_form_sub \
+            (sub_id, cand_cmte_id, form_tp, rpt_yr, begin_image_num) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            sub_id,
+            expected_filing['cand_cmte_id'],
+            expected_filing['form_type'],
+            expected_filing['report_year'],
+            expected_filing['begin_image_num'],
+        )
+
+    def assert_filings_equal(self, api_result, expected_filing):
+        assert api_result['report_year'] == expected_filing['report_year']
+        assert api_result['form_type'] == expected_filing['form_type']
+        assert api_result['pdf_url'] == expected_filing['pdf_url']
+
+    def clear_test_data(self):
+        tables = ["cmte_valid_fec_yr", "f_rpt_or_form_sub"]
+        for table in tables:
+            self.connection.execute("DELETE FROM disclosure.{}".format(table))


### PR DESCRIPTION
## Summary (required)

- Resolves #4821 
- Modify database function report_pdf_url_or_null to include more historical records

### Required reviewers

@pkfec @fec-jli 
Optional @fecjjeng 

## Impacted areas of the application

"pdf_url" returned by these endpoints:
/filings/ 
/committee/<committee_id>/filings/ 
/candidate/<candidate_id>/filings/


## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## How to test

- Checkout feature branch
- Run `pytest`;  Run `flyway migrate`
- "ofec_filings_all_mv_tmp_hc" was created to compare data change:
   count change of Null pdf_url
   before: 1018721  vs  after: 850320
  ```
      select count(*)
      from public.ofec_filings_all_mv
      where pdf_url is  null; 

      select count(*)
      from public.ofec_filings_all_mv_tmp_hc
      where pdf_url is null;
   ```
- Majority of newly added pdf_url are F1 and F2.
    ```
       select candidate_id, committee_id, form_type, report_year 
       from public.ofec_filings_all_mv_tmp_hc
       where pdf_url is not null
       except
       select candidate_id, committee_id, form_type, report_year 
       from public.ofec_filings_all_mv
       where pdf_url is not null
       order by 3 ;
    ```
  

- Run api on local and check changes in endpoints:   
    In models/filings.py, switch to temp mv
          class Filings(FecFileNumberMixin, CsvMixin, db.Model):
          __tablename__ = 'ofec_filings_all_mv_tmp_hc' 

Before:
https://api.open.fec.gov/v1/filings/?sort_null_only=false&page=1&sort_nulls_last=false&sort_hide_null=false&sort=-receipt_date&form_type=F1&api_key=DEMO_KEY&cycle=1996&per_page=20&committee_id=C00302695

<img width="542" alt="Screen Shot 2021-03-31 at 1 09 14 PM" src="https://user-images.githubusercontent.com/24396726/113184100-c8c79b00-9222-11eb-84f0-4c99742e0f5d.png">


After:
http://127.0.0.1:5000/v1/filings/?sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&committee_id=C00302695&form_type=F1&cycle=1996&sort=-receipt_date&per_page=20

<img width="720" alt="Screen Shot 2021-03-31 at 1 20 51 PM" src="https://user-images.githubusercontent.com/24396726/113185262-3f18cd00-9224-11eb-849c-2d7c4905d62e.png">


More examples:
http://127.0.0.1:5000/v1/committee/C00213512/filings/?sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&cycle=1996&sort=-receipt_date&per_page=20