### PR TITLE
Modify function report_pdf_url_or_null using report_year>1996

### DIFF
--- a/data/migrations/V0226__modify_report_pdf_url_or_null.sql
+++ b/data/migrations/V0226__modify_report_pdf_url_or_null.sql
@@ -1,0 +1,30 @@
+/*
+This migration file is for #4821
+Modify function: report_pdf_url_or_null to include more historic records, 
+but remove = from condition when comparing with 1996 
+*/
+
+--
+-- Name: report_pdf_url_or_null(text, numeric, text, text,  text); 
+-- Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_pdf_url_or_null(image_number text, report_year numeric, committee_type text, cand_id text, form_type text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $$
+begin
+    return case
+        when image_number is not null and (
+             report_year >= 2000 or
+             (committee_type not in ('S','H') and report_year >= 1993) or
+             (committee_type = 'H' and report_year > 1996) or
+             (form_type = 'F2' and substr(cand_id,1,1) = 'H' and report_year > 1996) or
+             (form_type = 'F2' and substr(cand_id,1,1) = 'P' and report_year >= 1993) 
+        ) then report_pdf_url(image_number)
+        else null
+        end;
+end
+$$;
+
+
+ALTER FUNCTION public.report_pdf_url_or_null(text, numeric, text, text, text) OWNER TO fec;

--- a/tests/integration/test_filings.py
+++ b/tests/integration/test_filings.py
@@ -14,14 +14,14 @@ class TestFilings(BaseTestCase):
     committee = {
         'valid_fec_yr_id': 1,
         'committee_id': 'C001',
-        'fec_election_yr': 1996,
+        'fec_election_yr': 1998,
         'committee_type': 'H',
         'date_entered': 'now()',
     }
 
     FIRST_FILING = {
         'cand_cmte_id': 'C001',
-        'report_year': 1996,
+        'report_year': 1997,
         'form_type': 'F1',
         'begin_image_num': '95039770818',
         'pdf_url': 'https://docquery.fec.gov/pdf/818/95039770818/95039770818.pdf'


### PR DESCRIPTION
## Summary (required)

- Resolves #4821 

Replace 'report_year >=1996' with 'report_year >1996'

### Required reviewers

@fec-jli @lbeaufort 

## Impacted areas of the application

General components of the application that this PR will affect:

"pdf_url" returned by these endpoints:
/filings/
/committee/<committee_id>/filings/
/candidate/<candidate_id>/filings/

## How to test
- Checkout feature branch; Run pytest; Run flyway migrate
- Run api on local and check changes in endpoints.  "ofec_filings_all_mv_tmp_hc" was created to compare data change:
   In models/filings.py, switch to temp mv
```
    class Filings(FecFileNumberMixin, CsvMixin, db.Model):
    tablename = 'ofec_filings_all_mv_tmp_hc'
  ```

**Before**
https://www.fec.gov/data/committee/C00302695/?tab=filings&cycle=1996
<img width="1022" alt="Screen Shot 2021-04-07 at 4 44 04 PM" src="https://user-images.githubusercontent.com/24396726/113931499-86710180-97c0-11eb-8260-371210bdcfb3.png">

**After**

http://127.0.0.1:5000/v1/filings/?sort=-receipt_date&sort_nulls_last=false&sort_null_only=false&committee_id=C00302695&per_page=20&page=1&sort_hide_null=false&cycle=1996&form_type=F1

The endpoint will return with valid pdf_url for three images 
Statement of organization 1996  96031271247 
Statement of organization 1995  95039782365 
Statement of organization 1995  95039754175

**Before**
https://www.fec.gov/data/candidate/H8NJ01077/?tab=filings
<img width="887" alt="Screen Shot 2021-04-07 at 4 59 49 PM" src="https://user-images.githubusercontent.com/24396726/113933558-bc16ea00-97c2-11eb-8fe4-61279966e723.png">
**After**
http://127.0.0.1:5000/v1/filings/?sort=-receipt_date&sort_nulls_last=false&sort_null_only=false&per_page=20&candidate_id=H8NJ01077&page=1&sort_hide_null=false&cycle=1998&form_type=F2