### PR TITLE
Send Slack alerts when found modified legal case (ADR/AF/MUR)

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -10,11 +10,6 @@ import ssl
 schedule = {}
 if env.app.get("space_name", "unknown-space").lower() != "feature":
     schedule = {
-        # Refresh materialized views everyday at 5am(EST).
-        "refresh_materialized_views": {
-            "task": "webservices.tasks.refresh.refresh_materialized_views",
-            "schedule": crontab(minute=0, hour=9),
-        },
         # Reload DAILY_MODIFIED_STARTING_AO at 9pm(EST) except Sunday.
         "reload_all_aos_daily_except_sunday": {
             "task": "webservices.tasks.legal_docs.reload_all_aos_when_change",
@@ -31,12 +26,21 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
             "schedule": crontab(minute="*/5", hour="10-23"),
         },
+        # Send modified legal case(during 6am-7pm EST) alerts to Slack every day at 7pm(EST)
+        "send_alert_legal_case": {
+            "task": "webservices.tasks.legal_docs.send_alert_most_recent_legal_case",
+            "schedule": crontab(minute=0, hour=23),
+        },
+        # Refresh materialized views everyday at 5am(EST).
+        "refresh_materialized_views": {
+            "task": "webservices.tasks.refresh.refresh_materialized_views",
+            "schedule": crontab(minute=0, hour=9),
+        },
         # Snapshot Elasticsearch at 12am(EST) in Sunday.
         "backup_elasticsearch_every_sunday": {
             "task": "webservices.tasks.legal_docs.create_es_backup",
             "schedule": crontab(minute=0, hour=4, day_of_week="sun"),
         },
-
     }
 
 

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -41,14 +41,15 @@ RECENTLY_MODIFIED_CASES = """
 SLACK_BOTS = "#bots"
 
 
-@app.task(once={'graceful': True}, base=QueueOnce)
-def refresh():
+@app.task(once={"graceful": True}, base=QueueOnce)
+def refresh_most_recent_legal_doc():
+    # refresh most recently(within 8 hours) modified legal_doc.
     with db.engine.connect() as conn:
-        refresh_aos(conn)
-        refresh_cases(conn)
+        refresh_most_recent_aos(conn)
+        refresh_most_recent_cases(conn)
 
 
-@app.task(once={'graceful': True}, base=QueueOnce)
+@app.task(once={"graceful": True}, base=QueueOnce)
 def reload_all_aos_when_change():
     """
     Reload all AOs if there were any new or modified AOs found for the past 24 hour period
@@ -56,65 +57,72 @@ def reload_all_aos_when_change():
     with db.engine.connect() as conn:
         row = conn.execute(DAILY_MODIFIED_STARTING_AO).first()
         if row:
-            logger.info("AO found %s modified at %s", row["ao_no"], row["pg_date"])
-            logger.info("Daily (%s) reload of all AOs starting", datetime.date.today().strftime("%A"))
+            logger.info(" AO found %s modified at %s", row["ao_no"], row["pg_date"])
+            logger.info(" Daily (%s) reload of all AOs starting", datetime.date.today().strftime("%A"))
             load_advisory_opinions()
