### PR TITLE
Add filter by case_doc_category_id in /legal/search/--5118

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -226,7 +226,6 @@ legal_universal_search = {
     'ao_entity_name': fields.List(IStr, required=False, description=docs.AO_ENTITY_NAME),
 
     'case_no': fields.List(IStr, required=False, description=docs.CASE_NO),
-    'case_document_category': fields.List(IStr, required=False, description=docs.CASE_DOCUMENT_CATEGORY),
     'case_respondents': fields.Str(IStr, required=False, description=docs.CASE_RESPONDONTS),
     'case_dispositions': fields.List(IStr, required=False, description=docs.CASE_DISPOSTIONS),
     'case_election_cycles': fields.Int(IStr, required=False, description=docs.CASE_ELECTION_CYCLES),
@@ -237,6 +236,10 @@ legal_universal_search = {
     'case_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'case_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
+
+    # case_doc_category_id is the key of case_document_category
+    'case_doc_category_id': fields.List(IStr(validate=validate.OneOf(['1', '2', '3', '4', '5', '6'])),
+                                    description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
 
     'mur_type': fields.Str(required=False, description=docs.MUR_TYPE),
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2033,6 +2033,15 @@ CASE_MAX_CLOSE_DATE = '''
 The latest date closed of case
 '''
 
+CASE_DOCUMENT_CATEGORY_DESCRIPTION = 'Select one or more case_doc_category_id to filter by corresponding CASE_DOCUMENT_CATEGORY:\n\
+        - 1 - Conciliation Agreements\n\
+        - 2 - Complaint, Responses, Designation of Counsel and Extensions of Timee\n\
+        - 3 - General Counsel Reports, Briefs, Notifications and Responses\n\
+        - 4 - Certifications\n\
+        - 5 - Civil Penalties, Disgorgements and Other Payments\n\
+        - 6 - Statements of Reasons \n\
+'
+
 MUR_TYPE = '''
 Type of MUR : current or archived
 '''

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -515,6 +515,7 @@ def get_documents(case_id, bucket):
                 "length": row["length"],
                 "text": row["ocrtext"],
                 "document_date": row["document_date"],
+                "doc_order_id": row["doc_order_id"],
             }
             if not row["fileimage"]:
                 logger.error(

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -48,6 +48,7 @@ CASE_DOCUMENT_MAPPINGS = {
         },
         "document_date": {"type": "date", "format": "dateOptionalTime"},
         "url": {"type": "text"},
+        "doc_order_id": {"type": "integer"},
     },
 }
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -188,9 +188,28 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     else:
         return apply_adr_specific_query_params(query, **kwargs)
 
-
+# Select one or more case_doc_category_id to filter by corresponding case_document_category
+# - 1 - Conciliation Agreements
+# - 2 - Complaint, Responses, Designation of Counsel and Extensions of Timee
+# - 3 - General Counsel Reports, Briefs, Notifications and Responses
+# - 4 - Certifications
+# - 5 - Civil Penalties, Disgorgements and Other Payments
+# - 6 - Statements of Reasons
 def get_case_document_query(q, **kwargs):
     combined_query = []
+    category_queries = []
+    if kwargs.get("case_doc_category_id"):
+
+        for doc_category_id in kwargs.get("case_doc_category_id"):
+            category_queries.append(
+                Q(
+                    "match",
+                    documents__doc_order_id=doc_category_id,
+                ),
+            )
+
+    combined_query.append(Q("bool", should=category_queries, minimum_should_match=1))
+
     if q:
         combined_query.append(Q("query_string", query=q, fields=["documents.text"]))
 


### PR DESCRIPTION
## Summary (required)
In order to create the legal web search app, we need add filter by case document type (doc_category)feature. Due to doc_category data is messy in db table, we will do filter by doc_order_id(filter name=case_doc_category_id) instead doc_category. doc_category_id is the key of doc_category. This PR will remove existing filter by **case_document_category** which is not working. 
and add new filter: case_doc_category_id

- Endpoint url ex: /legal/search/?type=murs&case_doc_order_id=2&case_doc_category_id=4
-  **doc_category_id and case_document_category** description:
1: "Conciliation Agreements"
2: "Complaint, Responses, Designation of Counsel and Extensions of Time"
3: "General Counsel Reports, Briefs, Notifications and Responses"
4: "Certifications"
5: "Civil Penalties, Disgorgements and Other Payments"
6: "Statements of Reasons"
<img width="650" alt="6_search_by_doc_type" src="https://user-images.githubusercontent.com/24395751/175986781-5e0aa0b6-d564-4547-a1d0-5586d90e6b0e.png">


- Resolves #5118 
- Ref: #5106 

### Required reviewers
two devs

## Impacted areas of the application
legal case search

### Completion criteria
- [x] Create filter by case_doc_category_id  to search by case_document_category which will  be used for 3 cases: murs, adrs, afs
- [ ] Recreate ES index("docs") and reload whole legal data
- [ ] Create follow-up ticket to reload ES data on stage and prod spaces
- [x] Sync with team 

## How to test
(test locally first)
- Follow wiki install ES7.4 locally and start it. [https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally)
- Check branch
- pytest
- Create index "docs" in local ES
`python manage.py create_index`
- Upload 8 sample murs in local ES
```
python manage.py load_current_murs -s 7958
python manage.py load_current_murs -s 7949
python manage.py load_current_murs -s 7927
python manage.py load_current_murs -s 7926
python manage.py load_current_murs -s 7923
python manage.py load_current_murs -s 7212
python manage.py load_current_murs -s 4633 
python manage.py load_current_murs -s 3987
```
- Make sure /legal/search/ endpoint works well
- Test filter
Ref test urls list: [https://docs.google.com/spreadsheets/d/1l3YKu-oBzOwBHH986YdyiYaSJTFdJBNxitZkt_Ew4zA/edit#gid=1143741195](https://docs.google.com/spreadsheets/d/1l3YKu-oBzOwBHH986YdyiYaSJTFdJBNxitZkt_Ew4zA/edit#gid=1143741195)
- Some test urls
(one case_doc_category_id)
http://127.0.0.1:5000/v1/legal/search/?type=murs&case_doc_category_id=1
(return 6 rows)

(more than one case_doc_category_id)
http://127.0.0.1:5000/v1/legal/search/?type=murs&case_doc_category_id=1&case_doc_category_id=2
(return 8 rows)
