### PR TITLE
Add two columns to real_efile and real_pfile f1 table

### DIFF
--- a/data/migrations/V0248__add_columns_to_real_efile_pfile_F1.sql
+++ b/data/migrations/V0248__add_columns_to_real_efile_pfile_F1.sql
@@ -1,0 +1,32 @@
+/*
+This is for issue #5134:
+Adding two new columns to real_efile.F1 and real_pfile.F1 tables in Aurora postgresql databases
+
+ALTER TABLE real_efile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1);
+ALTER TABLE real_pfile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1);
+
+The columns had already been added to these tables
+so contractor can insert data in all PROD/STAGE/DEV databases.
+However, official migration script is needed to add these to the version controlled base of the database structure.
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE real_efile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1)');
+    EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('ALTER TABLE real_pfile.F1 ADD COLUMN super_pac_lobbyist varchar(1), add column hybrid_pac_lobbyist varchar(1)');
+    EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+      


### PR DESCRIPTION
## Summary (required)

- #5134 
Adding two new columns to real_efile.F1 and real_pfile.F1 tables in Aurora postgresql databases


### Required reviewers

This is database work. Only requires database team to review.

## Impacted areas of the application

General components of the application that this PR will affect:

-  

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

- download the branch to local machine, invoke create_sample_db process. Make sure migration executed successfully.
Connect to local_db, verify the two new columns 
super_pac_lobbyist varchar(1),
hybrid_pac_lobbyist varchar(1)
had been added to the  following two tables:
real_efile.F1 
real_pfile.F1 

These two columns had already been added to the Aurora databases, the syntax in this migration file should allow the migration file to run without causing error. To test this:
delete from flyway_schema_history where version = '0248';
Then run flyway migration again. Flyway migration should execute successfully without error.

Run pytest, all test should completed successfully.

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
