### PR TITLE
Update refresh interval

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -10,14 +10,14 @@ import ssl
 schedule = {}
 if env.app.get("space_name", "unknown-space").lower() != "feature":
     schedule = {
-        # Task 1: This task is launched every 5 minutes during 6am-7pmEST(13 hours).
+        # Task 1: This task is launched every 5 minutes during 10am-23:55pm UTC (6am-7:55pm EST) (13 hours + 55 minutes).
         # Task 1A: refresh_most_recent_aos(conn):
-        # 1) Identify the most recently modified AO(s) within 8 hours
+        # 1) Identify the most recently modified AO(s) within 10 hours and 5 minutes
         # 2) For each modified AO, find the earliest AO referenced by the modified AO
         # 3) Reload all AO(s) starting from the referenced AO to the latest AO.
 
         # Task 1B: refresh_most_recent_cases(conn):
-        # When found modified case(s)(MUR/AF/ADR) within 8 hours,
+        # When found modified case(s)(MUR/AF/ADR) within 10 hours and 5 minutes,
         #   if published_flg = true, reload the case(s) on elasticsearch service.
         #   if published_flg = false, delete the case(s) on elasticsearch service.
         "refresh_legal_docs": {
@@ -39,11 +39,11 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.legal_docs.weekly_reload_all_aos",
             "schedule": crontab(minute=0, hour=1, day_of_week="sun"),
         },
-        # Task 4: This task is launched at 6pm(EST) everyday.
-        # When found modified case(s)(MUR/AF/ADR) in past 13 hours(6am-7pm EST), send case detail information to Slack.
+        # Task 4: This task is launched at 19:55pm(EST) everyday.
+        # When found modified case(s)(MUR/AF/ADR) in past 24 hours (19:55pm-19:55pm EST), send case detail information to Slack.
         "send_alert_legal_case": {
             "task": "webservices.tasks.legal_docs.send_alert_daily_modified_legal_case",
-            "schedule": crontab(minute=0, hour=23),
+            "schedule": crontab(minute=55, hour=23),
         },
         # Task 5: This task is launched at 12am(EST) only on Sunday.
         # Take Elasticsearch 'docs' index snapshot.

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -16,16 +16,16 @@ from webservices.tasks.utils import get_app_name
 logger = logging.getLogger(__name__)
 
 RECENTLY_MODIFIED_AOS = """
-    SELECT ao_no, pg_date
+    SELECT /* celery_legal_ao_5 */ ao_no, pg_date
     FROM aouser.aos_with_parsed_numbers
-    WHERE pg_date >= NOW() - '8 hour'::INTERVAL
+    WHERE pg_date >= NOW() - '10 hours + 5 minutes'::INTERVAL
     ORDER BY ao_year, ao_serial;
 """
 
 RECENTLY_MODIFIED_CASES = """
-    SELECT case_no, case_type, pg_date, published_flg
+    SELECT /* celery_legal_case_5 */ case_no, case_type, pg_date, published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
-    WHERE pg_date >= NOW() - '8 hour'::INTERVAL
+    WHERE pg_date >= NOW() - '10 hours + 5 minutes'::INTERVAL
     ORDER BY case_serial;
 """
 
@@ -37,11 +37,11 @@ DAILY_MODIFIED_AOS = """
     ORDER BY ao_year, ao_serial;
 """
 
-# for send_alert_daily_modified_legal_case(): during 6am-7pm(EST) (13 hours)
+# for send_alert_daily_modified_legal_case():  during 19:55pm-19:55pm(EST) (24 hours)
 DAILY_MODIFIED_CASES_SEND_ALERT = """
     SELECT case_no, case_type, pg_date, published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
-    WHERE pg_date >= NOW() - '13 hour'::INTERVAL
+    WHERE pg_date >= NOW() - '24 hour'::INTERVAL
     ORDER BY case_serial;
 """
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5238

Updates the refresh interval for AO's and cases to 10 hours, to ensure we are looking at recently modified during the full time the script isn't running (10-23 UTC note: crontax syntax is through the hour, so it's 10-23:59 UTC)

Also updates the slack message bot to include the AO's and MUR's published in the off hours and adds a keyword to search in the kibana logs for the next time we are having celery issues.

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Refresh statements for publishing AO's and Cases

## How to test

-Pushed to dev in a test branch to deploy overnight