### PR TITLE
Update document name of 24- and 48-hour reports

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -208,7 +208,7 @@ class TestFilings(ApiBaseTest):
     def test_regex(self):
         """ Getting rid of extra text that comes in the tables."""
         factories.FilingsFactory(
-            report_type_full='report    {more information than we want}',
+            report_type_full_original='report    {more information than we want}',
             committee_id='C007',
             form_type='RFAI',
             report_year=2004,

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -26,8 +26,7 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     report_type = db.Column(db.String, index=True, doc=docs.REPORT_TYPE)
     document_type = db.Column(db.String, index=True, doc=docs.DOC_TYPE)
     document_type_full = db.Column(db.String, doc=docs.DOC_TYPE)
-    report_type_full_text = db.Column('report_type_full', db.String, doc=docs.REPORT_TYPE)
-    # report_type_full = db.Column(db.String, doc=docs.REPORT_TYPE)
+    report_type_full_original = db.Column('report_type_full', db.String, doc=docs.REPORT_TYPE)
     beginning_image_number = db.Column(db.BigInteger, index=True, doc=docs.BEGINNING_IMAGE_NUMBER)
     ending_image_number = db.Column(db.BigInteger, doc=docs.ENDING_IMAGE_NUMBER)
     pages = db.Column(db.Integer, doc=docs.PAGES)
@@ -81,20 +80,20 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     filer_name_text = db.Column(TSVECTOR, doc=docs.FILER_NAME_TEXT)
 
     @property
+    def report_type_full(self):
+        return utils.report_type_full(
+            self.report_type,
+            self.form_type,
+            self.report_type_full_original,
+        )
+
+    @property
     def document_description(self):
         return utils.document_description(
             self.report_year,
             self.report_type_full,
             self.document_type_full,
             self.form_type,
-        )
-
-    @property
-    def report_type_full(self):
-        return utils.report_type__description(
-            self.report_type,
-            self.form_type,
-            self.report_type_full_text,
         )
 
 

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -6,6 +6,7 @@ from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
 from webservices import exceptions
 
+
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
 
@@ -25,7 +26,8 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     report_type = db.Column(db.String, index=True, doc=docs.REPORT_TYPE)
     document_type = db.Column(db.String, index=True, doc=docs.DOC_TYPE)
     document_type_full = db.Column(db.String, doc=docs.DOC_TYPE)
-    report_type_full = db.Column(db.String, doc=docs.REPORT_TYPE)
+    report_type_full_text = db.Column('report_type_full', db.String, doc=docs.REPORT_TYPE)
+    # report_type_full = db.Column(db.String, doc=docs.REPORT_TYPE)
     beginning_image_number = db.Column(db.BigInteger, index=True, doc=docs.BEGINNING_IMAGE_NUMBER)
     ending_image_number = db.Column(db.BigInteger, doc=docs.ENDING_IMAGE_NUMBER)
     pages = db.Column(db.Integer, doc=docs.PAGES)
@@ -85,6 +87,14 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
             self.report_type_full,
             self.document_type_full,
             self.form_type,
+        )
+
+    @property
+    def report_type_full(self):
+        return utils.report_type__description(
+            self.report_type,
+            self.form_type,
+            self.report_type_full_text,
         )
 
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -482,7 +482,7 @@ make_reports_schema = functools.partial(
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('idx', 'committee' , 'filer_name_text')},
+    options={'exclude': ('idx', 'committee', 'filer_name_text')},
 )
 
 augment_models(
@@ -879,8 +879,9 @@ BaseFilingsSchema = make_schema(
         'csv_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
+        'report_type_full': ma.fields.Str(),
     },
-    options={'exclude': ('committee', 'filer_name_text')},
+    options={'exclude': ('committee', 'filer_name_text', 'report_type_full_original',)},
 )
 
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -580,10 +580,10 @@ def get_percentage(numerators, denominators):
         return None
 
 
-def report_type_full(report_type, form_type, report_type_full_text):
+def report_type_full(report_type, form_type, report_type_full_original):
     if form_type in ('F5', 'F24') and report_type in ('24', '48'):
-        return report_type + "24-HOUR REPORT OF INDEPENDENT EXPENDITURES"
-    if form_type == 'F6':
+        return report_type + "-HOUR REPORT OF INDEPENDENT EXPENDITURES"
+    elif form_type == 'F6':
         return "48-HOUR NOTICE OF CONTRIBUTIONS OR LOANS RECEIVED"
     else:
