### PR TITLE
[MERGE BEFORE 4/19 RELEASE DEPLOYED]5058-upgrade GitPython from 3.1.0 to 3.1.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sqlalchemy-postgres-copy==0.3.0
 networkx==2.6.2
 SQLAlchemy==1.3.19
 icalendar==4.0.2
-GitPython==3.1.0
+GitPython==3.1.27
 gunicorn==19.10.0
 gevent==1.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent is gevent)


### PR DESCRIPTION
## Summary (required)
When checking snyk [https://app.snyk.io/org/fecgov/project/a95ea997-b012-4b3b-a026-2fdbe6ac0398](https://app.snyk.io/org/fecgov/project/a95ea997-b012-4b3b-a026-2fdbe6ac0398), get gitPython-Regular Expression Denial of Service (ReDoS) vulnerability 

- Resolves #5065 

### Required reviewers

0ne developer

## Impacted areas of the application
api

## How to test
- Check out dev branch
- run `snyk test --file=requirements.txt`, you will see gitpython warning.
<img width="500" alt="before" src="https://user-images.githubusercontent.com/24395751/163042927-bda90a94-41dd-45fe-89ac-a885fce93d71.png">

-  Checkout this branch
- `pip install -r requirements.txt`
- `pip freeze` make sure gitpython=3.1.27, make sure install new version gitpython
- run again `snyk test --file=requirements.txt`,  gitpython issue remove.
<img width="500" alt="after" src="https://user-images.githubusercontent.com/24395751/163043225-f6ecac72-5f50-4dfd-a61a-433c026e8a10.png">

- `pytest`
- test endpoints