### PR TITLE
 Add disbursement percents to schedule_b_by_recipient endpoint

### DIFF
--- a/data/migrations/V0239__ofec_sched_b_aggregate_recipient_mv.sql
+++ b/data/migrations/V0239__ofec_sched_b_aggregate_recipient_mv.sql
@@ -1,0 +1,49 @@
+
+-- This materialized view is created for ticket #4988.
+-- This materialized view includes committee total disbursements per cycle
+-- View: public.ofec_sched_b_aggregate_recipient_mv
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_b_aggregate_recipient_mv;
+
+CREATE MATERIALIZED VIEW public.ofec_sched_b_aggregate_recipient_mv
+AS
+SELECT sb.cmte_id,
+    sb.cycle,
+    sb.recipient_nm,
+    sb.non_memo_total,
+    sb.non_memo_count,
+    sb.memo_total,
+    sb.memo_count,
+    sb.idx,
+    v.disbursements
+FROM disclosure.dsc_sched_b_aggregate_recipient_new sb
+LEFT JOIN ofec_committee_totals_per_cycle_vw v ON sb.cmte_id = v.committee_id AND sb.cycle = v.cycle
+WITH DATA;
+
+ALTER TABLE IF EXISTS public.ofec_sched_b_aggregate_recipient_mv
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_sched_b_aggregate_recipient_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_b_aggregate_recipient_mv TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_sched_b_aggregate_recipient_mv_idx
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (idx);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_cmteid
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (cmte_id);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_cycle
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (cycle);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_nonmemocount
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (non_memo_count);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_nonmemototal
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (non_memo_total);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_recpnt_nm
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (recipient_nm);
+CREATE INDEX idx_ofec_sched_b_aggregate_recipient_mv_cycle_cmte_id
+    ON public.ofec_sched_b_aggregate_recipient_mv USING btree
+    (cycle, cmte_id);

--- a/manage.py
+++ b/manage.py
@@ -157,6 +157,7 @@ def refresh_materialized(concurrent=True):
         "totals_house_senate": ["ofec_totals_house_senate_mv"],
         "totals_ie": ["ofec_totals_ie_only_mv"],
         "totals_presidential": ["ofec_totals_presidential_mv"],
+        "sched_b_by_recipient": ["ofec_sched_b_aggregate_recipient_mv"],
     }
 
     graph = flow.get_graph()

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -148,6 +148,8 @@ class TestCommitteeAggregates(ApiBaseTest):
             'count': aggregate.count,
             'memo_total': aggregate.memo_total,
             'memo_count': aggregate.memo_count,
+            'committee_total_disbursements': aggregate.committee_total_disbursements,
+            'recipient_disbursement_percent': aggregate.recipient_disbursement_percent,
         }
         self.assertEqual(results[0], expected)
 

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -54,7 +54,7 @@ class BaseDisbursementAggregate(BaseAggregate):
 
 
 class ScheduleBByRecipient(BaseDisbursementAggregate):
-    __tablename__ = "ofec_sched_b_aggregate_recipient_mv_tmp_hc"
+    __tablename__ = "ofec_sched_b_aggregate_recipient_mv"
 
     recipient_name = db.Column('recipient_nm', db.String, primary_key=True, doc=docs.RECIPIENT_NAME)
     committee_total_disbursements = db.Column('disbursements', db.Numeric(30, 2), index=True, doc=docs.DISBURSEMENTS)

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -54,9 +54,16 @@ class BaseDisbursementAggregate(BaseAggregate):
 
 
 class ScheduleBByRecipient(BaseDisbursementAggregate):
-    __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_b_aggregate_recipient_new'
+    __tablename__ = "ofec_sched_b_aggregate_recipient_mv_tmp_hc"
+
     recipient_name = db.Column('recipient_nm', db.String, primary_key=True, doc=docs.RECIPIENT_NAME)
+    committee_total_disbursements = db.Column('disbursements', db.Numeric(30, 2), index=True, doc=docs.DISBURSEMENTS)
+
+    @property
+    def recipient_disbursement_percent(self):
+        numerators = [self.total]
+        denominators = [self.committee_total_disbursements]
+        return utils.get_percentage(numerators, denominators)
 
 
 class ScheduleBByRecipientID(BaseDisbursementAggregate):

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -46,6 +46,7 @@ def get_graph():
         'totals_house_senate',
         'totals_ie',
         'totals_presidential',
+        'sched_b_by_recipient',
     ]
     graph.add_nodes_from(MATERIALIZED_VIEWS)
 
@@ -123,6 +124,6 @@ def get_graph():
     ])
 
     graph.add_edge('ofec_pcc_to_pac', 'committee_history'),
