### PR TITLE
Add filer name keyword search in /efile/filings/

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -1,5 +1,6 @@
 import datetime
-
+import sqlalchemy as sa
+from webservices import rest
 from tests import factories
 from tests.common import ApiBaseTest
 from webservices.rest import api
@@ -211,26 +212,27 @@ class TestFilings(ApiBaseTest):
         self.assertEqual(results[0]['document_description'], 'RFAI: report 2004')
 
 
+# Test for endpoint:/efile/filings/ under tag:efiling (filings.EFilingsView)
 class TestEfileFiles(ApiBaseTest):
     def test_filter_date_efile(self):
         [
             factories.EFilingsFactory(
-                committee_id='C010',
+                committee_id="C010",
                 beginning_image_number=2,
                 filed_date=datetime.date(2012, 1, 1),
             ),
             factories.EFilingsFactory(
-                committee_id='C011',
+                committee_id="C011",
                 beginning_image_number=3,
                 filed_date=datetime.date(2013, 1, 1),
             ),
             factories.EFilingsFactory(
-                committee_id='C012',
+                committee_id="C012",
                 beginning_image_number=4,
                 filed_date=datetime.date(2014, 1, 1),
             ),
             factories.EFilingsFactory(
-                committee_id='C013',
+                committee_id="C013",
                 beginning_image_number=5,
                 filed_date=datetime.date(2015, 1, 1),
             ),
@@ -239,12 +241,12 @@ class TestEfileFiles(ApiBaseTest):
         min_date = datetime.date(2013, 1, 1)
         results = self._results(api.url_for(EFilingsView, min_receipt_date=min_date))
         self.assertTrue(
-            all(each for each in results if each['filed_date'] >= min_date.isoformat())
+            all(each for each in results if each["filed_date"] >= min_date.isoformat())
         )
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(EFilingsView, max_receipt_date=max_date))
         self.assertTrue(
-            all(each for each in results if each['filed_date'] <= max_date.isoformat())
+            all(each for each in results if each["filed_date"] <= max_date.isoformat())
         )
         results = self._results(
             api.url_for(
@@ -255,7 +257,7 @@ class TestEfileFiles(ApiBaseTest):
             all(
                 each
                 for each in results
-                if min_date.isoformat() <= each['filed_date'] <= max_date.isoformat()
+                if min_date.isoformat() <= each["filed_date"] <= max_date.isoformat()
             )
         )
 
@@ -263,12 +265,12 @@ class TestEfileFiles(ApiBaseTest):
 
         [
             factories.EFilingsFactory(
-                committee_id='C013',
+                committee_id="C013",
                 beginning_image_number=5,
                 filed_date=datetime.date(2015, 1, 1),
             ),
             factories.EFilingsFactory(
-                committee_id='C014',
+                committee_id="C014",
                 beginning_image_number=6,
                 filed_date=datetime.date(2015, 1, 2),
             ),
@@ -284,19 +286,19 @@ class TestEfileFiles(ApiBaseTest):
 
     def test_efilings(self):
         """ Check filings returns in general endpoint"""
-        factories.EFilingsFactory(committee_id='C001')
-        factories.EFilingsFactory(committee_id='C002')
+        factories.EFilingsFactory(committee_id="C001")
+        factories.EFilingsFactory(committee_id="C002")
 
         results = self._results(api.url_for(EFilingsView))
         self.assertEqual(len(results), 2)
 
     def test_committee_efilings(self):
         """ Check filing returns with a specified committee id"""
-        committee_id = 'C8675309'
+        committee_id = "C8675309"
         factories.EFilingsFactory(committee_id=committee_id)
 
         results = self._results(api.url_for(EFilingsView, committee_id=committee_id))
-        self.assertEqual(results[0]['committee_id'], committee_id)
+        self.assertEqual(results[0]["committee_id"], committee_id)
 
     def test_file_number_efilings(self):
         """ Check filing returns with a specified file number"""
@@ -304,4 +306,32 @@ class TestEfileFiles(ApiBaseTest):
         factories.EFilingsFactory(file_number=file_number)
 
         results = self._results(api.url_for(EFilingsView, file_number=file_number))
-        self.assertEqual(results[0]['file_number'], file_number)
+        self.assertEqual(results[0]["file_number"], file_number)
+
+    def test_fulltext_keyward_search(self):
+        [
+            factories.EFilingsFactory(
+                committee_id="C01",
+                committee_name="Danielle",
+            ),
+            factories.EFilingsFactory(
+                committee_id="C02",
+                committee_name="Dana",
+            ),
+        ]
+
+        factories.CommitteeSearchFactory(
+            id="C01", fulltxt=sa.func.to_tsvector("Danielle")
+        )
+        factories.CommitteeSearchFactory(
+            id="C02", fulltxt=sa.func.to_tsvector("Dana")
+        )
+        rest.db.session.flush()
+        results = self._results(api.url_for(EFilingsView, q="Danielle"))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["committee_id"], "C01")
+
+        results = self._results(api.url_for(EFilingsView, q="dan"))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["committee_id"], "C01")
+        self.assertEqual(results[1]["committee_id"], "C02")

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -308,7 +308,7 @@ class TestEfileFiles(ApiBaseTest):
         results = self._results(api.url_for(EFilingsView, file_number=file_number))
         self.assertEqual(results[0]["file_number"], file_number)
 
