### PR TITLE
Add fields to /totals/pac-party/

### DIFF
--- a/data/migrations/V0228__modify_ofec_totals_combined.sql
+++ b/data/migrations/V0228__modify_ofec_totals_combined.sql
@@ -1,0 +1,379 @@
+/*
+This migration file is for #4872
+
+New fields/columns need to be at the end
+
+1 - Modify `ofec_totals_combined_mv` and `ofec_totals_combined_vw` to add:
+    `committee_state`
+    `treasurer_name`,
+    `filing_frequency`,
+    `filing_frequency_full`,
+    `first_file_date`,
+
+2 - Modify `ofec_totals_pac_party_vw` to bring in new fields from `ofec_totals_combined_vw`
+
+*/
+
+
+-- 1 - Re-create `ofec_totals_combined_mv` with new fields
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_combined_mv_tmp;
+
+CREATE MATERIALIZED VIEW ofec_totals_combined_mv_tmp AS
+    WITH last_subset AS (
+     SELECT DISTINCT ON (v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr))) v_sum_and_det_sum_report.orig_sub_id,
+        v_sum_and_det_sum_report.cmte_id,
+        v_sum_and_det_sum_report.coh_cop,
+        v_sum_and_det_sum_report.debts_owed_by_cmte,
+        v_sum_and_det_sum_report.debts_owed_to_cmte,
+        v_sum_and_det_sum_report.net_op_exp,
+        v_sum_and_det_sum_report.net_contb,
+        v_sum_and_det_sum_report.rpt_yr,
+        get_cycle(v_sum_and_det_sum_report.rpt_yr) AS cycle
+       FROM disclosure.v_sum_and_det_sum_report
+      WHERE get_cycle(v_sum_and_det_sum_report.rpt_yr) >= 1979 AND (v_sum_and_det_sum_report.form_tp_cd::text <> 'F5'::text OR v_sum_and_det_sum_report.form_tp_cd::text = 'F5'::text AND (v_sum_and_det_sum_report.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text]))) AND v_sum_and_det_sum_report.form_tp_cd::text NOT IN ('F6','SL')
+      ORDER BY v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr)), (to_timestamp(v_sum_and_det_sum_report.cvg_end_dt::double precision)) DESC NULLS LAST
+    ), last AS (
+     SELECT ls.cmte_id,
+        ls.orig_sub_id,
+        ls.coh_cop,
+        ls.cycle,
+        ls.debts_owed_by_cmte,
+        ls.debts_owed_to_cmte,
+        ls.net_op_exp,
+        ls.net_contb,
+        ls.rpt_yr,
+        of.candidate_id,
+        of.beginning_image_number,
+        of.coverage_end_date,
+        of.form_type,
+        of.report_type_full,
+        of.report_type,
+        of.candidate_name,
+        of.committee_name
+       FROM last_subset ls
+         LEFT JOIN ofec_filings_all_vw of ON ls.orig_sub_id = of.sub_id
+    ), first AS (
+     SELECT DISTINCT ON (v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr))) v_sum_and_det_sum_report.coh_bop AS cash_on_hand,
+        v_sum_and_det_sum_report.cmte_id AS committee_id,
+        CASE
+            WHEN v_sum_and_det_sum_report.cvg_start_dt = 99999999::numeric THEN NULL::timestamp without time zone
+            ELSE v_sum_and_det_sum_report.cvg_start_dt::text::date::timestamp without time zone
+        END AS coverage_start_date,
+        get_cycle(v_sum_and_det_sum_report.rpt_yr) AS cycle
+       FROM disclosure.v_sum_and_det_sum_report
+      WHERE get_cycle(v_sum_and_det_sum_report.rpt_yr) >= 1979 AND (v_sum_and_det_sum_report.form_tp_cd::text <> 'F5'::text OR v_sum_and_det_sum_report.form_tp_cd::text = 'F5'::text AND (v_sum_and_det_sum_report.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text]))) AND v_sum_and_det_sum_report.form_tp_cd::text NOT IN ('F6','SL')
+      ORDER BY v_sum_and_det_sum_report.cmte_id, (get_cycle(v_sum_and_det_sum_report.rpt_yr)), (to_timestamp(v_sum_and_det_sum_report.cvg_end_dt::double precision))
+    ), committee_info AS (
+     SELECT DISTINCT ON (cmte_valid_fec_yr.cmte_id, cmte_valid_fec_yr.fec_election_yr) cmte_valid_fec_yr.cmte_id,
+        cmte_valid_fec_yr.fec_election_yr,
+        cmte_valid_fec_yr.cmte_nm,
+        cmte_valid_fec_yr.cmte_tp,
+        cmte_valid_fec_yr.cmte_dsgn,
+        cmte_valid_fec_yr.cmte_pty_affiliation_desc,
+        cmte_valid_fec_yr.cmte_st,
+        cmte_valid_fec_yr.tres_nm,
+        cmte_valid_fec_yr.cmte_filing_freq,
+        cmte_valid_fec_yr.cmte_filing_freq_desc
+       FROM disclosure.cmte_valid_fec_yr
+    ), dates AS (
+         SELECT f_rpt_or_form_sub.cand_cmte_id AS cmte_id,
+            min(f_rpt_or_form_sub.receipt_dt) AS first_file_date,
+            max(f_rpt_or_form_sub.receipt_dt) AS last_file_date,
+            max(f_rpt_or_form_sub.receipt_dt) FILTER (WHERE ((f_rpt_or_form_sub.form_tp)::text = 'F1'::text)) AS last_f1_date
+           FROM disclosure.f_rpt_or_form_sub
+          GROUP BY f_rpt_or_form_sub.cand_cmte_id
+        )
+ SELECT get_cycle(vsd.rpt_yr) AS cycle,
+    max(last.candidate_id::text) AS candidate_id,
+    max(last.candidate_name::text) AS candidate_name,
+    max(last.committee_name::text) AS committee_name,
+    max(last.beginning_image_number) AS last_beginning_image_number,
+    max(last.coh_cop) AS last_cash_on_hand_end_period,
+    max(last.debts_owed_by_cmte) AS last_debts_owed_by_committee,
+    max(last.debts_owed_to_cmte) AS last_debts_owed_to_committee,
+    max(last.net_contb) AS last_net_contributions,
+    max(last.net_op_exp) AS last_net_operating_expenditures,
+    max(last.report_type::text) AS last_report_type,
+    max(last.report_type_full::text) AS last_report_type_full,
+    max(last.rpt_yr) AS last_report_year,
+    max(last.coverage_end_date) AS coverage_end_date,
+    max(vsd.orig_sub_id) AS sub_id,
+    min(first.cash_on_hand) AS cash_on_hand_beginning_period,
+    min(first.coverage_start_date) AS coverage_start_date,
+    sum(vsd.all_loans_received_per) AS all_loans_received,
+    sum(vsd.cand_cntb) AS candidate_contribution,
+    sum(vsd.cand_loan_repymnt + vsd.oth_loan_repymts) AS loan_repayments_made,
+    sum(vsd.cand_loan_repymnt) AS loan_repayments_candidate_loans,
+    sum(vsd.cand_loan) AS loans_made_by_candidate,
+    sum(vsd.cand_loan_repymnt) AS repayments_loans_made_by_candidate,
+    sum(vsd.cand_loan) AS loans_received_from_candidate,
+    sum(vsd.coord_exp_by_pty_cmte_per) AS coordinated_expenditures_by_party_committee,
+    sum(vsd.exempt_legal_acctg_disb) AS exempt_legal_accounting_disbursement,
+    sum(vsd.fed_cand_cmte_contb_per) AS fed_candidate_committee_contributions,
+    sum(vsd.fed_cand_contb_ref_per) AS fed_candidate_contribution_refunds,
+    sum(vsd.fed_funds_per) > 0::numeric AS federal_funds_flag,
+    sum(vsd.ttl_fed_disb_per) AS fed_disbursements,
+    sum(vsd.fed_funds_per) AS federal_funds,
+    sum(vsd.fndrsg_disb) AS fundraising_disbursements,
+    sum(vsd.indv_contb) AS individual_contributions,
+    sum(vsd.indv_item_contb) AS individual_itemized_contributions,
+    sum(vsd.indv_ref) AS refunded_individual_contributions,
+    sum(vsd.indv_unitem_contb) AS individual_unitemized_contributions,
+    sum(vsd.loan_repymts_received_per) AS loan_repayments_received,
+    sum(vsd.loans_made_per) AS loans_made,
+    sum(vsd.net_contb) AS net_contributions,
+    sum(vsd.net_op_exp) AS net_operating_expenditures,
+    sum(vsd.non_alloc_fed_elect_actvy_per) AS non_allocated_fed_election_activity,
+    sum(vsd.offsets_to_fndrsg) AS offsets_to_fundraising_expenditures,
+    sum(vsd.offsets_to_legal_acctg) AS offsets_to_legal_accounting,
+    sum(vsd.offsets_to_op_exp + vsd.offsets_to_fndrsg + vsd.offsets_to_legal_acctg) AS total_offsets_to_operating_expenditures,
+    sum(vsd.offsets_to_op_exp) AS offsets_to_operating_expenditures,
+    sum(
+    CASE
+        WHEN vsd.form_tp_cd::text = 'F3X'::text THEN vsd.ttl_op_exp_per
+        ELSE vsd.op_exp_per
+    END) AS operating_expenditures,
+    sum(vsd.oth_cmte_contb) AS other_political_committee_contributions,
+    sum(vsd.oth_cmte_ref) AS refunded_other_political_committee_contributions,
+    sum(vsd.oth_loan_repymts) AS loan_repayments_other_loans,
+    sum(vsd.oth_loan_repymts) AS repayments_other_loans,
+    sum(vsd.oth_loans) AS all_other_loans,
+    sum(vsd.oth_loans) AS other_loans_received,
+    sum(vsd.other_disb_per) AS other_disbursements,
+    sum(vsd.other_fed_op_exp_per) AS other_fed_operating_expenditures,
+    sum(vsd.other_receipts) AS other_fed_receipts,
+    sum(vsd.other_receipts) AS other_receipts,
+    sum(vsd.pol_pty_cmte_contb) AS refunded_political_party_committee_contributions,
+    sum(vsd.pty_cmte_contb) AS political_party_committee_contributions,
+    sum(vsd.shared_fed_actvy_fed_shr_per) AS shared_fed_activity,
+    sum(vsd.shared_fed_actvy_nonfed_per) AS allocated_federal_election_levin_share,
+    sum(vsd.shared_fed_actvy_nonfed_per) AS shared_fed_activity_nonfed,
+    sum(vsd.shared_fed_op_exp_per) AS shared_fed_operating_expenditures,
+    sum(vsd.shared_nonfed_op_exp_per) AS shared_nonfed_operating_expenditures,
+    sum(vsd.tranf_from_nonfed_acct_per) AS transfers_from_nonfed_account,
+    sum(vsd.tranf_from_nonfed_levin_per) AS transfers_from_nonfed_levin,
+    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_affiliated_committee,
+    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_affiliated_party,
+    sum(vsd.tranf_from_other_auth_cmte) AS transfers_from_other_authorized_committee,
+    sum(vsd.tranf_to_other_auth_cmte) AS transfers_to_affiliated_committee,
+    sum(vsd.tranf_to_other_auth_cmte) AS transfers_to_other_authorized_committee,
+    sum(vsd.ttl_contb_ref) AS contribution_refunds,
+    sum(vsd.ttl_contb) AS contributions,
+    sum(vsd.ttl_disb) AS disbursements,
+    sum(vsd.ttl_fed_elect_actvy_per) AS fed_election_activity,
+    sum(vsd.ttl_fed_receipts_per) AS fed_receipts,
+    sum(vsd.ttl_loan_repymts) AS loan_repayments,
+    sum(vsd.ttl_loans) AS loans_received,
+    sum(vsd.ttl_loans) AS loans,
+    sum(vsd.ttl_nonfed_tranf_per) AS total_transfers,
+    sum(vsd.ttl_receipts) AS receipts,
+    max(committee_info.cmte_tp::text) AS committee_type,
+    max(expand_committee_type(committee_info.cmte_tp::text)) AS committee_type_full,
+    max(committee_info.cmte_dsgn::text) AS committee_designation,
+    max(expand_committee_designation(committee_info.cmte_dsgn::text)) AS committee_designation_full,
+    max(committee_info.cmte_pty_affiliation_desc::text) AS party_full,
+    vsd.cmte_id AS committee_id,
+    vsd.form_tp_cd AS form_type,
+    CASE
+        WHEN max(last.form_type::text) = ANY (ARRAY['F3'::text, 'F3P'::text]) THEN NULL::numeric
+        ELSE sum(vsd.indt_exp_per)
+    END AS independent_expenditures,
+    sum(vsd.exp_subject_limits_per) AS exp_subject_limits,
+    sum(vsd.exp_prior_yrs_subject_lim_per) AS exp_prior_years_subject_limits,
+    sum(vsd.ttl_exp_subject_limits) AS total_exp_subject_limits,
+    sum(vsd.subttl_ref_reb_ret_per) AS refunds_relating_convention_exp,
+    sum(vsd.item_ref_reb_ret_per) AS itemized_refunds_relating_convention_exp,
+    sum(vsd.unitem_ref_reb_ret_per) AS unitemized_refunds_relating_convention_exp,
+    sum(vsd.subttl_other_ref_reb_ret_per) AS other_refunds,
+    sum(vsd.item_other_ref_reb_ret_per) AS itemized_other_refunds,
+    sum(vsd.unitem_other_ref_reb_ret_per) AS unitemized_other_refunds,
+    sum(vsd.item_other_income_per) AS itemized_other_income,
+    sum(vsd.unitem_other_income_per) AS unitemized_other_income,
+    sum(vsd.subttl_convn_exp_disb_per) AS convention_exp,
+    sum(vsd.item_convn_exp_disb_per) AS itemized_convention_exp,
+    sum(vsd.unitem_convn_exp_disb_per) AS unitemized_convention_exp,
+    sum(vsd.item_other_disb_per) AS itemized_other_disb,
+    sum(vsd.unitem_other_disb_per) AS unitemized_other_disb,
+    --New fields
+    max(committee_info.cmte_st::text) AS committee_state,
+    max(committee_info.tres_nm::text) AS treasurer_name,
+    max(committee_info.cmte_filing_freq::text) AS filing_frequency,
+    max(committee_info.cmte_filing_freq_desc::text) AS filing_frequency_full,
+    min(dates.first_file_date::text::date) AS first_file_date
+   FROM disclosure.v_sum_and_det_sum_report vsd
+     -- New join
+     LEFT JOIN dates on vsd.cmte_id::text = dates.cmte_id::text
+     LEFT JOIN last ON vsd.cmte_id::text = last.cmte_id::text AND get_cycle(vsd.rpt_yr) = last.cycle
+     LEFT JOIN first ON vsd.cmte_id::text = first.committee_id::text AND get_cycle(vsd.rpt_yr) = first.cycle
+     LEFT JOIN committee_info ON vsd.cmte_id::text = committee_info.cmte_id::text AND get_cycle(vsd.rpt_yr)::numeric = committee_info.fec_election_yr
+  WHERE get_cycle(vsd.rpt_yr) >= 1979
+    AND (
+        vsd.form_tp_cd::text <> 'F5'::text
+        OR vsd.form_tp_cd::text = 'F5'::text
+        AND (
+            vsd.rpt_tp::text <> ALL (ARRAY['24'::character varying::text, '48'::character varying::text])
+            )
+        )
+    AND vsd.form_tp_cd::text NOT IN ('F6','SL')
+  GROUP BY vsd.cmte_id, vsd.form_tp_cd, (get_cycle(vsd.rpt_yr))
+  WITH DATA;
+
+-- Permissions
+ALTER TABLE public.ofec_totals_combined_mv_tmp OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_totals_combined_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_totals_combined_mv_tmp TO fec_read;
+
+-- Indexes
+CREATE UNIQUE INDEX idx_ofec_totals_combined_mv_tmp_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_dsgn_full_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (committee_designation_full COLLATE pg_catalog."default", sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_id_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (committee_id , sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_cmte_tp_full_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (committee_type_full, sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_cycle_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (cycle, sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_disb_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (disbursements, sub_id);
+CREATE INDEX idx_ofec_totals_combined_mv_tmp_receipts_sub_id
+    ON public.ofec_totals_combined_mv_tmp USING btree
+    (receipts, sub_id);
+
+-- Recreate vw -> select all from new _tmp MV
+
+-- Need to drop view because we're adding columns
+
+CREATE OR REPLACE VIEW ofec_totals_combined_vw
+AS SELECT * FROM ofec_totals_combined_mv_tmp;
+
+ALTER VIEW ofec_totals_combined_vw OWNER TO fec;
+GRANT SELECT ON ofec_totals_combined_vw TO fec_read;
+
+-- Drop old `MV`
+DROP MATERIALIZED VIEW public.ofec_totals_combined_mv;
+
+-- Rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_totals_combined_mv_tmp RENAME TO ofec_totals_combined_mv;
+
+-- Rename indexes
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_dsgn_full_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_dsgn_full_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_id_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_id_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cmte_tp_full_sub_id RENAME TO idx_ofec_totals_combined_mv_cmte_tp_full_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_cycle_sub_id RENAME TO idx_ofec_totals_combined_mv_cycle_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_disb_sub_id RENAME TO idx_ofec_totals_combined_mv_disb_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_receipts_sub_id RENAME TO idx_ofec_totals_combined_mv_receipts_sub_id;
+ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_sub_id RENAME TO idx_ofec_totals_combined_mv_sub_id;
+
+-- 2 - Modify `ofec_totals_pac_party_vw` to bring in new fields
+
+-- Replaces migration 190 (create view) and 202 (rename sub_id)
+
+CREATE OR REPLACE VIEW public.ofec_totals_pac_party_vw
+AS
+SELECT max(ofec_totals_combined_vw.sub_id) AS idx,
+    max(ofec_totals_combined_vw.committee_id::text) AS committee_id,
+    max(ofec_totals_combined_vw.committee_name) AS committee_name,
+    max(ofec_totals_combined_vw.committee_type) AS committee_type,
+    max(ofec_totals_combined_vw.committee_type_full) AS committee_type_full,
+    max(ofec_totals_combined_vw.committee_designation) AS committee_designation,
+    max(ofec_totals_combined_vw.committee_designation_full) AS committee_designation_full,
+    max(ofec_totals_combined_vw.coverage_start_date) AS coverage_start_date,
+    max(ofec_totals_combined_vw.coverage_end_date) AS coverage_end_date,
+    max(ofec_totals_combined_vw.cycle) AS cycle,
+    sum(COALESCE(ofec_totals_combined_vw.all_loans_received, 0.0)) AS all_loans_received,
+    sum(COALESCE(ofec_totals_combined_vw.allocated_federal_election_levin_share, 0.0)) AS allocated_federal_election_levin_share,
+    max(ofec_totals_combined_vw.cash_on_hand_beginning_period) AS cash_on_hand_beginning_period,
+    sum(COALESCE(ofec_totals_combined_vw.contribution_refunds, 0.0)) AS contribution_refunds,
+    sum(COALESCE(ofec_totals_combined_vw.contributions, 0.0)) AS contributions,
+    sum(COALESCE(ofec_totals_combined_vw.coordinated_expenditures_by_party_committee, 0.0)) AS coordinated_expenditures_by_party_committee,
+    sum(COALESCE(ofec_totals_combined_vw.convention_exp, 0.0)) AS convention_exp,
+    sum(COALESCE(ofec_totals_combined_vw.disbursements, 0.0)) AS disbursements,
+    sum(COALESCE(ofec_totals_combined_vw.exp_subject_limits, 0.0)) AS exp_subject_limits,
+    sum(COALESCE(ofec_totals_combined_vw.exp_prior_years_subject_limits, 0.0)) AS exp_prior_years_subject_limits,
+    sum(COALESCE(ofec_totals_combined_vw.fed_candidate_committee_contributions, 0.0)) AS fed_candidate_committee_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.fed_candidate_contribution_refunds, 0.0)) AS fed_candidate_contribution_refunds,
+    sum(COALESCE(ofec_totals_combined_vw.fed_disbursements, 0.0)) AS fed_disbursements,
+    sum(COALESCE(ofec_totals_combined_vw.fed_election_activity, 0.0)) AS fed_election_activity,
+    sum(COALESCE(ofec_totals_combined_vw.operating_expenditures, 0.0)) AS fed_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.fed_receipts, 0.0)) AS fed_receipts,
+    sum(COALESCE(ofec_totals_combined_vw.federal_funds, 0.0)) AS federal_funds,
+    sum(COALESCE(ofec_totals_combined_vw.independent_expenditures, 0.0)) AS independent_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.refunded_individual_contributions, 0.0)) AS refunded_individual_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.individual_itemized_contributions, 0.0)) AS individual_itemized_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.individual_unitemized_contributions, 0.0)) AS individual_unitemized_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.individual_contributions, 0.0)) AS individual_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.itemized_convention_exp, 0.0)) AS itemized_convention_exp,
+    sum(COALESCE(ofec_totals_combined_vw.itemized_other_disb, 0.0)) AS itemized_other_disb,
+    sum(COALESCE(ofec_totals_combined_vw.itemized_refunds_relating_convention_exp, 0.0)) AS itemized_refunds_relating_convention_exp,
+    sum(COALESCE(ofec_totals_combined_vw.itemized_other_income, 0.0)) AS itemized_other_income,
+    sum(COALESCE(ofec_totals_combined_vw.itemized_other_refunds, 0.0)) AS itemized_other_refunds,
+    max(ofec_totals_combined_vw.last_beginning_image_number) AS last_beginning_image_number,
+    max(ofec_totals_combined_vw.last_cash_on_hand_end_period) AS last_cash_on_hand_end_period,
+    max(ofec_totals_combined_vw.last_debts_owed_by_committee) AS last_debts_owed_by_committee,
+    max(ofec_totals_combined_vw.last_debts_owed_to_committee) AS last_debts_owed_to_committee,
+    max(ofec_totals_combined_vw.last_report_type_full) AS last_report_type_full,
+    max(ofec_totals_combined_vw.last_report_year) AS last_report_year,
+    sum(COALESCE(ofec_totals_combined_vw.loans, 0.0)) AS loans_and_loan_repayments_received,
+    sum(COALESCE(ofec_totals_combined_vw.loan_repayments, 0.0)) AS loans_and_loan_repayments_made,
+    sum(COALESCE(ofec_totals_combined_vw.loan_repayments_other_loans, 0.0)) AS loan_repayments_made,
+    sum(COALESCE(ofec_totals_combined_vw.loan_repayments_received, 0.0)) AS loan_repayments_received,
+    sum(COALESCE(ofec_totals_combined_vw.loans_made, 0.0)) AS loans_made,
+    sum(COALESCE(ofec_totals_combined_vw.transfers_to_other_authorized_committee, 0.0)) AS transfers_to_other_authorized_committee,
+    sum(COALESCE(ofec_totals_combined_vw.net_operating_expenditures, 0.0)) AS net_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.non_allocated_fed_election_activity, 0.0)) AS non_allocated_fed_election_activity,
+    sum(COALESCE(ofec_totals_combined_vw.total_transfers, 0.0)) AS total_transfers,
+    sum(COALESCE(ofec_totals_combined_vw.offsets_to_operating_expenditures, 0.0)) AS offsets_to_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.operating_expenditures, 0.0)) AS operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.other_disbursements, 0.0)) AS other_disbursements,
+    sum(COALESCE(ofec_totals_combined_vw.other_fed_operating_expenditures, 0.0)) AS other_fed_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.other_fed_receipts, 0.0)) AS other_fed_receipts,
+    sum(COALESCE(ofec_totals_combined_vw.other_refunds, 0.0)) AS other_refunds,
+    sum(COALESCE(ofec_totals_combined_vw.other_political_committee_contributions, 0.0)) AS other_political_committee_contributions,
+    max(ofec_totals_combined_vw.party_full) AS party_full,
+    sum(COALESCE(ofec_totals_combined_vw.political_party_committee_contributions, 0.0)) AS political_party_committee_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.receipts, 0.0)) AS receipts,
+    sum(COALESCE(ofec_totals_combined_vw.refunded_other_political_committee_contributions, 0.0)) AS refunded_other_political_committee_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.refunded_political_party_committee_contributions, 0.0)) AS refunded_political_party_committee_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.refunds_relating_convention_exp, 0.0)) AS refunds_relating_convention_exp,
+    sum(COALESCE(ofec_totals_combined_vw.shared_fed_activity, 0.0)) AS shared_fed_activity,
+    sum(COALESCE(ofec_totals_combined_vw.shared_fed_activity_nonfed, 0.0)) AS shared_fed_activity_nonfed,
+    sum(COALESCE(ofec_totals_combined_vw.shared_fed_operating_expenditures, 0.0)) AS shared_fed_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.shared_nonfed_operating_expenditures, 0.0)) AS shared_nonfed_operating_expenditures,
+    sum(COALESCE(ofec_totals_combined_vw.total_exp_subject_limits, 0.0)) AS total_exp_subject_limits,
+    sum(COALESCE(ofec_totals_combined_vw.transfers_from_affiliated_party, 0.0)) AS transfers_from_affiliated_party,
+    sum(COALESCE(ofec_totals_combined_vw.transfers_from_nonfed_account, 0.0)) AS transfers_from_nonfed_account,
+    sum(COALESCE(ofec_totals_combined_vw.transfers_from_nonfed_levin, 0.0)) AS transfers_from_nonfed_levin,
+    sum(COALESCE(ofec_totals_combined_vw.transfers_to_affiliated_committee, 0.0)) AS transfers_to_affiliated_committee,
+    sum(COALESCE(ofec_totals_combined_vw.net_contributions, 0.0)) AS net_contributions,
+    sum(COALESCE(ofec_totals_combined_vw.unitemized_convention_exp, 0.0)) AS unitemized_convention_exp,
+    sum(COALESCE(ofec_totals_combined_vw.unitemized_other_disb, 0.0)) AS unitemized_other_disb,
+    sum(COALESCE(ofec_totals_combined_vw.unitemized_other_income, 0.0)) AS unitemized_other_income,
+    sum(COALESCE(ofec_totals_combined_vw.unitemized_other_refunds, 0.0)) AS unitemized_other_refunds,
+    sum(COALESCE(ofec_totals_combined_vw.unitemized_refunds_relating_convention_exp, 0.0)) AS unitemized_refunds_relating_convention_exp,
+    --New fields
+    max(ofec_totals_combined_vw.committee_state) AS committee_state,
+    max(ofec_totals_combined_vw.treasurer_name) AS treasurer_name,
+    max(ofec_totals_combined_vw.filing_frequency) AS filing_frequency,
+    max(ofec_totals_combined_vw.filing_frequency_full) AS filing_frequency_full,
+    min(ofec_totals_combined_vw.first_file_date) AS first_file_date
+FROM ofec_totals_combined_vw
+WHERE ofec_totals_combined_vw.committee_type IN ('N', 'O', 'Q', 'V', 'W', 'X', 'Y')
+    AND ofec_totals_combined_vw.form_type IN ('F3X', 'F13', 'F4', 'F3','F3P')
+GROUP BY ofec_totals_combined_vw.committee_id, ofec_totals_combined_vw.cycle;
+
+-- Permissions
+
+ALTER TABLE public.ofec_totals_pac_party_vw OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_totals_pac_party_vw TO fec;
+
+GRANT SELECT ON TABLE public.ofec_totals_pac_party_vw TO fec_read;

