### PR TITLE
Upgrade networkx to 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.1
 python-dateutil==2.8.1
 sqlalchemy-postgres-copy==0.3.0
-networkx==1.11
+networkx==2.5.1
 SQLAlchemy==1.3.19
 icalendar==4.0.2
 GitPython==3.1.0


### PR DESCRIPTION
## Summary (required)
Currently, we are using networkx==1.11 and keep getting Snyk-High Vulnerability-Deserialization of Untrusted Data. The latest version of networkx==2.5.1, which released 0n 04/03/2021. [https://pypi.org/project/networkx/](https://pypi.org/project/networkx/). so this PR is to upgrade networkx==>2.5.1, even though v2.5.1 won't fix that Vulnerability, but we are ready to upgrade to the next major release which will fix the Vulnerability by networkx's announcement. 

- Partial Resolve #4818 

### Required reviewers
one backend developer

## Impacted areas of the application
refresh our materialized views

General components of the application that this PR will affect:
requirements.txt

## How to test
1)checkout branch
2)`pip install -r requirements.txt`
pip freeze to check networkx==2.5.1
3)pytest
4)run: `snyk test --file=requirements.txt --package-manager=pip`
you will still get Deserialization of Untrusted Data Vulnerability. (by networkx, they will fix this issue in the next major release) [https://github.com/networkx/networkx/issues/4728](https://github.com/networkx/networkx/issues/4728)
<img width="325" alt="vulnerability" src="https://user-images.githubusercontent.com/24395751/113910832-44879180-97a7-11eb-8991-3b759ee8676e.png">

5)`dropdb cfdm_test`
`createdb cfdm_test`
`invoke create_sample_db`
make sure 45 MVs get refreshed successfully.
<img width="417" alt="Screen Shot 2021-04-07 at 12 21 19 PM" src="https://user-images.githubusercontent.com/24395751/113910892-549f7100-97a7-11eb-9e25-38c4b1a25783.png">

6)double check api work as usual.



