### PR TITLE
5168-Snyk upgrade flyway 8.5.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.5.2/flyway-commandline-8.5.2-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-8.5.2:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.5.12/flyway-commandline-8.5.12-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-8.5.12:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 8.5.2 ([download](https://flywaydb.org/documentation/usage/commandline/))
-		* After downloading, open `flyway8.5.2/conf/flyway.conf` and set
+    * Flyway 8.5.12 ([download](https://flywaydb.org/documentation/usage/commandline/))
+		* After downloading, open `flyway8.5.12/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -687,9 +687,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-8.5.2.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-8.5.2-macosx-x64.tar.gz`, `flyway-commandline-8.5.2-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-8.5.12.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-8.5.12-macosx-x64.tar.gz`, `flyway-commandline-8.5.12-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-8.5.2` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-8.5.12` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "8.5.2"
-    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "8.5.2") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "8.5.12"
+    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "8.5.12") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-8.5.2.jar:app/gradle/lib/flyway-core-8.5.2.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-8.5.12.jar:app/gradle/lib/flyway-core-8.5.12.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5168 

Fixes vulnerabilities found in the flyway command line package. Note: I chose to upgrade to 8.5.12 and not 8.5.13 so that we could install through brew 

### Required reviewers

1-2 devs

## How to test

1. Confirm vulnerability on develop by running `snyk test --file=data/flyway/build.gradle`

2. Uninstall and remove your version of flyway and install Flyway 8.5.12 
**brew**:
run `brew uninstall flyway` and then run `brew install flyway` confirm with `flyway -v`
find your conf file in the Cellar and update (url and locations)
**Not through brew:**
Ref: [https://github.com/fecgov/openFEC#installing-flyway](https://github.com/fecgov/openFEC#installing-flyway)
For MacOS user, open Safari browser go to [https://flywaydb.org/documentation/usage/commandline/](https://flywaydb.org/documentation/usage/commandline/)
and download `flyway-commandline-8.5.12-macosx-x64.tar.gz`
update flyway conf file (url and locations)

3. Checkout this branch, activate virtual environment, `dropdb cfdm_test`, `createdb cfdm_test`, run `invoke create_sample_db`, `pytest`, `python manage.py runserver`

4. Run`snyk test --file=data/flyway/build.gradle` and confirm vulnerabilities are gone
