### PR TITLE
Rename totals and reports endpoints to use `entity_type` instead of `committee_type`

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -115,7 +115,7 @@ class TestDownloadTask(ApiBaseTest):
 
         for view in DOWNLOADABLE_RESOURCES:
             if view.endpoint in ['reportsview']:
-                url = api.url_for(view, committee_type=committee.committee_type)
+                url = api.url_for(view, entity_type=committee.committee_type)
             elif view.endpoint in [
                 'filingsview',
                 'committeereportsview',

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -44,7 +44,7 @@ class TestReports(ApiBaseTest):
     def test_reports_by_committee_type(self):
         presidential_report = factories.ReportsPresidentialFactory()
         house_report = factories.ReportsHouseSenateFactory()
-        results = self._results(api.url_for(ReportsView, committee_type='presidential'))
+        results = self._results(api.url_for(ReportsView, entity_type='presidential'))
         self._check_committee_ids(results, [presidential_report], [house_report])
 
     def test_reports_by_committee_type_and_cycle(self):
@@ -52,7 +52,7 @@ class TestReports(ApiBaseTest):
         presidential_report_2016 = factories.ReportsPresidentialFactory(cycle=2016)
         house_report_2016 = factories.ReportsHouseSenateFactory(cycle=2016)
         results = self._results(
-            api.url_for(ReportsView, committee_type='presidential', cycle=2016,)
+            api.url_for(ReportsView, entity_type='presidential', cycle=2016,)
         )
         self._check_committee_ids(
             results,
@@ -61,7 +61,7 @@ class TestReports(ApiBaseTest):
         )
         # Test repeated cycle parameter
         results = self._results(
-            api.url_for(ReportsView, committee_type='presidential', cycle=[2016, 2018],)
+            api.url_for(ReportsView, entity_type='presidential', cycle=[2016, 2018],)
         )
         self._check_committee_ids(
             results,
@@ -83,17 +83,17 @@ class TestReports(ApiBaseTest):
                 factory(is_amended=True),
             ]
 
-            results = self._results(api.url_for(ReportsView, committee_type=category))
+            results = self._results(api.url_for(ReportsView, entity_type=category))
             self.assertEqual(len(results), 2)
 
             results = self._results(
-                api.url_for(ReportsView, committee_type=category, is_amended='false')
+                api.url_for(ReportsView, entity_type=category, is_amended='false')
             )
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['committee_id'], reports[0].committee_id)
 
             results = self._results(
-                api.url_for(ReportsView, committee_type=category, is_amended='true')
+                api.url_for(ReportsView, entity_type=category, is_amended='true')
             )
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['committee_id'], reports[1].committee_id)
@@ -107,7 +107,7 @@ class TestReports(ApiBaseTest):
         )
         house_report_2016 = factories.ReportsHouseSenateFactory(report_year=2016)
         results = self._results(
-            api.url_for(ReportsView, committee_type='presidential', year=2016,)
+            api.url_for(ReportsView, entity_type='presidential', year=2016,)
         )
         self._check_committee_ids(
             results,
@@ -116,7 +116,7 @@ class TestReports(ApiBaseTest):
         )
         # Test repeated cycle parameter
         results = self._results(
-            api.url_for(ReportsView, committee_type='presidential', year=[2016, 2018],)
+            api.url_for(ReportsView, entity_type='presidential', year=[2016, 2018],)
         )
         self._check_committee_ids(
             results,
@@ -184,7 +184,7 @@ class TestReports(ApiBaseTest):
         results = self._results(
             api.url_for(
                 ReportsView,
-                committee_type='presidential',
+                entity_type='presidential',
                 beginning_image_number=number,
             )
         )
@@ -208,7 +208,7 @@ class TestReports(ApiBaseTest):
         results = self._results(
             api.url_for(
                 ReportsView,
-                committee_type='presidential',
+                entity_type='presidential',
                 beginning_image_number=number,
             )
         )
@@ -229,7 +229,7 @@ class TestReports(ApiBaseTest):
         results = self._results(
             api.url_for(
                 ReportsView,
-                committee_type='house-senate',
+                entity_type='house-senate',
                 beginning_image_number=number,
             )
         )
@@ -282,7 +282,7 @@ class TestReports(ApiBaseTest):
         )
         results = self._results(
             api.url_for(
-                ReportsView, committee_type='ie-only', beginning_image_number=number,
+                ReportsView, entity_type='ie-only', beginning_image_number=number,
             )
         )
         result = results[0]

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -82,7 +82,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         factories.TotalsPacFactory(**second_pac_total)
 
         results = self._results(
-            api.url_for(TotalsByEntityTypeView, committee_type='pac')
+            api.url_for(TotalsByEntityTypeView, entity_type='pac')
         )
         assert len(results) == 2
         assert results[0]['committee_id'] == 'C00001'