--- a/data/migrations/V0228__modify_ofec_totals_combined.sql
+++ b/data/migrations/V0228__modify_ofec_totals_combined.sql
@@ -10,7 +10,12 @@ New fields/columns need to be at the end
     `filing_frequency_full`,
     `first_file_date`,
 
-2 - Modify `ofec_totals_pac_party_vw` to bring in new fields from `ofec_totals_combined_vw`
+    Replaces V0204
+
+2 - Modify `ofec_totals_pac_party_vw` to bring in new fields
+from `ofec_totals_combined_vw`
+
+    Replaces V0190 (create view) and V0202 (rename `sub_id`)
 
 */
 
@@ -250,8 +255,6 @@ CREATE INDEX idx_ofec_totals_combined_mv_tmp_receipts_sub_id
 
 -- Recreate vw -> select all from new _tmp MV
 
--- Need to drop view because we're adding columns
-
 CREATE OR REPLACE VIEW ofec_totals_combined_vw
 AS SELECT * FROM ofec_totals_combined_mv_tmp;
 
@@ -274,8 +277,6 @@ ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_receipts_sub_id RENAME TO 
 ALTER INDEX IF EXISTS idx_ofec_totals_combined_mv_tmp_sub_id RENAME TO idx_ofec_totals_combined_mv_sub_id;
 
 -- 2 - Modify `ofec_totals_pac_party_vw` to bring in new fields
