### PR TITLE
Add committee id to tsvector column in five materialized views

### DIFF
--- a/data/migrations/V0257__ofec_filings_all_mv_add_cmteid_text.sql
+++ b/data/migrations/V0257__ofec_filings_all_mv_add_cmteid_text.sql
@@ -1,0 +1,258 @@
+/*
+For issue #5220
+This is the latest version of ofec_filings_all_mv
+Add committee ID to tsvector column and rename column 
+
+Previous version is V0251
+*/
+-- ----------
+-- ofec_filings_all_mv_tmp
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp 
+AS
+SELECT row_number() OVER () AS idx,
+    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	END AS candidate_id,
+	cand.name AS candidate_name,
+    filing_history.cand_cmte_id AS committee_id,
+    com.name AS committee_name,
+    filing_history.sub_id,
+    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+    filing_history.election_yr AS election_year,
+    filing_history.form_tp AS form_type,
+    filing_history.rpt_yr AS report_year,
+    get_cycle(filing_history.rpt_yr) AS cycle,
+    filing_history.rpt_tp AS report_type,
+    filing_history.to_from_ind AS document_type,
+    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+    filing_history.begin_image_num::bigint AS beginning_image_number,
+    filing_history.end_image_num AS ending_image_number,
+    filing_history.pages,
+    filing_history.ttl_receipts AS total_receipts,
+    filing_history.ttl_indt_contb AS total_individual_contributions,
+    filing_history.net_dons AS net_donations,
+    filing_history.ttl_disb AS total_disbursements,
+    filing_history.ttl_indt_exp AS total_independent_expenditures,
+    filing_history.ttl_communication_cost AS total_communication_cost,
+    filing_history.coh_bop AS cash_on_hand_beginning_period,
+    filing_history.coh_cop AS cash_on_hand_end_period,
+    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+    filing_history.hse_pers_funds_amt AS house_personal_funds,
+    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+    filing_history.tres_nm AS treasurer_name,
+    filing_history.file_num AS file_number,
+	CASE
+		WHEN upper(filing_history.form_tp) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	END AS previous_file_number,
+    report.rpt_tp_desc AS report_type_full,
+    filing_history.rpt_pgi AS primary_general_indicator,
+	filing_history.request_tp AS request_type,
+	filing_history.amndt_ind AS amendment_indicator,
+	filing_history.lst_updt_dt AS update_date,
+	report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.cand_cmte_id::text, filing_history.form_tp::text) AS pdf_url,
+	means_filed(filing_history.begin_image_num::text) AS means_filed,
+	report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	amendments.amendment_chain,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	END AS most_recent_file_number,
+	is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+	    	CASE 
+				WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+	    	CASE 
+				WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	END AS most_recent,
+	CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	END AS amendment_version,
+	cand.state,
+	cand.office,
+	cand.district,
+	cand.party,
+	cmte_valid_fec_yr.cmte_tp,
+	get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	END AS form_category,
+	cb.bank_depository_nm,
+    cb.bank_depository_st1,
+    cb.bank_depository_st2,
+    cb.bank_depository_city,
+    cb.bank_depository_st,
+    cb.bank_depository_zip,
+    cb.additional_bank_names,
+    to_tsvector(parse_fulltext(com.name||' '||filing_history.cand_cmte_id)) AS filer_name_text
+FROM disclosure.f_rpt_or_form_sub filing_history
+LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+LEFT JOIN ofec_committee_bank_vw cb ON filing_history.sub_id = cb.sub_id
+WHERE filing_history.rpt_yr >= 1979 AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+WITH DATA;
+
+
+
+ALTER TABLE public.ofec_filings_all_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (idx);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (amendment_indicator);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (beginning_image_number);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (candidate_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_end_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_start_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle, committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (district );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office_cmte_tp );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (party );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (primary_general_indicator );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (receipt_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (request_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type_full );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_year);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_disbursements);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_independent_expenditures);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_receipts);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (state );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_category);  
+CREATE INDEX idx_ofec_filings_all_mv_tmp_filer_name_text
+    ON public.ofec_filings_all_mv_tmp USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+-- drop old MV
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_filer_name_text RENAME TO idx_ofec_filings_all_mv_filer_name_text;

