### PR TITLE
Add filer_name_text filter in reports and 3 efiling reports endpoints

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -7,6 +7,10 @@ from webservices.rest import api
 from webservices.resources.filings import FilingsView, FilingsList, EFilingsView
 
 
+# Test 3 endpoints:
+# `/filings/` under tag:filing (filings.FilingsList)
+# `/committee/<committee_id>/filings/` under tag:filing (filings.FilingsView)
+# `/candidate/<candidate_id>/filings/` under tag:filing (filings.FilingsView)
 class TestFilings(ApiBaseTest):
     def test_committee_filings(self):
         """ Check filing returns with a specified committee id"""

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -418,6 +418,7 @@ reports = {
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
+    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 committee_reports = {

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -4,7 +4,7 @@ from webservices import docs, utils
 from webservices.common.models.dates import ReportType
 from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
-
+from webservices import exceptions
 
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
@@ -99,11 +99,15 @@ class EfilingsAmendments(db.Model):
     previous_file_number = db.Column('previd', db.Numeric, doc=docs.PREVIOUS_FILE_NUMBER)
 
     def next_in_chain(self, file_number):
-        if len(self.longest_chain) > 0 and self.depth <= len(self.longest_chain) - 1:
-            index = self.longest_chain.index(file_number)
-            return self.longest_chain[index + 1]
-        else:
-            return 0
+        try:
+            if len(self.longest_chain) > 0 and self.depth <= len(self.longest_chain) - 1:
+                index = self.longest_chain.index(file_number)
+                return self.longest_chain[index + 1]
+            else:
+                return 0
+        except Exception as ex:
+            raise exceptions.ApiError(
+                exceptions. NEXT_IN_CHAIN_DATA_ERROR, status_code=400)
 
 
 class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.Model):

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -3,7 +3,7 @@ from webservices import docs, utils
 from .base import db, BaseModel
 
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR
 
 from webservices.common.models.dates import ReportType
 from sqlalchemy.ext.declarative import declared_attr
@@ -236,6 +236,7 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
     fec_url = db.Column(db.String, doc=docs.FEC_URL)
     html_url = db.Column(db.String, doc=docs.HTML_URL)
     most_recent = db.Column('most_recent', db.Boolean, doc=docs.MOST_RECENT)
+    filer_name_text = db.Column(TSVECTOR, doc=docs.FILER_NAME_TEXT)
 
     @property
     def document_description(self):

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -10,6 +10,9 @@ IMAGE_NUMBER_ERROR = """Invalid image_number detected. A valid image_number is n
 KEYWORD_LENGTH_ERROR = """Invalid keyword, the keyword must be at least 3 characters in length.\
 """
 
+NEXT_IN_CHAIN_DATA_ERROR = """next_in_chain data error, please contact apiinfo@fec.gov.\
+"""
+
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -482,7 +482,7 @@ make_reports_schema = functools.partial(
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('idx', 'committee')},
+    options={'exclude': ('idx', 'committee' , 'filer_name_text')},
 )
 
 augment_models(


### PR DESCRIPTION
## Summary (required)
This PR will add filter **filer_name_text** in four endpoints:
`/reports/<string:entity_type>/` under tag: `financial`
`/efile/reports/presidential/` under tag:`efiling`
`/efile/reports/house-senate/` under tag:`efiling`
`/efile/reports/pac-party/'`under tag:`efiling`

- Resolves #issue_number
This PR will resolve the part of this [https://github.com/fecgov/openfec/issues/5160](https://github.com/fecgov/openfec/issues/5160)

- This PR refactor the function `EfilingsAmendments.next_in_chain` in models.filings.py
to handle bad data from public.efiling_amendment_chain_vw

### Required reviewers
1-2 devs

## Impacted areas of the application
`/reports/<string:entity_type>/` under tag: `financial`
`/efile/reports/presidential/` under tag:`efiling`
`/efile/reports/house-senate/` under tag:`efiling`
`/efile/reports/pac-party/'`under tag:`efiling`


## How to test
- Check out branch, point to dev db, pytest
- test api locally
- test new filter `filer_name_text` 

### 1)Test endpoint `/reports/<string:entity_type>/`
entity_type= (`presidential`, `pac-party`, `house-senate`)
(`ie-only` not done yet)

- entity_type = presidential
return total about 25051 rows
http://127.0.0.1:5000/v1/reports/presidential/
return 162 rows (add filter by “bid”)
http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=bid

- entity_type = house-senate
return total about 537765 rows
http://127.0.0.1:5000/v1/reports/house-senate/
return 208 rows (filter by “bid”)
http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=bid

- entity_type = pac-party
return total about 425736 rows
http://127.0.0.1:5000/v1/reports/pac-party/
return about 144 rows (filter by “bid”)
http://127.0.0.1:5000/v1/reports/pac-party/?filer_name_text=bid

- test invalid keyword (error (length < 3)
http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=ab
http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=a
http://127.0.0.1:5000/v1/reports/pac-party/?filer_name_text=ab
<img width="500" alt="1_1_presidential_reports" src="https://user-images.githubusercontent.com/24395751/183321759-3f21aa51-af54-42ec-8388-dfe782fc431f.png">

<img width="500" alt="2_1_house-senate_reports" src="https://user-images.githubusercontent.com/24395751/183321770-22e0b452-b234-464e-a2a1-463fe5d21e0f.png">

<img width="500" alt="3_1_pac-party_reports" src="https://user-images.githubusercontent.com/24395751/183321780-2a7bec85-89ea-468f-9433-4d49db2a4b97.png">

### 2)Test endpoint 
`/efile/reports/presidential/` under tag:`efiling`
return total about 389 rows
http://127.0.0.1:5000/v1/efile/reports/presidential/
return about 4 rows (filter by “bid”)
http://127.0.0.1:5000/v1/efile/reports/presidential/?filer_name_text=bid

### 3)Test endpoint 
`/efile/reports/house-senate/` under tag:`efiling`
return total about 16042 rows
http://127.0.0.1:5000/v1/efile/reports/house-senate/
return about 158  (filter by “san”)
http://127.0.0.1:5000/v1/efile/reports/house-senate/?filer_name_text=san

### 4)Test endpoint 
`/efile/reports/pac-party/'`under tag:`efiling`
return total about 41850 rows
http://127.0.0.1:5000/v1/efile/reports/pac-party/
return about 401  (filter by “san”)
http://127.0.0.1:5000/v1/efile/reports/pac-party/?filer_name_text=san

Check invalid keyword error (length < 3)
http://127.0.0.1:5000/v1/efile/reports/presidential/?filer_name_text=ab
http://127.0.0.1:5000/v1/efile/reports/house-senate/?filer_name_text=ab
http://127.0.0.1:5000/v1/efile/reports/pac-party/?filer_name_text=ab

<img width="500" alt="1_2_presidential_reports_efiling" src="https://user-images.githubusercontent.com/24395751/183322446-9acae2e0-9ea7-4cbe-94de-c25ceaea8189.png">

<img width="500" alt="2_2_house-senate_reports_efiing" src="https://user-images.githubusercontent.com/24395751/183322459-92bad54a-5431-47df-b93c-6942bd9fe61c.png">

<img width="500" alt="3_2_pac-party_reports_efiling" src="https://user-images.githubusercontent.com/24395751/183322470-49d1bc31-9ac1-46c3-aef8-81319cebf412.png">