-    
+    graph.add_edge('totals_combined', 'sched_b_by_recipient'),
 
     return graph

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -650,7 +650,7 @@ ScheduleBByRecipientSchema = make_schema(
         'recipient_disbursement_percent': ma.fields.Decimal(places=2),
     },
     options={
-        'exclude': ('idx', 'committee', 'recipient')
+        'exclude': ('idx', 'committee')
     },
 )
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -640,8 +640,23 @@ ScheduleBByRecipientIDSchema = make_schema(
         'exclude': ('idx', 'committee', 'recipient')
     },
 )
-
 augment_schemas(ScheduleBByRecipientIDSchema)
+
+
+# Schema/PageSchema for ScheduleBByRecipient
+ScheduleBByRecipientSchema = make_schema(
+    models.ScheduleBByRecipient,
+    fields={
+        'recipient_disbursement_percent': ma.fields.Decimal(places=2),
+    },
+    options={
+        'exclude': ('idx', 'committee', 'recipient')
+    },
+)
+
+ScheduleBByRecipientPageSchema = make_page_schema(ScheduleBByRecipientSchema, page_type=paging_schemas.SeekPageSchema)
+register_schema(ScheduleBByRecipientSchema)
+register_schema(ScheduleBByRecipientPageSchema)
 
 augment_itemized_aggregate_models(
     make_schema,
@@ -651,7 +666,6 @@ augment_itemized_aggregate_models(
     models.ScheduleAByState,
     models.ScheduleAByEmployer,
     models.ScheduleAByOccupation,
-    models.ScheduleBByRecipient,
     models.ScheduleBByPurpose,
 )
 


### PR DESCRIPTION
## Summary (required)

Add the total disbursements percents to`schedule_b_by_recipient` endpoint

- Resolves #4988 

- Add a new property`recipient_disbursement_percent` and compute the percentages inside common/models/aggregates.py `ScheduleBByRecipient` class.
- Add a migration file to include committee total disbursements which will be used to calculate recipient disbursements percentages and results are added to schedule_b_by_recipent endpoint.
- Add the new migration file to the daily mv refresh list in manage.py
- Add migration file dependency in flow.py
- Add required schema/pageschema for schedule_b_by_recipent in schemas.py
- Update the existing `test_disbursement_recipient` test case to include the new output columns.

### Required reviewers
- One backend developer is must. @patphongs you are optional

## Impacted areas of the application

- Display the disbursements percents on the spending section of PAC committee profile page

https://www.fec.gov/data/committee/C00727834/?tab=spending&cycle=2020#disbursement-transactions

-  **schedule_b_by_recipient API endpoint**: 
https://api.open.fec.gov/v1/schedules/schedule_b/by_recipient/?api_key=DEMO_KEY&per_page=20&sort_null_only=false&page=1&sort_hide_null=false&sort_nulls_last=false

## Screenshots

**schedule_b_by_recipient API endpoint in Production without percents**:
<img width="1007" alt="Screen Shot 2021-11-26 at 9 19 21 AM" src="https://user-images.githubusercontent.com/11650355/143595440-22029cc3-56c9-4849-983b-c007b3db3c78.png">

**schedule_b_by_recipient API endpoint  in local with percents**:
<img width="1002" alt="Screen Shot 2021-11-26 at 9 17 24 AM" src="https://user-images.githubusercontent.com/11650355/143595542-aa77205f-502a-431a-9468-5b0c73149c57.png">


## How to test

- checkout `feature/4988-add-disbursement-percents`
- on local flyway folder location run `flyway migrate`- to make sure V0239 migration runs OK (without any errors) against local cfdm_test database
- pytest 
- point to  `tmp_hc` mv in the aggregates model.py here: https://github.com/fecgov/openFEC/blob/feature/4988-add-disbursement-percents/webservices/common/models/aggregates.py#L57
<img width="760" alt="Screen Shot 2021-11-26 at 10 45 37 AM" src="https://user-images.githubusercontent.com/11650355/143605281-4c351723-2364-472f-a54b-c97d9591bde7.png">

- start server run: `./manage.py runserver`
- test `schedules/schedule_b/by_recipient`
- output/results show calculated percents on `recepient_disbursement_percent` 

Example: http://localhost:5000/v1/schedules/schedule_b/by_recipient/?sort_hide_null=false&cycle=2020&sort_nulls_last=false&page=1&committee_id=C00727834&sort_null_only=false&per_page=20

For more examples:
Spreadsheet has list of committees with negative disbursement percents and disbursement percents >100:
https://docs.google.com/spreadsheets/d/1c9nyJHzED6qHuHQaL0Q3f8Omz8ULexyM99z3YwfcgLY/edit#gid=0


