### PR TITLE
Update locust deprecated methods

### DIFF
--- a/data/migrations/V0248__add_columns_to_real_efile_pfile_F1.sql
+++ b/data/migrations/V0248__add_columns_to_real_efile_pfile_F1.sql
@@ -1,0 +1,32 @@
+/*
+This is for issue #5134:
+Adding two new columns to real_efile.F1 and real_pfile.F1 tables in Aurora postgresql databases
+
+ALTER TABLE real_efile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1);
+ALTER TABLE real_pfile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1);
+
+The columns had already been added to these tables
+so contractor can insert data in all PROD/STAGE/DEV databases.
+However, official migration script is needed to add these to the version controlled base of the database structure.
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE real_efile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1)');
+    EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE real_pfile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1)');
+    EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+      

--- a/locustfile.py
+++ b/locustfile.py
@@ -18,6 +18,7 @@ import random
 import resource
 
 import locust
+from locust import between
 
 
 # Avoid "Too many open files" error
@@ -427,5 +428,4 @@ class Tasks(locust.TaskSet):
 
 class Swarm(locust.HttpLocust):
     task_set = Tasks
-    min_wait = 5000
-    max_wait = 50000
+    wait_time = between(5000, 50000)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@braintree/sanitize-url": "^6.0.0",
         "async": "^2.6.4",
         "immutable": "^3.8.2",
+        "minimist": "^1.2.6",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
         "react-dom": "^16.7.0",
@@ -6112,7 +6113,7 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "json5": "lib/cli.js"
@@ -6602,9 +6603,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -6699,7 +6700,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -9953,7 +9954,7 @@
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
@@ -9963,7 +9964,7 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "json5": "lib/cli.js"
@@ -16628,7 +16629,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.6"
           }
         }
       }
@@ -17067,9 +17068,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -17148,7 +17149,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "move-concurrently": {
@@ -19805,7 +19806,7 @@
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
@@ -19815,7 +19816,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.6"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
+        "async": "^2.6.4",
         "immutable": "^3.8.2",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
@@ -671,9 +672,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -12123,9 +12124,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
     "immutable": "^3.8.2",
+    "minimist":"^1.2.6",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "swagger-tools": "^0.10.4",
+    "async":"^2.6.4",
     "swagger-ui-dist": "4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary (required)

- Resolves #5132

Replaces deprecated min_wait and max_wait with wait_time. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  locust wait times, openFEC

## How to test

- checkout this branch
- `pyenv install 3.8.12` (if not already installed)
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
-  `rm -rf node_modules`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install && npm run build`
- `pytest`
- `python manage.py runserver`
- run locust test (look for instruction inside locustfile.py file)
"""Load testing for the API and web app. Run from the root directory using the

`locust --host=https://api-stage.open.fec.gov/v1/` (stage)
`locust --host=https://api.open.fec.gov/v1/` (prod)
`locust --host=https://fec-dev-api.app.cloud.gov/v1/` (dev)

command, then open localhost:8089 to run tests.

API keys:
- Use an unlimited `FEC_WEB_API_KEY_PUBLIC`
- Borrow the `FEC_DOWNLOAD_API_KEY` from the staging space

"""