-    def test_fulltext_keyward_search(self):
+    def test_fulltext_keyword_search(self):
         [
             factories.EFilingsFactory(
                 committee_id="C01",
@@ -335,3 +335,9 @@ class TestEfileFiles(ApiBaseTest):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["committee_id"], "C01")
         self.assertEqual(results[1]["committee_id"], "C02")
+
+    def test_invalid_keyword(self):
+        response = self.app.get(
+            api.url_for(EFilingsView, q="ab")
+        )
+        self.assertEqual(response.status_code, 422)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -369,6 +369,7 @@ efilings = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'min_receipt_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
     'max_receipt_date': fields.Date(description=docs.MAX_RECEIPT_DATE),
+    'q': fields.List(fields.Str, description=docs.COMMITTEE_NAME),
 }
 
 reports = {

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -7,6 +7,7 @@ from webservices import schemas
 from webservices.common.views import ApiResource
 from webservices.common import counts
 from webservices.common import models
+from webservices import exceptions
 
 
 @doc(
@@ -130,9 +131,16 @@ class EFilingsView(ApiResource):
         )
 
     def build_query(self, **kwargs):
+        VALID_KEYWORD_LENGTH = 3
         query = super().build_query(**kwargs)
 
         if kwargs.get("q"):
+            for keyword in kwargs["q"]:
+                if len(keyword) < VALID_KEYWORD_LENGTH:  # noqa
+                    raise exceptions.ApiError(
+                        "Invalid keyword, the keyword must be at least 3 characters in length.",
+                        status_code=422,
+                    )
             query = query.join(
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,


### PR DESCRIPTION
## Summary (required)
This PR will be able to filter `/efile/filings/` endpoints by keyword filer_name.

- Resolves #issue_number
This PR will resolve the part of this [https://github.com/fecgov/openfec/issues/5160](https://github.com/fecgov/openfec/issues/5160)
- Add keyword validation, at least 3 chars in length

### Required reviewers
1-2 devs

## Impacted areas of the application
/efile/filings/

<img width="500" alt="eFiling_keyword_search" src="https://user-images.githubusercontent.com/24395751/178126295-962ffe25-4e92-4a53-b853-d22a1d25d432.png">



## How to test
- Check out branch, point to dev db, pytest
- test api locally
- test urls
1)(without filter, return total: 71367 rows)
http://127.0.0.1:5000/v1/efile/filings/

2)(q=san, will return 634 rows)
http://127.0.0.1:5000/v1/efile/filings/?q=san

3)(q=c006, will return 9013 rows)
http://127.0.0.1:5000/v1/efile/filings/?q=c006

4) get invalid keyword error (length < 3)
http://127.0.0.1:5000/v1/efile/filings/?q=ab

