### PR TITLE
 Cache cmte and cand totals endpoint.

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -194,22 +194,24 @@ def get_cache_header(url):
     DEFAULT_HEADER_TYPE = 'Cache-Control'
     DEFAULT_HEADER_PREFIX = 'public, max-age='
 
+    LONG_CACHE_ENDPOINTS = ['/totals', '/schedules/']
+
     if '/efile/' in url:
         return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, EFILING_CACHE)
     elif '/calendar-dates/' in url:
         return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, CALENDAR_CACHE)
     elif '/legal/' in url:
         return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, LEGAL_CACHE)
-    # This will work differently in local environment - will use local timezone
-    elif (
-        '/schedules/' in url and PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END
-    ):
-        peak_hours_expiration_time = datetime.combine(
-            datetime.now().date(), PEAK_HOURS_END
-        ).strftime('%a, %d %b %Y %H:%M:%S GMT')
-        return 'Expires', peak_hours_expiration_time
 
-    return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, DEFAULT_CACHE)
+    # This will work differently in local environment - will use local timezone
+    for endpoint in LONG_CACHE_ENDPOINTS:
+        if endpoint in url and PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END:
+            peak_hours_expiration_time = datetime.combine(
+                datetime.now().date(), PEAK_HOURS_END
+            ).strftime('%a, %d %b %Y %H:%M:%S GMT')
+            return 'Expires', peak_hours_expiration_time
+    else:
+        return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, DEFAULT_CACHE)
 
 
 @app.after_request


### PR DESCRIPTION
## Summary 

Cache committee and candidate totals endpoint.

- Resolves https://github.com/fecgov/openFEC/issues/4745

In rest.py add logic to cache `/totals` endpoint

### Required reviewers

@lbeaufort @fec-jli 


## Impacted areas of the application

General components of the application that this PR will affect:

-  API Umbrella cache 

## Screenshots
 **In Production, candidate and committee `/totals` endpoint are cached for 1 hour (default cache setting, max_age=3600sec):**
run: `curl -svo /dev/null "https://api.open.fec.gov/v1/candidate/H8NJ01077/totals?election_full=True&cycle=1998&api_key=DEMO_KEY"`

<img width="662" alt="Screen Shot 2021-05-03 at 3 18 16 PM" src="https://user-images.githubusercontent.com/11650355/116923835-20dc2d80-ac25-11eb-952e-b1d96b7dc9d5.png">

run: `curl -svo /dev/null "https://api.open.fec.gov/v1/committee/C00302695/totals/?per_page=20&page=1&sort_hide_null=false&sort_nulls_last=false&sort_null_only=false&sort=-cycle&api_key=DEMO_KEY"`

<img width="1110" alt="Screen Shot 2021-05-03 at 3 25 28 PM" src="https://user-images.githubusercontent.com/11650355/116923981-479a6400-ac25-11eb-9f0d-5ef4616f5539.png">




**In this feature branch,  candidate and committee `/totals` endpoint are cached during peak hours  (look at the expires header):** 
**cache candidate totals endpoint:**
 run: `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/candidate/H8NJ01077/totals?election_full=True&cycle=1998&api_key=DEMO_KEY"`
<img width="728" alt="Screen Shot 2021-05-03 at 3 49 43 PM" src="https://user-images.githubusercontent.com/11650355/116925619-6568c880-ac27-11eb-9d64-d2f73b908d1b.png">

**cache committee totals endpoint:** 
run: `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/committee/C00302695/totals/?per_page=20&page=1&sort_hide_null=false&sort_nulls_last=false&sort_null_only=false&sort=-cycle&api_key=DEMO_KEY"`
<img width="1173" alt="Screen Shot 2021-05-03 at 3 53 21 PM" src="https://user-images.githubusercontent.com/11650355/116925975-e1fba700-ac27-11eb-900b-c0aeec21ad4b.png">

## How to test

- deploy this feature branch to `stage`
- login cloud.gov/ stage environment
- Test candidate totals: 

   -  run `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/candidate/H8NJ01077/totals?election_full=True&cycle=1998&api_key=DEMO_KEY"`. Look for `Expires` header which should have the peak cache hours set on this endpoint

- Test committee totals:
    -  run `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/committee/C00302695/totals/?per_page=20&page=1&sort_hide_null=false&sort_nulls_last=false&sort_null_only=false&sort=-cycle&api_key=DEMO_KEY"`
   -  Look for `Expires` header which should have the peak cache hours set on this endpoint

- Test `legal` endpoint:
    - run `curl -svo /dev/null "https://stage.fec.gov/data/legal/advisory-opinions/2020-03/"`
    - Look for cache-control: max-age=600

- Test `calendar` endpoint:
    - run `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/calendar-dates/?per_page=500&sort=start_date&min_start_date=2021-3-26&calendar_category_id=33&calendar_category_id=34&api_key=DEMO_KEY"`
    - Look for Cache-Control: public, max-age=300

- Test default cache (1 hour) endpoint examples:
     - run `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/candidate/H8NJ01077/history/?page=1&sort_nulls_last=false&sort_null_only=false&per_page=20&sort_hide_null=false&sort=-two_year_period&election_full=true&api_key=DEMO_KEY"`
    
    - run `curl -svo /dev/null "https://api-stage.open.fec.gov/v1/filings? 
      candidate_id=H8NJ01077&form_type=F2&api_key=DEMO_KEY"`
   - Look for  Cache-Control: public, max-age=3600
