### PR TITLE
Fix multi-committee ID filter and downloads

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -23,6 +23,7 @@ from webservices.resources import (
     sched_d,
     sched_e,
     sched_f,
+    totals
 )
 
 from tests import factories
@@ -111,10 +112,14 @@ class TestDownloadTask(ApiBaseTest):
             sched_e.ScheduleEView,
             sched_e.ScheduleEEfileView,
             sched_f.ScheduleFView,
+            totals.TotalsByEntityTypeView
         }
 
         for view in DOWNLOADABLE_RESOURCES:
-            if view.endpoint in ['reportsview']:
+            if view.endpoint in [
+                'reportsview',
+                'totalsbyentitytypeview',
+            ]:
                 url = api.url_for(view, entity_type=committee.committee_type)
             elif view.endpoint in [
                 'filingsview',

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -180,6 +180,45 @@ class TestTotalsByEntityType(ApiBaseTest):
             assert len(results) == 1
             assert results[0][field] == self.second_pac_total.get(field)
 
+    def test_pac_party_multi_committee_id(self):
+
+        factories.TotalsPacFactory(**self.first_pac_total)
+        factories.TotalsPacFactory(**self.second_pac_total)
+        factories.TotalsPacFactory(
+            **{
+                "committee_id": "C00003",
+                "committee_type": "Q",
+                "cycle": 2016,
+                "committee_designation": "B",
+                "all_loans_received": 10,
+                "allocated_federal_election_levin_share": 20,
+                "treasurer_name": "Treasurer, Tom",
+                "committee_state": "CT",
+                "filing_frequency": "M",
+                "filing_frequency_full": "Monthly filer",
+                "first_file_date": datetime.date.fromisoformat("1984-12-31"),
+                "receipts": 200,
+                "disbursements": 50,
+                "sponsor_candidate_ids": ["H02"],
+                "organization_type": "T",
+                "organization_type_full": "Trade",
+            }
+        )
+
+        results = self._results(
+            api.url_for(
+                TotalsByEntityTypeView,
+                entity_type="pac-party",
+                committee_id=[
+                    self.first_pac_total.get("committee_id"),
+                    self.second_pac_total.get("committee_id"),
+                ],
+            )
+        )
+
+        assert len(results) == 2
+        self.assertTrue(all(each["committee_id"] != "C00003" for each in results))
+
     def test_filter_receipts(self):
 
         factories.TotalsPacFactory(**self.first_pac_total)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -415,7 +415,7 @@ committee_totals = {
 totals_by_entity_type = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_designation': fields.List(fields.Str, description=docs.DESIGNATION),
-    'committee_id': fields.Str(description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'committee_state': fields.List(IStr, description=docs.STATE_GENERIC),
         'filing_frequency': fields.List(

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -80,7 +80,7 @@ default_candidate_schemas = (
         },
     },
 )
-class TotalsByEntityTypeView(utils.Resource):
+class TotalsByEntityTypeView(ApiResource):
     @use_kwargs(args.paging)
     @use_kwargs(args.totals_by_entity_type)
     @use_kwargs(args.make_sort_args(default='-cycle'))
@@ -99,8 +99,9 @@ class TotalsByEntityTypeView(utils.Resource):
         )
         query = totals_class.query
 
+        # Committee ID needs to be handled separately because it's not in kwargs
         if committee_id is not None:
-            query = query.filter(totals_class.committee_id == committee_id)
+            query = query.filter(totals_class.committee_id.in_(committee_id))
 
         query = filters.filter_multi(
             query,


### PR DESCRIPTION
## Summary (required)

- Resolves #4947
- Resolves #4946

Fix multi-committee ID filter and downloads

### Required reviewers

Two developers, please

## Impacted areas of the application

General components of the application that this PR will affect:

-  PAC/Party datatable and download

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- Check out this branch
- Either run the CMS and point to your local API or deploy to the `dev` space
- Test downloads: https://dev.fec.gov/data/committees/pac-party/?cycle=2022 and hit "export"
- Test multi-committee search: https://dev.fec.gov/data/committees/pac-party/?committee_id=C00042366&committee_id=C00075820&cycle=2022 (should have two results) or http://localhost:5000/v1/totals/pac-party/?sort_hide_null=false&sort_nulls_last=true&committee_id=C00042366&committee_id=C00075820&cycle=2022&sort=-receipts&per_page=30&page=1

