### PR TITLE
5043- Remove type filter

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -376,7 +376,6 @@ reports = {
     'max_party_coordinated_expenditures': Currency(description=docs.MAX_FILTER),
     'min_total_contributions': Currency(description=docs.MIN_FILTER),
     'max_total_contributions': Currency(description=docs.MAX_FILTER),
-    'type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE_OLD),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
     'committee_id': fields.List(fields.Str, description=docs.COMMITTEE_ID),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -372,24 +372,6 @@ COMMITTEE_TYPE = 'The one-letter type code of the organization:\n\
         - Y party, qualified\n\
         - Z national party non-federal account\n\
 '
-COMMITTEE_TYPE_OLD = 'The `deprecated` one-letter type code of the organization:\n\
-        - C communication cost\n\
-        - D delegate\n\
-        - E electioneering communication\n\
-        - H House\n\
-        - I independent expenditure filer (not a committee)\n\
-        - N PAC - nonqualified\n\
-        - O independent expenditure-only (super PACs)\n\
-        - P presidential\n\
-        - Q PAC - qualified\n\
-        - S Senate\n\
-        - U single candidate independent expenditure\n\
-        - V PAC with non-contribution account, nonqualified\n\
-        - W PAC with non-contribution account, qualified\n\
-        - X party, nonqualified\n\
-        - Y party, qualified\n\
-        - Z national party non-federal account\n\
-'
 COMMITTEE_TYPE_STATE_AGGREGATE_TOTALS = COMMITTEE_TYPE + '\
         - all All Committee Types\n\
         - all_candidates All Candidate Committee Types (H, S, P)\n\

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -177,10 +177,7 @@ class ReportsView(views.ApiResource):
                     [kwargs.get('candidate_id')]
                 )
             )
-        if kwargs.get('type'):
-            query = query.filter(
-                models.CommitteeHistory.committee_type.in_(kwargs.get('type'))
-            )
+
         if kwargs.get('committee_type'):
             query = query.filter(
                 models.CommitteeHistory.committee_type.in_(kwargs.get('committee_type'))


### PR DESCRIPTION
## Summary (required)

- Resolves #5043 

Removes the old `type` filter which was replaced by the `committee_type` filter per our deprecation policy. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  financials/reports/{entity_type} endpoint

## Screenshots
![image](https://user-images.githubusercontent.com/66386084/159737141-02a2f0dd-7d4e-4c3b-bf91-70d870916484.png)



## Related PRs

-#[5042](https://github.com/fecgov/openFEC/pull/5042)

## How to test

- Check out this branch
-Try queries for financials/reports/string:entity_type/ using the new committee_type filter, the old filter,  and check that `type` is no longer shown 
-https://api.open.fec.gov/v1/reports/presidential/?committee_type=P&sort=-coverage_end_date&sort_nulls_last=false&page=1&api_key=DEMO_KEY&sort_hide_null=false&sort_null_only=false&per_page=20
-https://127.0.0.1:5000/v1/reports/presidential/?committee_type=P&sort=-coverage_end_date&sort_nulls_last=false&page=1&api_key=DEMO_KEY&sort_hide_null=false&sort_null_only=false&per_page=20
Old filter:
-https://api.open.fec.gov/v1/reports/presidential/?sort=-coverage_end_date&sort_nulls_last=false&page=1&api_key=DEMO_KEY&sort_hide_null=false&type=P&sort_null_only=false&per_page=20
-https://127.0.0.1:5000/v1/reports/presidential/?sort=-coverage_end_date&sort_nulls_last=false&page=1&api_key=DEMO_KEY&sort_hide_null=false&type=P&sort_null_only=false&per_page=20
-pytest test_reports.py
