### PR TITLE
Simplify follower (`SQLA_FOLLOWER`) logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Warning: never perform 'update all' when pointing to an RDS box via the SQLA_CON
 *Note: An additional setting for connecting to and utilizing mirrors/replica boxes can also be set with:*
 
 ```
-export SQLA_FOLLOWERS=<psql:address-to-replica-box-1>[,<psql:address-to-replica-box-2>,...]
+export SQLA_FOLLOWER=<psql:address-to-replica-box-1>[,<psql:address-to-replica-box-2>,...]
 ```
 
 *Note: This is a comma separated (with no spaces) string that contains one or more connection strings to any replicas/mirrors that are setup.*
@@ -659,7 +659,7 @@ caching, and rate limiting.
 Sorting fields include a compound index on on the filed to sort and a unique field. Because in cases where there were large amounts of data that had the same value that was being evaluated for sort, the was not a stable sort view for results and the results users received were inconsistent, some records given more than once, others given multiple times.
 
 ### Database mirrors/replicas
-Database mirrors/replicas are supported by the API if the `SQLA_FOLLOWERS` is set to one or more valid connection strings.  By default, setting this environment variable will shift all `read` operations to any mirrors/replicas that are available (and randomly choose one to target per request if there are more than one).
+Database mirrors/replicas are supported by the API if the `SQLA_FOLLOWER` is set to one or more valid connection strings.  By default, setting this environment variable will shift all `read` operations to any mirrors/replicas that are available (and randomly choose one to target per request if there are more than one).
 
 You can optionally choose to restrict traffic that goes to the mirrors/replicas to be the asynchronous tasks only by setting the `SQLA_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS` environment variable to something that will evaluate to `True` in Python (simply using `True` as the value is fine).  If you do this, you can also restrict which tasks are supported on the mirrors/replicas.  Supported tasks are configured by adding their fully qualified names to the `app.config['SQLALCHEMY_FOLLOWER_TASKS']` list in order to allow them.  By default, only the `download` task is enabled.
 

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -1,6 +1,5 @@
-import random
 import celery
-from sqlalchemy import orm
+from sqlalchemy import orm, create_engine
 from flask import request
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
 from flask_sqlalchemy import SignallingSession
@@ -13,8 +12,8 @@ class RoutingSession(SignallingSession):
     """
 
     @property
-    def followers(self):
-        return self.app.config['SQLALCHEMY_FOLLOWERS']
+    def follower(self):
+        return self.app.config['SQLALCHEMY_FOLLOWER']
 
     @property
     def follower_tasks(self):
@@ -26,13 +25,13 @@ class RoutingSession(SignallingSession):
 
     @property
     def use_follower(self):
-        # Check for read operations and configured followers.
+        # Check for read operations and configured follower.
         use_follower = (
             not self._flushing
-            and len(self.followers) > 0
+            and self.follower
         )
 
-        # Optionally restrict traffic to followers for only supported tasks.
+        # Optionally restrict traffic to follower for only supported tasks.
         if use_follower and self.restrict_follower_traffic_to_tasks:
             use_follower = (
                 celery.current_task
@@ -41,25 +40,10 @@ class RoutingSession(SignallingSession):
 
         return use_follower
 
-    @property
-    def route_schedule_a(self):
-        """If we have more than 1 replica, separate Schedule A traffic. """
-        return (
-            self.app.config['SQLALCHEMY_ROUTE_SCHEDULE_A'] and len(self.followers) > 1
-        )
 
     def get_bind(self, mapper=None, clause=None):
         if self.use_follower:
-            # Celery worker doesn't have request context
-            if request and self.route_schedule_a:
-                if '/schedule_a/' not in request.path:
-                    # Route all non-schedule A traffic to replica 1
-                    return self.followers[0]
-                else:
-                    # Split out Schedule A to remaining replicas
-                    return random.choice(self.followers[1:])
-
-            return random.choice(self.followers)
+            return create_engine(self.follower)
 
         return super().get_bind(mapper=mapper, clause=clause)
 

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -1,6 +1,5 @@
 import celery
 from sqlalchemy import orm, create_engine
-from flask import request
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
 from flask_sqlalchemy import SignallingSession
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -82,7 +82,7 @@ app.config['SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS'] = bool(
 app.config['SQLALCHEMY_FOLLOWER_TASKS'] = [
     'webservices.tasks.download.export_query',
 ]
-app.config['SQLALCHEMY_FOLLOWER'] = env.get_credential('SQLA_FOLLOWERS', '')
+app.config['SQLALCHEMY_FOLLOWER'] = env.get_credential('SQLA_FOLLOWER', '')
 
 app.config['PROPAGATE_EXCEPTIONS'] = True
 

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -7,7 +7,6 @@ import http
 import logging
 import os
 import ujson
-import sqlalchemy as sa
 import flask_cors as cors
 import flask_restful as restful
 
@@ -83,14 +82,8 @@ app.config['SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS'] = bool(
 app.config['SQLALCHEMY_FOLLOWER_TASKS'] = [
     'webservices.tasks.download.export_query',
 ]
-app.config['SQLALCHEMY_FOLLOWERS'] = [
-    sa.create_engine(follower.strip())
-    for follower in utils.split_env_var(env.get_credential('SQLA_FOLLOWERS', ''))
-    if follower.strip()
-]
-app.config['SQLALCHEMY_ROUTE_SCHEDULE_A'] = bool(
-    env.get_credential('SQLA_ROUTE_SCHEDULE_A', '')
-)
+app.config['SQLALCHEMY_FOLLOWER'] = env.get_credential('SQLA_FOLLOWERS', '')
+
 app.config['PROPAGATE_EXCEPTIONS'] = True
 
 # app.config['SQLALCHEMY_ECHO'] = True


### PR DESCRIPTION
## Summary (required)

- Partial resolution for #4843

Simplify follower (`SQLA_FOLLOWERS`) logic. The existing "choose a random replica" and "route schedule A traffic to one replica" logic is no longer needed as we have one connection string for the AWS aurora reader endpoints. The existing logic adds complexity and a little bit of latency, so it's a win-win to simplify the logic.

I did some [double-checking Locust testing](https://docs.google.com/spreadsheets/d/19v6WS0M533zqC63h--dOZJ2HQf7edfvXQRoSmyhfm2Y/edit#gid=0) (results can vary between tests) and the results seemed slightly faster, but this amount of performance improvement should be pretty negligible. 

### Required reviewers

2 of the selected reviewers, please

## Impacted areas of the application

General components of the application that this PR will affect:

-  "Under the hood" logic for connecting to read-only cluster endpoint


## How to test

- Run the application with and without `SQLA_FOLLOWERS` set