### PR TITLE
4935-Improve CircleCI error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
           # Commands listed here are from the CircleCI PostgreSQL config docs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
-            sudo apt-get --allow-releaseinfo-change update -qq && sudo apt-get install -y build-essential postgresql-client
+            sudo apt-get --allow-releaseinfo-change update -qq 
+            sudo apt-get install -y build-essential postgresql-client
             echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
 
       - run:

--- a/tasks.py
+++ b/tasks.py
@@ -143,7 +143,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/4935-improve-circleci-error-handling'),
 )
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4935 

Separates the build commands in CircleCI so if one fails, the build fails.

### Required reviewers

1 reviewer, but more are welcome

## Impacted areas of the application

General components of the application that this PR will affect:

-  CircleCI build

## Related PRs

-#4934

## How to test

This build should fail on the Install system dependencies step: https://app.circleci.com/pipelines/github/fecgov/openFEC/1067/workflows/c0e3c693-398f-405f-b84c-b99e8c1492d8/jobs/3550


