### PR TITLE
upgrade postgres circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:10.11
+      - image: circleci/postgres:13.5
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
@@ -32,7 +32,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/13.5/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway


### PR DESCRIPTION
## Summary (required)
API app is running on postgres v13.14. Upgrade circleci postgres docker image from v10.11 to v13.5 (this is the latest version available in 13.X)

- Resolves #5004

- Ref ticket(s)
-  https://github.com/fecgov/openFEC/issues/5002
- https://github.com/fecgov/openFEC/issues/4993
- https://github.com/fecgov/openFEC/issues/5001

(Include a summary of proposed changes and connect issue below)

### Required reviewers

one developer

## Impacted areas of the application

-  circleci postgres docker image

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

Before:


After:
<img width="1136" alt="Screen Shot 2022-02-08 at 7 05 44 PM" src="https://user-images.githubusercontent.com/11650355/153097409-ef9bdd5e-ad67-4fef-85cb-4a75c9e27bb3.png">




## How to test

-  deploy 

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
