### PR TITLE
fix schedule_b efile download multi same rows

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -860,7 +860,7 @@ ItemizedScheduleBfilingsSchema = make_schema(
     options={
         'relationships': [
             Relationship(
-                models.ScheduleEEfile.committee,
+                models.ScheduleBEfile.committee,
                 models.CommitteeHistory.name,
                 'committee_name',
                 1


### PR DESCRIPTION
## Summary (required)
Schedule B efiling export downloading same row 100,000 times

- Resolves [#4825 ](https://github.com/fecgov/openFEC/issues/4825)

### Required reviewers
two backend developers

## Impacted areas of the application
schems.py

General components of the application that this PR will affect:
disbursement--raw data--download 
  
## How to test
1)checkout branch
2)two optionals to test
a)deploy to stage space, test disbursement--raw data--download 
b)follow the wiki to setup Redis, Celery-worker on local to test disbursement--raw data--download.
[Set up Redis, Celery on local and test the task](https://github.com/fecgov/openFEC/wiki/Set-up-Redis,--Celery-on-local-and-test-the-tasks)

3)ex url like this: you can filter some data to export
https://stage.fec.gov/data/disbursements/?data_type=efiling&committee_id=C00702944