### PR TITLE
Add percentages to support PAC snapshot

### DIFF
--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -307,8 +307,63 @@ class TestTotals(ApiBaseTest):
         # Dates are weird - pulling them out to test separately
         result_first_file_date = results[0].pop('first_file_date')
         fields_first_file_date = fields.pop('first_file_date').isoformat()
-        self.assertEqual(results[0], fields)
         self.assertEqual(result_first_file_date, fields_first_file_date)
+
+        # Test calculated percentages
+
+        # `individual_contributions_percent`
+        individual_percent = utils.get_percentage(
+            [fields.get('individual_contributions')],
+            [fields.get('receipts')]
+        )
+        individual_percent_result = results[0].pop('individual_contributions_percent')
+        self.assertEqual(individual_percent, individual_percent_result)
+
+        # `party_and_other_committee_contributions_percent`
+        party_percent = utils.get_percentage(
+            [
+                fields.get('other_political_committee_contributions'),
+                fields.get('political_party_committee_contributions')
+            ],
+            [fields.get('receipts')]
+        )
+        party_percent_result = results[0].pop(
+            'party_and_other_committee_contributions_percent'
+        )
+        self.assertEqual(party_percent, party_percent_result)
+
+        # `contributions_ie_and_party_expenditures_made_percent`
+
+        contributions_made_percent = utils.get_percentage(
+            [
+                fields.get('fed_candidate_committee_contributions'),
+                fields.get('independent_expenditures'),
+                fields.get('coordinated_expenditures_by_party_committee'),
+
+            ],
+            [fields.get('disbursements')]
+        )
+        contributions_made_percent_result = results[0].pop(
+            'contributions_ie_and_party_expenditures_made_percent'
+        )
+        self.assertEqual(
+            contributions_made_percent, contributions_made_percent_result
+        )
+
+        # `operating_expenditures_percent`
+        operating_expenditures_percent = utils.get_percentage(
+            [fields.get('operating_expenditures')],
+            [fields.get('disbursements')]
+        )
+        operating_expenditures_percent_result = results[0].pop(
+            'operating_expenditures_percent'
+        )
+        self.assertEqual(
+            operating_expenditures_percent, operating_expenditures_percent_result
+        )
+
+        # Test the rest of the fields
+        self.assertEqual(results[0], fields)
 
     def test_Pac_totals(self):
         committee_id = 'C8675311'
@@ -384,8 +439,63 @@ class TestTotals(ApiBaseTest):
         # Dates are weird - pulling them out to test separately
         result_first_file_date = results[0].pop('first_file_date')
         fields_first_file_date = fields.pop('first_file_date').isoformat()
-        self.assertEqual(results[0], fields)
         self.assertEqual(result_first_file_date, fields_first_file_date)
+
+        # Test calculated percentages
+
+        # `individual_contributions_percent`
+        individual_percent = utils.get_percentage(
+            [fields.get('individual_contributions')],
+            [fields.get('receipts')]
+        )
+        individual_percent_result = results[0].pop('individual_contributions_percent')
+        self.assertEqual(individual_percent, individual_percent_result)
+
+        # `party_and_other_committee_contributions_percent`
+        party_percent = utils.get_percentage(
+            [
+                fields.get('other_political_committee_contributions'),
+                fields.get('political_party_committee_contributions')
+            ],
+            [fields.get('receipts')]
+        )
+        party_percent_result = results[0].pop(
+            'party_and_other_committee_contributions_percent'
+        )
+        self.assertEqual(party_percent, party_percent_result)
+
+        # `contributions_ie_and_party_expenditures_made_percent`
+
+        contributions_made_percent = utils.get_percentage(
+            [
+                fields.get('fed_candidate_committee_contributions'),
+                fields.get('independent_expenditures'),
+                fields.get('coordinated_expenditures_by_party_committee'),
+
+            ],
+            [fields.get('disbursements')]
+        )
+        contributions_made_percent_result = results[0].pop(
+            'contributions_ie_and_party_expenditures_made_percent'
+        )
+        self.assertEqual(
+            contributions_made_percent, contributions_made_percent_result
+        )
+
+        # `operating_expenditures_percent`
+        operating_expenditures_percent = utils.get_percentage(
+            [fields.get('operating_expenditures')],
+            [fields.get('disbursements')]
+        )
+        operating_expenditures_percent_result = results[0].pop(
+            'operating_expenditures_percent'
+        )
+        self.assertEqual(
+            operating_expenditures_percent, operating_expenditures_percent_result
+        )
+
+        # Test the rest of the fields
+        self.assertEqual(results[0], fields)
 
     def test_party_totals(self):
 
