### PR TITLE
add primary_key to dsc_sched_aggregate tables

### DIFF
--- a/data/migrations/V0246__add_PK_to_dsc_sched_aggregate_tables.sql
+++ b/data/migrations/V0246__add_PK_to_dsc_sched_aggregate_tables.sql
@@ -1,0 +1,355 @@
+/*
+This is for issue #5110:
+
+In addition to having unique value, all columns that made up the primary key requires can not be null).  Therefore a value need to used to represent null value.
+
+dsc_sched_a_aggregate_employer
+when is null, or upper (employer) = 'NULL', use 'NULL'
+
+dsc_sched_a_aggregate_occupation
+when is null, or upper (occupation) = 'NULL', use 'NULL'
+
+dsc_sched_a_aggregate_size
+size is a pre-determined value, no row is null
+
+dsc_sched_a_aggregate_state
+when is null, or ' ' or ' ' use ' '
+
+dsc_sched_a_aggregate_zip
+when is null, or upper (zip) = 'NULL', use 'NULL'
+
+dsc_sched_b_aggregate_purpose_new
+purpose is a pre-determined value, no row is null
+
+dsc_sched_b_aggregate_recipient_id_new
+already exclude rows with recipient_cmte_id is null, no need to handle null value.
+
+dsc_sched_b_aggregate_recipient_new
+when is null, or upper (recipient_nm) = 'NULL', use 'NULL'
+
+The data update and primary key creation had already been performed to these tables in order to make DMS working in all PROD/STAGE/DEV databases.
+However, official migration script is needed to add these to the version controlled base of the database structure.
+
+-- -----------------------------------------------------
+-- To verify the creation/existance of the primary key of the 'dsc_sched%_aggregate%' tables:
+
+select tablename, indexname from pg_indexes
+where schemaname = 'disclosure'
+and tablename like 'dsc_sched%_aggregate%'
+and indexname like '%pkey' order by 1, 2;
+
+dsc_sched_a_aggregate_employer  dsc_sched_a_aggregate_employer_pkey
+dsc_sched_a_aggregate_occupation    dsc_sched_a_aggregate_occupation_pkey
+dsc_sched_a_aggregate_size  dsc_sched_a_aggregate_size_pkey
+dsc_sched_a_aggregate_state dsc_sched_a_aggregate_state_pkey
+dsc_sched_a_aggregate_zip   dsc_sched_a_aggregate_zip_pkey
+dsc_sched_b_aggregate_purpose_new   dsc_sched_b_aggregate_purpose_new_pkey
+dsc_sched_b_aggregate_recipient_id_new  dsc_sched_b_agg_recpnt_id_new_pkey
+dsc_sched_b_aggregate_recipient_new dsc_sched_b_agg_recpnt_new_pkey
+
+*/
+
+
+-- -----------------------------------
+-- dsc_sched_a_aggregate_employer
+-- -----------------------------------
+-- employer column with no value (null) had been updated to 'NULL'
+update disclosure.dsc_sched_a_aggregate_employer set employer = 'NULL' where employer is null;
+
+alter table disclosure.dsc_sched_a_aggregate_employer alter column employer set default 'NULL';
+
+alter table disclosure.dsc_sched_a_aggregate_employer alter column employer set NOT NULL;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_employer add constraint dsc_sched_a_aggregate_employer_pkey primary key (cmte_id, cycle, employer);');
+  
+    EXCEPTION 
+             WHEN invalid_table_definition THEN 
+				null;
+				--RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_employer drop constraint uq_sched_a_aggregate_employer_cmte_id_cycle_employer;');
+  
+    EXCEPTION 
+             WHEN undefined_object THEN 
+				null;
+				--RAISE NOTICE 'undefined_object';
+             WHEN others THEN 
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;  
+END$$;
+	
+
+
+-- -----------------------------------
+-- dsc_sched_a_aggregate_occupation
+-- -----------------------------------
+
+-- occupation column with no value (null) had been updated to 'NULL'
+update disclosure.dsc_sched_a_aggregate_occupation set occupation = 'NULL' where occupation is null;
+
+alter table disclosure.dsc_sched_a_aggregate_occupation alter column occupation set default 'NULL';
+
+alter table disclosure.dsc_sched_a_aggregate_occupation alter column occupation set NOT NULL;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_occupation add constraint dsc_sched_a_aggregate_occupation_pkey primary key (cmte_id, cycle, occupation);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_occupation drop constraint uq_sched_a_aggregate_occupation_cmte_id_cycle_occupation;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+	
+
+-- -----------------------------------
+-- dsc_sched_a_aggregate_size
+-- -----------------------------------
+
+-- size is a pre-determined value, no row is null
+
+
+alter table disclosure.dsc_sched_a_aggregate_size alter column size set NOT NULL;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_size add constraint dsc_sched_a_aggregate_size_pkey primary key (cmte_id, cycle, size);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_size drop constraint uq_dsc_sched_a_aggregate_size_cmte_id_cycle_size;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+-- -----------------------------------
+-- dsc_sched_a_aggregate_state
+-- -----------------------------------
+
+-- state column's data type is varchar(2), can not use string 'NULL'
+-- state column with no value (null) had been updated to '  '
+update disclosure.dsc_sched_a_aggregate_state set state = '  ' where state is null;
+
+alter table disclosure.dsc_sched_a_aggregate_state alter column state set default '  ';
+
+alter table disclosure.dsc_sched_a_aggregate_state alter column state set NOT NULL;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_state add constraint dsc_sched_a_aggregate_state_pkey primary key (cmte_id, cycle, state);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_state drop constraint uq_dsc_sched_a_aggregate_state_cmte_id_cycle_state;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+	
+
+-- -----------------------------------
+-- dsc_sched_a_aggregate_zip
+-- -----------------------------------
+
+-- zip column with no value (null) had been updated to 'NULL'
+update disclosure.dsc_sched_a_aggregate_zip set zip = 'NULL' where zip is null;
+
+alter table disclosure.dsc_sched_a_aggregate_zip alter column zip set default 'NULL';
+
+alter table disclosure.dsc_sched_a_aggregate_zip alter column zip set NOT NULL;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_zip add constraint dsc_sched_a_aggregate_zip_pkey primary key (cmte_id, cycle, zip);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_a_aggregate_zip drop constraint uq_dsc_sched_a_aggregate_zip_cmte_id_cycle_zip;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+-- -----------------------------------
+-- dsc_sched_b_aggregate_purpose_new
+-- -----------------------------------
+-- purpose is a pre-determined value, no row is null
+
+alter table disclosure.dsc_sched_b_aggregate_purpose_new alter column purpose set NOT NULL;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_purpose_new add constraint dsc_sched_b_aggregate_purpose_new_pkey primary key (cmte_id, cycle, purpose);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_purpose_new drop constraint uq_dsc_sched_b_agg_purpose_new_cmte_id_cycle_purpose_new;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+
+
+-- -----------------------------------
+-- dsc_sched_b_aggregate_recipient_id_new
+-- -----------------------------------
+alter table disclosure.dsc_sched_b_aggregate_recipient_id_new alter column recipient_cmte_id set default 'NULL';
+
+alter table disclosure.dsc_sched_b_aggregate_recipient_id_new alter column recipient_cmte_id set NOT NULL;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_recipient_id_new add constraint dsc_sched_b_agg_recpnt_id_new_pkey primary key (cmte_id, cycle, RECIPIENT_cmte_id);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_recipient_id_new drop constraint uq_sched_b_agg_recpnt_id_cmte_id_cycle_recpnt_cmte_id;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+	
+-- -----------------------------------
+-- dsc_sched_b_aggregate_recipient_new
+-- -----------------------------------
+
+-- RECIPIENT_NM column with no value (null) had been updated to 'NULL'
+update disclosure.dsc_sched_b_aggregate_recipient_new set RECIPIENT_NM = 'NULL' where RECIPIENT_NM is null;
+
+alter table disclosure.dsc_sched_b_aggregate_recipient_new alter column RECIPIENT_NM set default 'NULL';
+
+alter table disclosure.dsc_sched_b_aggregate_recipient_new alter column RECIPIENT_NM set NOT NULL;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_recipient_new add constraint dsc_sched_b_agg_recpnt_new_pkey primary key (cmte_id, cycle, RECIPIENT_NM);');
+
+    EXCEPTION
+             WHEN invalid_table_definition THEN
+            null;
+            --RAISE NOTICE 'invalid_table_definition';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+--
+DO $$
+BEGIN
+    EXECUTE format('alter table disclosure.dsc_sched_b_aggregate_recipient_new drop constraint uq_dsc_sched_b_agg_recpnt_new_cmte_id_cycle_recpnt_new;');
+
+    EXCEPTION
+             WHEN undefined_object THEN
+            null;
+            --RAISE NOTICE 'undefined_object';
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+	
+
+


