### PR TITLE
5030-Narrow fix to suite value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
           # Commands listed here are from the CircleCI PostgreSQL config docs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
-            sudo apt-get --allow-releaseinfo-change update -qq && sudo apt-get install -y build-essential postgresql-client
+            sudo apt-get --allow-releaseinfo-change-suite update -qq && sudo apt-get install -y build-essential postgresql-client
             echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway
           command: |
-            sudo apt-get --allow-releaseinfo-change update && sudo apt-get install -y default-jdk
+            sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
             curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-linux-x64.tar.gz | tar zxv -C flyway
             echo 'export PATH=./flyway/flyway-5.2.4:$PATH' >> $BASH_ENV


### PR DESCRIPTION
## Summary 
- Resolves #5030 
This narrows the previous CircleCI fix to just changes in the 'Suite' value. After researching the issue and reading the --allow-releaseinfo-change documentation, I confirmed the logic of the current solution and the secuirty risk of missing updates to dependencies by allowing all. I found [this addition](https://stackoverflow.com/questions/68849201/disadvantage-of-using-allow-releaseinfo-change-for-apt-get-update) to mitigate the risk by using specialties, specifically narrowing just to 'Suite' instead of all release info values.  

### Required reviewers

1-2 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

-  CircleCI builds

## Screenshots
I ran the old code to confirm the solution logic still fails:
https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=circleci-test-build-apt-get&filter=all

Here's the updated build allowing just changes in 'Suite' values: 
https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=5030-improve-circleci-fix&filter=all

## Related PRs
- [#4933 ] 

