### PR TITLE
Modify database function report_fec_url 

### DIFF
--- a/data/migrations/V0227__modify_report_fec_url.sql
+++ b/data/migrations/V0227__modify_report_fec_url.sql
@@ -1,0 +1,33 @@
+/*
+This migration file is for #4053
+Modify function: report_fec_url not to generate invalid fec_url
+when file number is null 
+*/
+
+--
+-- Name: report_fec_url(text, numeric); 
+-- Type: FUNCTION; Schema: public; Owner: fec
+--
+
+CREATE OR REPLACE FUNCTION report_fec_url(image_number text, file_number integer) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+AS $$
+begin
+    return case
+        when (file_number < 1 or file_number is null) then null
+        when image_number is not null and not is_electronic(image_number) then format(
+            'https://docquery.fec.gov/paper/posted/%1$s.fec',
+            file_number
+        )
+        when image_number is not null and is_electronic(image_number) then format(
+            'https://docquery.fec.gov/dcdev/posted/%1$s.fec',
+            file_number
+        )
+        else null
+    end;
+end
+$$;
+
+
+
+ALTER FUNCTION public.report_fec_url(image_number text, file_number integer) OWNER TO fec;


### PR DESCRIPTION
## Summary (required)
- Resolves #4053 
- Modify the database function to handle scenario when file number is null

### Required reviewers
Two backend developers

## Impacted areas of the application
​/candidate​/{candidate_id}​/filings​/
​/committee​/{committee_id}​/filings​/
​/filings​/
/committee/{committee_id}/reports/
/reports/{committee_type}/


## How to test
- Download feature branch to local
- Run `pytest` to make sure all tests pass
- Run `flyway migrate` to make sure migration runs no error
- Check data change in endpoints.  When file_number is null, these endpoints will not have `fec_url` in output.

   - Change the below on local model file:  webservices/common/models/filings.py
```
      class Filings(FecFileNumberMixin, CsvMixin, db.Model):
            __tablename__ = 'ofec_filings_all_mv_tmp_hc'
```
**filing endpoint**
 before change:
https://api.open.fec.gov/v1/filings/?api_key=DEMO_KEY&sort=-receipt_date&page=1&report_type=YE&sort_nulls_last=false&committee_id=C00213512&sort_null_only=false&per_page=20&cycle=1998&sort_hide_null=false

<img width="400" alt="Screen Shot 2021-05-21 at 12 51 40 PM" src="https://user-images.githubusercontent.com/24396726/119172291-c3711a80-ba33-11eb-98ed-fcec509c5c68.png">

 after change:  no fec_url in output
http://127.0.0.1:5000/v1/filings/?sort=-receipt_date&sort_hide_null=false&sort_nulls_last=false&report_type=YE&sort_null_only=false&page=1&per_page=20&committee_id=C00213512&cycle=1998
  
2nd example - before change:
https://api.open.fec.gov/v1/filings/?api_key=DEMO_KEY&sort=-receipt_date&page=1&report_type=Q3&sort_nulls_last=false&committee_id=C00213512&sort_null_only=false&per_page=20&cycle=2000&sort_hide_null=false

after change: no fec_url in output
http://127.0.0.1:5000/v1/filings/?sort=-receipt_date&sort_hide_null=false&sort_nulls_last=false&report_type=Q3&sort_null_only=false&page=1&per_page=20&committee_id=C00213512&cycle=2000

**report endpoint**
Change the below on local model file: webservices/common/models/reports.py
```
class CommitteeReportsHouseSenate(CommitteeReports):
    __tablename__ = 'ofec_reports_house_senate_mv_tmp_hc'
```
before change:  invalid fec_uel with null file_number

https://api.open.fec.gov/v1/committee/C00213512/reports/?api_key=DEMO_KEY&sort=-coverage_end_date&page=1&report_type=YE&sort_nulls_last=false&sort_null_only=false&per_page=3&year=1999&sort_hide_null=false

after change:  returned fec_url is null with null file_number
http://127.0.0.1:5000/v1/committee/C00213512/reports/?report_type=YE&sort_hide_null=false&sort=-coverage_end_date&sort_null_only=false&sort_nulls_last=false&page=1&year=1999&per_page=3
