### PR TITLE
Fix circleCI builds: Allow OS release info to change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
           # Commands listed here are from the CircleCI PostgreSQL config docs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
-            sudo apt-get update -qq && sudo apt-get install -y build-essential postgresql-client
+            sudo apt-get --allow-releaseinfo-change update -qq && sudo apt-get install -y build-essential postgresql-client
             echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway
           command: |
-            sudo apt-get update && sudo apt-get install -y default-jdk
+            sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y default-jdk
             mkdir flyway
             curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-linux-x64.tar.gz | tar zxv -C flyway
             echo 'export PATH=./flyway/flyway-5.2.4:$PATH' >> $BASH_ENV


### PR DESCRIPTION
## Summary (required)

- Resolves #4933 

Allow OS release info to change

From https://stackoverflow.com/questions/68802802/repository-http-security-debian-org-debian-security-buster-updates-inrelease#comment121618773_68802802

Debian just released "bullseye" (debian.org/News/2021/20210814), so Buster moves into LTS - wiki.debian.org/LTS

Bullseye is brand new and Buster LTS goes through June 2024 so we should stick with Buster for now.

### Required reviewers

One approval requested, others welcome 

## Impacted areas of the application

General components of the application that this PR will affect:

-  CircleCI builds

## Before
https://app.circleci.com/pipelines/github/fecgov/openFEC/1078/workflows/c6687d4f-3c85-4fde-8665-156726045b5e/jobs/3548

<img width="1123" alt="Screen Shot 2021-08-17 at 11 34 48 AM" src="https://user-images.githubusercontent.com/31420082/129756609-d091cb02-02e1-4754-83e7-4e3973490104.png">


## After

https://app.circleci.com/pipelines/github/fecgov/openFEC/1079/workflows/6c56f11c-f849-4f22-bea3-87f61de1f9ed/jobs/3552

<img width="1110" alt="Screen Shot 2021-08-17 at 11 36 04 AM" src="https://user-images.githubusercontent.com/31420082/129756635-614dffbc-e450-4b46-a73a-405c99a87b2c.png">
<img width="1112" alt="Screen Shot 2021-08-17 at 11 36 18 AM" src="https://user-images.githubusercontent.com/31420082/129756645-237f5388-922a-4e24-9408-ee0ae8fa1621.png">


## How to test

- See that this build passes: https://app.circleci.com/pipelines/github/fecgov/openFEC/1079/workflows/6c56f11c-f849-4f22-bea3-87f61de1f9ed/jobs/3552
- Under `Install system dependencies` and `Install flyway`, no errors in CircleCI
