### PR TITLE
Add "order by" to af_dispositions

### DIFF
--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -140,7 +140,8 @@ AF_DISPOSITION_DATA = """
         dates,
         description
     FROM fecmur.af_case_disposition
-    WHERE case_id = %s;
+    WHERE case_id = %s
+    ORDER BY dates ASC;
 
 """
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5053

Add "order by dates asc" to af_dispositions query.  

### Required reviewers

One developer

## How to test
The feature branch has been deployed to dev space to test the change.  Local test can be done by following these steps:
1. Download feature branch and run `pytest`
2. Follow the wiki (https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally) set up Elasticsearch  7.4 on local, and load 4202 

`python manage.py load_admin_fines -s 4202`

3. start `./manage.py runserver`,  check this api and the af_disposition is listed chronologically
http://127.0.0.1:5000/v1/legal/docs/admin_fines/4202

**Before**:
<img width="500" alt="Screen Shot 2022-02-24 at 4 55 11 PM" src="https://user-images.githubusercontent.com/24396726/155614239-9e4edd62-8277-4801-870d-a2af33a93014.png">

**After**:
<img width="500" alt="Screen Shot 2022-02-24 at 4 13 39 PM" src="https://user-images.githubusercontent.com/24396726/155608729-97d9dbb3-63fd-4f3f-a308-ece2c3338130.png">