-            logger.info("Daily (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
-            slack_message = 'Daily reload of all AOs completed in {0} space'.format(get_app_name())
+            logger.info(" Daily (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
+            slack_message = "Daily reload of all AOs completed in {0} space".format(get_app_name())
+
             utils.post_to_slack(slack_message, SLACK_BOTS)
         else:
-            logger.info("No daily (%s) modified AOs found", datetime.date.today().strftime("%A"))
+            logger.info(" No daily (%s) modified AOs found", datetime.date.today().strftime("%A"))
             slack_message = \
-                'No modified AOs found for the day - Reload of all AOs skipped in {0} space'.format(get_app_name())
+                "No modified AOs found for the day - Reload of all AOs skipped in {0} space".format(get_app_name())
             utils.post_to_slack(slack_message, SLACK_BOTS)
 
 
-@app.task(once={'graceful': True}, base=QueueOnce)
+@app.task(once={"graceful": True}, base=QueueOnce)
 def reload_all_aos():
-    logger.info("Weekly (%s) reload of all AOs starting", datetime.date.today().strftime("%A"))
+    logger.info(" Weekly (%s) reload of all AOs starting", datetime.date.today().strftime("%A"))
     load_advisory_opinions()
-    logger.info("Weekly (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
-    slack_message = 'Weekly reload of all AOs completed in {0} space'.format(get_app_name())
+    logger.info(" Weekly (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
+    slack_message = "Weekly reload of all AOs completed in {0} space".format(get_app_name())
     utils.post_to_slack(slack_message, SLACK_BOTS)
 
 
-@app.task(once={'graceful': True}, base=QueueOnce)
+@app.task(once={"graceful": True}, base=QueueOnce)
 def create_es_backup():
     try:
-        logger.info("Weekly (%s) elasticsearch backup starting", datetime.date.today().strftime("%A"))
+        logger.info(" Weekly (%s) elasticsearch backup starting", datetime.date.today().strftime("%A"))
         create_es_snapshot()
-        logger.info("Weekly (%s) elasticsearch backup completed", datetime.date.today().strftime("%A"))
-        slack_message = 'Weekly elasticsearch backup completed in {0} space'.format(get_app_name())
+        logger.info(" Weekly (%s) elasticsearch backup completed", datetime.date.today().strftime("%A"))
+        slack_message = "Weekly elasticsearch backup completed in {0} space".format(get_app_name())
         utils.post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:
         logger.exception(error)
-        slack_message = '*ERROR* elasticsearch backup failed for {0}. Check logs.'.format(get_app_name())
+        slack_message = "*ERROR* elasticsearch backup failed for {0}. Check logs.".format(get_app_name())
         utils.post_to_slack(slack_message, SLACK_BOTS)
 
 
-def refresh_aos(conn):
+def refresh_most_recent_aos(conn):
     row = conn.execute(RECENTLY_MODIFIED_STARTING_AO).first()
     if row:
-        logger.info("AO %s found modified at %s", row["ao_no"], row["pg_date"])
+        logger.info(" AO %s found modified at %s", row["ao_no"], row["pg_date"])
         load_advisory_opinions(row["ao_no"])
     else:
-        logger.info("No modified AOs found")
+        logger.info(" No modified AOs found")
 
 
-def refresh_cases(conn):
-    logger.info('Checking for modified cases')
+def refresh_most_recent_cases(conn):
+    logger.info(" Checking for modified cases(MUR/AF/ADR)...")
     rs = conn.execute(RECENTLY_MODIFIED_CASES)
+    slack_message = ""
     if rs.returns_rows:
         load_count = 0
         deleted_case_count = 0
         for row in rs:
-            logger.info("%s %s found modified at %s", row["case_type"], row["case_no"], row["pg_date"])
+            logger.info(" %s %s found modified at %s", row["case_type"], row["case_no"], row["pg_date"])
             load_cases(row["case_type"], row["case_no"])
             if row["published_flg"]:
                 load_count += 1
-                logger.info("Total of %d case(s) loaded...", load_count)
+                logger.info(" Total of %d case(s) loaded...", load_count)
+                slack_message = slack_message + str(row["case_type"]) + " " + str(row["case_no"]) + " found modified at " + str(row["pg_date"])
             else:
                 deleted_case_count += 1
-                logger.info("Total of %d case(s) unpublished...", deleted_case_count)
+                logger.info(" Total of %d case(s) unpublished...", deleted_case_count)
+                slack_message = " Total of %d case(s) unpublished...", str(deleted_case_count)
     else:
-        logger.info("No modified cases found")
+        logger.info(" No modified cases found")
+    if slack_message:
+        slack_message = slack_message + " in {0} space".format(get_app_name())
+        utils.post_to_slack(slack_message, SLACK_BOTS)

--- a/webservices/tasks/refresh.py
+++ b/webservices/tasks/refresh.py
@@ -15,14 +15,14 @@ def refresh_materialized_views():
     """Update incremental aggregates, itemized schedules, materialized views,
     then slack a notification to the development team.
     """
-    manage.logger.info('Starting nightly refresh...')
+    manage.logger.info('Starting nightly refresh materialized views...')
     try:
         manage.refresh_materialized()
         download.clear_bucket()
-        slack_message = '*Success* nightly updates for {0} completed'.format(get_app_name())
+        slack_message = '*Success* nightly update materialized views for {0} completed'.format(get_app_name())
         utils.post_to_slack(slack_message, '#bots')
         manage.logger.info(slack_message)
     except Exception as error:
         manage.logger.exception(error)
-        slack_message = '*ERROR* nightly update failed for {0}. Check logs.'.format(get_app_name())
+        slack_message = '*ERROR* nightly update materialized views failed for {0}. Check logs.'.format(get_app_name())
         utils.post_to_slack(slack_message, '#bots')

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -47,4 +47,4 @@ def get_json_data(response):
 
 
 def get_app_name():
-    return env.get_credential("APP_NAME")
+    return env.get_credential("APP_NAME") if env.get_credential("APP_NAME") is not None else "fec | api | local"


### PR DESCRIPTION
### Summary
During reloading modified legal case(MUR/AF/ADR), we're experiencing two kinds of issue
- 1)miss whole single legal case. (ex: 09/16/2021, miss MUR_7133: https://fecgov.slack.com/archives/C3X34QQNQ/p1631904707013300 )
The cause of this see below explanation. We will coordinate with contractor to fix it.
- 2)miss legal cases's documents: we already put message into Kibana log.

### Ref tickets:
#4364 
[https://github.com/fecgov/openFEC/issues/4361](https://github.com/fecgov/openFEC/issues/4361)

### Changes are included in this PR
- New cron task to send Slack alerts once a day when there are modified legal case(MUR/AF/ADR) in production. 
- Add 'local' to APP_NAME when testing on local
- Add comments to each cron task.
- Clean some codes and change string value with single quote to double quote 

### Required reviewers
one backend developer is ok, two developers are better.

### Impacted areas of the application
General components of the application that this PR will affect:
Celery-worker cron task
 
### How to test
Option 1: Local test (hard to setup locally, but easy to test cronjob):
- Following wiki setup local env, make sure Redis, celery-beat, celery-worker, api work well: https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks
- Change tasks/legal_docs.py file, line41, SLACK_BOTS = “#test-bot"
- Modify tasks/__init__.py file, task:change send_alert_legal_case to every 2 mins.
```
 "send_alert_legal_case": {
            "task": "webservices.tasks.legal_docs.send_alert_most_recent_legal_case",
            "schedule": crontab(minute="*/2"),
        },
```
- Modify the query RECENTLY_MODIFIED_CASES_SEND_ALERT in tasks/legal_docs.py file, line 41
change  'n' hour to get modified case result return.
```
SELECT case_no, case_type, pg_date, published_flg
    FROM fecmur.cases_with_parsed_case_serial_numbers_vw
    WHERE pg_date >= NOW() - 'n hour'::INTERVAL 	
    and case_type='MUR'
    ORDER BY case_serial
```
- start celery-beat and celery-worker, check message in Slack/#test-bot.
It should be something like this:
```
...
ADR 945 found published at 2021-09-22 10:32:43.113921
ADR 1001 found published at 2021-09-16 09:39:32.261229
AF 2470 found published at 2021-09-16 15:00:58.298312
AF 3357 found published at 2021-09-16 15:01:05.270154
MUR 7220 found published at 2021-09-24 15:39:58.709447
MUR 7647 found published at 2021-09-24 09:53:37.252871
in fec | api | local
```
Note: if you don't setup Elasticsearch locally, you can comment out this task schedule to get rid of some error messages.
```
        "refresh_legal_docs": {
            "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
            "schedule": crontab(minute="*/5", hour="10-23"),
        },
 ```

Option 2: Deploy on dev:
- Create your own branch, modify the query RECENTLY_MODIFIED_CASES_SEND_ALERT in tasks/legal_docs.py file, line 41. change  'n' hour to get modified case result return.
- Change tasks/legal_docs.py file, line41, SLACK_BOTS = “#test-bot" 
- Modify tasks/__init__.py file, task:  send_alert_legal_case to change schedule to "*/2"
- Deploy your test branch to dev
- You should see alert message in slack channel.
It should be something like this:
```
...
ADR 945 found published at 2021-09-22 10:32:43.113921
ADR 1001 found published at 2021-09-16 09:39:32.261229
AF 2470 found published at 2021-09-16 15:00:58.298312
AF 3357 found published at 2021-09-16 15:01:05.270154
MUR 7220 found published at 2021-09-24 15:39:58.709447
MUR 7647 found published at 2021-09-24 09:53:37.252871
in fec | api | dev
```
Task Schedule Management Diagram:
[https://docs.google.com/drawings/d/1RjDRBGRzi6iZOqTSGTgyEgWPmOk5g5HWKAYOmrdD8GU/edit](https://docs.google.com/drawings/d/1RjDRBGRzi6iZOqTSGTgyEgWPmOk5g5HWKAYOmrdD8GU/edit)
<img width="620" alt="Task Schedule Management Diagram" src="https://user-images.githubusercontent.com/24395751/134842518-5369e8ae-8ac0-48c6-9308-d8e59df6fd6a.png">

