### PR TITLE
[Dev space] upgrade worker memory to 1GB 

### DIFF
--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: celery-worker
     instances: 1
-    memory: 512M
+    memory: 1G
     disk_quota: 1G
     no-route: true
     health-check-type: process


### PR DESCRIPTION
## Summary (required)

- Resolves #5046

- upgrade worker memory to 1GB in manifest_celery_worker_dev.yml

### Required reviewers

One developer

## Impacted areas of the application

-  Celery worker in `Dev` space