-
--- Replaces migration 190 (create view) and 202 (rename sub_id)
 
 CREATE OR REPLACE VIEW public.ofec_totals_pac_party_vw
 AS

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -63,6 +63,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
             'treasurer_name': 'Treasurer, Trudy',
             'committee_state': 'DC',
             'filing_frequency': 'Q',
+            'filing_frequency_full': 'Quarterly filer',
             'first_file_date': datetime.date.fromisoformat("1982-12-31"),
         }
         second_pac_total = {
@@ -74,6 +75,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
             'treasurer_name': 'Treasurer, Tom',
             'committee_state': 'CT',
             'filing_frequency': 'M',
+            'filing_frequency_full': 'Monthly filer',
             'first_file_date': datetime.date.fromisoformat("1984-12-31"),
         }
         factories.TotalsPacFactory(**first_pac_total)
@@ -245,6 +247,7 @@ class TestTotals(ApiBaseTest):
             'treasurer_name': 'Treasurer, Trudy',
             'committee_state': 'DC',
             'filing_frequency': 'Q',
+            'filing_frequency_full': 'Quarterly filer',
             'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'all_loans_received': 1,
             'allocated_federal_election_levin_share': 2,
@@ -321,6 +324,7 @@ class TestTotals(ApiBaseTest):
             'treasurer_name': 'Treasurer, Trudy',
             'committee_state': 'DC',
             'filing_frequency': 'Q',
