### PR TITLE
5124-Upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-SQLAlchemy==2.4.1
 gevent==20.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
 gunicorn==19.10.0
-GitPython==3.1.0
+GitPython==3.1.27
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary (required)

- Resolves #5124 

Upgrades GitPython to latest version to remove Regular Expression Denial of Service (ReDoS) vulnerability

### Required reviewers

1-2 dev

## How to test

1. Confirm vulnerability on develop by running `snyk test --file=requirements.txt`
2. `gh pr checkout 5183`
4. `pip install -r requirements.txt`
5. `pip freeze`  (check that gitpython=3.1.27)
6.  run  `snyk test --file=requirements.txt`,  gitpython issue should be gone
7.  `dropdb cfdm_test`, `createdb cfdm_test`, run `invoke create_sample_db`, `pytest`, `python manage.py runserver` test endpoints

