### PR TITLE
Add committee_id to text search

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -98,8 +98,8 @@ class TestFilings(ApiBaseTest):
             factories.FilingsFactory(report_year=1999),
             factories.FilingsFactory(request_type='5'),
             factories.FilingsFactory(state='MD'),
-            factories.FilingsFactory(filer_name_text="'action':3 'abc':2 'committee':4 'international':1"),
-            factories.FilingsFactory(filer_name_text="'action':3 'xyz':2 'committee':4 'international':1"),
+            factories.FilingsFactory(filer_name_text=sa.func.to_tsvector('international abc action committee C004')),
+            factories.FilingsFactory(filer_name_text=sa.func.to_tsvector('international xyz action committee C004')),
         ]
 
         filter_fields = (
@@ -119,7 +119,7 @@ class TestFilings(ApiBaseTest):
             ('request_type', '5'),
             ('state', 'MD'),
             ('candidate_id', 'H0001'),
-            ('filer_name_text', 'action'),
+            ('q_filer', 'action'),
         )
 
         # checking one example from each field
@@ -220,7 +220,7 @@ class TestFilings(ApiBaseTest):
 
     def test_invalid_keyword(self):
         response = self.app.get(
-            api.url_for(FilingsList, filer_name_text="ab")
+            api.url_for(FilingsList, q_filer="ab")
         )
         self.assertEqual(response.status_code, 422)
 
@@ -340,17 +340,17 @@ class TestEfileFiles(ApiBaseTest):
             id="C02", fulltxt=sa.func.to_tsvector("Dana")
         )
         rest.db.session.flush()
-        results = self._results(api.url_for(EFilingsView, filer_name_text="Danielle"))
+        results = self._results(api.url_for(EFilingsView, q_filer="Danielle"))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["committee_id"], "C01")
 
