### PR TITLE
Add committee_label to ofec_committee_history_mv

### DIFF
--- a/data/migrations/V0249__add_function_get_committee_label.sql
+++ b/data/migrations/V0249__add_function_get_committee_label.sql
@@ -1,0 +1,68 @@
+-- FUNCTION: public.get_committee_label(text,text, text)
+/*
+This is for issue #4915.
+This migration file creates database function: get_committee_label.
+Based on cmte_type, cmte_dsgn and org_tp, to generate committee_label
+*/
+-- DROP FUNCTION public.get_committee_label(text,text, text);
+
+
+CREATE OR REPLACE FUNCTION public.get_committee_label(
+    cmte_type text,
+    cmte_dsgn text,
+    org_type text)
+    RETURNS text
+    LANGUAGE 'plpgsql'
+AS $$
+    begin
+        return case 
+            WHEN cmte_type = 'H' and cmte_dsgn = 'P' THEN 'House - principal campaign committee'
+            WHEN cmte_type = 'H' and cmte_dsgn = 'A' THEN 'House - other authorized campaign committee'                       
+            WHEN cmte_type = 'H' and COALESCE(cmte_dsgn, 'F') IN ('B', 'D', 'U', 'F') THEN 'House'
+            WHEN cmte_type = 'S' and cmte_dsgn = 'P' THEN 'Senate - principal campaign committee'
+            WHEN cmte_type = 'S' and cmte_dsgn = 'A' THEN 'Senate - other authorized campaign committee'                       
+            WHEN cmte_type = 'S' and COALESCE(cmte_dsgn, 'F') IN ('B', 'D', 'U', 'F') THEN 'Senate'
+            WHEN cmte_type = 'P' and cmte_dsgn = 'P' THEN 'President - principal campaign committee'
+            WHEN cmte_type = 'P' and cmte_dsgn = 'A' THEN 'President - other authorized campaign committee'                       
+            WHEN cmte_type = 'P' and COALESCE(cmte_dsgn, 'F') IN ('B', 'D', 'U', 'F') THEN 'President'
+            WHEN cmte_type = 'D' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Delegate'     
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'C' THEN 'Corporation PAC - nonqualifed'                        
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'L' THEN 'Labor PAC - nonqualifed'                        
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'T' THEN 'Trade PAC - nonqualifed'                                         
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'M' THEN 'Membership PAC - nonqualifed'                        
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'V' THEN 'Cooperative PAC - nonqualifed'                        
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'W' THEN 'Corporation without stock PAC - nonqualifed'
+            WHEN cmte_type = 'N' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') THEN 'PAC - nonqualifed'  
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'C' THEN 'Corporation PAC - qualified'                        
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'L' THEN 'Labor PAC - qualified'                        
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'T' THEN 'Trade PAC - qualified'                                         
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'M' THEN 'Membership PAC - qualified'                        
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'V' THEN 'Cooperative PAC - qualified'                        
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') and org_type = 'W' THEN 'Corporation without stock PAC - qualified'
+            WHEN cmte_type = 'Q' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'P', 'U', 'F') THEN 'PAC - qualified'
+            WHEN cmte_type = 'O' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Super PAC (Independent Expenditure-Only)'    
+            WHEN cmte_type = 'U' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Single candidate independent expenditure' 
+            WHEN cmte_type = 'V' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Hybrid PAC (with non-Contribution Account) - nonqualified'     
+            WHEN cmte_type = 'W' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Hybrid PAC (with non-Contribution Account) - qualified' 
+            WHEN cmte_type = 'N' and cmte_dsgn = 'D' THEN 'Leadership PAC - nonqualifed'
+            WHEN cmte_type = 'Q' and cmte_dsgn = 'D' THEN 'Leadership PAC - qualified'
+            WHEN cmte_type = 'X' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Party - nonqualifed'
+            WHEN cmte_type = 'Y' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Party - qualified'
+            WHEN cmte_type = 'Z' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Party nonfederal account'
+            WHEN cmte_dsgn = 'J' THEN 'Joint fundraising'
+            WHEN cmte_type = 'I' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Independent expenditures reported by persons other than a political committee'
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'C' THEN 'Communication cost - Corporation'                        
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'L' THEN 'Communication cost - Labor Organization'                        
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'T' THEN 'Communication cost - Trade Association'                                         
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'M' THEN 'Communication cost - Membership Organization'                        
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'V' THEN 'Communication cost - Cooperative'                        
+            WHEN cmte_type = 'C' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') and org_type = 'W' THEN 'Communication cost - Corporation without Capital Stock'
+            WHEN cmte_type = 'C' and org_type IS NULL THEN 'Communication cost'
+            WHEN cmte_type = 'E' and COALESCE(cmte_dsgn, 'F') IN ('A', 'B', 'D', 'P', 'U', 'F') THEN 'Electioneering Communications' 
+      ELSE 'UNKNOWN'
+      end;
+   end
+$$;
+
+ALTER FUNCTION public.get_committee_label(text,text, text)
+    OWNER TO fec;

