### PR TITLE
Upgrade ujson to v5.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requests==2.25.1
 requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
-ujson==5.2.0 # decoding CSP violation reported
+ujson==5.4.0 # decoding CSP violation reported
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==5.5.3
 werkzeug==0.16.1


### PR DESCRIPTION
## Summary (required)

- In requirements.txt -->Upgrade ujson python package to v5.4.0

- Resolves #https://github.com/fecgov/openFEC/issues/5189

### Required reviewers

1 developer

## Screenshots

**Before:**
<img width="1001" alt="Screen Shot 2022-07-13 at 2 39 37 PM" src="https://user-images.githubusercontent.com/11650355/178818041-847aab6c-43a8-418c-a5ad-0d682b9ca442.png">


**After:**
![Screen Shot 2022-07-13 at 3 38 41 PM](https://user-images.githubusercontent.com/11650355/178818061-20dd8238-ad0e-492e-975e-eb4614f9828f.png)


## How to test

- run `snyk test --file=requirements.txt` on openFEC/develop branch. (ujson vulnerability will show in the terminal logs)
-  checkout branch : `git checkout feature/5189-upgrade-ujson`
- create new python virtual env and activate: `pyenv virtualenv venv-api3813`
- activate virtual env: `pyenv activate venv-api3813`
- install requirements: `pip install -r requirements.txt`  & `pip install -r requirements-dev.txt`
- run `snyk test --file=requirements.txt` (ujson is NOT a vulnerable packages anymore)
- run `pytest`( optional )
- start server ./manage.py runserver (optional)
- test swagger-ui (local api): http://localhost:5000/ (optional)
