### PR TITLE
[WIP] Upgrade  python to 3.8.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.8-buster
+      - image: circleci/python:3.8.12-buster
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.7 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 10 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.8.x


### PR DESCRIPTION
## Summary (required)

Upgrade OpenFEC python runtime to 3.8.12

- Resolves #4959

### Required reviewers
Two  backend

## Impacted areas of the application

	modified:   .circleci/config.yml
	modified:   README.md
	modified:   runtime.txt

## Related PRs
Previous upgrade to 3.7.4:
https://github.com/fecgov/openFEC/pull/3961:

## How to test
Helpfful FEC WIki page for considerations when updating python locally and at the app level: https://github.com/fecgov/openFEC/wiki/Updating-Python
- [ ]   checkout this branch
- [ ] `pip install -r {requirements.txt, requirements-dev.txt}`
- [ ]  activate a virtual environment  for `python@3.8.12`
- [ ] `pytest`
- [ ] `nvm use --lts`
- [ ] `npm install -g swagger-tools`
- [ ] `npm install`
- [ ] `npm run build`
- [ ] `run local api and test swagger-ui`
- [ ]  run local cms and point to local api, run redis and celery worker to test downloads
- [ ]  Maybe push to dev and test

