### PR TITLE
pin setuptools to 65.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 requests==2.25.1
 requests-aws4auth==1.0
+setuptools==65.1.1 # Pinned to fix the deploy errors caused by the latest setuptool version 65.3.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported


### PR DESCRIPTION
## Summary (required)

- Fix the current failing builds due to an issue with the most recent setuptools release and psycopg2

### Required reviewers

1-2 devs

I will deploy this today after it's been reviewed