### PR TITLE
upgrade postgres circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:10.11
+      - image: circleci/postgres:13.5
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
@@ -32,7 +32,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/10.11/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/13.5/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway


### PR DESCRIPTION
## Summary (required)
API app is running on postgres v13.14 (released on Dec 3, 2021 ). Upgrade circleci postgres docker image from v10.11 to v13.5 (this is the latest version available in 13.X, (released on Dec 7, 2021 ))

- Resolves #5004

- Ref ticket(s)
-  https://github.com/fecgov/openFEC/issues/5002
- https://github.com/fecgov/openFEC/issues/4993
- https://github.com/fecgov/openFEC/issues/5001

(Include a summary of proposed changes and connect issue below)

### Required reviewers

one developer

## Impacted areas of the application

-  circleci postgres docker image

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

Before:
<img width="1102" alt="Screen Shot 2022-02-08 at 7 26 17 PM" src="https://user-images.githubusercontent.com/11650355/153098578-9b44e840-f7ba-4ff4-b22c-d369f35ab08e.png">


After:
<img width="1136" alt="Screen Shot 2022-02-08 at 7 05 44 PM" src="https://user-images.githubusercontent.com/11650355/153097409-ef9bdd5e-ad67-4fef-85cb-4a75c9e27bb3.png">




## How to test

-  rerun circleci build on `feature/upgrade-postgres-circleci-docker-image` branch.
(https://app.circleci.com/pipelines/github/fecgov/openFEC/1235/workflows/25d24b6f-ead8-4d52-86b9-6a6684adbd33/jobs/3731)
- verify the `container circleci`, `install system dependencies` tasks on circleci now run on postgres 13.5
- pytests run OK
