### PR TITLE
upgrade-psycopg2-binary-fix-circleci-build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cfenv==0.5.2
 invoke==0.15.0
 kombu==4.6.3
 vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency of kombu
-psycopg2-binary==2.7.4
+psycopg2-binary==2.9.1
 werkzeug==0.16.1
 Flask==1.1.1
 Flask-Cors==3.0.9


### PR DESCRIPTION
## Summary (required)
circleci build failed when tried to merge pr https://github.com/fecgov/openFEC/issues/4901 . From error stack trace its appear that  `psycopg2-binary` v2.7.1  is causing the build issue.
```
Running setup.py install for psycopg2-binary: finished with status 'error'
              ERROR: Command errored out with exit status 1:
```

 circleci builds run OK after upgrading python package `psycopg2-binary` version to 2.9.1  in requirements.txt 


### Required reviewers

one developer is must

## Impacted areas of the application

- circleci build  on openFEC repo: cannot deploy the openFEC app to prod; cannot rerun previous builds


## How to test

Here is the latest circleci build after **upgrading psycopg2-binary version from 2.7.4 to 2.9.1**: https://app.circleci.com/pipelines/github/fecgov/openFEC/1144/workflows/dd7744dc-31dd-4f12-a0f4-3baae39451a7/jobs/3624

- rebuild this feature branch on circleci