+            'filing_frequency_full': 'Quarterly filer',
             'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'all_loans_received': 1,
             'allocated_federal_election_levin_share': 2,
@@ -398,6 +402,7 @@ class TestTotals(ApiBaseTest):
             'treasurer_name': 'Treasurer, Trudy',
             'committee_state': 'DC',
             'filing_frequency': 'Q',
+            'filing_frequency_full': 'Quarterly filer',
             'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'committee_name': 'PRESIDENTIAL INAUGURAL COMMITTEE',
             'coverage_start_date': '2012-12-10 00:00:00',

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -60,6 +60,10 @@ class TestTotalsByCommitteeType(ApiBaseTest):
             'cycle': 2018,
             'all_loans_received': 1,
             'allocated_federal_election_levin_share': 2,
+            'treasurer_name': 'Treasurer, Trudy',
+            'committee_state': 'DC',
+            'filing_frequency': 'Q',
+            'first_file_date': datetime.date.fromisoformat("1982-12-31"),
         }
         second_pac_total = {
             'committee_id': 'C00002',
@@ -67,6 +71,10 @@ class TestTotalsByCommitteeType(ApiBaseTest):
             'cycle': 2016,
             'all_loans_received': 10,
             'allocated_federal_election_levin_share': 20,
+            'treasurer_name': 'Treasurer, Tom',
+            'committee_state': 'CT',
+            'filing_frequency': 'M',
+            'first_file_date': datetime.date.fromisoformat("1984-12-31"),
         }
         factories.TotalsPacFactory(**first_pac_total)
         factories.TotalsPacFactory(**second_pac_total)