@@ -109,7 +109,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         }
         factories.CommitteeTotalsPerCycleFactory(**presidential_fields)
         results = self._results(
-            api.url_for(TotalsByEntityTypeView, cycle=2016, committee_type='presidential')
+            api.url_for(TotalsByEntityTypeView, cycle=2016, entity_type='presidential')
         )
         assert len(results) == 1
         self.assertEqual(results[0]['cycle'], presidential_fields['cycle'])
@@ -126,7 +126,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         }
         factories.TotalsPacFactory(**party_fields)
         results = self._results(
-            api.url_for(TotalsByEntityTypeView, committee_designation='U', committee_type='party')
+            api.url_for(TotalsByEntityTypeView, committee_designation='U', entity_type='party')
         )
         assert len(results) == 1
         self.assertEqual(results[0]['committee_designation'], party_fields['committee_designation'])

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -8,7 +8,7 @@ from webservices import utils
 from webservices.rest import api
 from webservices.resources.totals import (
     TotalsCommitteeView,
-    TotalsByCommitteeTypeView,
+    TotalsByEntityTypeView,
     ScheduleAByStateRecipientTotalsView,
 )
 
@@ -82,7 +82,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         factories.TotalsPacFactory(**second_pac_total)
 
         results = self._results(
-            api.url_for(TotalsByCommitteeTypeView, committee_type='pac')
+            api.url_for(TotalsByEntityTypeView, committee_type='pac')
         )
         assert len(results) == 2
         assert results[0]['committee_id'] == 'C00001'
@@ -109,7 +109,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         }
         factories.CommitteeTotalsPerCycleFactory(**presidential_fields)
         results = self._results(
-            api.url_for(TotalsByCommitteeTypeView, cycle=2016, committee_type='presidential')
+            api.url_for(TotalsByEntityTypeView, cycle=2016, committee_type='presidential')
         )
         assert len(results) == 1
         self.assertEqual(results[0]['cycle'], presidential_fields['cycle'])
@@ -126,7 +126,7 @@ class TestTotalsByCommitteeType(ApiBaseTest):
         }
         factories.TotalsPacFactory(**party_fields)
         results = self._results(
-            api.url_for(TotalsByCommitteeTypeView, committee_designation='U', committee_type='party')
+            api.url_for(TotalsByEntityTypeView, committee_designation='U', committee_type='party')
         )
         assert len(results) == 1
         self.assertEqual(results[0]['committee_designation'], party_fields['committee_designation'])

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -63,13 +63,6 @@ class District(fields.Str):
 
 election_full = fields.Bool(missing=True, description=docs.ELECTION_FULL)
 
-check_full_election_parameter = {
-    # Parameter `full_election` is replaced by `election_full`.
-    # if user pass full_election, send error message.
-    # this one is only used in resources/totals.py for CandidateTotalsView
-    'full_election': fields.Bool(description=docs.FULL_ELECTION),
-}
-
 paging = {
     'page': Natural(missing=1, description='For paginating through results, starting at page 1'),
     'per_page': per_page,

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -417,7 +417,7 @@ committee_totals = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
 }
 
