### PR TITLE
[High Priority]  Fix Snyk vulnerability: Upgrade celery, vine, click

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ Running Redis and Celery locally:
 
 ```
 redis-server
-celery worker --app webservices.tasks
+celery --app webservices.tasks worker
+celery --app webservices.tasks beat 
 ```
 
 ## Editing Swagger

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery beat --app webservices.tasks --loglevel INFO
+    command: celery --app webservices.tasks beat --loglevel INFO
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_beat_feature.yml
+++ b/manifests/manifest_celery_beat_feature.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery beat --app webservices.tasks --loglevel INFO
+    command: celery --app webservices.tasks beat --loglevel INFO
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery beat --app webservices.tasks --loglevel INFO
+    command: celery --app webservices.tasks beat --loglevel INFO
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery beat --app webservices.tasks --loglevel INFO
+    command: celery --app webservices.tasks beat --loglevel INFO
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_worker_feature.yml
+++ b/manifests/manifest_celery_worker_feature.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 3
+    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 3
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery worker --app webservices.tasks --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs3
     buildpacks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ git+https://github.com/18F/rdbms-subsetter
 
 # Testing
 pdbpp==0.9.1
-#click==6.7
 click==8.0.4
 
 # requirements.txt generation (pip-compile)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,8 @@ git+https://github.com/18F/rdbms-subsetter
 
 # Testing
 pdbpp==0.9.1
-click==6.7
+#click==6.7
+click==8.0.4
 
 # requirements.txt generation (pip-compile)
 pip-tools==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn==19.10.0
 GitPython==3.1.0
 icalendar==4.0.2
 invoke==0.15.0
-kombu==5.2.4
+kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x
 networkx==2.6.2
 prance[osv]>=0.19
 psycopg2-binary==2.9.1
@@ -39,7 +39,6 @@ marshmallow-sqlalchemy==0.15.0
 smart_open==1.8.0
 
 # Task queue
-#celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
 redis==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn==19.10.0
 GitPython==3.1.0
 icalendar==4.0.2
 invoke==0.15.0
-kombu==4.6.3
+kombu==5.2.4
 networkx==2.6.2
 prance[osv]>=0.19
 psycopg2-binary==2.9.1
@@ -25,7 +25,7 @@ requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
 ujson==5.2.0 # decoding CSP violation reported
-vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency of kombu
+vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==5.5.3
 werkzeug==0.16.1
 
@@ -42,7 +42,7 @@ smart_open==1.8.0
 #celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
-redis==3.2.0
+redis==4.2.2
 
 # testing and build in circle
 codecov==2.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,7 @@
 apispec==0.39.0
 certifi==2020.11.8
 cfenv==0.5.2
-invoke==0.15.0
-kombu==5.2.4
-vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
-psycopg2-binary==2.9.1
-werkzeug==0.16.1
-Flask==1.1.1
-Flask-Cors==3.0.9
-Flask-Script==2.0.6
-Flask-RESTful==0.3.7
-Flask-SQLAlchemy==2.4.1
-python-dateutil==2.8.1
-sqlalchemy-postgres-copy==0.3.0
-networkx==2.6.2
-SQLAlchemy==1.3.19
-icalendar==4.0.2
-GitPython==3.1.0
-gunicorn==19.10.0
-gevent==1.4.0
-greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
-webargs==5.5.3
-ujson==1.33
-requests==2.25.1
+defusedxml==0.6.0
 elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
 Flask==1.1.1
@@ -60,6 +39,7 @@ marshmallow-sqlalchemy==0.15.0
 smart_open==1.8.0
 
 # Task queue
+#celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
 redis==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ certifi==2020.11.8
 cfenv==0.5.2
 invoke==0.15.0
 kombu==5.2.4
-#vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency of kombu
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 psycopg2-binary==2.9.1
 werkzeug==0.16.1
@@ -61,7 +60,6 @@ marshmallow-sqlalchemy==0.15.0
 smart_open==1.8.0
 
 # Task queue
-#celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
 redis==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,29 @@
 apispec==0.39.0
 certifi==2020.11.8
 cfenv==0.5.2
-defusedxml==0.6.0
+invoke==0.15.0
+kombu==5.2.4
+#vine==1.3.0 # pinned temporarily to fix amqp dependency, which is a dependency of kombu
+vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
+psycopg2-binary==2.9.1
+werkzeug==0.16.1
+Flask==1.1.1
+Flask-Cors==3.0.9
+Flask-Script==2.0.6
+Flask-RESTful==0.3.7
+Flask-SQLAlchemy==2.4.1
+python-dateutil==2.8.1
+sqlalchemy-postgres-copy==0.3.0
+networkx==2.6.2
+SQLAlchemy==1.3.19
+icalendar==4.0.2
+GitPython==3.1.0
+gunicorn==19.10.0
+gevent==1.4.0
+greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
+webargs==5.5.3
+ujson==1.33
+requests==2.25.1
 elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
 Flask==1.1.1
@@ -39,7 +61,8 @@ marshmallow-sqlalchemy==0.15.0
 smart_open==1.8.0
 
 # Task queue
-celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
+#celery==4.3.0 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
+celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
 redis==3.2.0
 


### PR DESCRIPTION
## Summary 
**This is due 03/29/22 so we need to get it in upcoming release**

Upgrade to Celery 5.x has breaking changes:
- command to start the celery app has changed:

>      - celery --app webservices.tasks  beat 
>      - celery --app webservices.tasks worker

- minimum required kombu version is 5.0.0
 

- Resolves #5017
- Reference pr #4895

Upgrading Celery for Snyk recommended remediation path caused compatibility errors when installing  requirements.
<img width="1020" alt="Screen Shot 2022-03-24 at 9 04 39 PM" src="https://user-images.githubusercontent.com/5572856/160034770-f31b637e-6c9d-4fd0-9f96-88ed05299da2.png">
So I updated Click and Vine as well,   Now requirements can be installed without error and Pytest passes, 


1. Update click python package in:   requirements-dev.txt
2. Update celery, kombu, redis python packages in:   requirements.txt
3. Update the celery startup command in dev/feature/stage and prod manifest files 


### Required reviewers

Two backend developers must. @johnnyporkchops  git didn't let me add you to the reviewers list. please feel free to test this PR if your time permits.

## Impacted areas of the application

Celery tasks, Export results (download results set in fec.gov)

## How to test
- `git checkout 5017-snyk-medium-Celery-stored-command-injection` 
- `pyenv virtualenv 3.7.12 venv-api3712` 
- `pyenv activate venv-api3712`
- `pip install -r requirements.txt` 
- `pip install -r requirements-dev.txt`
- `rm -rf node_modules` (optional step)
- `npm i` (optional step)
- `npm run build` (optional step)
- `pytest`(all tests should pass)
- test downloads and celery tasks on local.Follow the [wiki instructions](https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks)
-  use this command to start celery worker on cli: `celery --app webservices.tasks  worker --loglevel INFO`

 

**OR**

Deploy this PR to Dev space:
- In tasks.py update:
> DEPLOY_RULES = (
>     
>     ('dev', lambda _, branch: branch == '5017-snyk-medium-Celery-stored-command-injection'),
> )
-  test export/downloads
- Example: https://dev.fec.gov/data/receipts/?data_type=processed&two_year_transaction_period=2022&min_date=01%2F01%2F2021&max_date=01%2F01%2F2021&contributor_state=CA&recipient_committee_type=S


**Note: I will the update the [wiki](https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks) after this PR is merged** 