### PR TITLE
Feature/Upgrade flyway to 852

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.4.3/flyway-commandline-8.4.3-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-8.4.3:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.5.2/flyway-commandline-8.5.2-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-8.5.2:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 8.4.3 ([download](https://flywaydb.org/getstarted/download))
-		* After downloading, open `flyway8.4.3/conf/flyway.conf` and set
+    * Flyway 8.5.2 ([download](https://flywaydb.org/documentation/usage/commandline/))
+		* After downloading, open `flyway8.5.2/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -686,9 +686,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-5.2.4.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-5.2.4-macosx-x64.tar.gz`, `flyway-commandline-5.2.4-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-8.5.2.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-8.5.2-macosx-x64.tar.gz`, `flyway-commandline-8.5.2-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-5.2.4` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-8.5.2` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -21,7 +21,7 @@ dependencies {
         exclude group: "com.google.protobuf", module: "protobuf-java"
         exclude group: "com.google.guava", module: "guava"
         constraints {
-	       implementation("org.postgresql:postgresql:42.2.14.jre6")
+	       implementation("org.postgresql:postgresql:42.2.25.jre6")
         }
     }
 }
@@ -63,7 +63,7 @@ task createRunScript {
 
 task copyPostgresJar(type: Copy) {
     into "$buildDir/drivers"
-    from configurations.runtime
+    from configurations.runtimeOnly
     include "postgres*.jar"
 }
 

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -1,28 +1,28 @@
-apply plugin: 'java'
-apply plugin: 'application'
+apply plugin: "java"
+apply plugin: "application"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation group: 'org.flywaydb', name: 'flyway-gradle-plugin', version: '8.4.3'
-    implementation(group: 'org.flywaydb', name: 'flyway-commandline', version: '8.4.3') {
-        exclude group: 'com.microsoft.sqlserver', module: 'msql-jdbc'
-        exclude group: 'com.h2database', module: 'h2'
-        exclude group: 'com.pivotal.jdbc', module: 'greenplumdriver'
-        exclude group: 'net.sourceforge.jtds', module: 'jtds'
-	exclude group: 'mysql', module: 'mysql-connector-java'
-        exclude group: 'org.apache.derby', module: 'derby'
-        exclude group: 'org.apache.derby', module: 'derbyclient'
-        exclude group: 'org.hsqldb', module: 'hsqldb'
-        exclude group: 'org.mariadb.jdbc', module: 'mariadb-java-client'
-        exclude group: 'org.xerial', module: 'sqlite-jdbc'
-	exclude group: 'com.google.protobuf', module: 'protobuf-java'
-	exclude group: 'com.google.guava', module: 'guava'
-	constraints {
-	    implementation('org.postgresql:postgresql:42.2.14.jre6')
-	}
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "8.5.2"
+    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "8.5.2") {
+        exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
+        exclude group: "com.h2database", module: "h2"
+        exclude group: "com.pivotal.jdbc", module: "greenplumdriver"
+        exclude group: "net.sourceforge.jtds", module: "jtds"
+	    exclude group: "mysql", module: "mysql-connector-java"
+        exclude group: "org.apache.derby", module: "derby"
+        exclude group: "org.apache.derby", module: "derbyclient"
+        exclude group: "org.hsqldb", module: "hsqldb"
+        exclude group: "org.mariadb.jdbc", module: "mariadb-java-client"
+        exclude group: "org.xerial", module: "sqlite-jdbc"
+        exclude group: "com.google.protobuf", module: "protobuf-java"
+        exclude group: "com.google.guava", module: "guava"
+        constraints {
+	       implementation("org.postgresql:postgresql:42.2.14.jre6")
+        }
     }
 }
 

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-8.4.3.jar:app/gradle/lib/flyway-core-8.4.3.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-8.5.2.jar:app/gradle/lib/flyway-core-8.5.2.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5059 

This PR will 
1)upgrade flyway to version 8.5.2 
2)be able to run snyk test on build.gradle.

### Required reviewers

1-2 developer, more welcome.

## How to test
PAET ONE: test flyway posgresslq driver (postgresql-42.2.25.jar) upgrade.
1. Test locally:
Ref: [https://github.com/fecgov/openFEC#installing-flyway](https://github.com/fecgov/openFEC#installing-flyway)
For MacOS user, open Safari browser go to [https://flywaydb.org/documentation/usage/commandline/](https://flywaydb.org/documentation/usage/commandline/)
and download `flyway-commandline-8.5.2-macosx-x64.tar.gz`
or you can download from google drive: [https://drive.google.com/drive/folders/1h5i4yL2pqlZc7ydSGahr_5ZZnVeUIGUJ](https://drive.google.com/drive/folders/1h5i4yL2pqlZc7ydSGahr_5ZZnVeUIGUJ)
update flyway conf file, activate virtue, run `invoke create_sample_db` no error.
2. Test on `dev` space, 
checkout feature branch, create your own test branch, deploy to dev space.
make sure without error and api works well.
Here is circleci log I deployed:
https://app.circleci.com/pipelines/github/fecgov/openFEC/1276/workflows/e22b1e6f-ed55-434d-a486-91f0d8487897/jobs/3777
<img width="350" alt="snyk_circleci_log" src="https://user-images.githubusercontent.com/24395751/157325577-7bc47465-c313-4c54-9f7e-2e2c193bdb9a.png">

3. Run snyk test locally to verify the vulnerable.
(1) you may need install Maven( `brew install maven`)
`mvn -v` #check Maven version
<img width="550" alt="snyk_version" src="https://user-images.githubusercontent.com/24395751/157335748-35067b5e-d133-4081-ada8-1e5113780055.png">
(2) Set Maven path in .bash.profile,
make sure you have: `export PATH="/usr/local/bin:$PATH"`

(3) Open new terminal, go to your local flyway-x.x.x/drivers/
run on flyway 8.4.3: `snyk test --scan-unmanaged --file=postgresql-42.2.19.jar`
(4) run on flyway 8.5.2: `snyk test --scan-unmanaged --file=postgresql-42.2.25.jar`
(5) Compare two results, you will see vulnerability gone.
<img width="600" alt="snyk_843_error" src="https://user-images.githubusercontent.com/24395751/157336798-6f97ab51-2948-4893-9022-9cc886988296.png">

<img width="600" alt="snyk_852_noerror" src="https://user-images.githubusercontent.com/24395751/157336824-e6bc47f0-0bb3-4b66-9a3e-a4c37b06f64f.png">
 
PART TWO: run snyk test on build.gradle
1)If you checkout develop branch, go to data/flyway
run: `snyk test`
you will get error: "Could not get unknown property 'runtime' ..." because  gradle 7.4 ( `gradle -v`) change property name `runtime` to `runtimeonly`
see document [https://stackoverflow.com/questions/60340509/could-not-get-unknown-property-runtime-for-configuration-container-of-type-org](https://stackoverflow.com/questions/60340509/could-not-get-unknown-property-runtime-for-configuration-container-of-type-org)
<img width="600" alt="snyk_gradle_error" src="https://user-images.githubusercontent.com/24395751/157338070-c3a55961-b0c4-4040-a51c-2dc8312e9d17.png">
2)check out this feature branch back
run: `snyk test` again.
you will be able to run it and get some vulnerabilities. We don't decide to fix these now.
<img width="600" alt="snyk_gradle_issue" src="https://user-images.githubusercontent.com/24395751/157338926-e4cf66d9-e34a-4b42-95af-a208a086a5d4.png">