-totals_by_committee_type = {
+totals_by_entity_type = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_designation': fields.List(fields.Str, description=docs.DESIGNATION),
     'committee_id': fields.Str(description=docs.COMMITTEE_ID),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -290,7 +290,6 @@ Filter records to only those that were applicable to a given year.
 ELECTION_FULL = '''`True` indicates that full election period of a candidate.
 `False` indicates that two year election cycle.'''
 
-FULL_ELECTION = 'Parameter `full_election` is replaced by `election_full`. Please use `election_full` instead.'
 
 COMMITTEE_STREET_1 = '''
 Street address of committee as reported on the Form 1
@@ -741,7 +740,6 @@ is the next year — for example, in 2015, the current cycle is 2016.
 
 For presidential and Senate candidates, multiple two-year cycles exist between elections.
 
-Parameter `full_election` is replaced by `election_full`. Please use `election_full` instead.
 '''
 
 SCHEDULE_A_TAG = '''

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -4,9 +4,6 @@ LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is usin
 from form F3X line number 16.
 """
 
-FULL_ELECTION_ERROR = """Parameter 'full_election' is replaced by 'election_full'. Please use 'election_full' instead.
-"""
-
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -128,7 +128,7 @@ def get_match_filters():
     tags=['financial'],
     description=docs.REPORTS,
     params={
-        'committee_type': {
+        'entity_type': {
             'description': 'House, Senate, presidential, independent expenditure only',
             'enum': ['presidential', 'pac-party', 'house-senate', 'ie-only'],
         },
@@ -139,9 +139,9 @@ class ReportsView(views.ApiResource):
     @use_kwargs(args.reports)
     @use_kwargs(args.make_multi_sort_args(default=['-coverage_end_date']))
     @marshal_with(schemas.CommitteeReportsPageSchema(), apply=False)
-    def get(self, committee_type=None, **kwargs):
+    def get(self, entity_type=None, **kwargs):
         query, reports_class, reports_schema = self.build_query(
-            committee_type=committee_type, **kwargs
+            entity_type=entity_type, **kwargs
         )
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
@@ -149,10 +149,10 @@ class ReportsView(views.ApiResource):
         page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
         return reports_schema().dump(page).data
 
-    def build_query(self, committee_type=None, **kwargs):
+    def build_query(self, entity_type=None, **kwargs):
         # For this endpoint we now enforce the enpoint specified to map the right model.
         reports_class, reports_schema = reports_schema_map.get(
-            reports_type_map.get(committee_type), default_schemas,
+            reports_type_map.get(entity_type), default_schemas,
         )
         query = reports_class.query
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -129,7 +129,8 @@ def get_match_filters():
     description=docs.REPORTS,
     params={
         'entity_type': {
-            'description': 'House, Senate, presidential, independent expenditure only',
+            'description': 'Committee groupings based on FEC filing form. \
+                Choose one of: `presidential`, `pac-party`, `house-senate`, or `ie-only`',
             'enum': ['presidential', 'pac-party', 'house-senate', 'ie-only'],
         },
     },

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -79,7 +79,7 @@ default_candidate_schemas = (
 )
 class TotalsByEntityTypeView(utils.Resource):
     @use_kwargs(args.paging)
-    @use_kwargs(args.totals_by_committee_type)
+    @use_kwargs(args.totals_by_entity_type)
     @use_kwargs(args.make_sort_args(default='-cycle'))
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, committee_id=None, entity_type=None, **kwargs):

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -77,7 +77,7 @@ default_candidate_schemas = (
         },
     },
 )
-class TotalsByCommitteeTypeView(utils.Resource):
+class TotalsByEntityTypeView(utils.Resource):
     @use_kwargs(args.paging)
     @use_kwargs(args.totals_by_committee_type)
     @use_kwargs(args.make_sort_args(default='-cycle'))

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -65,7 +65,9 @@ default_candidate_schemas = (
     description=docs.TOTALS,
     params={
         'entity_type': {
-            'description': 'House, Senate, presidential, independent expenditure only',
+            'description': 'Committee groupings based on FEC filing form. \
+                Choose one of: `presidential`, `pac`, `party`, `pac-party`, \
+                `house-senate`, or `ie-only`',
             'enum': [
                 'presidential',
                 'pac',

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -182,7 +182,6 @@ class CandidateTotalsView(utils.Resource):
     @use_kwargs(args.paging)
     @use_kwargs(args.candidate_totals_detail)
     @use_kwargs(args.make_sort_args(default='-cycle'))
-    @use_kwargs(args.check_full_election_parameter)
     @marshal_with(schemas.CommitteeTotalsPageSchema(), apply=False)
     def get(self, candidate_id, **kwargs):
         query, totals_class, totals_schema = self.build_query(
@@ -201,12 +200,6 @@ class CandidateTotalsView(utils.Resource):
         )
         query = totals_class.query
         query = query.filter(totals_class.candidate_id == candidate_id.upper())
-
-        if 'full_election' in kwargs.keys():
-            # full_election is replaced by election_full.
-            raise exceptions.ApiError(
-                exceptions.FULL_ELECTION_ERROR, status_code=400,
-            )
 
         if kwargs.get('election_full') is None:
             # not pass election_full

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -324,7 +324,7 @@ api.add_resource(
     '/candidate/<string:candidate_id>/committees/history/',
     '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
 )
-api.add_resource(totals.TotalsByCommitteeTypeView, '/totals/<string:committee_type>/')
+api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:committee_type>/')
 api.add_resource(totals.TotalsCommitteeView, '/committee/<string:committee_id>/totals/')
 api.add_resource(totals.CandidateTotalsView, '/candidate/<string:candidate_id>/totals/')
 api.add_resource(reports.ReportsView, '/reports/<string:committee_type>/')
@@ -469,7 +469,7 @@ apidoc.register(reports.CommitteeReportsView, blueprint='v1')
 apidoc.register(reports.EFilingHouseSenateSummaryView, blueprint='v1')
 apidoc.register(reports.EFilingPresidentialSummaryView, blueprint='v1')
 apidoc.register(reports.EFilingPacPartySummaryView, blueprint='v1')
-apidoc.register(totals.TotalsByCommitteeTypeView, blueprint='v1')
+apidoc.register(totals.TotalsByEntityTypeView, blueprint='v1')
 apidoc.register(totals.CandidateTotalsView, blueprint='v1')
 apidoc.register(totals.TotalsCommitteeView, blueprint='v1')
 apidoc.register(sched_a.ScheduleAView, blueprint='v1')

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -327,7 +327,7 @@ api.add_resource(
 api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:entity_type>/')
 api.add_resource(totals.TotalsCommitteeView, '/committee/<string:committee_id>/totals/')
 api.add_resource(totals.CandidateTotalsView, '/candidate/<string:candidate_id>/totals/')
-api.add_resource(reports.ReportsView, '/reports/<string:committee_type>/')
+api.add_resource(reports.ReportsView, '/reports/<string:entity_type>/')
 api.add_resource(reports.CommitteeReportsView, '/committee/<string:committee_id>/reports/')
 api.add_resource(search.CandidateNameSearch, '/names/candidates/')
 api.add_resource(search.CommitteeNameSearch, '/names/committees/')

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -324,7 +324,7 @@ api.add_resource(
     '/candidate/<string:candidate_id>/committees/history/',
     '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
 )
-api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:committee_type>/')
+api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:entity_type>/')
 api.add_resource(totals.TotalsCommitteeView, '/committee/<string:committee_id>/totals/')
 api.add_resource(totals.CandidateTotalsView, '/candidate/<string:candidate_id>/totals/')
 api.add_resource(reports.ReportsView, '/reports/<string:committee_type>/')


### PR DESCRIPTION
## Summary (required)

- Resolves #4886

Rename `/totals/<string:entity_type>/` and `/reports/<string:entity_type>/` endpoints to use `entity_type` instead of `committee_type`

### Required reviewers

2 developers, please

## Impacted areas of the application

-  No user impact - only under the hood.


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Check out this branch
- Try queries for `/totals/<string:entity_type>/`:  http://localhost:5000/v1/totals/pac-party/?sort_nulls_last=false&sort=-committee_id&sort_null_only=false&per_page=20&sort_hide_null=false&api_key=DEMO_KEY&cycle=2022&page=1
- Try queries  for `/reports/<string:entity_type>/` http://localhost:5000/v1/reports/pac-party/?sort_nulls_last=false&sort=-committee_id&sort_null_only=false&per_page=20&sort_hide_null=false&api_key=DEMO_KEY&cycle=2022&page=1

