### PR TITLE
upgrade flyway to v9.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/8.5.13/flyway-commandline-8.5.13-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-8.5.13:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.0.2/flyway-commandline-9.0.2-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-9.0.2:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 8.5.13 ([download](https://flywaydb.org/documentation/usage/commandline/))
-		* After downloading, open `flyway8.5.13/conf/flyway.conf` and set
+    * Flyway 9.0.2 ([download](https://flywaydb.org/documentation/usage/commandline/))
+		* After downloading, open `flyway9.0.2/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -687,9 +687,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-8.5.13.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-8.5.13-macosx-x64.tar.gz`, `flyway-commandline-8.5.13-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.0.2.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or are not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE, e.g., `flyway-commandline-9.0.2-macosx-x64.tar.gz`, `flyway-commandline-9.0.2-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-8.5.13` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.0.2` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "8.5.13"
-    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "8.5.13") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.0.2"
+    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.0.2") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"
@@ -21,7 +21,7 @@ dependencies {
         exclude group: "com.google.protobuf", module: "protobuf-java"
         exclude group: "com.google.guava", module: "guava"
         constraints {
-	       implementation("org.postgresql:postgresql:42.2.25.jre6")
+	       implementation("org.postgresql:postgresql:42.3.3.jar")
         }
     }
 }

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-8.5.13.jar:app/gradle/lib/flyway-core-8.5.13.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-9.0.2.jar:app/gradle/lib/flyway-core-9.0.2.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves https://github.com/fecgov/openFEC/issues/5182

Upgrade flyway to v9.0.2


### Required reviewers

1 or 2 backend developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  DB migrations, `invoke create_sample_db` script

## Related PRs

Related PRs against other branches:
https://github.com/fecgov/openFEC/pull/5071
https://github.com/fecgov/openFEC/pull/5177


## How to test

-  On develop branch: run `snyk test --file=data/flyway/build.gradle` (two vulnerabilities show up as described in issues-5182)
- uninstall flyway v8.5.13: run `brew uninstall flyway` 

###  Install latest flyway v9.0.2 via homebrew:
-  run `brew install flyway` or or Follow the setup instructions [here](https://docs.google.com/document/d/1pMi59CQOj0dO9WyRS-tCGxHqd9CRTOU_4GaBD4VNbGk/edit)

**OR**

### Download and setup flyway 
- MAC developers-->open Safari browser--> go to https://flywaydb.org/documentation/usage/commandline/#download-and-installation
and download [flyway-commandline-9.0.2-macosx-x64.tar.gz] 
- update `url` and `locations` in `flyway.conf` file
- update flyway version in `bash_profile` 
- verify flyway version: run `flyway -v` (Output may look something similar like :`Flyway Community Edition 9.0.2 by Redgate`)
- checkout feature branch: run `git checkout feature/upgrade-flyway-9.0.2`
- run `snyk test --file=data/flyway/build.gradle` (ZERO or NO vulnerabilities at this point)
- activate virtualenv: run `pyenv virtualenv venv-api3813`
- install requirements: run `pip install -r requirements.txt`
-  run `dropdb cfdm_test`
- run `createdb cfdm_test`
- run `invoke create_sample_db`
- run `pytest`
- run  `python manage.py runserver` (optional) 
- test API endpoints in a browser (optional)

