### PR TITLE
5203- update circlci docker images and pin flake8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.8.12
+      - image: cimg/python:3.8.13
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,18 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.8.12-buster
+      - image: cimg/python:3.8.12
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:13.5
+      - image: cimg/postgres:13.5
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
           POSTGRES_DB: cfdm_unit_test
 
-    working_directory: ~/repo
 
     steps:
       - checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ redis==4.2.2
 # testing and build in circle
 codecov==2.1.7
 factory_boy==2.8.1
+flake8==4.0.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
 nplusone==0.8.0


### PR DESCRIPTION
## Summary (required)

- Resolves #5203

This updates the docker images and pins flake8 until we can fix our tests failing in the most recent major version. That ticket is [here. ](https://github.com/fecgov/openFEC/issues/5217)

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci config

## Related PRs
https://github.com/fecgov/fec-cms/pull/5388

## How to test

I tried to test run circleci config locally via their CLI tools and wasn't able to run them successfully. I got some errors that they seems to know about and aren't moving forward with right now. I did deploy to dev and everything ran successfully. 
-checkout this branch
-deploy to dev
