### PR TITLE
Add filer_name_text filter in filings and efilings

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -94,6 +94,8 @@ class TestFilings(ApiBaseTest):
             factories.FilingsFactory(report_year=1999),
             factories.FilingsFactory(request_type='5'),
             factories.FilingsFactory(state='MD'),
+            factories.FilingsFactory(filer_name_text="'action':3 'abc':2 'committee':4 'international':1"),
+            factories.FilingsFactory(filer_name_text="'action':3 'xyz':2 'committee':4 'international':1"),
         ]
 
         filter_fields = (
@@ -113,6 +115,7 @@ class TestFilings(ApiBaseTest):
             ('request_type', '5'),
             ('state', 'MD'),
             ('candidate_id', 'H0001'),
+            ('filer_name_text', 'action'),
         )
 
         # checking one example from each field
@@ -210,6 +213,12 @@ class TestFilings(ApiBaseTest):
         results = self._results(api.url_for(FilingsView, committee_id='C007'))
 
         self.assertEqual(results[0]['document_description'], 'RFAI: report 2004')
+
+    def test_invalid_keyword(self):
+        response = self.app.get(
+            api.url_for(FilingsList, filer_name_text="ab")
+        )
+        self.assertEqual(response.status_code, 422)
 
 
 # Test for endpoint:/efile/filings/ under tag:efiling (filings.EFilingsView)
@@ -327,17 +336,17 @@ class TestEfileFiles(ApiBaseTest):
             id="C02", fulltxt=sa.func.to_tsvector("Dana")
         )
         rest.db.session.flush()
-        results = self._results(api.url_for(EFilingsView, q="Danielle"))
+        results = self._results(api.url_for(EFilingsView, filer_name_text="Danielle"))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["committee_id"], "C01")
 
-        results = self._results(api.url_for(EFilingsView, q="dan"))
+        results = self._results(api.url_for(EFilingsView, filer_name_text="dan"))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["committee_id"], "C01")
         self.assertEqual(results[1]["committee_id"], "C02")
 
     def test_invalid_keyword(self):
         response = self.app.get(
-            api.url_for(EFilingsView, q="ab")
+            api.url_for(EFilingsView, filer_name_text="ab")
         )
         self.assertEqual(response.status_code, 422)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -77,6 +77,18 @@ class ImageNumber(fields.Str):
                 status_code=422)
 
 
