### PR TITLE
5203- Upgrade circleci docker images (python 3.8 and PG 13.5), pin flake8 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,18 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.8.12-buster
+      - image: cimg/python:3.8
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: circleci/postgres:13.5
+      - image: cimg/postgres:13.5
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: "trust"
           POSTGRES_DB: cfdm_unit_test
 
-    working_directory: ~/repo
 
     steps:
       - checkout
@@ -66,13 +65,13 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
+            python3 -m venv .env
+            . .env/bin/activate
             pip install -r requirements.txt
 
       - save_cache:
           paths:
-            - ./venv
+            - ./.env
             - ./node_modules
           key: v2-fec-api-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
@@ -83,13 +82,13 @@ jobs:
       - run:
           name: Run tests
           command: |
-            . venv/bin/activate
+            . .env/bin/activate
             pytest
 
       - run:
           name: Perform post-test checks
           command: |
-            . venv/bin/activate
+            . .env/bin/activate
             codecov
 
       - store_artifacts:
@@ -119,6 +118,6 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            . venv/bin/activate
+            . .env/bin/activate
             nvm use default
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes --migrate-database

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     docker:
       # CircleCI maintains a library of pre-built images documented at
-      # https://circleci.com/docs/2.0/circleci-images/
+      # https://circleci.com/developer/images
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ redis==4.2.2
 # testing and build in circle
 codecov==2.1.7
 factory_boy==2.8.1
+flake8==4.0.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
 nplusone==0.8.0


### PR DESCRIPTION
## Summary (required)

- Resolves #5203

This updates the docker images and pins flake8 until we can fix our tests failing in the most recent major version. That ticket is [here. ](https://github.com/fecgov/openFEC/issues/5217)

I did rename the venv to clean cache and repair the builds, but as a bonus it now matches the CMS config file

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci config

## Related PRs
https://github.com/fecgov/fec-cms/pull/5388

## How to test

I tried to test run circleci config locally via their CLI tools and wasn't able to run them successfully. I got some errors that they seems to know about and aren't moving forward with right now. I did deploy to dev and everything ran successfully. 
-checkout this branch
-deploy to dev