### PR DESCRIPTION
## Summary (required)

- #5110 
add primary key to dsc_sched_a/b_aggregate tables to utilize AWS DMS to synchronize the data between PROD/STAGE/DEV databases.

### Required reviewers

This is database work. Only requires database team to review.

## Impacted areas of the application

General components of the application that this PR will affect:

-  

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

download the branch to local machine, invoke create_sample_db process. Make sure migration executed successfully.
Connect to local_db, verify the primary key and corresponding index created successfully.

select tablename, indexname from pg_indexes
where schemaname = 'disclosure'
and tablename like 'dsc_sched%_aggregate%'
and indexname like '%pkey' order by 1, 2;

-- there should be 8 rows returned

select kcu.table_schema,
       kcu.table_name,
       tco.constraint_name,
       kcu.ordinal_position as position,
       kcu.column_name as key_column
from information_schema.table_constraints tco
join information_schema.key_column_usage kcu 
     on kcu.constraint_name = tco.constraint_name
     and kcu.constraint_schema = tco.constraint_schema
     and kcu.constraint_name = tco.constraint_name
where tco.constraint_type = 'PRIMARY KEY'
and kcu.table_schema = 'disclosure'
and kcu.table_name like 'dsc_sched%_aggregate%' 
order by kcu.table_schema,
         kcu.table_name,
         position;

-- there should be 24 rows returns (8 primary key constraints, 3 columns each)

The primary key had already been added to the Aurora database, the syntax in this migration file should allow the migration file to run without causing error. To test this:
delete from flyway_schema_history where version = '0246';
Then run flyway migration again. Flyway migration should execute successfully without error.

Run pytest, all test should completed successfully.

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
