### PR TITLE
5075-upgrade braintree/sanitize-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@braintree/sanitize-url": "^2.1.0",
+        "@braintree/sanitize-url": "^6.0.0",
         "immutable": "^3.8.2",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
@@ -88,9 +88,9 @@
       "dev": true
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-2.1.0.tgz",
-      "integrity": "sha1-VJqdH5I8m8eVOlhdPpqpQpvo/ig="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -11619,9 +11619,9 @@
       }
     },
     "@braintree/sanitize-url": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-2.1.0.tgz",
-      "integrity": "sha1-VJqdH5I8m8eVOlhdPpqpQpvo/ig="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz",
+      "integrity": "sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w=="
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:lint": "npm run format && npm run lint"
   },
   "dependencies": {
-    "@braintree/sanitize-url": "^2.1.0",
+    "@braintree/sanitize-url": "^6.0.0",
     "immutable": "^3.8.2",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",


### PR DESCRIPTION
## Summary

- Resolves #5075 

Upgrades braintree/sanitize-url to v.6.0.0 remediate vulnerabilities to Cross-site Scripting (XSS) due to improper sanitization in sanitizeUrl function.

### Required reviewers
1-2 devs 

## Impacted areas of the application

General components of the application that this PR will affect:

-  openFEC

## Screenshots
Before:
<img width="1440" alt="Screen Shot 2022-03-16 at 5 10 08 PM" src="https://user-images.githubusercontent.com/66386084/158702336-ec6db1ee-7a0f-4d43-97c4-2fc8f3b6a34f.png">
After:
<img width="1415" alt="Screen Shot 2022-03-16 at 5 03 50 PM" src="https://user-images.githubusercontent.com/66386084/158702360-51593234-8caf-409e-9fa0-35c422304a00.png">


## How to test
- run `snyk test` locally on develop to confirm vulnerability
`snyk test --file=requirements.txt --package-manager=pip`
`snyk test --file=package.json`
- checkout this branch
-  `rm -rf node_modules`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install && npm run build`
- run `snyk test` 
you should see one less vulnerability (see screenshots above)

Also--- thank you @pkfec and @fec-jli (I got most of these snyk instructions from you both!)
