### PR TITLE
4958-upgrade flask

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=webservices.rest
+FLASK_DEBUG=1

--- a/README.md
+++ b/README.md
@@ -200,25 +200,29 @@ export SQLA_FOLLOWERS=<psql:address-to-replica-box-1>[,<psql:address-to-replica-
 #### Run locally
 Follow these steps every time you want to work on this project locally.
 
-1. Set the FLASK_APP environment variable to specify how to load the application. Flask is used when running the project locally, so you will want to turn the debugger on as well. If you'd like to run in  development mode (reloader will trigger whenever your code or imported modules change and debugger is on by default) you can set FLASK_ENV=development.
-```
-export FLASK_APP=webservices.rest
-export FLASK_DEBUG=1
-
-```
+1. Set the FLASK_APP environment variable to specify how to load the application. Flask is used when running the project locally, so you will want to turn the debugger on as well. If you'd like to run in  development mode (reloader will trigger whenever your code or imported modules change and debugger is on by default) you can set FLASK_ENV=development. Pyenv-dotenv should set these for you automatically by reading .flaskenv. 
+   ```
+   export FLASK_APP=webservices.rest
+   export FLASK_DEBUG=1
+   ```
 
 2. If you are using the legal search portion of the site, you will need Elastic Search running.
 Navigate to the installation folder (eg., `elasticsearch-7.4`) and run:
 
-```
-cd bin
-./elasticsearch
-```
+   ```
+   cd bin
+   ./elasticsearch
+   ```
 
 2. Start the web server:
 
    ```
    flask run
+   ```
+   or
+
+   ```
+   python cli.py run
    ```
 
 3. View your local version of the site at [http://localhost:5000](http://localhost:5000).
@@ -403,7 +407,7 @@ To accomplish this, follow these steps:
 
    ```
    name: one-off-app-name
-   command: "<your command here, e.g., python manage.py refresh_materialized> && sleep infinity"
+   command: "<your command here, e.g., python cli.py refresh_materialized> && sleep infinity"
    no-route: true
    ```
 
@@ -579,7 +583,7 @@ The materialized views are manually refreshed when something needs to be removed
 * Run this command:
     
     ```
-    cf run-task api 'python manage.py refresh_materialized' --name refresh
+    cf run-task api 'python cli.py refresh_materialized' --name refresh
     ```
 * Check status of task:
 
@@ -600,37 +604,37 @@ There are some management commands to manage (display, create, delete, restore) 
 More information is available by invoking each of these commands with a `--help` option. These commands can be run as [tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html) on `cloud.gov`, e.g.,
 #### Display, Configure and Delete a repository
 ```
-cf run-task api --command "python manage.py display_repositories" -m 2G --name display_repositories
+cf run-task api --command "python cli.py display_repositories" -m 2G --name display_repositories
 ```
 ```
-cf run-task api --command "python manage.py configure_snapshot_repository -r <repository_name>" -m 4G --name configure_docs_snapshot_repository
+cf run-task api --command "python cli.py configure_snapshot_repository <repository_name>" -m 4G --name configure_docs_snapshot_repository
 ```
 ```
-cf run-task api --command "python manage.py delete_repository -r <repository_name>" -m 4G --name delete_repository
+cf run-task api --command "python cli.py delete_repository <repository_name>" -m 4G --name delete_repository
 ```
 #### Display, Create and Delete an index
 We have two indexes for FEC legal documents, one is used for current legal documents, another is used for archived MURs.
 ```
-cf run-task api --command "python manage.py display_index_alias" -m 2G --name display_index_alias
+cf run-task api --command "python cli.py display_index_alias" -m 2G --name display_index_alias
 ```
 ```
-cf run-task api --command "python manage.py create_index -i <index_name> -a [alias_name1,alias_name2]" -m 2G --name create_index
+cf run-task api --command "python cli.py create_index <index_name> [alias_name1,alias_name2]" -m 2G --name create_index
 ```
 ```
-cf run-task api --command "python manage.py delete_index -i <index_name>" -m 2G --name delete_index
+cf run-task api --command "python cli.py delete_index <index_name>" -m 2G --name delete_index
 ```
 #### Reloading all current legal documents with no downtime (excludes archived MURs)
 ```
-cf run-task api --command "python manage.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data
+cf run-task api --command "python cli.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data
 ```
 This command is typically used when there is a schema change. A staging index (DOCS_STAGING_INDEX) is built and populated in the background. When ready, the staging index is moved to the current index (DOCS_INDEX) with no downtime.
 
 #### Initialize the current legal documents and archived MURs (with downtime)
 ```
-cf run-task api --command "python manage.py initialize_current_legal_docs" -m 4G --name initialize_docs_data
+cf run-task api --command "python cli.py initialize_current_legal_docs" -m 4G --name initialize_docs_data
 ```
 ```
-cf run-task api --command "python manage.py initialize_archived_mur_docs" -m 4G --name initialize_arch_mur_data
+cf run-task api --command "python cli.py initialize_archived_mur_docs" -m 4G --name initialize_arch_mur_data
 ```
 These commands are used to reload all legal docs with downtime (approximately two hours).
 
@@ -641,37 +645,37 @@ cf logs api | grep <some key word>
 ```
 #### Loading advisory opinions [beginning with FROM_AO_NO through newest AO]
 ```
-cf run-task api --command "python manage.py load_advisory_opinions [-f FROM_AO_NO]" -m 4G --name load_advisory_opinions
+cf run-task api --command "python cli.py load_advisory_opinions [FROM_AO_NO]" -m 4G --name load_advisory_opinions
 ```
 #### Loading current MURs (type=murs and mur_type=current) [only one MUR_NO]
 ```
-cf run-task api --command "python manage.py load_current_murs [-s MUR_NO]" -m 4G --name load_current_murs
+cf run-task api --command "python cli.py load_current_murs [MUR_NO]" -m 4G --name load_current_murs
 ```
 #### Loading ADRs [only one ADR_NO]
 ```
-cf run-task api --command "python manage.py load_adrs [-s ADR_NO]"  -m 4G --name load_adrs
+cf run-task api --command "python cli.py load_adrs [ADR_NO]"  -m 4G --name load_adrs
 ```
 #### Loading Admin Fines [only one AF_NO]
 ```
-cf run-task api --command "python manage.py load_admin_fines [-s AF_NO]" --name load_admin_fines
+cf run-task api --command "python cli.py load_admin_fines [AF_NO]" --name load_admin_fines
 ```
 #### Loading regulations
 ```
-cf run-task api --command "python manage.py load_regulations" --name load_regulations
+cf run-task api --command "python cli.py load_regulations" --name load_regulations
 ```
 This command requires that the environment variable `FEC_EREGS_API` is set to the API endpoint of a valid `eregs` instance.
 #### Loading statutes
 ```
-cf run-task api --command "python manage.py load_statutes" --name load_statutes
+cf run-task api --command "python cli.py load_statutes" --name load_statutes
 ```
 #### Loading archived murs(type=murs and mur_type=archived)
 (load one arch_mur):
 ```
-cf run-task api --command "python manage.py load_archived_murs [-m MUR_NO]" --name upload_one_arch_mur
+cf run-task api --command "python cli.py load_archived_murs [MUR_NO]" --name upload_one_arch_mur
 ```
 (load all arch_mur):
 ```
-cf run-task api --command "python manage.py load_archived_murs" --name upload_arch_mur
+cf run-task api --command "python cli.py load_archived_murs" --name upload_arch_mur
 ```
 ### Production stack
 The OpenFEC API is a Flask application deployed using the gunicorn WSGI server behind

--- a/README.md
+++ b/README.md
@@ -200,7 +200,14 @@ export SQLA_FOLLOWERS=<psql:address-to-replica-box-1>[,<psql:address-to-replica-
 #### Run locally
 Follow these steps every time you want to work on this project locally.
 
-1. If you are using the legal search portion of the site, you will need Elastic Search running.
+1. Set the FLASK_APP environment variable to specify how to load the application. Flask is used when running the project locally, so you will want to turn the debugger on as well. If you'd like to run in  development mode (reloader will trigger whenever your code or imported modules change and debugger is on by default) you can set FLASK_ENV=development.
+```
+export FLASK_APP=webservices.rest
+export FLASK_DEBUG=1
+
+```
+
+2. If you are using the legal search portion of the site, you will need Elastic Search running.
 Navigate to the installation folder (eg., `elasticsearch-7.4`) and run:
 
 ```
@@ -211,7 +218,7 @@ cd bin
 2. Start the web server:
 
    ```
-   ./manage.py runserver
+   flask run
    ```
 
 3. View your local version of the site at [http://localhost:5000](http://localhost:5000).

--- a/bin/cf_env_setup.sh
+++ b/bin/cf_env_setup.sh
@@ -3,7 +3,7 @@
 # This is a convenience script to setup the app container environment to match
 # what was uploaded with the buildpack when you SSH into an app container.
 # This must be run if you want to interact with the application and run
-# anything as you'd expect, e.g., ./manage.py showmigrations for a Python app
+# anything as you'd expect, e.g., ./cli.py showmigrations for a Python app
 # built with Django.
 
 # This script is built using the commands and information outlined here:

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
-python manage.py cf_startup
+python cli.py cf_startup
 gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 9 webservices.rest:app

--- a/cli.py
+++ b/cli.py
@@ -13,40 +13,121 @@ import webservices.legal_docs as legal_docs
 cli = FlaskGroup(app)
 logger = logging.getLogger("cli")
 
-cli.command(legal_docs.load_regulations)
-cli.command(legal_docs.load_statutes)
-cli.command(legal_docs.load_advisory_opinions)
-cli.command(legal_docs.load_current_murs)
-cli.command(legal_docs.load_adrs)
-cli.command(legal_docs.load_admin_fines)
-cli.command(legal_docs.load_archived_murs)
-cli.command(legal_docs.extract_pdf_text)
+@app.cli.command('load_regulations')
+def load_regulations():
+    legal_docs.load_regulations()  
 
-cli.command(legal_docs.delete_doctype_from_es)
-cli.command(legal_docs.delete_single_doctype_from_es)
-cli.command(legal_docs.delete_murs_from_s3)
-cli.command(legal_docs.show_legal_data)
+@app.cli.command('load_statutes')
+def load_statutes():
+    legal_docs.load_statutes()
 
-cli.command(legal_docs.create_index)
-cli.command(legal_docs.restore_from_staging_index)
-cli.command(legal_docs.delete_index)
-cli.command(legal_docs.display_index_alias)
-cli.command(legal_docs.display_mappings)
+@app.cli.command('load_advisory_opinions')
+def load_advisory_opinions():
+    legal_docs.load_advisory_opinions()
 
-cli.command(legal_docs.initialize_current_legal_docs)
-cli.command(legal_docs.initialize_archived_mur_docs)
-cli.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+@app.cli.command('load_current_murs')
+def load_current_murs():
+    legal_docs.load_current_murs()  
 
-cli.command(legal_docs.configure_snapshot_repository)
-cli.command(legal_docs.delete_repository)
-cli.command(legal_docs.display_repositories)
+@app.cli.command('load_adrs')
+def load_adrs():
+    legal_docs.load_adrs()
 
-cli.command(legal_docs.create_es_snapshot)
-cli.command(legal_docs.restore_es_snapshot)
-cli.command(legal_docs.restore_es_snapshot_downtime)
-cli.command(legal_docs.delete_snapshot)
-cli.command(legal_docs.display_snapshots)
-cli.command(legal_docs.display_snapshot_detail)
+@app.cli.command('load_admin_fines')
+def load_admin_fines():
+    legal_docs.load_admin_fines()
+
+@app.cli.command('load_archived_murs')
+def load_archived_murs():
+    legal_docs.load_archived_murs()
+
+@app.cli.command('extract_pdf_text')
+def extract_pdf_text():
+    legal_docs.extract_pdf_text()
+
+@app.cli.command('delete_doctype_from_es')
+def delete_doctype_from_es():
+    legal_docs.delete_doctype_from_es()
+
+@app.cli.command('delete_single_doctype_from_es')
+def delete_single_doctype_from_es():
+    legal_docs.delete_single_doctype_from_es()
+
+@app.cli.command('delete_murs_from_s3')
+def delete_murs_from_s3():
+    legal_docs.delete_murs_from_s3()
+
+@app.cli.command('show_legal_data')
+def show_legal_data():
+    legal_docs.show_legal_data()
+
+@app.cli.command('create_index')
+def create_index():
+    legal_docs.create_index()  
+
+@app.cli.command('restore_from_staging_index')
+def restore_from_staging_index():
+    legal_docs.restore_from_staging_index()
+
+@app.cli.command('delete_index')
+def delete_index():
+    legal_docs.delete_index()
+
+@app.cli.command('display_index_alias')
+def display_index_alias():
+    legal_docs.display_index_alias()  
+
+@app.cli.command('display_mappings')
+def display_mappings():
+    legal_docs.display_mappings()
+
+@app.cli.command('initialize_current_legal_docs')
+def initialize_current_legal_docs():
+    legal_docs.initialize_current_legal_docs()
+
+@app.cli.command('initialize_archived_mur_docs')
+def initialize_archived_mur_docs():
+    legal_docs.initialize_archived_mur_docs()
+
+@app.cli.command('refresh_current_legal_docs_zero_downtime')
+def refresh_current_legal_docs_zero_downtime():
+    legal_docs.refresh_current_legal_docs_zero_downtime()
+
+@app.cli.command('configure_snapshot_repository')
+def configure_snapshot_repository():
+    legal_docs.configure_snapshot_repository()
+
+@app.cli.command('delete_repository')
+def delete_repository():
+    legal_docs.delete_repository()
+
+@app.cli.command('display_repositories')
+def display_repositories():
+    legal_docs.display_repositories()
+
+@app.cli.command('create_es_snapshot')
+def create_es_snapshot():
+    legal_docs.create_es_snapshot()
+
+@app.cli.command('restore_es_snapshot')
+def restore_es_snapshot():
+    legal_docs.restore_es_snapshot()
+
+@app.cli.command('restore_es_snapshot_downtime')
+def restore_es_snapshot_downtime():
+    legal_docs.restore_es_snapshot_downtime()
+
+@app.cli.command('delete_snapshot')
+def delete_snapshot():
+    legal_docs.delete_snapshot()
+
+@app.cli.command('display_snapshots')
+def display_snapshots():
+    legal_docs.display_snapshots()
+
+@app.cli.command('display_snapshot_detail')
+def display_snapshot_detail():
+    legal_docs.display_snapshot_detail()
 
 
 @app.cli.command('refresh_materialized')

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import click
+import logging
+import manage
+
+from flask.cli import FlaskGroup
+from webservices.common import models
+from webservices.rest import app, db
+import webservices.legal_docs as legal_docs
+
+
+cli = FlaskGroup(app)
+logger = logging.getLogger("cli")
+
+cli.command(legal_docs.load_regulations)
+cli.command(legal_docs.load_statutes)
+cli.command(legal_docs.load_advisory_opinions)
+cli.command(legal_docs.load_current_murs)
+cli.command(legal_docs.load_adrs)
+cli.command(legal_docs.load_admin_fines)
+cli.command(legal_docs.load_archived_murs)
+cli.command(legal_docs.extract_pdf_text)
+
+cli.command(legal_docs.delete_doctype_from_es)
+cli.command(legal_docs.delete_single_doctype_from_es)
+cli.command(legal_docs.delete_murs_from_s3)
+cli.command(legal_docs.show_legal_data)
+
+cli.command(legal_docs.create_index)
+cli.command(legal_docs.restore_from_staging_index)
+cli.command(legal_docs.delete_index)
+cli.command(legal_docs.display_index_alias)
+cli.command(legal_docs.display_mappings)
+
+cli.command(legal_docs.initialize_current_legal_docs)
+cli.command(legal_docs.initialize_archived_mur_docs)
+cli.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+
+cli.command(legal_docs.configure_snapshot_repository)
+cli.command(legal_docs.delete_repository)
+cli.command(legal_docs.display_repositories)
+
+cli.command(legal_docs.create_es_snapshot)
+cli.command(legal_docs.restore_es_snapshot)
+cli.command(legal_docs.restore_es_snapshot_downtime)
+cli.command(legal_docs.delete_snapshot)
+cli.command(legal_docs.display_snapshots)
+cli.command(legal_docs.display_snapshot_detail)
+
+
+@app.cli.command('refresh_materialized')
+# @click.option('--concurrent/--no-concurrent', type=bool, default=True)
+@click.argument('concurrent', default=True, type=bool)
+def refresh_materialized_cli(concurrent=True):
+    manage.refresh_materialized()
+
+
+@app.cli.command('cf_startup')
+def cf_startup_cli():
+    manage.cf_startup()
+
+
+@app.cli.command('slack_message')
+@click.argument('message')
+def slack_message_cli(message):
+    manage.slack_message(message)
+
+
+@app.shell_context_processor
+def make_shell_context():
+    return {'app': app, 'db': db, 'models': models}
+
+
+if __name__ == "__main__":
+    cli()

--- a/cli.py
+++ b/cli.py
@@ -8,130 +8,189 @@ from flask.cli import FlaskGroup
 from webservices.common import models
 from webservices.rest import app, db
 import webservices.legal_docs as legal_docs
+from webservices.legal_docs.es_management import DOCS_REPOSITORY_NAME
 
 
 cli = FlaskGroup(app)
 logger = logging.getLogger("cli")
 
+
 @app.cli.command('load_regulations')
-def load_regulations():
+def load_regulations_cli():
     legal_docs.load_regulations()  
 
+
 @app.cli.command('load_statutes')
-def load_statutes():
+def load_statutes_cli():
     legal_docs.load_statutes()
 
+
 @app.cli.command('load_advisory_opinions')
-def load_advisory_opinions():
-    legal_docs.load_advisory_opinions()
+@click.argument('from_ao_no', default=None, required=False)
+def load_advisory_opinions_cli(from_ao_no):
+    legal_docs.load_advisory_opinions(from_ao_no)
+
 
 @app.cli.command('load_current_murs')
-def load_current_murs():
-    legal_docs.load_current_murs()  
+@click.argument('specific_mur_no', default=None, required=False)
+def load_current_murs_cli(specific_mur_no):
+    legal_docs.load_current_murs(specific_mur_no)  
+
 
 @app.cli.command('load_adrs')
-def load_adrs():
-    legal_docs.load_adrs()
+@click.argument('specific_adr_no', default=None, required=False)
+def load_adrs_cli(specific_adr_no):
+    legal_docs.load_adrs(specific_adr_no)
+
 
 @app.cli.command('load_admin_fines')
-def load_admin_fines():
-    legal_docs.load_admin_fines()
+@click.argument('specific_af_no', default=None, required=False)
+def load_admin_fines_cli(specific_af_no):
+    legal_docs.load_admin_fines(specific_af_no)
+
 
 @app.cli.command('load_archived_murs')
-def load_archived_murs():
-    legal_docs.load_archived_murs()
+@click.argument('mur_no', default=None, required=False)
+def load_archived_murs_cli(mur_no):
+    legal_docs.load_archived_murs(mur_no)
+
 
 @app.cli.command('extract_pdf_text')
-def extract_pdf_text():
-    legal_docs.extract_pdf_text()
+@click.argument('mur_no', default=None, required=False)
+def extract_pdf_text_cli(mur_no):
+    legal_docs.extract_pdf_text(mur_no)
+
 
 @app.cli.command('delete_doctype_from_es')
-def delete_doctype_from_es():
-    legal_docs.delete_doctype_from_es()
+@click.argument('index_name', default=None, required=False)
+@click.argument('doc_type', default=None, required=False)
+def delete_doctype_from_es_cli(index_name, doc_type):
+    legal_docs.delete_doctype_from_es(index_name, doc_type)
+
 
 @app.cli.command('delete_single_doctype_from_es')
-def delete_single_doctype_from_es():
-    legal_docs.delete_single_doctype_from_es()
+@click.argument('index_name', default=None, required=False)
+@click.argument('doc_type', default=None, required=False)
+@click.argument('num_doc_id', default=None, required=False)
+def delete_single_doctype_from_es_cli(index_name, doc_type, num_doc_id):
+    legal_docs.delete_single_doctype_from_es(index_name, doc_type, num_doc_id)
+
 
 @app.cli.command('delete_murs_from_s3')
-def delete_murs_from_s3():
+def delete_murs_from_s3_cli():
     legal_docs.delete_murs_from_s3()
 
+
 @app.cli.command('show_legal_data')
-def show_legal_data():
+def show_legal_data_cli():
     legal_docs.show_legal_data()
 
+
 @app.cli.command('create_index')
-def create_index():
-    legal_docs.create_index()  
+@click.argument('index_name', default=None, required=False)
+@click.argument('aliases_name', default=None, required=False)
+def create_index_cli(index_name, aliases_name):
+    legal_docs.create_index(index_name, aliases_name)  
+
 
 @app.cli.command('restore_from_staging_index')
-def restore_from_staging_index():
+def restore_from_staging_index_cli():
     legal_docs.restore_from_staging_index()
 
+
 @app.cli.command('delete_index')
-def delete_index():
-    legal_docs.delete_index()
+@click.argument('index_name', default=None, required=False)
+def delete_index_cli(index_name):
+    legal_docs.delete_index(index_name)
+
 
 @app.cli.command('display_index_alias')
-def display_index_alias():
+def display_index_alias_cli():
     legal_docs.display_index_alias()  
 
+
 @app.cli.command('display_mappings')
-def display_mappings():
+def display_mappings_cli():
     legal_docs.display_mappings()
 
+
 @app.cli.command('initialize_current_legal_docs')
-def initialize_current_legal_docs():
+def initialize_current_legal_docs_cli():
     legal_docs.initialize_current_legal_docs()
 
+
 @app.cli.command('initialize_archived_mur_docs')
-def initialize_archived_mur_docs():
+def initialize_archived_mur_docs_cli():
     legal_docs.initialize_archived_mur_docs()
 
+
 @app.cli.command('refresh_current_legal_docs_zero_downtime')
-def refresh_current_legal_docs_zero_downtime():
+def refresh_current_legal_docs_zero_downtime_cli():
     legal_docs.refresh_current_legal_docs_zero_downtime()
 
+
 @app.cli.command('configure_snapshot_repository')
-def configure_snapshot_repository():
-    legal_docs.configure_snapshot_repository()
+@click.argument('index_name', default=DOCS_REPOSITORY_NAME, required=False)
+def configure_snapshot_repository_cli(repository_name):
+    legal_docs.configure_snapshot_repository(repository_name)
+
 
 @app.cli.command('delete_repository')
-def delete_repository():
-    legal_docs.delete_repository()
+@click.argument('repository_name', default=None, required=False)
+def delete_repository_cli(repository_name):
+    legal_docs.delete_repository(repository_name)
+
 
 @app.cli.command('display_repositories')
-def display_repositories():
+def display_repositories_cli():
     legal_docs.display_repositories()
 
+
 @app.cli.command('create_es_snapshot')
-def create_es_snapshot():
-    legal_docs.create_es_snapshot()
+@click.argument('repository_name', default=None, required=False)
+@click.argument('snapshot_name', default="auto_backup", required=False)
+@click.argument('index_name', default=None, required=False)
+def create_es_snapshot_cli(repository_name, snapshot_name, index_name):
+    legal_docs.create_es_snapshot(repository_name, snapshot_name, index_name)
+
 
 @app.cli.command('restore_es_snapshot')
-def restore_es_snapshot():
-    legal_docs.restore_es_snapshot()
+@click.argument('repository_name', default=None, required=False)
+@click.argument('snapshot_name', default=None, required=False)
+@click.argument('index_name', default=None, required=False)
+def restore_es_snapshot_cli(repository_name, snapshot_name, index_name):
+    legal_docs.restore_es_snapshot(repository_name, snapshot_name, index_name)
+
 
 @app.cli.command('restore_es_snapshot_downtime')
-def restore_es_snapshot_downtime():
-    legal_docs.restore_es_snapshot_downtime()
+@click.argument('repository_name', default=None, required=False)
+@click.argument('snapshot_name', default=None, required=False)
+@click.argument('index_name', default=None, required=False)
+def restore_es_snapshot_downtime_cli(repository_name, snapshot_name, index_name):
+    legal_docs.restore_es_snapshot_downtime(repository_name, snapshot_name, index_name)
+
 
 @app.cli.command('delete_snapshot')
-def delete_snapshot():
-    legal_docs.delete_snapshot()
+@click.argument('repository_name', default=None, required=False)
+@click.argument('snapshot_name', default=None, required=False)
+def delete_snapshot_cli(repository_name, snapshot_name):
+    legal_docs.delete_snapshot(repository_name, snapshot_name)
+
 
 @app.cli.command('display_snapshots')
-def display_snapshots():
-    legal_docs.display_snapshots()
+@click.argument('repository_name', default=None, required=False)
+def display_snapshots_cli(repository_name):
+    legal_docs.display_snapshots(repository_name)
+
 
 @app.cli.command('display_snapshot_detail')
-def display_snapshot_detail():
-    legal_docs.display_snapshot_detail()
+@click.argument('repository_name', default=None, required=False)
+@click.argument('snapshot_name', default=None, required=False)
+def display_snapshot_detail_cli(repository_name, snapshot_name):
+    legal_docs.display_snapshot_detail(repository_name, snapshot_name)
 
 
 @app.cli.command('refresh_materialized')
-# @click.option('--concurrent/--no-concurrent', type=bool, default=True)
 @click.argument('concurrent', default=True, type=bool)
 def refresh_materialized_cli(concurrent=True):
     manage.refresh_materialized()

--- a/manage.py
+++ b/manage.py
@@ -142,7 +142,7 @@ def cf_startup():
     """Migrate schemas on `cf push`."""
     check_config()
     if env.index == "0":
-        subprocess.Popen(["python", "manage.py", "refresh_materialized"])
+        subprocess.Popen(["python", "cli.py", "refresh_materialized"])
 
 
 def slack_message(message):

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import click
 import glob
 import logging
 import subprocess
@@ -7,8 +8,7 @@ import multiprocessing
 import networkx as nx
 import sqlalchemy as sa
 
-from flask_script import Server
-from flask_script import Manager
+from flask.cli import FlaskGroup
 from webservices import flow
 from webservices.common import models
 from webservices.env import env
@@ -18,48 +18,43 @@ from webservices.common.util import get_full_path
 import webservices.legal_docs as legal_docs
 from webservices.utils import post_to_slack
 
-manager = Manager(app)
-logger = logging.getLogger("manager")
+cli = FlaskGroup(app)
+logger = logging.getLogger("cli")
 
-# The Flask app server should only be used for local testing, so we default to
-# using debug mode and auto-reload. To disable debug mode locally, pass the
-# --no-debug flag to `runserver`.
-manager.add_command("runserver", Server(use_debugger=True, use_reloader=True))
+cli.command(legal_docs.load_regulations)
+cli.command(legal_docs.load_statutes)
+cli.command(legal_docs.load_advisory_opinions)
+cli.command(legal_docs.load_current_murs)
+cli.command(legal_docs.load_adrs)
+cli.command(legal_docs.load_admin_fines)
+cli.command(legal_docs.load_archived_murs)
+cli.command(legal_docs.extract_pdf_text)
 
-manager.command(legal_docs.load_regulations)
-manager.command(legal_docs.load_statutes)
-manager.command(legal_docs.load_advisory_opinions)
-manager.command(legal_docs.load_current_murs)
-manager.command(legal_docs.load_adrs)
-manager.command(legal_docs.load_admin_fines)
-manager.command(legal_docs.load_archived_murs)
-manager.command(legal_docs.extract_pdf_text)
+cli.command(legal_docs.delete_doctype_from_es)
+cli.command(legal_docs.delete_single_doctype_from_es)
+cli.command(legal_docs.delete_murs_from_s3)
+cli.command(legal_docs.show_legal_data)
 
-manager.command(legal_docs.delete_doctype_from_es)
-manager.command(legal_docs.delete_single_doctype_from_es)
-manager.command(legal_docs.delete_murs_from_s3)
-manager.command(legal_docs.show_legal_data)
+cli.command(legal_docs.create_index)
+cli.command(legal_docs.restore_from_staging_index)
+cli.command(legal_docs.delete_index)
+cli.command(legal_docs.display_index_alias)
+cli.command(legal_docs.display_mappings)
 
-manager.command(legal_docs.create_index)
-manager.command(legal_docs.restore_from_staging_index)
-manager.command(legal_docs.delete_index)
-manager.command(legal_docs.display_index_alias)
-manager.command(legal_docs.display_mappings)
+cli.command(legal_docs.initialize_current_legal_docs)
+cli.command(legal_docs.initialize_archived_mur_docs)
+cli.command(legal_docs.refresh_current_legal_docs_zero_downtime)
 
-manager.command(legal_docs.initialize_current_legal_docs)
-manager.command(legal_docs.initialize_archived_mur_docs)
-manager.command(legal_docs.refresh_current_legal_docs_zero_downtime)
+cli.command(legal_docs.configure_snapshot_repository)
+cli.command(legal_docs.delete_repository)
+cli.command(legal_docs.display_repositories)
 
-manager.command(legal_docs.configure_snapshot_repository)
-manager.command(legal_docs.delete_repository)
-manager.command(legal_docs.display_repositories)
-
-manager.command(legal_docs.create_es_snapshot)
-manager.command(legal_docs.restore_es_snapshot)
-manager.command(legal_docs.restore_es_snapshot_downtime)
-manager.command(legal_docs.delete_snapshot)
-manager.command(legal_docs.display_snapshots)
-manager.command(legal_docs.display_snapshot_detail)
+cli.command(legal_docs.create_es_snapshot)
+cli.command(legal_docs.restore_es_snapshot)
+cli.command(legal_docs.restore_es_snapshot_downtime)
+cli.command(legal_docs.delete_snapshot)
+cli.command(legal_docs.display_snapshots)
+cli.command(legal_docs.display_snapshot_detail)
 
 
 def execute_sql_file(path):
@@ -88,7 +83,9 @@ def execute_sql_folder(path, processes):
             execute_sql_file(path)
 
 
-@manager.command
+@app.cli.command('refresh_materialized')
+#  @click.option('--concurrent/--no-concurrent', type=bool, default=True)
+@click.argument('concurrent', default=True, type=bool)
 def refresh_materialized(concurrent=True):
     """Refresh materialized views in dependency order
        We usually want to refresh them concurrently so that we don't block other
@@ -181,12 +178,12 @@ def refresh_materialized(concurrent=True):
                         sa.text(refresh_command).execution_options(autocommit=True)
                     )
             else:
-                logger.error("Error refreshing node %s: not found.".format(node))
+                logger.error("Error refreshing node {}: not found.".format(node))
 
     logger.info("Finished refreshing materialized views.")
 
 
-@manager.command
+@app.cli.command('cf_startup')
 def cf_startup():
     """Migrate schemas on `cf push`."""
     check_config()
@@ -194,7 +191,8 @@ def cf_startup():
         subprocess.Popen(["python", "manage.py", "refresh_materialized"])
 
 
-@manager.command
+@app.cli.command('slack_message')
+@click.argument('message')
 def slack_message(message):
     """ Sends a message to the bots channel. you can add this command to ping you when a task is done, etc.
     run ./manage.py slack_message 'The message you want to post'
@@ -202,10 +200,10 @@ def slack_message(message):
     post_to_slack(message, "#bots")
 
 
-@manager.shell
+@app.shell_context_processor
 def make_shell_context():
-    return dict(app=app, db=db, models=models)
+    return {'app': app, 'db': db, 'models': models}
 
 
 if __name__ == "__main__":
-    manager.run()
+    cli()

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -3,7 +3,7 @@ applications:
 - name: <name>-kill-<date>
   memory: 1024M
   disk_quota: 1024M
-  command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python manage.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
+  command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python cli.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
   no-route: true
   path: ../
   stack: cflinuxfs3

--- a/manifests/manifest_task_feature.yml.template
+++ b/manifests/manifest_task_feature.yml.template
@@ -3,7 +3,7 @@ applications:
 - name: <name>-kill-<date>
   memory: 1024M
   disk_quota: 1024M
-  command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python manage.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
+  command: "(<put your command here> && echo SUCCESS || echo FAIL) && sleep infinity"  # "(python cli.py refresh_materialized && echo SUCCESS || echo FAIL) && sleep infinity"
   no-route: true
   path: ../
   stack: cflinuxfs3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ git+https://github.com/18F/rdbms-subsetter
 
 # Testing
 pdbpp==0.9.1
-click==8.0.4
+click==8.1.3
 
 # requirements.txt generation (pip-compile)
 pip-tools==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,9 @@ cfenv==0.5.2
 defusedxml==0.6.0
 elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
-Flask==1.1.1
+Flask==2.1.2
 Flask-Cors==3.0.9
-Flask-RESTful==0.3.7
-Flask-Script==2.0.6
+Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.4.1
 gevent==20.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
@@ -27,7 +26,7 @@ SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==5.5.3
-werkzeug==0.16.1
+werkzeug==2.0.0
 
 # Marshalling
 flask-apispec==0.7.0
@@ -46,9 +45,7 @@ redis==4.2.2
 # testing and build in circle
 codecov==2.1.7
 factory_boy==2.8.1
-itsdangerous==1.1.0 #pinned to fix pytest deprecation warning
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
-jinja2==3.0.3 #pinned to fix pytest and circle deploy errors caused by the latest jinja2 v3.1.1
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
 nplusone==0.8.0
 pytest==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ networkx==2.6.2
 prance[osv]>=0.19
 psycopg2-binary==2.9.1
 python-dateutil==2.8.1
+python-dotenv>=0.20.0
 requests==2.25.1
 requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ networkx==2.6.2
 prance[osv]>=0.19
 psycopg2-binary==2.9.1
 python-dateutil==2.8.1
-python-dotenv>=0.20.0
+python-dotenv>=0.20.0 # Sets variable defaults in .flaskenv file
 requests==2.25.1
 requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0

--- a/tasks.py
+++ b/tasks.py
@@ -280,7 +280,7 @@ def create_sample_db(ctx):
 
     print("Refreshing materialized views...")
     os.environ["SQLA_CONN"] = db_conn  # SQLA_CONN is used by manage.py tasks
-    subprocess.check_call(['python', 'manage.py', 'refresh_materialized'])
+    subprocess.check_call(['python', 'cli.py', 'refresh_materialized'])
     print("Materialized views refreshed")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def migrate_db(request):
         rest.app.config['SQLALCHEMY_DATABASE_URI'] = common.TEST_CONN
         reset_schema()
         run_migrations()
-        manage.refresh_materialized(concurrent=False)
+        manage.refresh_materialized(False)
 
 
 def run_migrations():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def migrate_db(request):
         rest.app.config['SQLALCHEMY_DATABASE_URI'] = common.TEST_CONN
         reset_schema()
         run_migrations()
-        manage.refresh_materialized(False)
+        manage.refresh_materialized(concurrent=False)
 
 
 def run_migrations():

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -74,7 +74,7 @@ def initialize_current_legal_docs():
     Create the Elasticsearch DOCS_INDEX and loads all the different types of legal documents.
     This would lead to a brief outage while the docs are reloaded.
 
-    ex: cf run-task api --command "python manage.py initialize_current_legal_docs" -m 4G --name initialize_docs_data
+    ex: cf run-task api --command "python cli.py initialize_current_legal_docs" -m 4G --name initialize_docs_data
     """
 
     # by default create index DOCS_INDEX and two aliases: DOCS_ALIAS and SEARCH_ALIAS
@@ -87,7 +87,7 @@ def initialize_archived_mur_docs():
     Create the Elasticsearch ARCHIVED_MURS_INDEX and loads all the archived mur legal documents.
     This would lead to a brief outage while the docs are reloaded.
 
-    ex: cf run-task api --command "python manage.py initialize_archived_mur_docs" -m 4G --name initialize_arch_mur_data
+    ex: cf run-task api --command "python cli.py initialize_archived_mur_docs" -m 4G --name initialize_arch_mur_data
     """
     create_index(ARCHIVED_MURS_INDEX, (ARCHIVED_MURS_ALIAS + "," + SEARCH_ALIAS))
     load_archived_murs()
@@ -99,7 +99,7 @@ def refresh_current_legal_docs_zero_downtime():
     When done, moves the staging index to the production index with no downtime.
     This is typically used when there is a schema change.
 
-    ex: cf run-task api --command "python manage.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data
+    ex: cf run-task api --command "python cli.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data
     """
 
     # Create 'docs_staging' index

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -375,12 +375,12 @@ def create_index(index_name=None, aliases_name=None):
     b)create_index(ARCHIVED_MURS_INDEX, (ARCHIVED_MURS_ALIAS + "," + SEARCH_ALIAS))
 
     How to run locally:
-    a) python manage.py create_index
-    b) python manage.py create_index -i archived_murs -a archived_murs_index,docs_search
+    a) python cli.py create_index
+    b) python  cli.py create_index archived_murs archived_murs_index,docs_search
 
     How to call task command:
-    a) cf run-task api --command "python manage.py create_index" -m 2G --name create_index
-    b) cf run-task api --command "python manage.py create_index -i archived_murs -a archived_murs_index,docs_search" -m 2G --name create_index
+    a) cf run-task api --command "python cli.py create_index" -m 2G --name create_index
+    b) cf run-task api --command "python cli.py create_index archived_murs archived_murs_index,docs_search" -m 2G --name create_index
     """
     index_name = index_name or DOCS_INDEX
     aliases_list = []
@@ -444,10 +444,10 @@ def display_index_alias():
     Returns all indices and aliases.
 
     How to run locally:
-        python manage.py display_index_alias
+        python cli.py display_index_alias
 
     How to call task command:
-        cf run-task api --command "display_index_alias" -m 2G --name display_index_alias
+        cf run-task api --command "python cli.py display_index_alias" -m 2G --name display_index_alias
     """
     es_client = create_es_client()
     indices = es_client.cat.indices(format="JSON")
@@ -464,10 +464,10 @@ def display_mappings():
     Returns all index mappings.
 
     How to run locally:
-        python manage.py display_mappings
+        python cli.py display_mappings
 
     How to call task command:
-        cf run-task api --command "display_mappings" -m 2G --name display_mappings
+        cf run-task api --command "python cli.py display_mappings" -m 2G --name display_mappings
     """
     es_client = create_es_client()
     indices = es_client.cat.indices(format="JSON")
@@ -488,12 +488,12 @@ def delete_index(index_name=None):
     b)delete_index(ARCHIVED_MURS_INDEX)
 
     How to run locally:
-    a) python manage.py delete_index -i docs
-    b) python manage.py delete_index -i archived_murs
+    a) python cli.py delete_index docs
+    b) python cli.py delete_index archived_murs
 
     How to call task command:
