### PR TITLE
Upgrade flyway to 8.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/5.2.4/flyway-commandline-5.2.4-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-5.2.4:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.4.3/flyway-commandline-8.4.3-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-8.4.3:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 5.2.4 ([download](https://flywaydb.org/getstarted/download))
-		* After downloading, open `flyway5.2.4/conf/flyway.conf` and set
+    * Flyway 8.4.3 ([download](https://flywaydb.org/getstarted/download))
+		* After downloading, open `flyway8.4.3/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '5.2.4'
-    implementation(group: 'org.flywaydb', name: 'flyway-commandline', version: '5.2.4') {
+    implementation group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '8.4.3'
+    implementation(group: 'org.flywaydb', name: 'flyway-commandline', version: '8.4.3') {
         exclude group: 'com.microsoft.sqlserver', module: 'msql-jdbc'
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-5.2.4.jar:app/gradle/lib/flyway-core-5.2.4.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-8.4.3.jar:app/gradle/lib/flyway-core-8.4.3.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5006 

This PR upgrade flyway to version 8.4.3

### Required reviewers

1-2 developer

## Screenshots
![image](https://user-images.githubusercontent.com/24396726/153075924-42ae4341-3c79-4e07-b73f-7af1270d0efc.png)

## How to test
1. Run flyway on local, with version 5.2.4, this warning message will appear:
![image](https://user-images.githubusercontent.com/24396726/153079660-9441408d-3a2b-451d-b905-857b4ab61c99.png)

2. Install 8.4.3 and run flyway on local, this warning is gone.
3. The feature branch was deployed to dev space and here is circleci log:
https://app.circleci.com/pipelines/github/fecgov/openFEC/1232/workflows/5ebc8c92-5fce-4396-b845-41836395b415/jobs/3726



