### PR TITLE
Fix 404 error when a case is unpublished

### DIFF
--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -258,7 +258,7 @@ def load_cases(case_type, case_no=None):
                     try:
                         logger.info("Found an unpublished case - deleting {0}: {1} from ES".format(
                             case_type, case["no"]))
-                        es_client.delete(index=DOCS_ALIAS, id="case['doc_id']")
+                        es_client.delete(index=DOCS_ALIAS, id=case["doc_id"])
                         logger.info("Successfully deleted {} {} from ES".format(case_type, case["no"]))
                     except Exception as err:
                         logger.error("An error occurred while deteting an unpublished case.{0} {1} {2}".format(


### PR DESCRIPTION
## Summary (required)

Elasticsearch service throws a 404 error trying to delete a unpublish case (MUR, ADR or AF) from the website. 

- Resolves #5013 
- Remove the double quotes surrounding the id, when a case is deleted by its id.

### Required reviewers

One developer

## Impacted areas of the application

-  Enforcements/MUR, ADR and AF 

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)



## How to test

- 