-    a) cf run-task api --command "python manage.py delete_index -i docs" -m 2G --name delete_index
-    b) cf run-task api --command "python manage.py delete_index -i archived_murs" -m 2G --name delete_index
+    a) cf run-task api --command "python cli.py delete_index docs" -m 2G --name delete_index
+    b) cf run-task api --command "python cli.py delete_index archived_murs" -m 2G --name delete_index
     """
     # TODO: check if DOCS_INDEX exist before deleting.
     es_client = create_es_client()
@@ -678,8 +678,8 @@ def configure_snapshot_repository(repository_name=DOCS_REPOSITORY_NAME):
     This needs to get re-run when s3 credentials change for each api app deployment.
 
     How to call task command:
-    cf run-task api --command "python manage.py configure_snapshot_repository -r repository_docs" -m 2G --name configure_snapshot_repository_docs
-    cf run-task api --command "python manage.py configure_snapshot_repository -r repository_archived_murs" -m 2G --name configure_snapshot_repository_arch_mur
+    cf run-task api --command "python cli.py configure_snapshot_repository repository_docs" -m 2G --name configure_snapshot_repository_docs
+    cf run-task api --command "python cli.py configure_snapshot_repository repository_archived_murs" -m 2G --name configure_snapshot_repository_arch_mur
     """
     es_client = create_es_client()
     logger.info(" Configuring snapshot repository: {0}".format(repository_name))