@@ -465,8 +575,63 @@ class TestTotals(ApiBaseTest):
         # Dates are weird - pulling them out to test separately
         result_first_file_date = results[0].pop('first_file_date')
         fields_first_file_date = fields.pop('first_file_date').isoformat()
-        self.assertEqual(results[0], fields)
         self.assertEqual(result_first_file_date, fields_first_file_date)
+
+        # Test calculated percentages
+
+        # `individual_contributions_percent`
+        individual_percent = utils.get_percentage(
+            [fields.get('individual_contributions')],
+            [fields.get('receipts')]
+        )
+        individual_percent_result = results[0].pop('individual_contributions_percent')
+        self.assertEqual(individual_percent, individual_percent_result)
+
+        # `party_and_other_committee_contributions_percent`
+        party_percent = utils.get_percentage(
+            [
+                fields.get('other_political_committee_contributions'),
+                fields.get('political_party_committee_contributions')
+            ],
+            [fields.get('receipts')]
+        )
+        party_percent_result = results[0].pop(
+            'party_and_other_committee_contributions_percent'
+        )
+        self.assertEqual(party_percent, party_percent_result)
+
+        # `contributions_ie_and_party_expenditures_made_percent`
+
+        contributions_made_percent = utils.get_percentage(
+            [
+                fields.get('fed_candidate_committee_contributions'),
+                fields.get('independent_expenditures'),
+                fields.get('coordinated_expenditures_by_party_committee'),
+
+            ],
+            [fields.get('disbursements')]
+        )
+        contributions_made_percent_result = results[0].pop(
+            'contributions_ie_and_party_expenditures_made_percent'
+        )
+        self.assertEqual(
+            contributions_made_percent, contributions_made_percent_result
+        )
+
+        # `operating_expenditures_percent`
+        operating_expenditures_percent = utils.get_percentage(
+            [fields.get('operating_expenditures')],
+            [fields.get('disbursements')]
+        )
+        operating_expenditures_percent_result = results[0].pop(
+            'operating_expenditures_percent'
+        )
+        self.assertEqual(
+            operating_expenditures_percent, operating_expenditures_percent_result
+        )
+
+        # Test other fields
+        self.assertEqual(results[0], fields)
 
     def test_ie_totals(self):
         committee_id = 'C8675312'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -323,3 +323,19 @@ class TestEnvVarSplit(TestCase):
         for test_case in test_cases:
             result = utils.split_env_var(test_case)
             self.assertEqual(result, expected)
+
+
+class TestPercentages(TestCase):
+    def test_get_percentage(self):
+        test_cases = [
+            ([3], [9], 33.33),
+            ([2, 3], [10], 50.0),
+            ([1, 2, 3], [10], 60.0),
+            ([1, 2, 3], [0], None),
+            ([2], [5, 5], 20.0),
+            ([0], [10], 0),
+        ]
+        for test_case in test_cases:
+            numerator, denominator, expected = test_case
+            result = utils.get_percentage(numerator, denominator)
+            self.assertEqual(result, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -353,8 +353,8 @@ class TestPercentages(TestCase):
             ([1, None, 3], [10], None),
         ]
         for test_case in test_cases:
-            numerator, denominator, expected = test_case
-            result = utils.get_percentage(numerator, denominator)
+            numerators, denominators, expected = test_case
+            result = utils.get_percentage(numerators, denominators)
             self.assertEqual(result, expected)
 
         # Developer forgets to put values in list

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -335,12 +335,22 @@ class TestPercentages(TestCase):
             ([1, 2, 3], [10], 60.0),
             ([2], [5, 5], 20.0),
             ([0], [10], 0),
-            # Unusual data scenarios should return None
-            ([1, 2, 3], [0], None),  # Divide by zero
-            ([10], [5], None),  # Over 100%
-            ([-10], [5], None),  # Negative numerator
-            ([10], [-5], None),  # Negative denominator
-            ([None], [None], None),  # Null values
+            ([0, 0, 0], [10], 0),
+            # Unusual but should still calculate
+            ([10], [5], 200.0),  # Over 100%
+            ([-5], [10], -50.0),  # Negative numerator
+            ([5], [-10], -50.0),  # Negative denominator
+            ([-5], [-10], 50.0),  # Both negative
+            ([1], [10000], .01),  # Under 1%
+            # None == Unable to calculate
+            # Divide by zero
+            ([1, 2, 3], [0], None),
+            # Null values
+            ([None], [None], None),
+            ([0], [None], None),
+            ([None], [100], None),
+            ([], [], None),
+            ([1, None, 3], [10], None),
         ]
         for test_case in test_cases:
             numerator, denominator, expected = test_case

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 from flask import request
 from webargs import flaskparser
