### PR TITLE
Send to slack alerts and bots channels error message when refresh db fails

### DIFF
--- a/webservices/tasks/refresh_db.py
+++ b/webservices/tasks/refresh_db.py
@@ -9,20 +9,25 @@ from webservices.tasks.utils import get_app_name
 
 logger = logging.getLogger(__name__)
 
+SLACK_BOTS = "#bots"
+SLACK_ALERTS = "#alerts"
+
 
 @app.task
 def refresh_materialized_views():
     """
     Refresh public materialized views.
     """
-    manage.logger.info("Starting daily update materialized views...")
+    manage.logger.info(" Starting daily update materialized views...")
     try:
         manage.refresh_materialized()
         download.clear_bucket()
-        slack_message = "*Success* daily update materialized views for {0} completed".format(get_app_name())
-        utils.post_to_slack(slack_message, '#bots')
+        slack_message = "*Success* daily update materialized views for {0} completed.".format(get_app_name())
+        utils.post_to_slack(slack_message, SLACK_BOTS)
         manage.logger.info(slack_message)
     except Exception as error:
         manage.logger.exception(error)
-        slack_message = "*ERROR* daily update materialized views failed for {0}. Check logs.".format(get_app_name())
-        utils.post_to_slack(slack_message, "#bots")
+        slack_message = "*ERROR* daily update materialized views failed for {0}.".format(get_app_name())
+        slack_message = slack_message + "\n Error message: " + str(error)
+        utils.post_to_slack(slack_message, SLACK_BOTS)
+        utils.post_to_slack(slack_message, SLACK_ALERTS)


### PR DESCRIPTION
## Summary (required)
When the daily refresh db materialized views fails, the error message should be posted to slack #alerts channel.

- Resolves #4901 

modify tasks/refresh_db.py exception section to send error message to Slack #alerts and #bots channels

### Required reviewers

One developer is good, more are welcome.

## Impacted areas of the application
schedule task

## How to test
Option 1: Local test:
- Following wiki setup local env, make sure Redis, celery-beat, celery-worker, api work well: https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks
- Modify tasks/__init__.py file, task:refresh_materialized_views to every 2 mins.
```
        "send_alert_ao": {
            "task": "webservices.tasks.refresh_db.refresh_materialized_views",
            "schedule": crontab(minute="*/2"),
        },
```
- Modify tasks/refresh_db.py, add test code `10 * (1 / 0)` in line 27

- start celery-beat and celery-worker, check message in Slack/#alerts.
It should be something like this:
```
ERROR daily update materialized views failed for fec | api | local.
Error message: division by zero
```

Option 2: Deploy on dev:
- Create your own test branch 
- Modify tasks/refresh_db.py, add test code `10 * (1 / 0)` in line 27
- Modify tasks/__init__.py file, task:  refresh_db.refresh_materialized_views to change schedule to "*/2"
- Deploy your test branch to dev
- You should see message in slack #alerts channel.
It should be something like this:
```
ERROR daily update materialized views failed for fec | api | dev.
Error message: division by zero
```