-        return report_type_full_text
+        return report_type_full_original

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -578,3 +578,12 @@ def get_percentage(numerators, denominators):
     except Exception as exception:
         logger.debug(exception, False)
         return None
+
+
+def report_type_full(report_type, form_type, report_type_full_text):
+    if form_type in ('F5', 'F24') and report_type in ('24', '48'):
+        return report_type + "24-HOUR REPORT OF INDEPENDENT EXPENDITURES"
+    if form_type == 'F6':
+        return "48-HOUR NOTICE OF CONTRIBUTIONS OR LOANS RECEIVED"
+    else:
+        return report_type_full_text


### PR DESCRIPTION
## Summary (required)

- Resolves #5222 

In this PR, "report_type_full" is switched to use a function in utils.py to update the document name for Form 5, Form 6 and Form 24.

when form_tp in ('F24', 'F5') and rpt_tp = '24' then '24-HOUR REPORT OF INDEPENDENT EXPENDITURES'
when form_tp in ('F24', 'F5') and rpt_tp = '48' then '48-HOUR REPORT OF INDEPENDENT EXPENDITURES'
when form_tp = 'F6' then '48-HOUR NOTICE OF CONTRIBUTIONS OR LOANS RECEIVED'

## Required reviewers

1-2 developers

## Impacted areas of the application
API: /filings/

## How to test
- Download feature branch and run `pytest`
- Start api on local and test these endpoints.

- Form 5 & 24 hour report

**Before Change**
<img width="437" alt="Screen Shot 2022-09-09 at 1 31 05 PM" src="https://user-images.githubusercontent.com/24396726/189410594-f69bb5f7-3abe-4974-bbc8-cff96bd1bea6.png">
https://api.open.fec.gov/v1/filings/?sort_hide_null=false&file_number=1627780&sort_null_only=false&form_type=F5&per_page=20&sort=-receipt_date&page=1&sort_nulls_last=false&api_key=DEMO_KEY

**After change**
<img width="437" alt="Screen Shot 2022-09-09 at 1 36 10 PM" src="https://user-images.githubusercontent.com/24396726/189411245-668e7911-b115-4024-81a9-9ae2ac3cc3b4.png">
http://127.0.0.1:5000/v1/filings/?sort_null_only=false&sort_nulls_last=false&sort_hide_null=false&sort=-receipt_date&per_page=20&form_type=F5&page=1&file_number=1627780

- Form 24 and 48 hour report

**Before Change**
<img width="457" alt="Screen Shot 2022-09-09 at 1 40 34 PM" src="https://user-images.githubusercontent.com/24396726/189411928-03fa8b12-fe72-44c7-950a-4ed728c5159b.png">
https://api.open.fec.gov/v1/filings/?sort_hide_null=false&file_number=1628710&sort_null_only=false&form_type=F24&per_page=20&sort=-receipt_date&page=1&sort_nulls_last=false&api_key=DEMO_KEY

**After change**
<img width="457" alt="Screen Shot 2022-09-09 at 1 43 56 PM" src="https://user-images.githubusercontent.com/24396726/189412432-89a7bdb9-4202-4c1b-87aa-f9b53a3adf27.png">
http://127.0.0.1:5000/v1/filings/?sort_null_only=false&sort_nulls_last=false&sort_hide_null=false&sort=-receipt_date&per_page=20&form_type=F24&page=1&file_number=1628710

- Form 6

**Before Change**
<img width="611" alt="Screen Shot 2022-09-09 at 1 47 49 PM" src="https://user-images.githubusercontent.com/24396726/189413071-93149572-f4ec-46c1-a342-62b53472bfba.png">
https://api.open.fec.gov/v1/filings/?sort_hide_null=false&sort_null_only=false&file_number=1628612&form_type=F6&per_page=20&sort=-receipt_date&page=1&sort_nulls_last=false&api_key=DEMO_KEY

**After change**
<img width="643" alt="Screen Shot 2022-09-09 at 1 49 21 PM" src="https://user-images.githubusercontent.com/24396726/189413359-a2b50b9b-c760-4e3b-8540-9b078d917989.png">
http://127.0.0.1:5000/v1/filings/?sort_null_only=false&sort_nulls_last=false&sort_hide_null=false&sort=-receipt_date&per_page=20&form_type=F6&page=1&file_number=1628612