@@ -77,6 +85,17 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         assert len(results) == 2
         assert results[0]['committee_id'] == 'C00001'
         assert results[1]['committee_id'] == 'C00002'
+
+        # Test all fields for result #2
+
+        # Dates are weird - pulling them out to test separately
+        result_first_file_date = results[1].pop('first_file_date')
+        expected_first_file_date = second_pac_total.pop('first_file_date').isoformat()
+        self.assertEqual(result_first_file_date, expected_first_file_date)
+
+        # Check all the results for fields we've created in `second_pac_total`
+        test_subset = {k: v for k, v in results[1].items() if k in second_pac_total}
+        self.assertEqual(test_subset, second_pac_total)
 
     def test_cycle_filter(self):
         presidential_fields = {

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 
 from tests import factories
@@ -222,6 +223,10 @@ class TestTotals(ApiBaseTest):
         pac_party_fields = {
             'committee_id': committee_id,
             'cycle': 2016,
+            'treasurer_name': 'Treasurer, Trudy',
+            'committee_state': 'DC',
+            'filing_frequency': 'Q',
+            'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'all_loans_received': 1,
             'allocated_federal_election_levin_share': 2,
             'coordinated_expenditures_by_party_committee': 3,
@@ -277,7 +282,11 @@ class TestTotals(ApiBaseTest):
         results = self._results(
             api.url_for(TotalsCommitteeView, committee_id=committee_id)
         )
+        # Dates are weird - pulling them out to test separately
+        result_first_file_date = results[0].pop('first_file_date')
+        fields_first_file_date = fields.pop('first_file_date').isoformat()
         self.assertEqual(results[0], fields)
+        self.assertEqual(result_first_file_date, fields_first_file_date)
 
     def test_Pac_totals(self):
         committee_id = 'C8675311'
@@ -290,6 +299,10 @@ class TestTotals(ApiBaseTest):
         pac_fields = {
             'committee_id': committee_id,
             'cycle': 2016,
+            'treasurer_name': 'Treasurer, Trudy',
+            'committee_state': 'DC',
+            'filing_frequency': 'Q',
+            'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'all_loans_received': 1,
             'allocated_federal_election_levin_share': 2,
             'coordinated_expenditures_by_party_committee': 3,
@@ -345,7 +358,11 @@ class TestTotals(ApiBaseTest):
         results = self._results(
             api.url_for(TotalsCommitteeView, committee_id=committee_id)
         )
+        # Dates are weird - pulling them out to test separately
+        result_first_file_date = results[0].pop('first_file_date')
+        fields_first_file_date = fields.pop('first_file_date').isoformat()
         self.assertEqual(results[0], fields)
+        self.assertEqual(result_first_file_date, fields_first_file_date)
 
     def test_party_totals(self):
 
@@ -359,6 +376,10 @@ class TestTotals(ApiBaseTest):
         party_fields = {
             'committee_id': committee_id,
             'cycle': 2014,
+            'treasurer_name': 'Treasurer, Trudy',
+            'committee_state': 'DC',
+            'filing_frequency': 'Q',
+            'first_file_date': datetime.date.fromisoformat("1982-12-31"),
             'committee_name': 'PRESIDENTIAL INAUGURAL COMMITTEE',
             'coverage_start_date': '2012-12-10 00:00:00',
             'coverage_end_date': '2013-08-07 00:00:00',
@@ -417,7 +438,11 @@ class TestTotals(ApiBaseTest):
         results = self._results(
             api.url_for(TotalsCommitteeView, committee_id=committee_id)
         )
+        # Dates are weird - pulling them out to test separately
+        result_first_file_date = results[0].pop('first_file_date')
+        fields_first_file_date = fields.pop('first_file_date').isoformat()
         self.assertEqual(results[0], fields)
+        self.assertEqual(result_first_file_date, fields_first_file_date)
 
     def test_ie_totals(self):
         committee_id = 'C8675312'

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -213,6 +213,7 @@ class CommitteeTotalsPacParty(CommitteeTotals):
     treasurer_name = db.Column(db.String(100), index=True, doc=docs.TREASURER_NAME)
     committee_state = db.Column(db.String(2), index=True, doc=docs.COMMITTEE_STATE)
     filing_frequency = db.Column(db.String(1), doc=docs.FILING_FREQUENCY)
+    filing_frequency_full = db.Column(db.String, doc=docs.FILING_FREQUENCY)
     first_file_date = db.Column(db.Date, index=True, doc=docs.FIRST_FILE_DATE)
 
 

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -210,6 +210,10 @@ class CommitteeTotalsPacParty(CommitteeTotals):
     unitemized_convention_exp = db.Column(db.Numeric(30, 2))
     itemized_other_disb = db.Column(db.Numeric(30, 2))
     unitemized_other_disb = db.Column(db.Numeric(30, 2))
+    treasurer_name = db.Column(db.String(100), index=True, doc=docs.TREASURER_NAME)
+    committee_state = db.Column(db.String(2), index=True, doc=docs.COMMITTEE_STATE)
+    filing_frequency = db.Column(db.String(1), doc=docs.FILING_FREQUENCY)
+    first_file_date = db.Column(db.Date, index=True, doc=docs.FIRST_FILE_DATE)
 
 
 class CommitteeTotalsHouseSenate(CommitteeTotals):


### PR DESCRIPTION
## Summary (required)

Resolves #4872: 

- Add new fields to `/totals/committee_type/` endpoint:
  - `treasurer_name`
  - `committee_state`
  - `filing_frequency`
  - `filing_frequency_full`
  - `first_file_date` 
- Add tests

**Notes**
- This change only applies to types `pac-party`, `pac`, and `party`, and **not** `presidential`, `house-senate`, or `ie-only` (fields won't appear)
- I'm hoping to rename this endpoint later to `/totals/entity_type/` endpoint because `committee_type` means specifically the 1-letter code FEC uses. I didn't want this PR to get too big.

### Required reviewers

- @hcaofec if you could please review the database changes
- @fec-jli and/or @pkfec, thank you!

## Impacted areas of the application

**fec.gov**
- Committee profile pages (totals should be unchanged, only adding fields)
- (feature in progress) PAC/Party datatable

**API**
- `/totals/<string:committee_type>/` only for types `pac-party`, `pac`, and `party` (uses [`default_schemas`](https://github.com/fecgov/openFEC/blob/82233df98543c1683de149b9f6c5a8b1372ce27c/webservices/resources/totals.py#L34-L37))
- `/committee/<string:committee_id>/totals/` for `committee_type` other than `P`, `H`, `S`, and `I` (uses [`default_schemas`](https://github.com/fecgov/openFEC/blob/82233df98543c1683de149b9f6c5a8b1372ce27c/webservices/resources/totals.py#L34-L37))

**Database**
- New fields/joins are commented in the migration file as `New fields/New join`
- Add new function `expand_filing_frequency`   
- Modify `ofec_totals_combined_mv` and `ofec_totals_combined_vw` to add:
    `committee_state`
    `treasurer_name`,
    `filing_frequency`,
    `filing_frequency_full`,
    `first_file_date`,
- Modify `ofec_totals_pac_party_vw` to bring in new fields from `ofec_totals_combined_vw`

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Check out this branch
- Run tests
- Run migrations with `flyway migrate`
- In `openFEC/webservices/common/models/totals.py`,  Go to `class CommitteeTotalsPacParty(CommitteeTotals)` and point it to `__tablename__ = 'ofec_totals_pac_party_vw_lb'` (created for testing data on 6/9/21, will be stale since these don't get refreshed, script is here: https://github.com/fecgov/openFEC/issues/4872#issuecomment-857733910)
- Go to http://localhost:5000/v1/totals/pac-party/?sort_nulls_last=false&sort=-committee_id&sort_null_only=false&per_page=20&sort_hide_null=false&api_key=DEMO_KEY&cycle=2022&page=1
- Verify that the fields  `treasurer_name`, `committee_state`, `filing_frequency`, and ` first_file_date` appear
- Go to http://localhost:5000/v1/committee/C00005488/totals/?api_key=5JX2rcWDNrf0UEmIdVwE8Oab8cg9V27NdAb7pJVs&per_page=100&page=1
- Verify that the fields  `treasurer_name`, `committee_state`, `filing_frequency`, and ` first_file_date` appear
- Test of any other thing that I might have overlooked

