### PR TITLE
Upgrade networkx to v2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.1
 python-dateutil==2.8.1
 sqlalchemy-postgres-copy==0.3.0
-networkx==2.5.1
+networkx==2.6.2
 SQLAlchemy==1.3.19
 icalendar==4.0.2
 GitPython==3.1.0


### PR DESCRIPTION
## Summary (required)

- Resolves #4836

Upgrade networkx python package from v2.5.1 to v2.6.2

### Required reviewers

Atleast one backend developer

## Screenshots

**With existing networkx 2.5.1:**

<img width="1411" alt="Screen Shot 2021-07-28 at 11 10 15 AM" src="https://user-images.githubusercontent.com/11650355/127347824-399d5942-bf53-4f4d-9c78-87dab59c539b.png">


**After upgrading networkx 2.6.2:**

<img width="1412" alt="Screen Shot 2021-07-28 at 11 11 27 AM" src="https://user-images.githubusercontent.com/11650355/127347846-0cc79333-c3e2-4ff4-b79c-55430d1556d9.png">


## How to test
- checkout feature/4836-upgrade-networkx
- create/activate new python virtual
- run pip install -r requirements.txt
- run `snyk test --file=requirements.txt --package-manager=pip`