-        results = self._results(api.url_for(EFilingsView, filer_name_text="dan"))
+        results = self._results(api.url_for(EFilingsView, q_filer="dan"))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]["committee_id"], "C01")
         self.assertEqual(results[1]["committee_id"], "C02")
 
     def test_invalid_keyword(self):
         response = self.app.get(
-            api.url_for(EFilingsView, filer_name_text="ab")
+            api.url_for(EFilingsView, q_filer="ab")
         )
         self.assertEqual(response.status_code, 422)

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1380,18 +1380,22 @@ class TestScheduleE(ApiBaseTest):
     def test_filter_sched_e_spender_name_text(self):
         [
             factories.ScheduleEFactory(
-                committee_id='C001', spender_name_text="'action':3 'abc':2 'committee':4 'international':1",
+                committee_id='C001', spender_name_text=sa.func.to_tsvector('international abc action committee C001'),
             ),
             factories.ScheduleEFactory(
-                committee_id='C002', spender_name_text="'action':3 'xyz':2 'committee':4 'international':1",
+                committee_id='C002', spender_name_text=sa.func.to_tsvector('international xyz action committee C002'),
             ),
         ]
         results = self._results(
-            api.url_for(ScheduleEView, spender_name_text='action', **self.kwargs)
+            api.url_for(ScheduleEView, q_spender='action', **self.kwargs)
         )
         self.assertEqual(len(results), 2)
         results = self._results(
-            api.url_for(ScheduleEView, spender_name_text='abc', **self.kwargs)
+            api.url_for(ScheduleEView, q_spender='abc', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+        results = self._results(
+            api.url_for(ScheduleEView, q_spender='C001', **self.kwargs)
         )
         self.assertEqual(len(results), 1)
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -374,7 +374,7 @@ filings = {
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
     'form_category': fields.List(IStr, description=docs.FORM_CATEGORY),
-    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 efilings = {
@@ -382,7 +382,7 @@ efilings = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'min_receipt_date': fields.Date(description=docs.MIN_RECEIPT_DATE),
     'max_receipt_date': fields.Date(description=docs.MAX_RECEIPT_DATE),
-    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 reports = {
@@ -418,7 +418,7 @@ reports = {
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
-    'filer_name_text': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
 }
 
 committee_reports = {
@@ -922,7 +922,7 @@ schedule_e = {
     'min_filing_date': fields.Date(description=docs.MIN_FILED_DATE),
     'max_filing_date': fields.Date(description=docs.MAX_FILED_DATE),
     'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
-    'spender_name_text': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
+    'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
 }
 
 schedule_e_efile = {

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -6,6 +6,7 @@ from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
 from webservices import exceptions
 
+
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
 

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -254,7 +254,6 @@ class ScheduleAEfile(BaseRawItemized):
         return name
 
 
-
 class ScheduleB(BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_b'

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -594,11 +594,11 @@ Additional banks or depositories in which the committee deposits funds, holds ac
 '''
 
 FILER_NAME_TEXT = '''
-Keyword search for filer name
+Keyword search for filer name or ID
 '''
 
 SPENDER_NAME_TEXT = '''
-Keyword search for spender name
+Keyword search for spender name or ID
 '''
 
 PRIMARY_GENERAL_INDICATOR = '''

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -5,9 +5,7 @@ from webservices import docs
 from webservices import utils
 from webservices import schemas
 from webservices.common.views import ApiResource
-from webservices.common import counts
 from webservices.common import models
-from webservices import exceptions
 
 
 @doc(
@@ -98,7 +96,7 @@ class FilingsList(BaseFilings):
         ("committee_id", models.Filings.committee_id),
         ("candidate_id", models.Filings.candidate_id),
     ]
-    filter_fulltext_fields = [("filer_name_text", models.Filings.filer_name_text),]
+    filter_fulltext_fields = [("q_filer", models.Filings.filer_name_text), ]
 
     @property
     def args(self):
@@ -124,7 +122,7 @@ class EFilingsView(ApiResource):
     filter_range_fields = [
         (("min_receipt_date", "max_receipt_date"), models.EFilings.filed_date),
     ]
-    filter_fulltext_fields = [("filer_name_text", models.CommitteeSearch.fulltxt)]
+    filter_fulltext_fields = [("q_filer", models.CommitteeSearch.fulltxt)]
 
     @property
     def args(self):
@@ -140,7 +138,7 @@ class EFilingsView(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
 
-        if kwargs.get("filer_name_text"):
+        if kwargs.get("q_filer"):
             query = query.join(
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -172,7 +172,7 @@ class ReportsView(views.ApiResource):
             ('beginning_image_number', reports_class.beginning_image_number),
         ]
 
-        filter_fulltext_fields = [("filer_name_text", reports_class.filer_name_text),]
+        filter_fulltext_fields = [("q_filer", reports_class.filer_name_text), ]
 
         if hasattr(reports_class, 'committee'):
             query = reports_class.query.outerjoin(reports_class.committee).options(
@@ -283,7 +283,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
         ('file_number', model.file_number),
         ('committee_id', model.committee_id),
     ]
-    filter_fulltext_fields = [("filer_name_text", models.CommitteeSearch.fulltxt)]
+    filter_fulltext_fields = [("q_filer", models.CommitteeSearch.fulltxt)]
 
     @property
     def args(self):
@@ -298,7 +298,7 @@ class EFilingHouseSenateSummaryView(views.ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
 
-        if kwargs.get("filer_name_text"):
+        if kwargs.get("q_filer"):
             query = query.join(
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,
@@ -329,7 +329,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
         ('file_number', model.file_number),
         ('committee_id', model.committee_id),
     ]
-    filter_fulltext_fields = [("filer_name_text", models.CommitteeSearch.fulltxt)]
+    filter_fulltext_fields = [("q_filer", models.CommitteeSearch.fulltxt)]
 
     @property
     def args(self):
@@ -344,7 +344,7 @@ class EFilingPresidentialSummaryView(views.ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
 
-        if kwargs.get("filer_name_text"):
+        if kwargs.get("q_filer"):
             query = query.join(
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,
@@ -375,7 +375,7 @@ class EFilingPacPartySummaryView(views.ApiResource):
         ('file_number', model.file_number),
         ('committee_id', model.committee_id),
     ]
-    filter_fulltext_fields = [("filer_name_text", models.CommitteeSearch.fulltxt)]
+    filter_fulltext_fields = [("q_filer", models.CommitteeSearch.fulltxt)]
 
     @property
     def args(self):
@@ -390,7 +390,7 @@ class EFilingPacPartySummaryView(views.ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
 
-        if kwargs.get("filer_name_text"):
+        if kwargs.get("q_filer"):
             query = query.join(
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -49,7 +49,7 @@ class ScheduleEView(ItemizedResource):
     ]
     filter_fulltext_fields = [
         ('payee_name', models.ScheduleE.payee_name_text),
-        ('spender_name_text', models.ScheduleE.spender_name_text),
+        ('q_spender', models.ScheduleE.spender_name_text),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleE.expenditure_date),

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -404,7 +404,7 @@ register_schema(CommitteePageSchema)
 # create JFC committee schema
 JFCCommitteeSchema = make_schema(
     models.JFCCommittee,
-    options={'exclude': ( 'idx', 'committee_id', 'most_recent_filing_flag', )},
+    options={'exclude': ('idx', 'committee_id', 'most_recent_filing_flag', )},
 )
 # End create JFC committee schema
 
@@ -482,7 +482,7 @@ make_reports_schema = functools.partial(
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('idx', 'committee' , 'filer_name_text')},
+    options={'exclude': ('idx', 'committee', 'filer_name_text')},
 )
 
 augment_models(


### PR DESCRIPTION
## Summary (required)

- Resolves #5219 

After database change, api change is completed in this ticket to change the filter name to q_filer/q_spender

### Required reviewers

- 1-2 developers

## Related PRs
[Database change PR ](https://github.com/fecgov/openFEC/pull/5231) 

## Screenshots

<img width="1059" alt="Screen Shot 2022-09-07 at 10 59 33 AM" src="https://user-images.githubusercontent.com/24396726/188911400-e8911515-f0fb-4395-9d0e-a80808a05df1.png">

<img width="1042" alt="Screen Shot 2022-09-07 at 11 38 52 AM" src="https://user-images.githubusercontent.com/24396726/188920360-6343227a-f5a9-464a-a48e-39e8c461f248.png">

## How to test
- Download feature branch
- Run `pytest`
- Run `flask run` to start api on local and test these endpoints:
- /filings/
http://127.0.0.1:5000/v1/filings/?per_page=20&sort_null_only=false&sort_hide_null=false&q_filer=C00081&sort_nulls_last=false&page=1&sort=-receipt_date

http://127.0.0.1:5000/v1/filings/?per_page=20&sort_null_only=false&sort_hide_null=false&q_filer=am&sort_nulls_last=false&page=1&sort=-receipt_date

http://127.0.0.1:5000/v1/efile/filings/?sort_nulls_last=false&page=1&sort=-receipt_date&sort_hide_null=false&q_filer=amer&per_page=20&sort_null_only=false

- /schedules/schedule_e/, q_spender="future"
http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_nulls_last=false&per_page=20&q_spender=future&sort=-expenditure_date&sort_null_only=false&sort_hide_null=false

- /reports/presidential/,  q_filer="amer";  q_filer="C0066"
http://127.0.0.1:5000/v1/reports/presidential/?q_filer=amer&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/reports/presidential/?q_filer=C0066&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/efile/reports/presidential/?per_page=20&page=1&sort=-receipt_date&sort_nulls_last=false&sort_null_only=false&q_filer=C0066&sort_hide_null=false

- /reports/house-senate/,  q_filer="C0007"
http://127.0.0.1:5000/v1/reports/house-senate/?q_filer=C0007&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/efile/reports/house-senate/?per_page=20&page=1&sort=-receipt_date&sort_nulls_last=false&sort_null_only=false&q_filer=C0071&sort_hide_null=false

- /reports/pac-party/,    q_filer="C0071"
http://127.0.0.1:5000/v1/reports/pac-party/?q_filer=C0071&sort=-coverage_end_date&sort_hide_null=false&page=1&sort_nulls_last=false&sort_null_only=false&per_page=20

http://127.0.0.1:5000/v1/efile/reports/pac-party/?per_page=20&page=1&sort=-receipt_date&sort_nulls_last=false&sort_null_only=false&q_filer=C0071&sort_hide_null=false