@@ -713,7 +713,7 @@ def delete_repository(repository_name=None):
     Delete a s3 repository.
 
     How to call task command:
-    cf run-task api --command "python manage.py delete_repository -r repository_test" -m 2G --name delete_repository
+    cf run-task api --command "python cli.py delete_repository repository_test" -m 2G --name delete_repository
     """
     if repository_name:
         try:
@@ -733,7 +733,7 @@ def display_repositories():
     Returns all the repositories.
 
     How to call task command:
-    cf run-task api --command "python manage.py display_repositories" -m 2G --name display_repositories
+    cf run-task api --command "python cli.py display_repositories" -m 2G --name display_repositories
     """
 
     es_client = create_es_client()
@@ -754,9 +754,9 @@ def create_es_snapshot(repository_name=None, snapshot_name="auto_backup", index_
     Create elasticsearch shapshot of specific 'index_name'(=index1,index2...) in 'repository_name'.
 
     How to call task command:
-    ex1: cf run-task api --command "python manage.py create_es_snapshot -r repository_docs -i docs" -m 2G --name snapshot_docs
-    ex1: cf run-task api --command "python manage.py create_es_snapshot -r repository_archived_murs -i archived_murs -m 2G --name snapshot_archived_murs
-    ex3: cf run-task api --command "python manage.py create_es_snapshot -i docs,archived_murs" -m 2G --name create_snapshot_2index
+    ex1: cf run-task api --command "python cli.py create_es_snapshot repository_docs docs" -m 2G --name snapshot_docs
+    ex1: cf run-task api --command "python cli.py create_es_snapshot repository_archived_murs archived_murs" -m 2G --name snapshot_archived_murs
+    ex3: cf run-task api --command "python cli.py create_es_snapshot docs archived_murs" -m 2G --name create_snapshot_2index
     """
     es_client = create_es_client()
     index_name_list = []
@@ -792,8 +792,8 @@ def delete_snapshot(repository_name=None, snapshot_name=None):
     Delete a snapshot.
 
     How to call task command:
-    ex1: cf run-task api --command "python manage.py delete_snapshot -r repository_docs -s docs_202010272134_auto_backup" -m 2G --name delete_snapshot
-    ex2: cf run-task api --command "python manage.py delete_snapshot -s docs_202010272132_auto_backup" -m 2G --name delete_snapshot
+    ex1: cf run-task api --command "python cli.py delete_snapshot repository_docs docs_202010272134_auto_backup" -m 2G --name delete_snapshot
+    ex2: cf run-task api --command "python cli.py delete_snapshot docs_202010272132_auto_backup" -m 2G --name delete_snapshot
     """
     if repository_name and snapshot_name:
         configure_snapshot_repository(repository_name)
@@ -817,7 +817,7 @@ def restore_es_snapshot(repository_name=None, snapshot_name=None, index_name=Non
     -Default to most recent snapshot, optionally specify `snapshot_name`
 
     How to call task command:
-    ex: cf run-task api --command "python manage.py restore_es_snapshot -r repository_docs -s docs_202010272132_auto_backup -i docs" -m 2G --name restore_es_snapshot
+    ex: cf run-task api --command "python cli.py restore_es_snapshot repository_docs docs_202010272132_auto_backup docs" -m 2G --name restore_es_snapshot
     """
     es_client = create_es_client()
 
@@ -870,8 +870,8 @@ def restore_es_snapshot_downtime(repository_name=None, snapshot_name=None, index
     -Default to most recent snapshot, optionally specify `snapshot_name`
 
     How to call task command:
-    ex: cf run-task api --command "python manage.py restore_es_snapshot_downtime -r repository_docs -s docs_202010272130_auto_backup -i docs" -m 2G --name restore_es_snapshot_downtime
-    ex: cf run-task api --command "python manage.py restore_es_snapshot_downtime -r repository_archived_murs -s archived_murs_202010272130_auto_backup -i archived_murs" -m 2G --name restore_es_snapshot_downtime
+    ex: cf run-task api --command "python cli.py restore_es_snapshot_downtime repository_docs docs_202010272130_auto_backup docs" -m 2G --name restore_es_snapshot_downtime
+    ex: cf run-task api --command "python cli.py restore_es_snapshot_downtime repository_archived_murs archived_murs_202010272130_auto_backup archived_murs" -m 2G --name restore_es_snapshot_downtime
     """
     es_client = create_es_client()
 
@@ -919,8 +919,8 @@ def display_snapshots(repository_name=None):
     Returns all the snapshots in the repository.
 
     How to call task command:
-    ex1: cf run-task api --command "python manage.py display_snapshots -r repository_docs" -m 2G --name display_snapshots
-    ex2: cf run-task api --command "python manage.py display_snapshots -r repository_archived_murs" -m 2G --name display_snapshots
+    ex1: cf run-task api --command "python cli.py display_snapshots repository_docs" -m 2G --name display_snapshots
+    ex2: cf run-task api --command "python cli.py display_snapshots repository_archived_murs" -m 2G --name display_snapshots
     """
     es_client = create_es_client()
     repository_name = repository_name or DOCS_REPOSITORY_NAME
@@ -940,8 +940,8 @@ def display_snapshot_detail(repository_name=None, snapshot_name=None):
     Returns all the snapshot detail (include uuid) in the repository.
 
     How to call task command:
-    ex1: cf run-task api --command "python manage.py display_snapshot_detail -s docs_202010*" -m 2G --name display_snapshot
-    ex2: cf run-task api --command "python manage.py display_snapshot_detail -r repository_archived_murs -s archived_murs*" -m 2G --name display_snapshot_detail
+    ex1: cf run-task api --command "python cli.py display_snapshot_detail repository_name docs_202010*" -m 2G --name display_snapshot
+    ex2: cf run-task api --command "python cli.py display_snapshot_detail repository_archived_murs archived_murs*" -m 2G --name display_snapshot_detail
     """
     es_client = create_es_client()
     repository_name = repository_name or DOCS_REPOSITORY_NAME
@@ -961,7 +961,7 @@ def display_snapshot_detail(repository_name=None, snapshot_name=None):
 def delete_doctype_from_es(index_name=None, doc_type=None):
     """
     Deletes all records with the given `doc_type` from Elasticsearch
-    Ex: cf run-task api --command "python manage.py delete_doctype_from_es -i docs -d adrs" -m 2G --name delete_adrs
+    Ex: cf run-task api --command "python cli.py delete_doctype_from_es docs adrs" -m 2G --name delete_adrs
     """
     body = {"query": {"match": {"type": doc_type}}}
 
@@ -977,8 +977,8 @@ def delete_doctype_from_es(index_name=None, doc_type=None):
 def delete_single_doctype_from_es(index_name=None, doc_type=None, num_doc_id=None):
     """
     Deletes single record with the given `doc_type` and `doc_id` from Elasticsearch
-    Ex: cf run-task api --command "python manage.py delete_single_doctype_from_es -i docs -d admin_fines -n af_4201" -m 2G --name delete_one_af
-        cf run-task api --command "python manage.py delete_single_doctype_from_es -i docs -d advisory_opinions -n advisory_opinions_2021-08" -m 2G --name delete_one_ao
+    Ex: cf run-task api --command "python cli.py delete_single_doctype_from_es docs admin_fines af_4201" -m 2G --name delete_one_af
+        cf run-task api --command "python cli.py delete_single_doctype_from_es docs advisory_opinions advisory_opinions_2021-08" -m 2G --name delete_one_ao
     """
     body = {"query": {
         "bool": {

--- a/webservices/legal_docs/regulations.py
+++ b/webservices/legal_docs/regulations.py
@@ -11,7 +11,7 @@ from .es_management import (  # noqa
 )
 import json
 
-logger = logging.getLogger("manager")
+logger = logging.getLogger(__name__)
 
 # for debug, uncomment this line
 # logger.setLevel(logging.DEBUG)

--- a/webservices/legal_docs/statutes.py
+++ b/webservices/legal_docs/statutes.py
@@ -10,7 +10,7 @@ from .es_management import (  # noqa
     DOCS_ALIAS,
 )
 
-logger = logging.getLogger("manager")
+logger = logging.getLogger(__name__)
 
 
 def get_xml_tree_from_url(url):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -20,7 +20,7 @@ from flask import redirect
 from flask import render_template
 from flask import Flask
 from flask import Blueprint
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 from webargs.flaskparser import FlaskParser
 from flask_apispec import FlaskApiSpec
 from webservices import spec


### PR DESCRIPTION
## Summary (required)

- Resolves #4958 

This is a major version upgrade with several breaking changes. Flask-Script has been deprecated, so it was removed and the Flask in-built CLI (which runs with click) was used to replace that functionality. There were a few changes to commands and some extra variables that need to be set which are noted in the README. **They will all be in the how-to below, but note that to run the server you must now use `flask run` or `python cli.py run`**

The commands used to be run with, for example: `python manage.py refresh_materialized`, in my first commit, but if I keep the CLI decorators on those functions I get a TypeError when I run the integration tests with pytest. 
If you run `pytest tests/integration/test_advisory_opinions.py -x` on the original commit you will see the errors. I fixed this issue by re-defining the functions for the CLI in a separate file (cli.py). If anyone has a better solution, or would like to offer suggestions on this item I would be very open to switching it up. 

 I've uploaded a .flaskenv file so we wouldn't have to manually export the FLASK_APP and FLASK_DEBUG variables in terminal. I added python-dotenv to the requirements.txt file which automatically loads the variables from the .flaskenv file. I ran locust tests (results below) and found no difference from our current speeds and failures. 

NOTE: I will update [the wiki](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally) before the release is live.

I've noted that we have a ticket to fix the import app anti-pattern and think we should fix that separately. 

Sources I found helpful:
https://flask.palletsprojects.com/en/2.1.x/cli/
https://blog.miguelgrinberg.com/post/migrating-from-flask-script-to-the-new-flask-cli
https://click.palletsprojects.com/en/8.1.x/commands/


# Required reviewers
2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Local testing environment (specifically running any task in your terminal)


## How to test

- `gh pr checkout 5186`
- `pyenv install 3.8.12` 
- `pyenv virtualenv 3.8.12 venv-api3812` 
- `pyenv activate venv-api3812`
- `pip install -r requirements.txt` 
- `pip install -r requirements-dev.txt`
- `rm -rf node_modules` (optional step) (check for correct node version, switch with `nvm install 14.15.5`)
- `npm i && npm run build` 
- `dropdb cfdm_test`
- `createdb cfdm_test`
- `invoke create_sample_db`
- `pytest` (all tests should pass)
-  `python cli.py run` OR `flask run` and test swagger-ui
- try out the other CLI commands such as `python cli.py refresh_materialized`,  `python cli.py create_index` (any of the tasks in the wiki, but make sure to replace manage.py with cli.py and also remove flask options ie -i, -f,...would be happy to pair with anyone on this and running tasks)
-  deploy this branch to dev 
-  login to cloud.gov & make sure you're on dev 
- `cf tasks api` to see the tasks that have been tested 
- `cf run-task api --command "python cli.py display_snapshot_detail repository_archived_murs archived_murs*" -m 2G --name display_snapshot_detail" -m 2G --name display_snapshot_detail` (or any other task you'd like to run) 
- `cf tasks api` (Should run successfully---takes a few minutes depending on the command) 
- run locust testing (I already did this and the results are in a comment below.) 