### PR TITLE
Add spender_name_text filter in /schedules/schedule_e/

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1230,6 +1230,9 @@ class TestScheduleB(ApiBaseTest):
             assert results[0][column.key] == values[0]
 
 
+# Test endpoints:
+# /schedules/schedule_e/ (sched_e.ScheduleEView)
+# /schedules/schedule_e/efile/ (sched_e.ScheduleEEfileView)
 class TestScheduleE(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
 
@@ -1373,6 +1376,24 @@ class TestScheduleE(ApiBaseTest):
         [factories.ScheduleEFactory(payee_name=payee) for payee in payee_names]
         results = self._results(api.url_for(ScheduleEView, payee_name='test'))
         self.assertEqual(len(results), len(payee_names))
+
+    def test_filter_sched_e_spender_name_text(self):
+        [
+            factories.ScheduleEFactory(
+                committee_id='C001', spender_name_text="'action':3 'abc':2 'committee':4 'international':1",
+            ),
+            factories.ScheduleEFactory(
+                committee_id='C002', spender_name_text="'action':3 'xyz':2 'committee':4 'international':1",
+            ),
+        ]
+        results = self._results(
+            api.url_for(ScheduleEView, spender_name_text='action', **self.kwargs)
+        )
+        self.assertEqual(len(results), 2)
+        results = self._results(
+            api.url_for(ScheduleEView, spender_name_text='abc', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
 
     def test_schedule_e_filter_fulltext_fail(self):
         """

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -922,7 +922,7 @@ schedule_e = {
     'min_filing_date': fields.Date(description=docs.MIN_FILED_DATE),
     'max_filing_date': fields.Date(description=docs.MAX_FILED_DATE),
     'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
-
+    'spender_name_text': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
 }
 
 schedule_e_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -632,6 +632,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     schedule_type = db.Column('schedule_type', db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     pdf_url = db.Column(db.String)
+    spender_name_text = db.Column(TSVECTOR)
 
 
 class ScheduleEEfile(BaseRawItemized):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -597,6 +597,10 @@ FILER_NAME_TEXT = '''
 Keyword search for filer name
 '''
 
+SPENDER_NAME_TEXT = '''
+Keyword search for spender name
+'''
+
 PRIMARY_GENERAL_INDICATOR = '''
 Primary general indicator
 '''

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -11,6 +11,7 @@ from webservices.common import views
 from webservices.common.views import ItemizedResource
 
 
+# Use for endpoint `/schedules/schedule_e/` under tag: independent expenditure
 @doc(
     tags=['independent expenditures'],
     description=docs.SCHEDULE_E,
@@ -48,6 +49,7 @@ class ScheduleEView(ItemizedResource):
     ]
     filter_fulltext_fields = [
         ('payee_name', models.ScheduleE.payee_name_text),
+        ('spender_name_text', models.ScheduleE.spender_name_text),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleE.expenditure_date),
@@ -114,6 +116,7 @@ class ScheduleEView(ItemizedResource):
         return query
 
 
+# Use for endpoint `/schedules/schedule_e/efile/` under tag: independent expenditure
 @doc(
     tags=['independent expenditures'],
     description=docs.EFILING_TAG,

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -802,6 +802,7 @@ ScheduleESchema = make_schema(
     options={
         'exclude': (
             'payee_name_text',
+            'spender_name_text',
         ),
         'relationships': [
             Relationship(


### PR DESCRIPTION
## Summary (required)
This PR will add keyword filter **spender_name_text** in `/schedules/schedule_e/` endpoint.

This PR will resolve the part of this [https://github.com/fecgov/openfec/issues/5160](https://github.com/fecgov/openfec/issues/5160)

[Click here to check the status of endpoint list (want to add keyword text filter)](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=0)

Ref PRs:
https://github.com/fecgov/openFEC/pull/5209
https://github.com/fecgov/openFEC/pull/5210


### Required reviewers
1-2 devs

## Impacted areas of the application
`/schedules/schedule_e/`


## How to test
- Check out branch, point to dev db, pytest
- test api locally
- test urls


Test `/schedules/schedule_e/`:
1)return total about 1422063 rows (without filter)
http://127.0.0.1:5000/v1/schedules/schedule_e/?

2)return about 297 rows (filter by spender_name_text=san)
http://127.0.0.1:5000/v1/schedules/schedule_e/?spender_name_text=san

3)check invalid keyword error (length < 3)
http://127.0.0.1:5000/v1/schedules/schedule_e/?spender_name_text=ab

<img width="500" alt="IE_spender_name_text" src="https://user-images.githubusercontent.com/24395751/183799716-7365a0bc-5e85-4601-bd4b-b919c9d466e8.png">