@@ -331,11 +333,20 @@ class TestPercentages(TestCase):
             ([3], [9], 33.33),
             ([2, 3], [10], 50.0),
             ([1, 2, 3], [10], 60.0),
-            ([1, 2, 3], [0], None),
             ([2], [5, 5], 20.0),
             ([0], [10], 0),
+            # Unusual data scenarios should return None
+            ([1, 2, 3], [0], None),  # Divide by zero
+            ([10], [5], None),  # Over 100%
+            ([-10], [5], None),  # Negative numerator
+            ([10], [-5], None),  # Negative denominator
+            ([None], [None], None),  # Null values
         ]
         for test_case in test_cases:
             numerator, denominator, expected = test_case
             result = utils.get_percentage(numerator, denominator)
             self.assertEqual(result, expected)
+
+        # Developer forgets to put values in list
+        with pytest.raises(TypeError):
+            utils.get_percentage(5, 10)

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -1,7 +1,7 @@
 from .base import db, BaseModel
 from sqlalchemy.ext.declarative import declared_attr
 
-from webservices import docs
+from webservices import docs, utils
 
 
 class CommitteeTotals(BaseModel):
@@ -215,6 +215,44 @@ class CommitteeTotalsPacParty(CommitteeTotals):
     filing_frequency = db.Column(db.String(1), doc=docs.FILING_FREQUENCY)
     filing_frequency_full = db.Column(db.String, doc=docs.FILING_FREQUENCY)
     first_file_date = db.Column(db.Date, index=True, doc=docs.FIRST_FILE_DATE)
+
+    @property
+    def individual_contributions_percent(self):
+        """ Line 11(a)(iii) divided by Line 19 """
+        numerators = [self.individual_contributions]
+        denominators = [self.receipts]
+        return utils.get_percentage(numerators, denominators)
+
+
+    @property
+    def party_and_other_committee_contributions_percent(self):
+        """  (Line 11(b) + Line 11(c)) divided by Line 19 """
+        numerators = [
+            self.other_political_committee_contributions,
+            self.political_party_committee_contributions,
+        ]
+        denominators = [self.receipts]
+        return utils.get_percentage(numerators, denominators)
+
+    @property
+    def contributions_ie_and_party_expenditures_made_percent(self):
+        """  (Line 23 + 24 + 25) divided by Line 31 """
+
+        numerators = [
+            self.fed_candidate_committee_contributions,
+            self.independent_expenditures,
+            self.coordinated_expenditures_by_party_committee,
+        ]
+        denominators = [self.disbursements,]
+        return utils.get_percentage(numerators, denominators)
+
+    @property
+    def operating_expenditures_percent(self):
+        """  Line 21(c) divided by Line 31 """
+
+        numerators = [self.operating_expenditures]
+        denominators = [self.disbursements]
+        return utils.get_percentage(numerators, denominators)
 
 
 class CommitteeTotalsHouseSenate(CommitteeTotals):

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -243,7 +243,7 @@ class CommitteeTotalsPacParty(CommitteeTotals):
             self.independent_expenditures,
             self.coordinated_expenditures_by_party_committee,
         ]
