### PR TITLE
 Fix pytest depreciation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ webtest==2.0.34
 factory_boy==2.8.1
 itsdangerous==1.1.0 #pinned to fix pytest deprecation warning
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
+importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency o
 psycopg2-binary==2.7.4
 werkzeug==0.16.1
 Flask==1.1.1
-itsdangerous==1.1.0 #pinned to fix pytest warnings while running test_sort_bad tests
 Flask-Cors==3.0.9
 Flask-Script==2.0.6
 Flask-RESTful==0.3.7
@@ -52,4 +51,5 @@ pytest-flake8==1.0.6
 nplusone==0.8.0
 webtest==2.0.34
 factory_boy==2.8.1
-
+itsdangerous==1.1.0 #pinned to fix pytest deprecation warning
+jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency o
 psycopg2-binary==2.7.4
 werkzeug==0.16.1
 Flask==1.1.1
+itsdangerous==1.1.0 #pinned to fix pytest warnings while running test_sort_bad tests
 Flask-Cors==3.0.9
 Flask-Script==2.0.6
 Flask-RESTful==0.3.7


### PR DESCRIPTION
## Summary (required)
In circleci, inside the `Run test` task, 3 different depreciation warning messages appear in the docker console/terminal. 
Pinned following packages to address the warnings in requirements.txt:

1.  itsdangerous==1.1.0
2.  importlib-metadata==3.10.1
3.  jsonschema==3.2.0

- Resolves #4950 



### Required reviewers

one developer is required.

## Impacted areas of the application

circleci/pytest

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## How to test

1. Local
- checkout branch
- run `pytest -s -v` : gives a verbose output.  Depreciation warnings no longer appear in the console/terminal

2. Create a test branch and push it upstream:
- in circleci/run tests tasks : Depreciation warnings no longer appear in the console/terminal