--- a/data/migrations/V0258__ofec_report_presidential_mv_add_cmteid_text.sql
+++ b/data/migrations/V0258__ofec_report_presidential_mv_add_cmteid_text.sql
@@ -1,0 +1,242 @@
+/*
+For issue #5220
+This is the latest version of ofec_reports_presidential_mv
+Add committee ID to tsvector column and rename column 
+
+Previous version is V0252
+*/
+-- -----------------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_reports_presidential_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3p.cmte_id AS committee_id,
+    f3p.rpt_yr + f3p.rpt_yr % 2::numeric AS cycle,
+    f3p.cvg_start_dt AS coverage_start_date,
+    f3p.cvg_end_dt AS coverage_end_date,
+    f3p.begin_image_num AS beginning_image_number,
+    f3p.cand_contb_per AS candidate_contribution_period,
+    f3p.cand_contb_ytd AS candidate_contribution_ytd,
+    f3p.coh_bop AS cash_on_hand_beginning_period,
+    f3p.coh_cop AS cash_on_hand_end_period,
+    f3p.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3p.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3p.end_image_num AS end_image_number,
+    f3p.exempt_legal_acctg_disb_per AS exempt_legal_accounting_disbursement_period,
+    f3p.exempt_legal_acctg_disb_ytd AS exempt_legal_accounting_disbursement_ytd,
+    f3p.exp_subject_limits AS expenditure_subject_to_limits,
+    f3p.fed_funds_per AS federal_funds_period,
+    f3p.fed_funds_ytd AS federal_funds_ytd,
+    f3p.fndrsg_disb_per AS fundraising_disbursements_period,
+    f3p.fndrsg_disb_ytd AS fundraising_disbursements_ytd,
+    f3p.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3p.indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3p.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3p.indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3p.indv_contb_per AS total_individual_contributions_period,
+    f3p.indv_contb_ytd AS total_individual_contributions_ytd,
+    f3p.items_on_hand_liquidated,
+    f3p.loans_received_from_cand_per AS loans_received_from_candidate_period,
+    f3p.loans_received_from_cand_ytd AS loans_received_from_candidate_ytd,
+    f3p.net_contb_sum_page_per AS net_contributions_cycle_to_date,
+    f3p.net_op_exp_sum_page_per AS net_operating_expenditures_cycle_to_date,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_exp_ytd,
+    f3p.offsets_to_fndrsg_exp_per AS offsets_to_fundraising_expenditures_period,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_expenditures_ytd,
+    f3p.offsets_to_legal_acctg_per AS offsets_to_legal_accounting_period,
+    f3p.offsets_to_legal_acctg_ytd AS offsets_to_legal_accounting_ytd,
+    f3p.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3p.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3p.op_exp_per AS operating_expenditures_period,
+    f3p.op_exp_ytd AS operating_expenditures_ytd,
+    f3p.other_disb_per AS other_disbursements_period,
+    f3p.other_disb_ytd AS other_disbursements_ytd,
+    f3p.other_loans_received_per AS other_loans_received_period,
+    f3p.other_loans_received_ytd,
+    f3p.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3p.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3p.other_receipts_per AS other_receipts_period,
+    f3p.other_receipts_ytd,
+    f3p.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3p.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3p.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3p.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3p.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3p.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3p.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3p.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3p.repymts_loans_made_by_cand_per AS repayments_loans_made_by_candidate_period,
+    f3p.repymts_loans_made_cand_ytd AS repayments_loans_made_candidate_ytd,
+    f3p.repymts_other_loans_per AS repayments_other_loans_period,
+    f3p.repymts_other_loans_ytd AS repayments_other_loans_ytd,
+    f3p.rpt_yr AS report_year,
+    f3p.subttl_sum_page_per AS subtotal_summary_period,
+    f3p.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3p.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3p.ttl_contb_per AS total_contributions_period,
+    f3p.ttl_contb_ytd AS total_contributions_ytd,
+    f3p.ttl_disb_per AS total_disbursements_period,
+    f3p.ttl_disb_ytd AS total_disbursements_ytd,
+    f3p.ttl_loan_repymts_made_per AS total_loan_repayments_made_period,
+    f3p.ttl_loan_repymts_made_ytd AS total_loan_repayments_made_ytd,
+    f3p.ttl_loans_received_per AS total_loans_received_period,
+    f3p.ttl_loans_received_ytd AS total_loans_received_ytd,
+    f3p.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3p.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3p.ttl_per AS total_period,
+    f3p.ttl_receipts_per AS total_receipts_period,
+    f3p.ttl_receipts_ytd AS total_receipts_ytd,
+    f3p.ttl_ytd AS total_ytd,
+    f3p.tranf_from_affilated_cmte_per AS transfers_from_affiliated_committee_period,
+    f3p.tranf_from_affiliated_cmte_ytd AS transfers_from_affiliated_committee_ytd,
+    f3p.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3p.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3p.rpt_tp AS report_type,
+    f3p.rpt_tp_desc AS report_type_full,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3p.receipt_dt AS receipt_date,
+    f3p.file_num AS file_number,
+    f3p.amndt_ind AS amendment_indicator,
+    f3p.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3p.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3p.begin_image_num::text), f3p.cmte_id::text, f3p.file_num::text) AS html_url,
+    report_fec_url(f3p.begin_image_num::text, f3p.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3p.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name,
+    to_tsvector(parse_fulltext(cmte.cmte_nm||' '||f3p.cmte_id)) AS filer_name_text
+  FROM disclosure.nml_form_3p f3p
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3p.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3p.rpt_yr + f3p.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3p.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3p.file_num = amendments.file_num
+  WHERE f3p.rpt_yr >= 1979::numeric AND f3p.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_presidential_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_presidential_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_presidential_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_presidential_mv_tmp_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+ 
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_is_amen_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (is_amended, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (receipt_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+    
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_filer_name_text
+    ON public.ofec_reports_presidential_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_presidential_vw AS 
+SELECT * FROM public.ofec_reports_presidential_mv_tmp;
+
+ALTER TABLE public.ofec_reports_presidential_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_reports_presidential_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_presidential_vw TO fec_read;
+
+
+-- drop old MV:ofec_reports_presidential_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp 
+  RENAME TO ofec_reports_presidential_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_idx RENAME TO idx_ofec_reports_presidential_mv_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_disb_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_presidential_mv_beg_image_num_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_presidential_mv_cmte_id_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_end_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_start_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_presidential_mv_cyc_cmte_id;
+ 
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_presidential_mv_cyc_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_presidential_mv_is_amen_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_presidential_mv_rcpt_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_type_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_presidential_mv_filer_name_text;

--- a/data/migrations/V0259__ofec_report_house_senate_mv_add_cmteid_text.sql
+++ b/data/migrations/V0259__ofec_report_house_senate_mv_add_cmteid_text.sql
@@ -1,0 +1,232 @@
+/*
+This is migration is for issue #5220
+This is the latest version of ofec_reports_house_senate_mv
+Add committee ID to tsvector column and rename column 
+
+-- Previous mv is V0253
+*/
+-- -----------------------------------------------------
+
+-- --------public.ofec_reports_house_senate_mv--------------
+DROP MATERIALIZED VIEW IF EXISTS public.oofec_reports_house_senate_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_house_senate_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3.cmte_id AS committee_id,
+    f3.rpt_yr + f3.rpt_yr % 2::numeric AS cycle,
+    f3.cvg_start_dt AS coverage_start_date,
+    f3.cvg_end_dt AS coverage_end_date,
+    f3.agr_amt_pers_contrib_gen AS aggregate_amount_personal_contributions_general,
+    f3.agr_amt_contrib_pers_fund_prim AS aggregate_contributions_personal_funds_primary,
+    f3.all_other_loans_per AS all_other_loans_period,
+    f3.all_other_loans_ytd,
+    f3.begin_image_num AS beginning_image_number,
+    f3.cand_contb_per AS candidate_contribution_period,
+    f3.cand_contb_ytd AS candidate_contribution_ytd,
+    f3.coh_bop AS cash_on_hand_beginning_period,
+    GREATEST(f3.coh_cop_i, f3.coh_cop_ii) AS cash_on_hand_end_period,
+    f3.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3.end_image_num AS end_image_number,
+    f3.grs_rcpt_auth_cmte_gen AS gross_receipt_authorized_committee_general,
+    f3.grs_rcpt_auth_cmte_prim AS gross_receipt_authorized_committee_primary,
+    f3.grs_rcpt_min_pers_contrib_gen AS gross_receipt_minus_personal_contribution_general,
+    f3.grs_rcpt_min_pers_contrib_prim AS gross_receipt_minus_personal_contributions_primary,
+    f3.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3.loan_repymts_cand_loans_per AS loan_repayments_candidate_loans_period,
+    f3.loan_repymts_cand_loans_ytd AS loan_repayments_candidate_loans_ytd,
+    f3.loan_repymts_other_loans_per AS loan_repayments_other_loans_period,
+    f3.loan_repymts_other_loans_ytd AS loan_repayments_other_loans_ytd,
+    f3.loans_made_by_cand_per AS loans_made_by_candidate_period,
+    f3.loans_made_by_cand_ytd AS loans_made_by_candidate_ytd,
+    f3.net_contb_per AS net_contributions_period,
+    f3.net_contb_ytd AS net_contributions_ytd,
+    f3.net_op_exp_per AS net_operating_expenditures_period,
+    f3.net_op_exp_ytd AS net_operating_expenditures_ytd,
+    f3.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3.op_exp_per AS operating_expenditures_period,
+    f3.op_exp_ytd AS operating_expenditures_ytd,
+    f3.other_disb_per AS other_disbursements_period,
+    f3.other_disb_ytd AS other_disbursements_ytd,
+    f3.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3.other_receipts_per AS other_receipts_period,
+    f3.other_receipts_ytd,
+    f3.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3.ref_ttl_contb_col_ttl_ytd AS refunds_total_contributions_col_total_ytd,
+    f3.subttl_per AS subtotal_period,
+    f3.ttl_contb_ref_col_ttl_per AS total_contribution_refunds_col_total_period,
+    f3.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3.ttl_contb_column_ttl_per AS total_contributions_column_total_period,
+    f3.ttl_contb_per AS total_contributions_period,
+    f3.ttl_contb_ytd AS total_contributions_ytd,
+    GREATEST(f3.ttl_disb_per_i, f3.ttl_disb_per_ii) AS total_disbursements_period,
+    f3.ttl_disb_ytd AS total_disbursements_ytd,
+    f3.ttl_indv_contb_per AS total_individual_contributions_period,
+    f3.ttl_indv_contb_ytd AS total_individual_contributions_ytd,
+    f3.ttl_indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3.ttl_indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3.ttl_loan_repymts_per AS total_loan_repayments_made_period,
+    f3.ttl_loan_repymts_ytd AS total_loan_repayments_made_ytd,
+    f3.ttl_loans_per AS total_loans_received_period,
+    f3.ttl_loans_ytd AS total_loans_received_ytd,
+    f3.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3.ttl_op_exp_per AS total_operating_expenditures_period,
+    f3.ttl_op_exp_ytd AS total_operating_expenditures_ytd,
+    GREATEST(f3.ttl_receipts_per_i, f3.ttl_receipts_ii) AS total_receipts_period,
+    f3.ttl_receipts_ytd AS total_receipts_ytd,
+    f3.tranf_from_other_auth_cmte_per AS transfers_from_other_authorized_committee_period,
+    f3.tranf_from_other_auth_cmte_ytd AS transfers_from_other_authorized_committee_ytd,
+    f3.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3.rpt_tp AS report_type,
+    f3.rpt_tp_desc AS report_type_full,
+    f3.rpt_yr AS report_year,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3.receipt_dt AS receipt_date,
+    f3.file_num AS file_number,
+    f3.amndt_ind AS amendment_indicator,
+    f3.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3.begin_image_num::text), f3.cmte_id::text, f3.file_num::text) AS html_url,
+    report_fec_url(f3.begin_image_num::text, f3.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name,
+    to_tsvector(parse_fulltext(cmte.cmte_nm||' '||f3.cmte_id)) AS filer_name_text
+  FROM disclosure.nml_form_3 f3
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3.rpt_yr + f3.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3.file_num = amendments.file_num
+  WHERE f3.rpt_yr >= 1979::numeric AND f3.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_house_senate_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_house_senate_mv_tmp_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cyc_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_is_amen_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_filer_name_text
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_house_senate_vw AS 
+  SELECT * FROM public.ofec_reports_house_senate_mv_tmp;
+
+
+-- drop old MV:ofec_reports_house_senate_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv_tmp 
+  RENAME TO ofec_reports_house_senate_mv;
+
+
+-- rename all indexes
+
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_idx RENAME TO idx_ofec_reports_house_senate_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_disb_period_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_house_senate_mv_beg_image_num_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_house_senate_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_house_senate_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_house_senate_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_house_senate_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_house_senate_mv_filer_name_text;
+

--- a/data/migrations/V0260__ofec_report_pac_party_mv_add_cmteid_text.sql
+++ b/data/migrations/V0260__ofec_report_pac_party_mv_add_cmteid_text.sql
@@ -1,0 +1,258 @@
+/*
+This is migration is for issue #5220
+his is the latest version of ofec_reports_pac_party_mv
+Add committee ID to tsvector column and rename column 
+
+-- Previous mv is V0254
+*/
+-- -----------------------------------------------------
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_pac_party_mv_tmp AS
+    SELECT row_number() OVER () AS idx,
+        rpt.committee_id,
+        rpt.cycle,
+        rpt.coverage_start_date,
+        rpt.coverage_end_date,
+        rpt.all_loans_received_period,
+        rpt.all_loans_received_ytd,
+        rpt.allocated_federal_election_levin_share_period,
+        rpt.beginning_image_number,
+        rpt.calendar_ytd,
+        rpt.cash_on_hand_beginning_calendar_ytd,
+        rpt.cash_on_hand_beginning_period,
+        rpt.cash_on_hand_close_ytd,
+        rpt.cash_on_hand_end_period,
+        rpt.coordinated_expenditures_by_party_committee_period,
+        rpt.coordinated_expenditures_by_party_committee_ytd,
+        rpt.debts_owed_by_committee,
+        rpt.debts_owed_to_committee,
+        rpt.end_image_number,
+        rpt.fed_candidate_committee_contribution_refunds_ytd,
+        rpt.fed_candidate_committee_contributions_period,
+        rpt.fed_candidate_committee_contributions_ytd,
+        rpt.fed_candidate_contribution_refunds_period,
+        rpt.independent_expenditures_period,
+        rpt.independent_expenditures_ytd,
+        rpt.refunded_individual_contributions_period,
+        rpt.refunded_individual_contributions_ytd,
+        rpt.individual_itemized_contributions_period,
+        rpt.individual_itemized_contributions_ytd,
+        rpt.individual_unitemized_contributions_period,
+        rpt.individual_unitemized_contributions_ytd,
+        rpt.loan_repayments_made_period,
+        rpt.loan_repayments_made_ytd,
+        rpt.loan_repayments_received_period,
+        rpt.loan_repayments_received_ytd,
+        rpt.loans_made_period,
+        rpt.loans_made_ytd,
+        rpt.net_contributions_period,
+        rpt.net_contributions_ytd,
+        rpt.net_operating_expenditures_period,
+        rpt.net_operating_expenditures_ytd,
+        rpt.non_allocated_fed_election_activity_period,
+        rpt.non_allocated_fed_election_activity_ytd,
+        rpt.nonfed_share_allocated_disbursements_period,
+        rpt.offsets_to_operating_expenditures_period,
+        rpt.offsets_to_operating_expenditures_ytd,
+        rpt.other_disbursements_period,
+        rpt.other_disbursements_ytd,
+        rpt.other_fed_operating_expenditures_period,
+        rpt.other_fed_operating_expenditures_ytd,
+        rpt.other_fed_receipts_period,
+        rpt.other_fed_receipts_ytd,
+        rpt.refunded_other_political_committee_contributions_period,
+        rpt.refunded_other_political_committee_contributions_ytd,
+        rpt.other_political_committee_contributions_period,
+        rpt.other_political_committee_contributions_ytd,
+        rpt.refunded_political_party_committee_contributions_period,
+        rpt.refunded_political_party_committee_contributions_ytd,
+        rpt.political_party_committee_contributions_period,
+        rpt.political_party_committee_contributions_ytd,
+        rpt.report_year,
+        rpt.shared_fed_activity_nonfed_ytd,
+        rpt.shared_fed_activity_period,
+        rpt.shared_fed_activity_ytd,
+        rpt.shared_fed_operating_expenditures_period,
+        rpt.shared_fed_operating_expenditures_ytd,
+        rpt.shared_nonfed_operating_expenditures_period,
+        rpt.shared_nonfed_operating_expenditures_ytd,
+        rpt.subtotal_summary_page_period,
+        rpt.subtotal_summary_ytd,
+        rpt.total_contribution_refunds_period,
+        rpt.total_contribution_refunds_ytd,
+        rpt.total_contributions_period,
+        rpt.total_contributions_ytd,
+        rpt.total_disbursements_period,
+        rpt.total_disbursements_ytd,
+        rpt.total_fed_disbursements_period,
+        rpt.total_fed_disbursements_ytd,
+        rpt.total_fed_election_activity_period,
+        rpt.total_fed_election_activity_ytd,
+        rpt.total_fed_operating_expenditures_period,
+        rpt.total_fed_operating_expenditures_ytd,
+        rpt.total_fed_receipts_period,
+        rpt.total_fed_receipts_ytd,
+        rpt.total_individual_contributions_period,
+        rpt.total_individual_contributions_ytd,
+        rpt.total_nonfed_transfers_period,
+        rpt.total_nonfed_transfers_ytd,
+        rpt.total_operating_expenditures_period,
+        rpt.total_operating_expenditures_ytd,
+        rpt.total_receipts_period,
+        rpt.total_receipts_ytd,
+        rpt.transfers_from_affiliated_party_period,
+        rpt.transfers_from_affiliated_party_ytd,
+        rpt.transfers_from_nonfed_account_period,
+        rpt.transfers_from_nonfed_account_ytd,
+        rpt.transfers_from_nonfed_levin_period,
+        rpt.transfers_from_nonfed_levin_ytd,
+        rpt.transfers_to_affiliated_committee_period,
+        rpt.transfers_to_affilitated_committees_ytd,
+        rpt.form_tp,
+        rpt.report_type,
+        rpt.report_type_full,
+        rpt.is_amended,
+        rpt.receipt_date,
+        rpt.file_number,
+        rpt.amendment_indicator,
+        rpt.amendment_indicator_full,
+        rpt.means_filed,
+        rpt.html_url,
+        rpt.fec_url,
+        amendments.amendment_chain,
+        amendments.prev_file_num AS previous_file_number,
+        amendments.mst_rct_file_num AS most_recent_file_number,
+        is_most_recent(rpt.file_number::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+        rpt.committee_name,
+        to_tsvector(parse_fulltext(rpt.committee_name||' '||rpt.committee_id)) AS filer_name_text    
+    FROM ofec_pac_party_report_vw rpt
+    LEFT JOIN ofec_filings_amendments_all_vw amendments ON rpt.file_number = amendments.file_num
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_pac_party_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_pac_party_mv_tmp_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_ie_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (independent_expenditures_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_is_amen_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_filer_name_text
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_pac_party_vw AS 
+  SELECT * FROM public.ofec_reports_pac_party_mv_tmp;
+
+
+-- drop old MV:ofec_reports_pac_party_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp 
+  RENAME TO ofec_reports_pac_party_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_idx RENAME TO idx_ofec_reports_pac_party_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_pac_party_mv_beg_image_num_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_pac_party_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_pac_party_mv_cyc_cmte_id;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_pac_party_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_ie_period_idx RENAME TO idx_ofec_reports_pac_party_mv_ie_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_pac_party_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_pac_party_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_disb_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_pac_party_mv_filer_name_text;

--- a/data/migrations/V0261__ofec_sched_e_mv_add_spender_id_text.sql
+++ b/data/migrations/V0261__ofec_sched_e_mv_add_spender_id_text.sql
@@ -1,0 +1,549 @@
+/*
+This is migration is for issue ##5220
+This is the latest version of  public.ofec_sched_e_mv
+Add spender ID to tsvector column and rename column 
+
+-- Previous migration file is V0255
+*/
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_e_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_sched_e_mv_tmp AS
+WITH SE AS
+(SELECT
+fe.cmte_id,
+fe.cmte_nm,
+fe.pye_nm,
+fe.payee_l_nm,
+fe.payee_f_nm,
+fe.payee_m_nm,
+fe.payee_prefix,
+fe.payee_suffix,
+fe.pye_st1,
+fe.pye_st2,
+fe.pye_city,
+fe.pye_st,
+fe.pye_zip,
+fe.entity_tp,
+fe.entity_tp_desc,
+fe.exp_desc,
+fe.catg_cd,
+fe.catg_cd_desc,
+fe.s_o_cand_id,
+fe.s_o_cand_nm,
+fe.s_o_cand_nm_first,
+fe.s_o_cand_nm_last,
+fe.s_o_cand_m_nm,
+fe.s_o_cand_prefix,
+fe.s_o_cand_suffix,
+fe.s_o_cand_office,
+fe.s_o_cand_office_desc,
+fe.s_o_cand_office_st,
+fe.s_o_cand_office_st_desc,
+fe.s_o_cand_office_district,
+fe.s_o_ind,
+fe.s_o_ind_desc,
+fe.election_tp,
+fe.fec_election_tp_desc,
+fe.cal_ytd_ofc_sought,
+fe.dissem_dt,
+fe.exp_amt,
+coalesce(fe.exp_dt, fe.dissem_dt) as exp_dt,
+fe.exp_tp,
+fe.exp_tp_desc,
+fe.memo_cd,
+fe.memo_cd_desc,
+fe.memo_text,
+fe.conduit_cmte_id,
+fe.conduit_cmte_nm,
+fe.conduit_cmte_st1,
+fe.conduit_cmte_st2,
+fe.conduit_cmte_city,
+fe.conduit_cmte_st,
+fe.conduit_cmte_zip,
+fe.indt_sign_nm,
+fe.indt_sign_dt,
+fe.notary_sign_nm,
+fe.notary_sign_dt,
+fe.notary_commission_exprtn_dt,
+fe.filer_l_nm,
+fe.filer_f_nm,
+fe.filer_m_nm,
+fe.filer_prefix,
+fe.filer_suffix,
+fe.action_cd,
+fe.action_cd_desc,
+fe.tran_id,
+fe.back_ref_tran_id,
+fe.back_ref_sched_nm,
+fe.schedule_type,
+fe.schedule_type_desc,
+fe.line_num,
+fe.image_num,
+fe.file_num,
+fe.link_id,
+fe.orig_sub_id,
+fe.sub_id,
+fe.filing_form,
+fe.rpt_tp,
+fe.rpt_yr,
+fe.election_cycle,
+fe.pdf_url,
+coalesce(fe.rpt_tp, '') in ('24', '48') as is_notice,
+fe.payee_name_text,
+fr.amndt_ind,
+fr.prev_file_num,
+to_timestamp(to_char(fr.receipt_dt, '99999999'), 'YYYYMMDD')::timestamp without time zone as receipt_dt,
+true as most_recent
+FROM disclosure.fec_fitem_sched_e fe
+JOIN disclosure.f_rpt_or_form_sub fr
+ON fe.link_id = fr.sub_id
+-- -----------------
+UNION
+-- public.fec_sched_e_notice_vw
+-- -----------------
+SELECT
+se.cmte_id,
+se.cmte_nm,
+se.pye_nm,
+se.payee_l_nm,
+se.payee_f_nm,
+se.payee_m_nm,
+se.payee_prefix,
+se.payee_suffix,
+se.pye_st1,
+se.pye_st2,
+se.pye_city,
+se.pye_st,
+se.pye_zip,
+se.entity_tp,
+se.entity_tp_desc,
+se.exp_desc,
+se.catg_cd,
+se.catg_cd_desc,
+se.s_o_cand_id,
+se.s_o_cand_nm,
+se.s_o_cand_nm_first,
+se.s_o_cand_nm_last,
+se.s_0_cand_m_nm AS s_o_cand_m_nm,
+se.s_0_cand_prefix AS s_o_cand_prefix,
+se.s_0_cand_suffix AS s_o_cand_suffix,
+se.s_o_cand_office,
+se.s_o_cand_office_desc,
+se.s_o_cand_office_st,
+se.s_o_cand_office_st_desc,
+se.s_o_cand_office_district,
+se.s_o_ind,
+se.s_o_ind_desc,
+se.election_tp,
+se.fec_election_tp_desc,
+se.cal_ytd_ofc_sought,
+se.dissem_dt,
+se.exp_amt,
+coalesce(se.exp_dt, se.dissem_dt) as exp_dt,
+se.exp_tp,
+se.exp_tp_desc,
+se.memo_cd,
+se.memo_cd_desc,
+se.memo_text,
+se.conduit_cmte_id,
+se.conduit_cmte_nm,
+se.conduit_cmte_st1,
+se.conduit_cmte_st2,
+se.conduit_cmte_city,
+se.conduit_cmte_st,
+se.conduit_cmte_zip,
+se.indt_sign_nm,
+se.indt_sign_dt,
+se.notary_sign_nm,
+se.notary_sign_dt,
+se.notary_commission_exprtn_dt,
+se.filer_l_nm,
+se.filer_f_nm,
+se.filer_m_nm,
+se.filer_prefix,
+se.filer_suffix,
+se.amndt_ind AS action_cd,
+se.amndt_ind_desc AS action_cd_desc,
+CASE
+    WHEN "substring"(se.sub_id::character varying::text, 1, 1) = '4'::text THEN se.tran_id
+    ELSE NULL::character varying
+END AS tran_id,
+CASE
+    WHEN "substring"(se.sub_id::character varying::text, 1, 1) = '4'::text THEN se.back_ref_tran_id
+    ELSE NULL::character varying
+END AS back_ref_tran_id,
+CASE
+    WHEN "substring"(se.sub_id::character varying::text, 1, 1) = '4'::text THEN se.back_ref_sched_nm
+    ELSE NULL::character varying
+END AS back_ref_sched_nm,
+'SE' AS schedule_type,
+se.form_tp_desc AS schedule_type_desc,
+se.line_num,
+se.image_num,
+se.file_num,
+se.link_id,
+se.orig_sub_id,
+se.sub_id,
+'F24' AS filing_form,
+f24.rpt_tp,
+f24.rpt_yr,
+f24.rpt_yr + mod(f24.rpt_yr, 2::numeric) AS election_cycle,
+image_pdf_url(se.image_num) as pdf_url,
+coalesce(f24.rpt_tp, '') in ('24', '48') as is_notice,
+to_tsvector(parse_fulltext(se.pye_nm)) as payee_name_text,
+f24.amndt_ind,
+f24.prev_file_num,
+f24.receipt_dt,
+(CASE WHEN pa.mst_rct_file_num is null THEN null WHEN f24.file_num = pa.mst_rct_file_num THEN true ELSE false end) as most_recent
+FROM disclosure.nml_sched_e se
+JOIN disclosure.nml_form_24 f24
+ON se.link_id = f24.sub_id
+LEFT OUTER JOIN ofec_processed_financial_amendment_chain_vw pa
+ON f24.file_num = pa.file_num
+WHERE f24.delete_ind IS NULL
+    AND se.delete_ind IS NULL
+    AND se.amndt_ind::text <> 'D'::text
+-- -----------------
+UNION
+-- Add in records for the Form 5 filings
+-- -----------------
+SELECT
+ff57.filer_cmte_id,
+null AS cmte_nm,
+ff57.pye_nm,
+ff57.pye_l_nm,
+ff57.pye_f_nm,
+ff57.pye_m_nm,
+ff57.pye_prefix,
+ff57.pye_suffix,
+ff57.pye_st1,
+ff57.pye_st2,
+ff57.pye_city,
+ff57.pye_st,
+ff57.pye_zip,
+ff57.entity_tp,
+ff57.entity_tp_desc,
+ff57.exp_tp_desc,
+ff57.catg_cd,
+ff57.catg_cd_desc,
+ff57.s_o_cand_id,
+ff57.s_o_cand_nm,
+ff57.s_o_cand_f_nm,
+ff57.s_o_cand_l_nm,
+ff57.s_o_cand_m_nm,
+ff57.s_o_cand_prefix,
+ff57.s_o_cand_suffix,
+ff57.s_o_cand_office,
+ff57.s_o_cand_office_desc,
+ff57.s_o_cand_office_st,
+ff57.s_o_cand_office_state_desc,
+ff57.s_o_cand_office_district,
+ff57.s_o_ind,
+ff57.s_o_ind_desc,
+ff57.election_tp,
+ff57.fec_election_tp_desc,
+ff57.cal_ytd_ofc_sought,
+null AS dissem_dt,
+ff57.exp_amt,
+ff57.exp_dt,
+ff57.exp_tp,
+ff57.exp_tp_desc,
+null AS memo_cd,
+null AS memo_cd_desc,
+null AS memo_text,
+ff57.conduit_cmte_id,
+ff57.conduit_cmte_nm,
+ff57.conduit_cmte_st1,
+ff57.conduit_cmte_st2,
+ff57.conduit_cmte_city,
+ff57.conduit_cmte_st,
+ff57.conduit_cmte_zip,
+null AS indt_sign_nm,
+null AS indt_sign_dt,
+null AS notary_sign_nm,
+null AS notary_sign_dt,
+null AS notary_commission_exprtn_dt,
+null AS filer_l_nm,
+null AS filer_f_nm,
+null AS filer_m_nm,
+null AS filer_prefix,
+null AS filer_suffix,
+ff57.action_cd,
+ff57.action_cd_desc,
+ff57.tran_id,
+null AS back_ref_tran_id,
+null AS back_ref_sched_nm,
+ff57.schedule_type,
+ff57.schedule_type_desc,
+null AS line_num,
+ff57.image_num,
+ff57.file_num,
+ff57.link_id,
+ff57.orig_sub_id,
+ff57.sub_id,
+ff57.filing_form,
+ff57.rpt_tp,
+ff57.rpt_yr,
+ff57.election_cycle,
+image_pdf_url(ff57.image_num) as pdf_url,
+coalesce(ff57.rpt_tp, '') in ('24', '48') AS is_notice,
+to_tsvector(parse_fulltext(ff57.pye_nm)),
+fr.amndt_ind,
+fr.prev_file_num,
+to_timestamp(to_char(fr.receipt_dt, '99999999'), 'YYYYMMDD')::timestamp without time zone as receipt_dt,
+true as most_recent
+FROM disclosure.fec_fitem_f57 ff57
+JOIN disclosure.f_rpt_or_form_sub fr
+ON ff57.link_id = fr.sub_id
+-- -----------------
+UNION
+-- public.fec_f57_notice_vw
+-- -----------------
+SELECT
+f57.filer_cmte_id,
+null AS cmte_nm,
+f57.pye_nm,
+f57.pye_l_nm,
+f57.pye_f_nm,
+f57.pye_m_nm,
+f57.pye_prefix,
+f57.pye_suffix,
+f57.pye_st1,
+f57.pye_st2,
+f57.pye_city,
+f57.pye_st,
+f57.pye_zip,
+f57.entity_tp,
+f57.entity_tp_desc,
+f57.exp_tp_desc,
+f57.catg_cd,
+f57.catg_cd_desc,
+f57.s_o_cand_id,
+f57.s_o_cand_nm,
+f57.s_o_cand_f_nm,
+f57.s_o_cand_l_nm,
+f57.s_o_cand_m_nm,
+f57.s_o_cand_prefix,
+f57.s_o_cand_suffix,
+f57.s_o_cand_office,
+f57.s_o_cand_office_desc,
+f57.s_o_cand_office_st,
+f57.s_o_cand_office_state_desc,
+f57.s_o_cand_office_district,
+f57.s_o_ind,
+f57.s_o_ind_desc,
+f57.election_tp,
+f57.fec_election_tp_desc,
+f57.cal_ytd_ofc_sought,
+null AS dissem_dt,
+f57.exp_amt,
+f57.exp_dt,
+f57.exp_tp,
+f57.exp_tp_desc,
+null AS memo_cd,
+null AS memo_cd_desc,
+null AS memo_text,
+f57.conduit_cmte_id,
+f57.conduit_cmte_nm,
+f57.conduit_cmte_st1,
+f57.conduit_cmte_st2,
+f57.conduit_cmte_city,
+f57.conduit_cmte_st,
+f57.conduit_cmte_zip,
+null AS indt_sign_nm,
+null AS indt_sign_dt,
+null AS notary_sign_nm,
+null AS notary_sign_dt,
+null AS notary_commission_exprtn_dt,
+null AS filer_l_nm,
+null AS filer_f_nm,
+null AS filer_m_nm,
+null AS filer_prefix,
+null AS filer_suffix,
+f57.amndt_ind,
+f57.amndt_ind_desc,
+CASE
+    WHEN "substring"(f57.sub_id::character varying::text, 1, 1) = '4'::text THEN f57.tran_id
+    ELSE NULL::character varying
+END AS tran_id,
+null AS back_ref_tran_id,
+null AS back_ref_sched_nm,
+'SE-F57' AS schedule_type,
+f57.form_tp_desc AS schedule_type_desc,
+null AS line_num,
+f57.image_num,
+f57.file_num,
+f57.link_id,
+f57.orig_sub_id,
+f57.sub_id,
+'F5' AS filing_form,
+f5.rpt_tp,
+f5.rpt_yr,
+f5.rpt_yr + mod(f5.rpt_yr, 2::numeric) AS election_cycle,
+image_pdf_url(f57.image_num) as pdf_url,
+coalesce(f5.rpt_tp, '') in ('24', '48') AS is_notice,
+to_tsvector(parse_fulltext(f57.pye_nm)),
+f5.amndt_ind AS amendment_indicator,
+f5.prev_file_num AS previous_file_num,
+f57.receipt_dt,
+(CASE WHEN pa.mst_rct_file_num is null THEN null WHEN f5.file_num = pa.mst_rct_file_num THEN true ELSE false end) as most_recent
+FROM disclosure.nml_form_57 f57
+JOIN disclosure.nml_form_5 f5
+ON f57.link_id = f5.sub_id
+LEFT OUTER JOIN ofec_processed_financial_amendment_chain_vw pa
+ON f5.file_num = pa.file_num
+WHERE (f5.rpt_tp::text = ANY (ARRAY['24'::character varying::text, '48'::character varying::text]))
+    AND f57.amndt_ind::text <> 'D'::text
+    AND f57.delete_ind IS NULL
+    AND f5.delete_ind IS NULL
+)
+SELECT
+SE.cmte_id,
+SE.cmte_nm,
+pye_nm,
+payee_l_nm,
+payee_f_nm,
+payee_m_nm,
+payee_prefix,
+payee_suffix,
+pye_st1,
+pye_st2,
+pye_city,
+pye_st,
+pye_zip,
+entity_tp,
+entity_tp_desc,
+exp_desc,
+catg_cd,
+catg_cd_desc,
+s_o_cand_id,
+s_o_cand_nm,
+s_o_cand_nm_first,
+s_o_cand_nm_last,
+s_o_cand_m_nm,
+s_o_cand_prefix,
+s_o_cand_suffix,
+s_o_cand_office_desc,
+s_o_cand_office_st_desc,
+CASE when se.s_o_ind in ('O', 'S') then se.s_o_ind else NULL::character varying END AS s_o_ind,
+s_o_ind_desc,
+election_tp,
+fec_election_tp_desc,
+cal_ytd_ofc_sought,
+dissem_dt,
+exp_amt,
+exp_dt,
+exp_tp,
+exp_tp_desc,
+memo_cd,
+memo_cd_desc,
+memo_text,
+conduit_cmte_id,
+conduit_cmte_nm,
+conduit_cmte_st1,
+conduit_cmte_st2,
+conduit_cmte_city,
+conduit_cmte_st,
+conduit_cmte_zip,
+indt_sign_nm,
+indt_sign_dt,
+notary_sign_nm,
+notary_sign_dt,
+notary_commission_exprtn_dt,
+filer_l_nm,
+filer_f_nm,
+filer_m_nm,
+filer_prefix,
+filer_suffix,
+action_cd,
+action_cd_desc,
+tran_id,
+back_ref_tran_id,
+back_ref_sched_nm,
+schedule_type,
+schedule_type_desc,
+line_num,
+image_num,
+file_num,
+prev_file_num,
+amndt_ind,
+reps.rptnum AS amndt_number,
+link_id,
+orig_sub_id,
+sub_id,
+filing_form,
+rpt_tp,
+rpt_yr,
+election_cycle,
+pdf_url,
+is_notice,
+payee_name_text,
+COALESCE(s_o_cand_office, cand.cand_office) AS cand_office,
+COALESCE(s_o_cand_office_st, cand.cand_office_st) AS cand_office_st,
+COALESCE(s_o_cand_office_district, cand.cand_office_district) AS cand_office_district,
+cand.cand_pty_affiliation,
+cmte.cmte_tp,
+cmte.cmte_dsgn,
+now() as pg_date,
+receipt_dt as filing_date,
+most_recent,
+to_tsvector(parse_fulltext(se.cmte_nm||' '||SE.cmte_id)) as spender_name_text
+FROM se
+LEFT OUTER JOIN disclosure.cand_valid_fec_yr cand
+ON se.s_o_cand_id = cand.cand_id AND se.election_cycle = cand.fec_election_yr
+LEFT OUTER JOIN disclosure.cmte_valid_fec_yr cmte
+ON se.cmte_id = cmte.cmte_id AND se.election_cycle = cmte.fec_election_yr
+LEFT OUTER JOIN real_efile.reps ON se.file_num = reps.repid
+;
+
+-- grants
+ALTER TABLE public.ofec_sched_e_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_e_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_e_mv_tmp TO fec_read;
+
+-- Set up the unique key
+create unique index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_sub_id on ofec_sched_e_mv_tmp (sub_id);
+
+
+-- Create simple indices on filtered columns
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_cmte_id on ofec_sched_e_mv_tmp (cmte_id);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_cand_id on ofec_sched_e_mv_tmp (s_o_cand_id);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_filing_form on ofec_sched_e_mv_tmp (filing_form);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_election_cycle on ofec_sched_e_mv_tmp (election_cycle);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_is_notice on ofec_sched_e_mv_tmp (is_notice);
+
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_cand_office on ofec_sched_e_mv_tmp (cand_office);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_cand_office_st on ofec_sched_e_mv_tmp (cand_office_st);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_cand_pty on ofec_sched_e_mv_tmp (cand_pty_affiliation);
+
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_filing_dt on ofec_sched_e_mv_tmp (filing_date);
+create index IF NOT EXISTS idx_ofec_sched_e_mv_tmp_spender_name_text on ofec_sched_e_mv_tmp USING gin (spender_name_text);
+
+
+-- ------------------------
+CREATE OR REPLACE VIEW ofec_sched_e_vw AS
+SELECT * FROM ofec_sched_e_mv_tmp;
+
+ALTER VIEW ofec_sched_e_vw OWNER TO fec;
+GRANT SELECT ON ofec_sched_e_vw TO fec_read;
+GRANT ALL ON public.ofec_sched_e_vw TO fec;
+-- ------------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_e_mv;
+
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_sched_e_mv_tmp RENAME TO ofec_sched_e_mv;
+
+-- ---------------------------------
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_sub_id RENAME TO idx_ofec_sched_e_mv_sub_id;
+
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_cmte_id RENAME TO idx_ofec_sched_e_mv_cmte_id;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_cand_id RENAME TO idx_ofec_sched_e_mv_cand_id;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_filing_form RENAME TO idx_ofec_sched_e_mv_filing_form;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_election_cycle RENAME TO idx_ofec_sched_e_mv_election_cycle;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_is_notice RENAME TO idx_ofec_sched_e_mv_is_notice;
+
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_cand_office RENAME TO idx_ofec_sched_e_mv_cand_office;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_cand_office_st RENAME TO idx_ofec_sched_e_mv_cand_office_st;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_cand_pty RENAME TO idx_ofec_sched_e_mv_cand_pty;
+
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_filing_dt RENAME TO idx_ofec_sched_e_mv_filing_dt;
+ALTER INDEX IF EXISTS idx_ofec_sched_e_mv_tmp_spender_name_text RENAME TO idx_ofec_sched_e_mv_spender_name_text;


### PR DESCRIPTION
## Summary (required)

- Resolves #5220 

Add committee id to newly created tsvector column to make id a searchable item.

API:
/reports/presidential/ 
/reports/house-senate/ 
/reports/pac-party/

/schedules/schedule_e/
/filings/

### Required reviewers
1-2 developers

## How to test
- Download feature branch
- Run `pytest` to test all test cases
- Run `flyway migrate` to test migration
- Switch data models to mv_tmp to test api locally on text search.
**models/filings.py:**
```
class Filings(FecFileNumberMixin, CsvMixin, db.Model):
    __tablename__ = 'ofec_filings_all_mv_tmp_hc'
```

**models/reports.py**
```
class CommitteeReportsHouseSenate(CommitteeReports):
    __tablename__ = 'ofec_reports_house_senate_mv_tmp_hc'

class CommitteeReportsPacParty(CommitteeReports):
    __tablename__ = 'ofec_reports_pac_party_mv_tmp_hc'

class CommitteeReportsPresidential(CommitteeReports):
    __tablename__ = 'ofec_reports_presidential_mv_tmp_hc'
```

**models.py/itemized.py**
```
class ScheduleE(PdfMixin, BaseItemized):
    __tablename__ = 'ofec_sched_e_mv_tmp_hc'
```





- /filings/

http://127.0.0.1:5000/v1/filings/?per_page=20&sort_null_only=false&sort_hide_null=false&filer_name_text=C0008&sort_nulls_last=false&page=1&sort=-receipt_date

http://127.0.0.1:5000/v1/filings/?per_page=20&sort_null_only=false&sort_hide_null=false&filer_name_text=amer&sort_nulls_last=false&page=1&sort=-receipt_date

- /schedules/schedule_e/

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_nulls_last=false&per_page=20&spender_name_text=san&sort=-expenditure_date&sort_null_only=false&sort_hide_null=false

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_nulls_last=false&per_page=20&spender_name_text=s&sort=-expenditure_date&sort_null_only=false&sort_hide_null=false

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_nulls_last=false&per_page=20&spender_name_text=C900&sort=-expenditure_date&sort_null_only=false&sort_hide_null=false

- /reports/presidential/ 

http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=C006&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=amer&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=am&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

- /reports/house-senate/ 

http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=C006&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=Amer&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=Am&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

- /reports/pac-party/

http://127.0.0.1:5000/v1/reports/pac-party/?filer_name_text=C006&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/pac-party/?filer_name_text=C0&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/pac-party/?filer_name_text=can&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

