### PR TITLE
Upgrade python to 3.9.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 ### Project prerequisites
 1. Ensure you have the following requirements installed:
 
-    * Python (the latest 3.8 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
+    * Python (the latest 3.9 release, which includes `pip` and and a built-in version of `virtualenv` called `venv`).
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 10 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ Flask==2.1.2
 Flask-Cors==3.0.9
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.4.1
-gevent==20.4.0
-greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
+gevent==21.12.0
 gunicorn==19.10.0
 GitPython==3.1.27
 icalendar==4.0.2

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.x
+python-3.9.x


### PR DESCRIPTION
## Summary (required)

- Upgrades python to 3.9 to match CMS (https://github.com/fecgov/fec-cms/pull/5401) CMS needed to be upgraded to upgrade cg-django-uaa most recent version released and remove wagtail login vulnerability


### Required reviewers

1-2 devs

## Related PRs
https://github.com/fecgov/fec-cms/pull/5401

## How to test
- `git checkout feature/5247-upgrade-python`
- `pyenv install 3.9.13` 
- `pyenv virtualenv 3.9.13 venv-api3913` 
- `pyenv activate venv-api3913`
- `pip install -r requirements.txt` 
- `pip install -r requirements-dev.txt`
- `rm -rf node_modules` (optional step)
- `npm i` (optional step)
- `npm run build` (optional step)
- `pytest`(all tests should pass)
-  `flask run` and test swagger-ui
-  deploy a this branch to `Dev` space.  Verify API on circleci build/deploys OK while running on python v3.9.13 @runtime
