### PR TITLE
Update celery worker memory

### DIFF
--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: celery-worker
     instances: 1
-    memory: 1G
+    memory: 512M
     disk_quota: 1G
     no-route: true
     health-check-type: process

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -2,7 +2,7 @@
 applications:
   - name: celery-worker
     instances: 6
-    memory: 1G
+    memory: 1.5G
     disk_quota: 1G
     no-route: true
     health-check-type: process


### PR DESCRIPTION
## Summary (required)

Allocate more memory to worker instances in Production to address worker out of memory issues happening more frequently in production.

- Related issue #4864 

(Include a summary of proposed changes and connect issue below)
 - Reduce worker memory to 512M in manifest_celery_worker_dev.yml
 - Increase worker memory to 1.5G  manifest_celery_worker_prod.yml

### Required reviewers

-  Any one backend developer.

## Impacted areas of the application
-  Downloads, Scheduled tasks.