-        denominators = [self.disbursements,]
+        denominators = [self.disbursements]
         return utils.get_percentage(numerators, denominators)
 
     @property

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -479,6 +479,10 @@ make_totals_schema = functools.partial(
         'transaction_coverage_date': ma.fields.Date(
             attribute='transaction_coverage.transaction_coverage_date',
             default=None),
+        'individual_contributions_percent': ma.fields.Decimal(places=2),
+        'party_and_other_committee_contributions_percent': ma.fields.Decimal(places=2),
+        'contributions_ie_and_party_expenditures_made_percent': ma.fields.Decimal(places=2),
+        'operating_expenditures_percent': ma.fields.Decimal(places=2),
     },
     options={
         'exclude': ('transaction_coverage', 'idx')

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -545,3 +545,15 @@ class DateTimeEncoder(JSONEncoder):
     def default(self, obj):
         if isinstance(obj, (datetime.date, datetime.datetime)):
             return obj.isoformat()
+
+
+def get_percentage(numerators, denominators):
+    """Calculate the percentage numerator (top) is of denominator (bottom), 2 decimals
+    """
+    numerator = sum(value or 0 for value in numerators)
+    denominator = sum(value or 0 for value in denominators)
+    # Handle divide by zero errors
+    try:
+        return round((numerator / denominator) * 100, 2)
+    except:
+        return None

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -549,11 +549,26 @@ class DateTimeEncoder(JSONEncoder):
 
 def get_percentage(numerators, denominators):
     """Calculate the percentage numerator (top) is of denominator (bottom), 2 decimals
+
+    For unusual data scenarios, return None
     """
-    numerator = sum(value or 0 for value in numerators)
-    denominator = sum(value or 0 for value in denominators)
-    # Handle divide by zero errors
+
+    # Values must be in a list
+    if not isinstance(numerators, list) and denominators(numerators, list):
+        raise TypeError("Numerator and denominators must be type 'list'")
+
+    # Return percentage if between 0 and 100
     try:
-        return round((numerator / denominator) * 100, 2)
-    except:
+        numerator = sum(value or 0 for value in numerators)
+        denominator = sum(value or 0 for value in denominators)
+        percentage = round((numerator / denominator) * 100, 2)
+        return percentage if 0 <= percentage <= 100 else None
+
+    # None for divide by zero errors
+    except ZeroDivisionError:
         return None
+
+    # Output unexpected exceptions
+    except Exception as exception:
+        logger.error(exception, False)
+        raise

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -574,4 +574,4 @@ def get_percentage(numerators, denominators):
     # Output unexpected exceptions
     except Exception as exception:
         logger.error(exception, False)
-        raise
+        return None

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -557,12 +557,15 @@ def get_percentage(numerators, denominators):
     if not isinstance(numerators, list) and denominators(numerators, list):
         raise TypeError("Numerator and denominators must be type 'list'")
 
-    # Return percentage if between 0 and 100
+    # Unable to calculate unless all values are present
+    if None in numerators or None in denominators:
+        return None
+
     try:
         numerator = sum(value or 0 for value in numerators)
         denominator = sum(value or 0 for value in denominators)
         percentage = round((numerator / denominator) * 100, 2)
-        return percentage if 0 <= percentage <= 100 else None
+        return percentage
 
     # None for divide by zero errors
     except ZeroDivisionError:

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -548,22 +548,22 @@ class DateTimeEncoder(JSONEncoder):
 
 
 def get_percentage(numerators, denominators):
-    """Calculate the percentage numerator (top) is of denominator (bottom), 2 decimals
+    """Calculate the percentage numerators (top) are of denominators (bottom), 2 decimals
 
-    For unusual data scenarios, return None
+    If unable to calculate, return None
     """
 
     # Values must be in a list
-    if not isinstance(numerators, list) and denominators(numerators, list):
+    if not isinstance(numerators, list) and isinstance(denominators, list):
         raise TypeError("Numerator and denominators must be type 'list'")
 
-    # Unable to calculate unless all values are present
+    # Unable to calculate unless ALL values are present
     if None in numerators or None in denominators:
         return None
 
     try:
-        numerator = sum(value or 0 for value in numerators)
-        denominator = sum(value or 0 for value in denominators)
+        numerator = sum(value for value in numerators)
+        denominator = sum(value for value in denominators)
         percentage = round((numerator / denominator) * 100, 2)
         return percentage
 
@@ -571,7 +571,7 @@ def get_percentage(numerators, denominators):
     except ZeroDivisionError:
         return None
 
-    # Output unexpected exceptions
+    # Output unexpected exceptions in debug mode
     except Exception as exception:
-        logger.error(exception, False)
+        logger.debug(exception, False)
         return None


### PR DESCRIPTION
## Summary (required)

Resolves #4877

- Add percentages to support PAC snapshot
- Handle unusual data scenarios (see #4876)

### Required reviewers

Two developers requested, others welcome

## Impacted areas of the application

General components of the application that this PR will affect:

Add 4 new fields to /committee/<committee_id/totals endpoint (feeds committee profile page totals):
- `individual_contributions_percent`
- `party_and_other_committee_contributions_percent`             
- `contributions_ie_and_party_expenditures_made_percent`                
- `operating_expenditures_percent`

## How to test

- Check out this branch
- Test unusual data scenarios: https://docs.google.com/spreadsheets/d/18Wt98l1lN4tMCAzzLcQOMpCxpAT5I_zoLGZAfiKPVc4/edit#gid=0
- Test a few committees: http://localhost:5000/v1/committee/<EXAMPLE_COMMITTEE_ID>/totals/?cycle=<EXAMPLE>


