### PR TITLE
5125- upgrade async 2.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
+        "async": "^2.6.4",
         "immutable": "^3.8.2",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
@@ -671,9 +672,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -12123,9 +12124,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "swagger-tools": "^0.10.4",
+    "async":"^2.6.4",
     "swagger-ui-dist": "4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary (required)

- Resolves #5125 

Pins async to 2.6.4 to remove vulnerability to Prototype Pollution. We do not currently use the affected MapValues() method, but I thought it would be a good idea to upgrade just in case. 

### Required reviewers

1-2 devs

## How to test
- run `snyk test` locally on develop to confirm vulnerability
`snyk test --file=package.json`
You should see the prototype pollution vulnerability
- checkout this branch
- `pyenv install 3.8.12` (if not already installed)
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
-  `rm -rf node_modules`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install && npm run build`
- run `snyk test --file=package.json` 
- `pytest`