### PR TITLE
4959-upgrade-python-3.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.7.8-buster
+      - image: circleci/python:3.8.12-buster
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.7 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 10 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ click==8.0.4
 # requirements.txt generation (pip-compile)
 pip-tools==4.2.0
 #locust
-locustio==0.10.0
+locustio==0.14.6 #upgrade locustio to python 3.8 compatible version
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.8.x


### PR DESCRIPTION
## Summary (required)

Upgrade openFEC repo to use python v3.8.x 
Helpful [FEC WIki page](https://github.com/fecgov/openFEC/wiki/Updating-Python) for considerations when updating python locally and at the app level: 

- Resolves #4959
- Reference PR #5084, #3961:


(Include a summary of proposed changes and connect issue below)

1. Upgrade python runtime version to 3.8.x in setup.py
2. Update circleci python docker image version to 3.8.12-buster in circleci/config.yml
3. Update  python version in README.md file
4. Upgrade locustio  package to python 3.8.x compatible version in requirements-dev.txt


### Required reviewers

Two backend developers must

## Impacted areas of the application

General components of the application that this PR will affect:

-  Circleci builds, Locust tests, API app deployment

## Related PRs
(https://github.com/fecgov/openFEC/pull/5084) 

## How to test
- `git checkout 4959-upgrade-python`
- `pyenv install 3.8.12` 
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
- `pip install -r requirements.txt` 
- `pip install -r requirements-dev.txt`
- `rm -rf node_modules` (optional step)
- `npm i` (optional step)
- `npm run build` (optional step)
- `pytest`(all tests should pass)
- run locust test (look for instruction inside locustfile.py file)
-  `./manage.py runserver` and test swagger-ui
-  deploy a this branch to `Dev` space.  Verify API on circleci build/deploys OK while running on python v3.8.12 @runtime

