### PR TITLE
5132-Update locust deprecated methods

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -18,6 +18,7 @@ import random
 import resource
 
 import locust
+from locust import between
 
 
 # Avoid "Too many open files" error
@@ -427,5 +428,4 @@ class Tasks(locust.TaskSet):
 
 class Swarm(locust.HttpLocust):
     task_set = Tasks
-    min_wait = 5000
-    max_wait = 50000
+    wait_time = between(5000, 50000)


### PR DESCRIPTION
## Summary (required)

- Resolves #5132

Replaces deprecated min_wait and max_wait with wait_time. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  locust wait times, openFEC

## How to test

- checkout this branch
- `pyenv install 3.8.12` (if not already installed)
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
-  `rm -rf node_modules`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install && npm run build`
- `pytest`
- `python manage.py runserver`
- run locust test (look for instruction inside locustfile.py file)
"""Load testing for the API and web app. Run from the root directory using the

`locust --host=https://api-stage.open.fec.gov/v1/` (stage)
`locust --host=https://api.open.fec.gov/v1/` (prod)
`locust --host=https://fec-dev-api.app.cloud.gov/v1/` (dev)

command, then open localhost:8089 to run tests.

API keys:
- Use an unlimited `FEC_WEB_API_KEY_PUBLIC`
- Borrow the `FEC_DOWNLOAD_API_KEY` from the staging space

"""