### PR TITLE
Add validation to image_number field

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -236,7 +236,7 @@ class TestScheduleA(ApiBaseTest):
         response = self.app.get(
             api.url_for(ScheduleAView, contributor_zip='96%', cycle=2018)
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 422)
 
     def test_schedule_a_missing_secondary_index(self):
         response = self.app.get(

--- a/tests/test_operations_log.py
+++ b/tests/test_operations_log.py
@@ -32,7 +32,7 @@ class TestOperationsLog(ApiBaseTest):
             candidate_committee_id='03',
             report_year=2017,
             transaction_data_complete_date=datetime.date(2016, 10, 15),
-        ),
+        )
 
     def test_empty_query(self):
 
@@ -193,3 +193,9 @@ class TestOperationsLog(ApiBaseTest):
                 <= max_date.isoformat()
             )
         )
+
+    def test_invalid_image_number(self):
+        response = self.app.get(
+            api.url_for(OperationsLogView, beginning_image_number='fec-12345')
+        )
+        self.assertEqual(response.status_code, 422)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -61,6 +61,22 @@ class District(fields.Str):
         return '{0:0>2}'.format(value)
 
 
+class ImageNumber(fields.Str):
+
+    def _validate(self, value):
+        super()._validate(value)
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            raise exceptions.ApiError(
+                exceptions.IMAGE_NUMBER_ERROR,
+                status_code=422)
+        if value < 0:
+            raise exceptions.ApiError(
+                exceptions.IMAGE_NUMBER_ERROR,
+                status_code=422)
+
+
 election_full = fields.Bool(missing=True, description=docs.ELECTION_FULL)
 
 paging = {
@@ -321,7 +337,7 @@ filings = {
     'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
     'request_type': fields.List(IStr, description=docs.REQUEST_TYPE),
     'document_type': fields.List(IStr, description=docs.DOC_TYPE),
-    'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
+    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'min_receipt_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
     'max_receipt_date': fields.Date(description=docs.MAX_RECEIPT_DATE),
@@ -352,7 +368,7 @@ efilings = {
 reports = {
     'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
+    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
     'is_amended': fields.Bool(description=docs.IS_AMENDED),
     'most_recent': fields.Bool(description=docs.MOST_RECENT),
@@ -387,7 +403,7 @@ reports = {
 committee_reports = {
     'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
+    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
     'is_amended': fields.Bool(description=docs.IS_AMENDED),
     'min_disbursements_amount': Currency(description=docs.MIN_FILTER),
@@ -448,13 +464,9 @@ candidate_totals_detail = {
 
 
 itemized = {
-    # TODO(jmcarp) Request integer image numbers from FEC and update argument types
-    'image_number': fields.List(
-        fields.Str,
-        description='The image number of the page where the schedule item is reported',
-    ),
-    'min_image_number': fields.Str(),
-    'max_image_number': fields.Str(),
+    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
+    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
+    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_amount': Currency(description='Filter for all amounts greater than a value.'),
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': fields.Date(description='Minimum date'),
@@ -656,10 +668,7 @@ schedule_b_efile = {
     # if the contributor is registered with the FEC.'),
     # 'recipient_name': fields.List(fields.Str, description='Name of recipient'),
     'disbursement_description': fields.List(fields.Str, description='Description of disbursement'),
-    'image_number': fields.List(
-        fields.Str,
-        description='The image number of the page where the schedule item is reported',
-    ),
+    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
     'recipient_city': fields.List(IStr, description='City of recipient'),
     'recipient_state': fields.List(IStr, description='State of recipient'),
     'max_date': fields.Date(
@@ -681,12 +690,9 @@ schedule_b_efile = {
 
 schedule_c = {
     # TODO(jmcarp) Request integer image numbers from FEC and update argument types
-    'image_number': fields.List(
-        fields.Str,
-        description=docs.IMAGE_NUMBER,
-    ),
-    'min_image_number': fields.Str(),
-    'max_image_number': fields.Str(),
+    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
+    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
+    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_amount': Currency(description=docs.MIN_FILTER),
     'max_amount': Currency(description=docs.MAX_FILTER),
     'line_number': fields.Str(description=docs.LINE_NUMBER),
@@ -700,12 +706,9 @@ schedule_c = {
 }
 
 schedule_d = {
-    'image_number': fields.List(
-        fields.Str,
-        description='The image number of the page where the schedule item is reported',
-    ),
-    'min_image_number': fields.Str(),
-    'max_image_number': fields.Str(),
+    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
+    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
+    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_date': fields.Date(description='Minimum load date'),
     'max_date': fields.Date(description='Maximum load date'),
     'min_payment_period': fields.Float(),
@@ -906,7 +909,7 @@ schedule_e_efile = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
-    'image_number': fields.List(fields.Str, description=docs.IMAGE_NUMBER),
+    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
         description=docs.SUPPORT_OPPOSE_INDICATOR),
@@ -984,7 +987,7 @@ auditCase = {
 operations_log = {
     'candidate_committee_id': fields.List(IStr, description=docs.CAND_CMTE_ID),
     'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
-    'beginning_image_number': fields.List(fields.Str, description=docs.BEGINNING_IMAGE_NUMBER),
+    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'form_type': fields.List(IStr, description=docs.FORM_TYPE),
     'amendment_indicator': fields.List(IStr, description=docs.AMENDMENT_INDICATOR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1421,6 +1421,10 @@ CANDIDATE_MAX_FIRST_FILE_DATE = 'Selects all candidates whose first filing was r
 # schedules
 MEMO_CODE = "'X' indicates that the amount is NOT to be included in the itemization total."
 
+
+
+
+
 # schedule A
 CONTRIBUTOR_ID = 'The FEC identifier should be represented here if the contributor is registered with the FEC.'
 EMPLOYER = 'Employer of contributor as reported on the committee\'s filing'
@@ -1696,6 +1700,10 @@ down to all entries from form `F3X` line number `16`.
 IMAGE_NUMBER = '''
 An unique identifier for each page where the electronic or paper filing is reported.
 '''
+
+MAX_IMAGE_NUMBER = 'Maxium image number of the page where the schedule item is reported'
+
+MIN_IMAGE_NUMBER = 'Minium image number of the page where the schedule item is reported'
 
 MIN_FILTER = '''
 Filter for all amounts greater than a value.

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,7 +1,10 @@
 
 LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is using the following format:
 'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries
-from form F3X line number 16.
+from form F3X line number 16.\
+"""
+
+IMAGE_NUMBER_ERROR = """Invalid image_number detected. A valid image_number is numeric only.\
 """
 
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -123,7 +123,7 @@ class ScheduleAView(ItemizedResource):
                 if re.search('[^a-zA-Z0-9-\s]', value):  # noqa
                     raise exceptions.ApiError(
                         'Invalid zip code. It can not have special character',
-                        status_code=400,
+                        status_code=422,
                     )
                 else:
                     zip_list.append(value[:5])


### PR DESCRIPTION
## Summary (required)

- Resolves #5094

Validation is added for the input of image_number field.  This field should be numeric only. If non-numeric value is passed as image number, 422 will return by endpoint.

### Required reviewers

2 developers, more is welcome.

## Impacted areas of the application

Any input field that is for an image number

## How to test

- Run `pytest` on local
- Start api on local

1) Pass invalid ibeginning_image_number
http://127.0.0.1:5000/v1/filings/?beginning_image_number=fec-140000&sort_hide_null=false&sort_nulls_last=false&sort=-receipt_date&sort_null_only=false&per_page=20&page=1

<img width="818" alt="Screen Shot 2022-05-02 at 5 16 13 PM" src="https://user-images.githubusercontent.com/24396726/166329136-a645a18b-1861-4ad1-bfc3-5082bb74917c.png">

2) Pass invalid min_image_number
http://127.0.0.1:5000/v1/schedules/schedule_c/?sort_null_only=false&per_page=20&min_image_number=FEC-77891&page=1&sort_nulls_last=true&sort_hide_null=false&sort=-incurred_date

