### PR TITLE
Fix sort function for CandidateTotalAggregateView

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1963,3 +1963,32 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "district": "01",
             },
         )
+
+    def test_filter_by_party(self):
+        # aggregate_by="office-party", office=H, party=DEM,
+        # election_full default=true, election_year=2016, is_active_candidate=True
+        # return one rows:
+        # row 1: 2016/H/DEM/total=1000+2000=3000
+        results = self._results(api.url_for(
+            CandidateTotalAggregateView,
+            aggregate_by="office-party",
+            office="H",
+            is_active_candidate=True,
+            election_year=2016,
+            party="DEM",)
+        )
+        assert len(results) == 1
+        assert_dicts_subset(
+            results[0],
+            {
+                "election_year": 2016,
+                "total_receipts": 3000,
+                "total_disbursements": 3000,
+                "total_individual_itemized_contributions": 3000,
+                "total_transfers_from_other_authorized_committee": 3000,
+                "total_other_political_committee_contributions": 3000,
+                "total_cash_on_hand_end_period": 3000,
+                "party": "DEM",
+                "office": "H",
+            },
+        )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1024,6 +1024,7 @@ candidate_total_aggregate = {
     'max_election_cycle': fields.Int(description=docs.CYCLE),
     'state': fields.List(IStr, description=docs.STATE),
     'district': fields.List(IStr, description=docs.DISTRICT),
+    'party': fields.Str(validate=validate.OneOf(['', 'DEM', 'REP', 'OTHER']), description=docs.PARTY),
     'aggregate_by': fields.Str(
         validate=validate.OneOf(['office', 'office-state', 'office-state-district', 'office-party']),
         description=docs.AGGREGATE_BY),


### PR DESCRIPTION
## Summary (required)
For the new endpoint: `/candidates/totals/aggregates/`, we need combination sort function (ex, sort by state and district). 
This PR will:
1) Fix combination fort
2) Add filter by `party` and test case.
3) Show how to use combination sort function.

- Resolves #5102 

### Required reviewers
1 developer. more welcome

## Impacted areas of the application
endpoint: `/candidates/totals/aggregates/`

## How to test
- Checkout branch
- `pytest`
- Test URLs:
1)Test combination sorting
How to pass multi sort arguments?
ex: `sort=-election_year&sort=state&sort=district`
(Use - for descending order)

[http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort=state&sort=district&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-state-district&is_active_candidate=true&page=1&election_full=true&office=H&sort_hide_null=false](http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort=state&sort=district&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-state-district&is_active_candidate=true&page=1&election_full=true&office=H&sort_hide_null=false)

[http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort=state&sort=-district&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-state-district&is_active_candidate=true&page=1&election_full=true&office=H&sort_hide_null=false](http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort=state&sort=-district&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-state-district&is_active_candidate=true&page=1&election_full=true&office=H&sort_hide_null=false)

Test filter by party:
[http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-party&is_active_candidate=true&page=1&party=DEM&election_full=true&sort_hide_null=false](http://127.0.0.1:5000/v1/candidates/totals/aggregates/?sort=-election_year&sort_null_only=false&election_year=2020&sort_nulls_last=false&per_page=20&aggregate_by=office-party&is_active_candidate=true&page=1&party=DEM&election_full=true&sort_hide_null=false)
