### PR TITLE
5125-Snyk Prototype Pollution upgrade async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
+        "async": "^2.6.4",
         "immutable": "^3.8.2",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
@@ -671,9 +672,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -12123,9 +12124,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "swagger-tools": "^0.10.4",
+    "async":"^2.6.4",
     "swagger-ui-dist": "4.5.0"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ Flask-Cors==3.0.9
 Flask-RESTful==0.3.7
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.1
-gevent==1.4.0
-greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
+gevent==20.4.0
 gunicorn==19.10.0
 GitPython==3.1.0
 icalendar==4.0.2


### PR DESCRIPTION
## Summary (required)

- Resolves #5125 

Pins async to 2.6.4 to remove vulnerability to Prototype Pollution. We do not currently use the affected MapValues() method, but I thought it would be a good idea to upgrade just in case. I also pinned gevent to 20.4.0 as I could not get requirements.txt to install with pip version 22 without upgrading. 

### Required reviewers

1-2 devs

## How to test
- run `snyk test` locally on develop to confirm vulnerability
`snyk test --file=package.json`
You should see the prototype pollution vulnerability
- checkout this branch
- `pyenv install 3.8.12` (if not already installed)
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
-  `rm -rf node_modules`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install && npm run build`
- run `snyk test --file=package.json` 
- `pytest`