### PR TITLE
Remove duplicate indexes on real_efile_sb4 table and also create index on real_efile_sa7 table

### DIFF
--- a/data/migrations/V0042__add_comid_index_to_real_efile_tables.sql
+++ b/data/migrations/V0042__add_comid_index_to_real_efile_tables.sql
@@ -1,3 +1,0 @@
-CREATE INDEX CONCURRENTLY real_efile_sb4_comid_idx ON real_efile.sb4 USING btree (comid);
-
-CREATE INDEX CONCURRENTLY real_efile_sa7_comid_idx ON real_efile.sa7 USING btree (comid);

--- a/data/migrations/V0256__fix_duplicate_indexes_on_real_efile_tables.sql
+++ b/data/migrations/V0256__fix_duplicate_indexes_on_real_efile_tables.sql
@@ -1,0 +1,11 @@
+-- Drop duplicate comid, repid indexes
+
+DROP INDEX IF EXISTS real_efile.real_efile_sb4_comid_idx;
+
+DROP INDEX IF EXISTS real_efile.real_efile_sb4_repid_idx;
+
+-- This index already exist in database. Original creation statment was in V0042 migration file. 
+-- We had to delete 0042 migration file due to the incompatability of syntax to the new version of flyway which we have to upgrade to satisfy security vulnerability
+-- flyway new version 9.1.2/CREATE INDEX CONCURRENTLY  
+
+CREATE INDEX IF NOT EXISTS real_efile_sa7_comid_idx ON real_efile.sa7 USING btree (comid);


### PR DESCRIPTION
## Summary (required)

[Flyway v9.1.2](https://flywaydb.org/documentation/learnmore/releaseNotes#9.1.2) hangs on `CREATE INDEX CONCURRENTLY` statements. Unlike the traditional session locking,  Flyway V9.1.2 comes with transactional level locking  which is causing the `CREATE INDEX CONCURRENTLY` statements to hang. 
This is a breaking change on [flyway](https://github.com/flyway/flyway/pull/3394#issuecomment-1201513370)


As a result of this change, in openFEC database migration [`V0042`](https://github.com/fecgov/openFEC/blob/develop/data/migrations/V0042__add_comid_index_to_real_efile_tables.sql#L1-L3) hangs  when  the following commands or tasks run:

1. `flyway migrate`
2. `invoke create_sample_db`
3. `pytest` (mostly integration tests)  


Changes include:
 - Delete/Remove V0042 that has duplicate indexes on real_efile_sb4 table 
 - Create indexe on real_efile_sa7 table in V0256 migration file

### Required reviewers

1 or 2 database developers

## Impacted areas of the application

- flyway migrate, invoke create_sample_db task and pytest (integration tests)  
- Database migrations


## How to test

- checkout  `feature/fix-duplicate-indexes-real-efile`
- In your local cfdm_test database, execute:
`delete from public.flyway_schema_history where version ='0042';`
- run `flyway migrate` or `invoke create_sample_db` (make sure 256 migrations run OK)
- run pytest (integrations tests PASS)

Note: ***After this PR gets merged, @fecjjeng @hcaofec will drop V0042 migration from `public.flyway_schema_history` table on dev database and later on from Stage and Prod databases as well.