--- a/data/migrations/V0250__add_committee_label_ofec_committee_history_mv.sql
+++ b/data/migrations/V0250__add_committee_label_ofec_committee_history_mv.sql
@@ -1,0 +1,212 @@
+/*
+This migration file is for #4915
+
+1) Add `committee_label` to ofec_committee_history_mv and ofec_committee_history_vw
+
+Replaces V0238
+
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_committee_history_mv_tmp AS
+WITH cycles AS
+(
+    SELECT cmte_valid_fec_yr.cmte_id,
+    array_agg(cmte_valid_fec_yr.fec_election_yr) FILTER (WHERE cmte_valid_fec_yr.fec_election_yr is not NULL)::integer[] AS cycles,
+    max(cmte_valid_fec_yr.fec_election_yr) AS max_cycle
+    FROM disclosure.cmte_valid_fec_yr
+    GROUP BY cmte_valid_fec_yr.cmte_id
+), dates AS
+(
+    SELECT f_rpt_or_form_sub.cand_cmte_id AS cmte_id,
+    min(f_rpt_or_form_sub.receipt_dt) AS first_file_date,
+    max(f_rpt_or_form_sub.receipt_dt) AS last_file_date,
+    max(f_rpt_or_form_sub.receipt_dt) FILTER (WHERE f_rpt_or_form_sub.form_tp::text = 'F1'::text) AS last_f1_date,
+    min(f_rpt_or_form_sub.receipt_dt) FILTER (WHERE f_rpt_or_form_sub.form_tp::text = 'F1'::text) AS first_f1_date,
+    max(get_cycle(f_rpt_or_form_sub.rpt_yr)) AS last_cycle_has_activity,
+    array_agg(DISTINCT get_cycle(f_rpt_or_form_sub.rpt_yr)) FILTER (WHERE f_rpt_or_form_sub.rpt_yr is not NULL) AS cycles_has_activity
+    FROM disclosure.f_rpt_or_form_sub
+    GROUP BY f_rpt_or_form_sub.cand_cmte_id
+), candidates AS
+(
+    SELECT cand_cmte_linkage.cmte_id,
+    array_agg(DISTINCT cand_cmte_linkage.cand_id)::text[] AS candidate_ids
+    FROM disclosure.cand_cmte_linkage
+    GROUP BY cand_cmte_linkage.cmte_id
+), reports AS
+(
+    SELECT f_rpt_or_form_sub.cand_cmte_id AS cmte_id,
+    max(get_cycle(f_rpt_or_form_sub.rpt_yr)) AS last_cycle_has_financial,
+    array_agg(DISTINCT get_cycle(f_rpt_or_form_sub.rpt_yr)) FILTER (WHERE f_rpt_or_form_sub.rpt_yr is not NULL) AS cycles_has_financial
+    FROM disclosure.f_rpt_or_form_sub
+    WHERE upper(f_rpt_or_form_sub.form_tp::text) = ANY (ARRAY['F3'::text, 'F3X'::text, 'F3P'::text, 'F3L'::text, 'F4'::text, 'F5'::text, 'F7'::text, 'F13'::text, 'F24'::text, 'F6'::text, 'F9'::text, 'F10'::text, 'F11'::text])
+    GROUP BY f_rpt_or_form_sub.cand_cmte_id
+), leadership_pac_linkage AS
+(
+    SELECT cand_cmte_linkage_alternate.cmte_id, cand_cmte_linkage_alternate.fec_election_yr,
+    array_agg(DISTINCT cand_cmte_linkage_alternate.cand_id)::text[] AS sponsor_candidate_ids
+    FROM disclosure.cand_cmte_linkage_alternate
+    WHERE linkage_type = 'D'
+    GROUP BY cand_cmte_linkage_alternate.cmte_id, cand_cmte_linkage_alternate.fec_election_yr
+)
+SELECT DISTINCT ON (fec_yr.cmte_id, fec_yr.fec_election_yr) row_number() OVER () AS idx,
+    fec_yr.fec_election_yr AS cycle,
+    fec_yr.cmte_id AS committee_id,
+    fec_yr.cmte_nm AS name,
+    fec_yr.tres_nm AS treasurer_name,
+    to_tsvector(parse_fulltext(fec_yr.tres_nm::text)::text) AS treasurer_text,
+    f1.org_tp AS organization_type,
+    expand_organization_type(f1.org_tp::text) AS organization_type_full,
+    fec_yr.cmte_st1 AS street_1,
+    fec_yr.cmte_st2 AS street_2,
+    fec_yr.cmte_city AS city,
+    fec_yr.cmte_st AS state,
+    expand_state(fec_yr.cmte_st::text) AS state_full,
+    fec_yr.cmte_zip AS zip,
+    f1.tres_city AS treasurer_city,
+    f1.tres_f_nm AS treasurer_name_1,
+    f1.tres_l_nm AS treasurer_name_2,
+    f1.tres_m_nm AS treasurer_name_middle,
+    f1.tres_ph_num AS treasurer_phone,
+    f1.tres_prefix AS treasurer_name_prefix,
+    f1.tres_st AS treasurer_state,
+    f1.tres_st1 AS treasurer_street_1,
+    f1.tres_st2 AS treasurer_street_2,
+    f1.tres_suffix AS treasurer_name_suffix,
+    f1.tres_title AS treasurer_name_title,
+    f1.tres_zip AS treasurer_zip,
+    f1.cust_rec_city AS custodian_city,
+    f1.cust_rec_f_nm AS custodian_name_1,
+    f1.cust_rec_l_nm AS custodian_name_2,
+    f1.cust_rec_m_nm AS custodian_name_middle,
+    f1.cust_rec_nm AS custodian_name_full,
+    f1.cust_rec_ph_num AS custodian_phone,
+    f1.cust_rec_prefix AS custodian_name_prefix,
+    f1.cust_rec_st AS custodian_state,
+    f1.cust_rec_st1 AS custodian_street_1,
+    f1.cust_rec_st2 AS custodian_street_2,
+    f1.cust_rec_suffix AS custodian_name_suffix,
+    f1.cust_rec_title AS custodian_name_title,
+    f1.cust_rec_zip AS custodian_zip,
+    fec_yr.cmte_email AS email,
+    f1.cmte_fax AS fax,
+    fec_yr.cmte_url AS website,
+    f1.form_tp AS form_type,
+    f1.leadership_pac,
+    f1.lobbyist_registrant_pac,
+    f1.cand_pty_tp AS party_type,
+    f1.cand_pty_tp_desc AS party_type_full,
+    f1.qual_dt AS qualifying_date,
+    dates.first_file_date::text::date AS first_file_date,
+    dates.last_file_date::text::date AS last_file_date,
+    dates.last_f1_date::text::date AS last_f1_date,
+    fec_yr.cmte_dsgn AS designation,
+    expand_committee_designation(fec_yr.cmte_dsgn::text) AS designation_full,
+    fec_yr.cmte_tp AS committee_type,
+    expand_committee_type(fec_yr.cmte_tp::text) AS committee_type_full,
+    fec_yr.cmte_filing_freq AS filing_frequency,
+    fec_yr.cmte_pty_affiliation AS party,
+    fec_yr.cmte_pty_affiliation_desc AS party_full,
+    cycles.cycles,
+    COALESCE(candidates.candidate_ids, '{}'::text[]) AS candidate_ids,
+    f1.affiliated_cmte_nm AS affiliated_committee_name,
+    reports.last_cycle_has_financial,
+    reports.cycles_has_financial,
+    dates.last_cycle_has_activity,
+    dates.cycles_has_activity,
+    is_committee_active(fec_yr.cmte_filing_freq) AS is_active,
+    l.sponsor_candidate_ids,
+    (case when pcc.cand_id is null then false else true end)::bool as convert_to_pac_flag,
+    pcc.first_cmte_nm as former_committee_name,
+    pcc.cand_id as former_candidate_id,
+    pcc.cand_name as former_candidate_name,
+    pcc.candidate_election_year as former_candidate_election_year,
+    dates.first_f1_date::text::date AS first_f1_date,
+    get_committee_label(fec_yr.cmte_tp, fec_yr.cmte_dsgn,f1.org_tp) as committee_label
+FROM disclosure.cmte_valid_fec_yr fec_yr
+LEFT JOIN fec_vsum_f1_vw f1 ON fec_yr.cmte_id::text = f1.cmte_id::text AND fec_yr.fec_election_yr >= f1.rpt_yr
+LEFT JOIN cycles ON fec_yr.cmte_id::text = cycles.cmte_id::text
+LEFT JOIN dates ON fec_yr.cmte_id::text = dates.cmte_id::text
+LEFT JOIN candidates ON fec_yr.cmte_id::text = candidates.cmte_id::text
+LEFT JOIN reports ON fec_yr.cmte_id::text = reports.cmte_id::text
+LEFT JOIN leadership_pac_linkage l ON fec_yr.cmte_id::text = l.cmte_id::text AND fec_yr.fec_election_yr = l.fec_election_yr
+LEFT JOIN ofec_pcc_to_pac_vw pcc on pcc.cmte_id = fec_yr.cmte_id and pcc.fec_election_yr = fec_yr.fec_election_yr
+WHERE cycles.max_cycle >= 1979::numeric AND NOT (fec_yr.cmte_id::text IN ( SELECT DISTINCT unverified_filers_vw.cmte_id
+        FROM unverified_filers_vw
+        WHERE unverified_filers_vw.cmte_id::text ~~ 'C%'::text))
+ORDER BY fec_yr.cmte_id, fec_yr.fec_election_yr DESC, f1.rpt_yr DESC
+WITH DATA;
+
+--Permissions
+
+ALTER TABLE public.ofec_committee_history_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_committee_history_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_committee_history_mv_tmp TO fec_read;
+
+--Indices
+
+CREATE UNIQUE INDEX idx_ofec_committee_history_mv_tmp_idx
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (idx);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_committee_id
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (committee_id);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_cycle_committee_id
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (cycle, committee_id);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_cycle
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (cycle);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_designation
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (designation);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_first_file_date
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (first_file_date);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_name
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (name);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_state
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (state);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_comid_state
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (committee_id, state);
+CREATE INDEX idx_ofec_committee_history_mv_tmp_first_f1_date
+ ON public.ofec_committee_history_mv_tmp
+ USING btree
+ (first_f1_date);
+
+
+-- ---------
+CREATE OR REPLACE VIEW public.ofec_committee_history_vw AS
+SELECT * FROM public.ofec_committee_history_mv_tmp;
+
+ALTER TABLE public.ofec_committee_history_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_committee_history_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_committee_history_vw TO fec_read;
+
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv;
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_committee_history_mv_tmp RENAME TO ofec_committee_history_mv;
+-- ----------
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_idx RENAME TO idx_ofec_committee_history_mv_idx;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_committee_id RENAME TO idx_ofec_committee_history_mv_committee_id;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_cycle_committee_id RENAME TO idx_ofec_committee_history_mv_cycle_committee_id;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_cycle RENAME TO idx_ofec_committee_history_mv_cycle;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_designation RENAME TO idx_ofec_committee_history_mv_designation;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_first_file_date RENAME TO idx_ofec_committee_history_mv_first_file_date;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_name RENAME TO idx_ofec_committee_history_mv_name;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_state RENAME TO idx_ofec_committee_history_mv_state;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_comid_state RENAME TO idx_ofec_committee_history_mv_comid_state;
+ALTER INDEX public.idx_ofec_committee_history_mv_tmp_first_f1_date RENAME TO idx_ofec_committee_history_mv_first_f1_date;

--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -85,6 +85,7 @@ class CommitteeHistory(BaseCommittee):
     former_candidate_election_year = db.Column(db.Integer, doc=docs.CANDIDATE_ELECTION_YEAR)
     convert_to_pac_flag = db.Column(db.Boolean, doc=docs.CONVERT_TO_PAC_FLAG)
     sponsor_candidate_ids = db.Column(ARRAY(db.Text), doc=docs.SPONSOR_CANDIDATE_ID)
+    committee_label = db.Column(db.Text, doc=docs.COMMITTEE_LABEL)
 
     jfc_committee = db.relationship(
         'JFCCommittee',

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -392,6 +392,9 @@ PAC_PARTY_TYPE = 'The one-letter type code of a PAC/Party organization:\n\
         - X party, nonqualified\n\
         - Y party, qualified\n\
 '
+COMMITTEE_LABEL = '''
+Display the label of committee based on committee type, designation and organization type
+'''
 
 LEADERSHIP_PAC_INDICATE = '''
 Indicates if the committee is a leadership PAC


### PR DESCRIPTION
## Summary (required)

- Resolves #4915 

- Database function and new column are created to display committee type using more common names.

### Required reviewers

2 developers

## Impacted areas of the application

New output field "committee_label" is added to endpoints
/committee/{committee_id}/history/
/committee/{committee_id}/history/{cycle}/

/candidate/{candidate_id}/committees/history/
/candidate/{candidate_id}/committees/history/{cycle}

## Screenshots

<img width="478" alt="Screen Shot 2022-07-14 at 2 40 21 PM" src="https://user-images.githubusercontent.com/24396726/179058898-2dcc4a0c-806f-4948-94ea-5fc580c30778.png">

## How to test
- Download feature branch
- Run `pytest`
- Run `flyway migration`
- Switch the model below to temporary table and start api on local:
 ```
class` CommitteeHistory(BaseCommittee):
 __tablename__ = 'ofec_committee_history_mv_tmp_hc'
```

Before the change:
https://api.open.fec.gov/v1/committee/C00000729/history/?page=1&election_full=true&sort=-cycle&sort_hide_null=false&sort_nulls_last=false&api_key=DEMO_KEY&sort_null_only=false&per_page=20

<img width="380" alt="Screen Shot 2022-07-15 at 12 28 15 PM" src="https://user-images.githubusercontent.com/24396726/179266901-5907b40e-4a5c-4966-89e3-3ca5c4feb33d.png">

After change:
http://127.0.0.1:5000/v1/committee/C00000729/history/?page=1&sort_null_only=false&sort_hide_null=false&sort_nulls_last=false&election_full=true&per_page=20&sort=-cycle
<img width="380" alt="Screen Shot 2022-07-15 at 12 30 17 PM" src="https://user-images.githubusercontent.com/24396726/179267191-eee16dd7-695a-4511-9893-b6abf0fe756a.png">


http://127.0.0.1:5000/v1/committee/C00000547/history/?page=1&sort_null_only=false&sort_hide_null=false&sort_nulls_last=false&election_full=true&per_page=20&sort=-cycle

<img width="443" alt="Screen Shot 2022-07-15 at 12 44 15 PM" src="https://user-images.githubusercontent.com/24396726/179269506-43c80d0b-ac94-4aaa-ad0f-186489139ede.png">



http://127.0.0.1:5000/v1/committee/C00000059/history/?page=1&sort_null_only=false&sort_hide_null=false&sort_nulls_last=false&election_full=true&per_page=20&sort=-cycle
<img width="420" alt="Screen Shot 2022-07-15 at 12 45 29 PM" src="https://user-images.githubusercontent.com/24396726/179269771-9187a107-9b89-4225-ae53-79a618650c8a.png">






