### PR TITLE
Modify reload AOs to handle multiple AOs to ES

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -10,44 +10,48 @@ import ssl
 schedule = {}
 if env.app.get("space_name", "unknown-space").lower() != "feature":
     schedule = {
-        # Task 1: This task is launched every 5 minutes during 6am-7pm(EST).
-        # When found any modified AO within 8 hours, reload all AOs.
-        # When found modified case(s)(MUR/AF/ADR) within 8 hours, reload/delete the modified case(s).
+        # Task 1: This task is launched every 5 minutes during 6am-7pmEST(13 hours).
+        # Task 1A: refresh_most_recent_aos(conn):
+        # 1) Identify the most recently modified AO(s) within 8 hours
+        # 2) For each modified AO, find the earliest AO referenced by the modified AO
+        # 3) Reload all AO(s) starting from the referenced AO to the latest AO.
+
+        # Task 1B: refresh_most_recent_cases(conn):
+        # When found modified case(s)(MUR/AF/ADR) within 8 hours,
+        #   if published_flg = true, reload the case(s) on elasticsearch service.
+        #   if published_flg = false, delete the case(s) on elasticsearch service.
         "refresh_legal_docs": {
             "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
             "schedule": crontab(minute="*/5", hour="10-23"),
         },
         # Task 2: This task is launched at 9pm(EST) everyday except Sunday.
-        # When found any modified AO in past 24 hours, reload all AOs.
+        # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
+        # 2) For each modified AO, find the earliest AO referenced by the modified AO
+        # 3) Reload all AO(s) starting from the referenced AO to the latest AO
+        # 4) Send AO detail information to Slack.
         "reload_all_aos_daily_except_sunday": {
             "task": "webservices.tasks.legal_docs.daily_reload_all_aos_when_change",
             "schedule": crontab(minute=0, hour=1, day_of_week="mon,tue,wed,thu,fri,sat"),
         },
-        # Task 3: This task is launched at 9pm(EST) only on Sunday.
+        # Task 3: This task is launched at 9pm(EST) weekly only on Sunday.
         # Reload all AOs.
         "reload_all_aos_every_sunday": {
             "task": "webservices.tasks.legal_docs.weekly_reload_all_aos",
             "schedule": crontab(minute=0, hour=1, day_of_week="sun"),
         },
         # Task 4: This task is launched at 6pm(EST) everyday.
-        # When found modified AO(s) in past 24 hours, send AO detail information to Slack.
-        "send_alert_ao": {
-            "task": "webservices.tasks.legal_docs.send_alert_daily_modified_ao",
-            "schedule": crontab(minute=0, hour=22),
-        },
-        # Task 5: This task is launched at 7pm(EST) everyday.
-        # When found modified case(s)(MUR/AF/ADR) during 6am-7pm(EST), send case detail information to Slack.
+        # When found modified case(s)(MUR/AF/ADR) in past 13 hours(6am-7pm EST), send case detail information to Slack.
         "send_alert_legal_case": {
             "task": "webservices.tasks.legal_docs.send_alert_daily_modified_legal_case",
             "schedule": crontab(minute=0, hour=23),
         },
-        # Task 6: This task is launched at 12am(EST) only on Sunday.
+        # Task 5: This task is launched at 12am(EST) only on Sunday.
         # Take Elasticsearch 'docs' index snapshot.
         "backup_elasticsearch_every_sunday": {
             "task": "webservices.tasks.legal_docs.create_es_backup",
             "schedule": crontab(minute=0, hour=4, day_of_week="sun"),
         },
-        # Task 7: This task is launched at 5am(EST) everyday.
+        # Task 6: This task is launched at 5am(EST) everyday.
         # Refresh public materialized views.
         "refresh_materialized_views": {
             "task": "webservices.tasks.refresh_db.refresh_materialized_views",

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -15,41 +15,34 @@ from webservices.tasks.utils import get_app_name
 
 logger = logging.getLogger(__name__)
 
-DAILY_MODIFIED_AO = """
-    SELECT ao_no, pg_date
-    FROM aouser.aos_with_parsed_numbers
-    WHERE pg_date >= NOW() - '24 hour'::INTERVAL
-    ORDER BY ao_year, ao_serial
-    LIMIT 1;
-"""
-
-RECENTLY_MODIFIED_STARTING_AO = """
+RECENTLY_MODIFIED_AOS = """
     SELECT ao_no, pg_date
     FROM aouser.aos_with_parsed_numbers
     WHERE pg_date >= NOW() - '8 hour'::INTERVAL
-    ORDER BY ao_year, ao_serial
-    LIMIT 1;
+    ORDER BY ao_year, ao_serial;
 """
 
 RECENTLY_MODIFIED_CASES = """
     SELECT case_no, case_type, pg_date, published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE pg_date >= NOW() - '8 hour'::INTERVAL
-    ORDER BY case_serial
+    ORDER BY case_serial;
 """
 
-DAILY_MODIFIED_AOS_SEND_ALERT = """
+# For daily_reload_all_aos_when_change(): in past 24 hours(9pm-9pm EST)
+DAILY_MODIFIED_AOS = """
     SELECT ao_no, pg_date
     FROM aouser.aos_with_parsed_numbers
     WHERE pg_date >= NOW() - '24 hour'::INTERVAL
-    ORDER BY ao_year, ao_serial
+    ORDER BY ao_year, ao_serial;
 """
 
+# for send_alert_daily_modified_legal_case(): during 6am-7pm(EST) (13 hours)
 DAILY_MODIFIED_CASES_SEND_ALERT = """
     SELECT case_no, case_type, pg_date, published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE pg_date >= NOW() - '13 hour'::INTERVAL
-    ORDER BY case_serial
+    ORDER BY case_serial;
 """
 
 SLACK_BOTS = "#bots"
@@ -58,8 +51,16 @@ SLACK_BOTS = "#bots"
 @app.task(once={"graceful": True}, base=QueueOnce)
 def refresh_most_recent_legal_doc():
     """
-    When found any modified AO within 8 hours, reload all AOs.
-    When found modified case(s)(MUR/AF/ADR) within 8 hours, reload/delete the modified case(s).
+        # Task 1: This task is launched every 5 minutes during 6am-7pmEST(13 hours).
+        # Task 1A: refresh_most_recent_aos(conn):
+        # 1) Identify the most recently modified AO(s) within 8 hours
+        # 2) For each modified AO, find the earliest AO referenced by the modified AO
+        # 3) Reload all AO(s) starting from the referenced AO to the latest AO.
+
+        # Task 1B: refresh_most_recent_cases(conn):
+        # When found modified case(s)(MUR/AF/ADR) within 8 hours,
+        #   if published_flg = true, reload the case(s) on elasticsearch service.
+        #   if published_flg = false, delete the case(s) on elasticsearch service.
     """
     with db.engine.connect() as conn:
         refresh_most_recent_aos(conn)
@@ -68,22 +69,29 @@ def refresh_most_recent_legal_doc():
 
 def refresh_most_recent_aos(conn):
     """
-    When found any modified AO within 8 hours, relead all AOs starting the earliest AO.
+        # 1) Identify the most recently modified AO(s) within 8 hours
+        # 2) For each modified AO, find the earliest AO referenced by the modified AO
+        # 3) Reload all AO(s) starting from the referenced AO to the latest AO.
     """
-    logger.info(" Checking for recently modified AO...")
-    row = conn.execute(RECENTLY_MODIFIED_STARTING_AO).first()
-    if row:
-        logger.info(" Recently modified AO %s found at %s", row["ao_no"], row["pg_date"])
-        load_advisory_opinions(row["ao_no"])
-    else:
+    logger.info(" Checking for recently modified AOs...")
+    rs = conn.execute(RECENTLY_MODIFIED_AOS)
+    row_count = 0
+    for row in rs:
+        if row:
+            row_count += 1
+            logger.info(" Recently modified AO %s found at %s", row["ao_no"], row["pg_date"])
+            load_advisory_opinions(row["ao_no"])
+    if row_count <= 0:
         logger.info(" No recently modified AO(s) found.")
+    else:
+        logger.info(" Total of %d ao(s) loaded to elasticsearch successfully.", row_count)
 
 
 def refresh_most_recent_cases(conn):
     """
-    When found modified case(s)(MUR/AF/ADR) within 8 hours,
-        if published_flg = true reload the modified case(s).
-        if published_flg = false delete the case(s)
+        # When found modified case(s)(MUR/AF/ADR) within 8 hours,
+        #   if published_flg = true, reload the case(s) on elasticsearch service.
+        #   if published_flg = false, delete the case(s) on elasticsearch service.
     """
     logger.info(" Checking for recently modified cases(MUR/AF/ADR)...")
     rs = conn.execute(RECENTLY_MODIFIED_CASES)
@@ -96,7 +104,7 @@ def refresh_most_recent_cases(conn):
         load_cases(row["case_type"], row["case_no"])
         if row["published_flg"]:
             load_count += 1
-            logger.info(" Total of %d case(s) loaded to elasticsearch.", load_count)
+            logger.info(" Total of %d case(s) loaded to elasticsearch successfully.", load_count)
         else:
             deleted_case_count += 1
             logger.info(" Total of %d case(s) unpublished.", deleted_case_count)
@@ -108,18 +116,34 @@ def refresh_most_recent_cases(conn):
 @app.task(once={"graceful": True}, base=QueueOnce)
 def daily_reload_all_aos_when_change():
     """
-    When found any modified AO in past 24 hours, reload all AOs, because AO may reference backward and forward AO.
+        # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
+        # 2) For each modified AO, find the earliest AO referenced by the modified AO
+        # 3) Reload all AO(s) starting from the referenced AO to the latest AO
+        # 4) Send AO detail information to Slack.
     """
+    slack_message = ""
+    logger.info(" Checking for daily modified AOs...")
     with db.engine.connect() as conn:
-        row = conn.execute(DAILY_MODIFIED_AO).first()
-        if row:
-            logger.info(" Daily AO found %s modified at %s", row["ao_no"], row["pg_date"])
-            logger.info(" Daily (%s) reload of all AOs ", datetime.date.today().strftime("%A"))
-            load_advisory_opinions(row["ao_no"])
-            logger.info(" Daily (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
-
-        else:
+        rs = conn.execute(DAILY_MODIFIED_AOS)
+        row_count = 0
+        for row in rs:
+            if row:
+                row_count += 1
+                logger.info(" Daily modified AO %s found at %s", row["ao_no"], row["pg_date"])
+                logger.info(" Daily (%s) reload of all AOs ", datetime.date.today().strftime("%A"))
+                load_advisory_opinions(row["ao_no"])
+                slack_message = slack_message + "AO_" + str(row["ao_no"]) + " found modified at " + str(row["pg_date"])
+                slack_message = slack_message + "\n"
+        if row_count <= 0:
             logger.info(" No daily (%s) modified AOs found. Skip reload", datetime.date.today().strftime("%A"))
+            slack_message = "No daily modified AO found."
+        else:
+            logger.info(
+                " Daily (%s) total of %d ao(s) reload to elasticsearch successfully.", datetime.date.today().strftime("%A"), row_count)
+
+    if slack_message:
+        slack_message = slack_message + " in " + get_app_name()
+        utils.post_to_slack(slack_message, SLACK_BOTS)
 
 
 @app.task(once={"graceful": True}, base=QueueOnce)
@@ -129,28 +153,9 @@ def weekly_reload_all_aos():
     """
     logger.info(" Weekly (%s) reload of all AOs ", datetime.date.today().strftime("%A"))
     load_advisory_opinions()
-    logger.info(" Weekly (%s) reload of all AOs completed", datetime.date.today().strftime("%A"))
-    slack_message = "Weekly reload of all AOs completed in {0} space".format(get_app_name())
+    logger.info(" Weekly (%s) reload of all AOs completed successfully", datetime.date.today().strftime("%A"))
+    slack_message = "Weekly reload of all AOs completed successfully in {0} space".format(get_app_name())
     utils.post_to_slack(slack_message, SLACK_BOTS)
-
-
-@app.task(once={"graceful": True}, base=QueueOnce)
-def send_alert_daily_modified_ao():
-    # When found modified AO(s) in past 24 hours, send AO detail information to Slack.
-    slack_message = ""
-    with db.engine.connect() as conn:
-        rs = conn.execute(DAILY_MODIFIED_AOS_SEND_ALERT)
-        row_count = 0
-        for row in rs:
-            row_count += 1
-            slack_message = slack_message + "AO_" + str(row["ao_no"]) + " found modified at " + str(row["pg_date"])
-            slack_message = slack_message + "\n"
-    if row_count <= 0:
-        slack_message = "No daily modified AO found"
-
-    if slack_message:
-        slack_message = slack_message + " in " + get_app_name()
-        utils.post_to_slack(slack_message, SLACK_BOTS)
 
 
 @app.task(once={"graceful": True}, base=QueueOnce)


### PR DESCRIPTION
## Summary (required)
In this PR, we modify the AO reload task function to handle multiple AOs to elasticsearch
that include two functions: 
`refresh_most_recent_aos()`
`daily_reload_all_aos_when_change()`

- Resolves #4976 
modify tasks/legal_docs.py `refresh_most_recent_aos()` and `daily_reload_all_aos_when_change()` functions to handle multiple AOs and send AO detail information in Slack.

### Required reviewers
One developer is good, more are welcome.

## Impacted areas of the application
schedule task for reload multiple modified AOs

## How to test
Only local test:
- Checkout branch, create your test branch and into virtual env.
- Set SQLA_CONN to point dev read-only
- Reference wiki disable redis_url in webservices/tasks/__init__.py https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks 
We only need three terminals for this PR test: Redis, celery-beat, celery-worker
- Modify tasks/legal_docs.py file: 
```
SLACK_BOTS = "#test-bot"
```
- comment out line 76 and line 97 in tasks/legal_docs.py, don't upload to ES from local
load_advisory_opinions(row["ao_no"])
load_cases(row["case_type"], row["case_no"]) 

- `export SLACK_HOOK="xxxxx"` in celery-worker terminal

Test A (test function refresh_most_recent_aos):
- Modify tasks/__init__.py file, task: `refresh_legal_docs` to every 2 mins and disable all other schedules. 
```
        "refresh_legal_docs": {
            "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
            "schedule": crontab(minute="*/2"),
        },
```
- Modify the query **RECENTLY_MODIFIED_AOS** in tasks/legal_docs.py file, line 21
change  'n' hour to return **multiple** modified ao result. ex:
```
    SELECT ao_no, pg_date
    FROM aouser.aos_with_parsed_numbers
    WHERE pg_date >= NOW() - '400 hour'::INTERVAL
    ORDER BY ao_year, ao_serial
```
- start redis server, celery-beat and celery-worker, check message in Slack/#test-bot.
It should be something like this:
```
AO_2021-13 found modified at 2022-01-12 11:18:50.488695
AO_2022-01 found modified at 2022-01-13 11:18:55.779646
in fec | api | local
```

Test B (test function daily_reload_all_aos_when_change):
- Modify tasks/__init__.py file, task: `daily_reload_all_aos_when_change` to every 2 mins and disable all other schedules. 
```
        "reload_all_aos_daily_except_sunday": {
            "task": "webservices.tasks.legal_docs.daily_reload_all_aos_when_change",
            "schedule": crontab(minute="*/2"),
        },
```

- Modify the query **DAILY_MODIFIED_AOS** in tasks/legal_docs.py file, line 36
change  'n' hour to return **multiple** modified ao result. ex:
```
    SELECT ao_no, pg_date
    FROM aouser.aos_with_parsed_numbers
    WHERE pg_date >= NOW() - '400 hour'::INTERVAL
    ORDER BY ao_year, ao_serial
```
- start redis server, celery-beat and celery-worker, check message in Slack/#test-bot.
It should be something like this:
```
AO_2021-13 found modified at 2022-01-12 11:18:50.488695
AO_2022-01 found modified at 2022-01-13 11:18:55.779646
in fec | api | local
```
and check your celery-worker terminal, you should see below:
<img width="1131" alt="Screen Shot 2022-01-24 at 9 39 44 PM" src="https://user-images.githubusercontent.com/24395751/151059400-8227bbbf-c300-42af-8c79-e1456c5c5896.png">

Tip: How to clean Redis db:
1)Start Redis server and keep this terminal on.
2)Open an new terminal, go to Redis config location
`cd /usr/local/etc/ `
3)Start Redis-cli
`command redis-cli `
4)clean Redis db
`flushall`