+class Keyword(fields.Str):
+
+    def _validate(self, value):
+        VALID_KEYWORD_LENGTH = 3
+        super()._validate(value)
+        if len(value) < VALID_KEYWORD_LENGTH:  # noqa
+            raise exceptions.ApiError(
+                exceptions.KEYWORD_LENGTH_ERROR,
+                status_code=422,
+            )
+
+
 election_full = fields.Bool(missing=True, description=docs.ELECTION_FULL)
 
 paging = {
@@ -362,6 +374,7 @@ filings = {
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
     'form_category': fields.List(IStr, description=docs.FORM_CATEGORY),
+    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 efilings = {
@@ -369,7 +382,7 @@ efilings = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'min_receipt_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
     'max_receipt_date': fields.Date(description=docs.MAX_RECEIPT_DATE),
-    'q': fields.List(fields.Str, description=docs.COMMITTEE_NAME),
+    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 reports = {

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -1,9 +1,9 @@
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
+from .base import db
 from webservices import docs, utils
 from webservices.common.models.dates import ReportType
 from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
-from .base import db
 
 
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
@@ -15,7 +15,7 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     candidate_id = db.Column(db.String, index=True, doc=docs.CANDIDATE_ID)
     candidate_name = db.Column(db.String, doc=docs.CANDIDATE_NAME)
     cycle = db.Column(db.Integer, doc=docs.RECORD_CYCLE)
-    sub_id = db.Column(db.BigInteger, index=True, primary_key=True)
+    sub_id = db.Column(db.BigInteger, index=True, primary_key=True, doc=docs.SUB_ID)
     coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
     receipt_date = db.Column(db.Date, index=True, doc=docs.RECEIPT_DATE)
@@ -29,30 +29,30 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     beginning_image_number = db.Column(db.BigInteger, index=True, doc=docs.BEGINNING_IMAGE_NUMBER)
     ending_image_number = db.Column(db.BigInteger, doc=docs.ENDING_IMAGE_NUMBER)
     pages = db.Column(db.Integer, doc=docs.PAGES)
-    total_receipts = db.Column(db.Numeric(30, 2))
-    total_individual_contributions = db.Column(db.Numeric(30, 2))
-    net_donations = db.Column(db.Numeric(30, 2))
-    total_disbursements = db.Column(db.Numeric(30, 2))
-    total_independent_expenditures = db.Column(db.Numeric(30, 2))
-    total_communication_cost = db.Column(db.Numeric(30, 2))
+    total_receipts = db.Column(db.Numeric(30, 2), doc=docs.TOTAL_RECEIPTS)
+    total_individual_contributions = db.Column(db.Numeric(30, 2), doc=docs.TOTAL_INDIVIDUAL_CONTRIBUTIONS)
+    net_donations = db.Column(db.Numeric(30, 2), doc=docs.NET_DONATIONS)
+    total_disbursements = db.Column(db.Numeric(30, 2), doc=docs.TOTAL_DISBURSEMENTS)
+    total_independent_expenditures = db.Column(db.Numeric(30, 2), doc=docs.TOTAL_INDEPENDENT_EXPENDITURES)
+    total_communication_cost = db.Column(db.Numeric(30, 2), doc=docs.TOTAL_COMMUNICATION_COST)
     cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2), doc=docs.CASH_ON_HAND_BEGIN_PERIOD)
     cash_on_hand_end_period = db.Column(db.Numeric(30, 2), doc=docs.CASH_ON_HAND_END_PERIOD)
     debts_owed_by_committee = db.Column(db.Numeric(30, 2), doc=docs.DEBTS_OWED_BY_COMMITTEE)
     debts_owed_to_committee = db.Column(db.Numeric(30, 2), doc=docs.DEBTS_OWED_TO_COMMITTEE)
-    house_personal_funds = db.Column(db.Numeric(30, 2))
-    senate_personal_funds = db.Column(db.Numeric(30, 2))
-    opposition_personal_funds = db.Column(db.Numeric(30, 2))
+    house_personal_funds = db.Column(db.Numeric(30, 2), doc=docs.HOUSE_PERSONAL_FUNDS)
+    senate_personal_funds = db.Column(db.Numeric(30, 2), doc=docs.SENATE_PERSONAL_FUNDS)
+    opposition_personal_funds = db.Column(db.Numeric(30, 2), doc=docs.OPPOSITION_PERSONAL_FUNDS)
     treasurer_name = db.Column(db.String, doc=docs.TREASURER_NAME)
-    file_number = db.Column(db.BigInteger)
-    primary_general_indicator = db.Column(db.String, index=True)
-    request_type = db.Column(db.String)
+    file_number = db.Column(db.BigInteger, doc=docs.FILE_NUMBER)
+    primary_general_indicator = db.Column(db.String, index=True, doc=docs.PRIMARY_GENERAL_INDICATOR)
+    request_type = db.Column(db.String, doc=docs.REQUEST_TYPE)
     amendment_indicator = db.Column(db.String, index=True, doc=docs.AMENDMENT_CHAIN)
-    update_date = db.Column(db.Date)
-    pdf_url = db.Column(db.String)
-    fec_url = db.Column(db.String)
+    update_date = db.Column(db.Date, doc=docs.UPDATE_DATE)
+    pdf_url = db.Column(db.String, doc=docs.PDF_URL)
+    fec_url = db.Column(db.String, doc=docs.FEC_URL)
     means_filed = db.Column(db.String, doc=docs.MEANS_FILED)
-    is_amended = db.Column(db.Boolean)
-    most_recent = db.Column(db.Boolean)
+    is_amended = db.Column(db.Boolean, doc=docs.IS_AMENDED)
+    most_recent = db.Column(db.Boolean, doc=docs.MOST_RECENT)
     html_url = db.Column(db.String, doc=docs.HTML_URL)
     # If f2 filing, the state of the candidate, else the state of the committee
     state = db.Column(db.String, doc=docs.STATE)
@@ -64,18 +64,19 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     office = db.Column('office_cmte_tp', db.String, index=True, doc=docs.OFFICE)
     party = db.Column(db.String, doc=docs.PARTY)
     committee_type = db.Column('cmte_tp', db.String, doc=docs.COMMITTEE_TYPE)
-    amendment_chain = db.Column(ARRAY(db.Numeric))
-    previous_file_number = db.Column(db.BigInteger)
+    amendment_chain = db.Column(ARRAY(db.Numeric), doc=docs.AMENDMENT_CHAIN)
+    previous_file_number = db.Column(db.BigInteger, doc=docs.PREVIOUS_FILE_NUMBER)
     most_recent_file_number = db.Column(db.BigInteger)
-    amendment_version = db.Column(db.Integer)
+    amendment_version = db.Column(db.Integer, doc=docs.AMENDMENT_VERSION)
     form_category = db.Column(db.String, index=True, doc=docs.FORM_CATEGORY)
-    bank_depository_name = db.Column('bank_depository_nm', db.String, doc=docs.bank_depository_nm)
-    bank_depository_street_1 = db.Column('bank_depository_st1', db.String, doc=docs.bank_depository_st1)
-    bank_depository_street_2 = db.Column('bank_depository_st2', db.String, doc=docs.bank_depository_st2)
-    bank_depository_city = db.Column(db.String, doc=docs.bank_depository_city)
-    bank_depository_state = db.Column('bank_depository_st', db.String, doc=docs.bank_depository_st)
-    bank_depository_zip = db.Column(db.String, doc=docs.bank_depository_zip)
-    additional_bank_names = db.Column(ARRAY(db.String), doc=docs.additional_bank_names)
+    bank_depository_name = db.Column('bank_depository_nm', db.String, doc=docs.BANK_DEPOSITORY_NM)
+    bank_depository_street_1 = db.Column('bank_depository_st1', db.String, doc=docs.BANK_DEPOSITORY_ST1)
+    bank_depository_street_2 = db.Column('bank_depository_st2', db.String, doc=docs.BANK_DEPOSITORY_ST2)
+    bank_depository_city = db.Column(db.String, doc=docs.BANK_DEPOSITORY_CITY)
+    bank_depository_state = db.Column('bank_depository_st', db.String, doc=docs.BANK_DEPOSITORY_ST)
+    bank_depository_zip = db.Column(db.String, doc=docs.BANK_DEPOSITORY_ZIP)
+    additional_bank_names = db.Column(ARRAY(db.String), doc=docs.ADDITIONAL_BANK_NAMES)
+    filer_name_text = db.Column(TSVECTOR, doc=docs.FILER_NAME_TEXT)
 
     @property
     def document_description(self):
@@ -90,12 +91,12 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
 class EfilingsAmendments(db.Model):
     __tablename__ = 'efiling_amendment_chain_vw'
     file_number = db.Column('repid', db.BigInteger, index=True, primary_key=True, doc=docs.FILE_NUMBER)
-    amendment_chain = db.Column(ARRAY(db.Numeric))
+    amendment_chain = db.Column(ARRAY(db.Numeric), doc=docs.AMENDMENT_CHAIN)
     longest_chain = db.Column(ARRAY(db.Numeric))
     most_recent_filing = db.Column(db.Numeric)
     depth = db.Column(db.Numeric)
     last = db.Column(db.Numeric)
-    previous_file_number = db.Column('previd', db.Numeric)
+    previous_file_number = db.Column('previd', db.Numeric, doc=docs.PREVIOUS_FILE_NUMBER)
 
     def next_in_chain(self, file_number):
         if len(self.longest_chain) > 0 and self.depth <= len(self.longest_chain) - 1:

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -412,6 +412,12 @@ PARTY_TYPE_FULL = '''
 Description of the type of party the committee is, only if applicable
 '''
 
+HOUSE_PERSONAL_FUNDS = 'House personal funds'
+
+SENATE_PERSONAL_FUNDS = 'Senate personal funds'
+
+OPPOSITION_PERSONAL_FUNDS = 'Opposition personal funds'
+
 TREASURER_NAME = 'Name of the Committee\'s treasurer. If multiple treasurers for the \
 committee, the most recent treasurer will be shown.'
 
@@ -551,33 +557,50 @@ A unique identifier assigned to each candidate registered with the FEC.
 If a person runs for several offices, that person will have separate candidate IDs for each office. This is a filter for Leadership PAC sponsor.
 '''
 
-bank_depository_nm = '''
+PREVIOUS_FILE_NUMBER = '''
+Previous filing ID number
+'''
+
+AMENDMENT_VERSION = '''
+Amendment version
+'''
+
+BANK_DEPOSITORY_NM = '''
 Primary bank or depository in which the committee deposits funds, holds accounts, rents safety deposit boxes or maintains funds.
 '''
 
-bank_depository_st1 = '''
+BANK_DEPOSITORY_ST1 = '''
 Street of bank or depository as reported on their Form 1.
 '''
 
-bank_depository_st2 = '''
+BANK_DEPOSITORY_ST2 = '''
 Second line of the street of bank or depository as reported on the Form 1
 '''
 
-bank_depository_city = '''
+BANK_DEPOSITORY_CITY = '''
 City of bank or depository as reported on the Form 1
 '''
 
-bank_depository_st = '''
+BANK_DEPOSITORY_ST = '''
 State of bank or depository as reported on the Form 1
 '''
 
-bank_depository_zip = '''
+BANK_DEPOSITORY_ZIP = '''
 Zip code of bank or depository as reported on the Form 1
 '''
 
-additional_bank_names = '''
+ADDITIONAL_BANK_NAMES = '''
 Additional banks or depositories in which the committee deposits funds, holds accounts, rents safety deposit boxes or maintains funds.
 '''
+
+FILER_NAME_TEXT = '''
+Keyword search for filer name
+'''
+
+PRIMARY_GENERAL_INDICATOR = '''
+Primary general indicator
+'''
+
 # ======== committee end ===========
 
 
@@ -733,6 +756,10 @@ HTML link to the filing.
 
 FEC_URL = '''
 fec link to the filing.
+'''
+
+PDF_URL = '''
+pdf link to the filing
 '''
 
 TWO_YEAR_TRANSACTION_PERIOD = '''
@@ -1508,6 +1535,13 @@ def add_period(var):
 def add_ytd(var):
     return var + ' total for the year to date'
 
+
+TOTAL_RECEIPTS = 'Total receipts'
+TOTAL_INDIVIDUAL_CONTRIBUTIONS = 'Total individual contributions'
+NET_DONATIONS = 'Net donations'
+TOTAL_DISBURSEMENTS = 'Total disbursements'
+TOTAL_INDEPENDENT_EXPENDITURES = 'Total independent expenditures'
+TOTAL_COMMUNICATION_COST = 'Total communications cost'
 
 # shared
 CASH_ON_HAND_BEGIN_PERIOD = 'Balance for the committee at the start of the two-year period'

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -7,6 +7,9 @@ from form F3X line number 16.\
 IMAGE_NUMBER_ERROR = """Invalid image_number detected. A valid image_number is numeric only.\
 """
 
+KEYWORD_LENGTH_ERROR = """Invalid keyword, the keyword must be at least 3 characters in length.\
+"""
+
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -879,7 +879,7 @@ BaseFilingsSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('committee', )},
+    options={'exclude': ('committee', 'filer_name_text')},
 )
 
 


### PR DESCRIPTION
## Summary (required)
This PR will be able to filter `/filings/`and `/efile/filings/` two endpoints by keyword **filer_name_text**.

- Resolves #issue_number
This PR will resolve the part of this [https://github.com/fecgov/openfec/issues/5160](https://github.com/fecgov/openfec/issues/5160)
- Create new Keyword validation function to allow at least 3 chars in length.

### Required reviewers
1-2 devs

## Impacted areas of the application
/filings/
/efile/filings/


<img width="500" alt="eFiling_keyword_search" src="https://user-images.githubusercontent.com/24395751/181800658-b2b94335-c836-4131-a849-b5abe4bb6d82.png">


## How to test
- Check out branch, point to dev db, pytest
- test api locally
- test urls


For test /filings/:

1)without filter, count=3198758
http://127.0.0.1:5000/v1/filings/

2)with filter:filer_name_text=san, count=24565
http://127.0.0.1:5000/v1/filings/?filer_name_text=san

3)check invalid keyword error (length < 3)
http://127.0.0.1:5000/v1/filings/?filer_name_text=ab

--------------------
For test /efile/filings/:

1)(without filter, return total: about 83705 rows)
http://127.0.0.1:5000/v1/efile/filings/

2)(with filter: filer_name_text=san, will return about 706 rows)
http://127.0.0.1:5000/v1/efile/filings/?filer_name_text=san

3)Check invalid keyword error (length < 3)
http://127.0.0.1:5000/v1/efile/filings/?filer_name_text=ab
