### PR TITLE
Upgrade flyway to 851

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.4.3/flyway-commandline-8.4.3-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-8.4.3:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.5.1/flyway-commandline-8.5.1-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-8.5.1:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 8.4.3 ([download](https://flywaydb.org/getstarted/download))
-		* After downloading, open `flyway8.4.3/conf/flyway.conf` and set
+    * Flyway 8.5.1 ([download](https://flywaydb.org/documentation/commandline/))
+		* After downloading, open `flyway8.5.1/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -686,9 +686,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-5.2.4.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-5.2.4-macosx-x64.tar.gz`, `flyway-commandline-5.2.4-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-8.5.1.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-8.5.1-macosx-x64.tar.gz`, `flyway-commandline-8.5.1-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-5.2.4` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-8.5.1` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '8.4.3'
-    implementation(group: 'org.flywaydb', name: 'flyway-commandline', version: '8.4.3') {
+    implementation group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '8.5.1'
+    implementation(group: 'org.flywaydb', name: 'flyway-commandline', version: '8.5.1') {
         exclude group: 'com.microsoft.sqlserver', module: 'msql-jdbc'
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-8.4.3.jar:app/gradle/lib/flyway-core-8.4.3.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-8.5.1.jar:app/gradle/lib/flyway-core-8.5.1.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5059 

This PR upgrade flyway to version 8.5.1

### Required reviewers

1-2 developer

## How to test
1. Test locally, Ref: [https://github.com/fecgov/openFEC#installing-flyway](https://github.com/fecgov/openFEC#installing-flyway)
For MacOS user, open Safari browser to download
flyway-commandline-8.5.1-macosx-x64.tar.gz 
or you can download from google drive: [https://drive.google.com/drive/folders/1h5i4yL2pqlZc7ydSGahr_5ZZnVeUIGUJ](https://drive.google.com/drive/folders/1h5i4yL2pqlZc7ydSGahr_5ZZnVeUIGUJ)
update flyway conf file, activate virtue, run `invoke create_sample_db`
2. checkout feature branch
3. deploy to dev space without any error
4. Here is circleci log:
https://app.circleci.com/pipelines/github/fecgov/openFEC/1267/workflows/bb13e20e-79dc-4512-af90-2c4c6b1e5a8e/jobs/3768

<img width="350" alt="Screen Shot 2022-03-04 at 1 21 26 PM" src="https://user-images.githubusercontent.com/24395751/156823232-59668074-48b5-480b-8df5-da8014397580.png">
