### PR TITLE
Add sorting by case number and by advisory opinions number in legal/search

### DIFF
--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -29,6 +29,9 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         expected_ao = {
             "type": "advisory_opinions",
             "no": "2017-01",
+            "ao_no": "2017-01",
+            "ao_year": 2017,
+            "ao_serial": 1,
             "doc_id": "advisory_opinions_2017-01",
             "name": "An AO name",
             "summary": "An AO summary",
@@ -330,6 +333,9 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         expected_ao1 = {
             "type": "advisory_opinions",
             "no": "2015-01",
+            "ao_no": "2015-01",
+            "ao_year": 2015,
+            "ao_serial": 1,
             "doc_id": "advisory_opinions_2015-01",
             "name": "AO name1",
             "summary": "AO summary1",
@@ -351,8 +357,11 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "entities": [],
         }
         expected_ao2 = {
-            "no": "2015-02",
             "type": "advisory_opinions",
+            "no": "2015-02",
+            "ao_no": "2015-02",
+            "ao_year": 2015,
+            "ao_serial": 2,
             "doc_id": "advisory_opinions_2015-02",
             "name": "An AO name2",
             "summary": "An AO summary2",
@@ -376,6 +385,9 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         expected_ao3 = {
             "type": "advisory_opinions",
             "no": "2016-01",
+            "ao_no": "2016-01",
+            "ao_year": 2016,
+            "ao_serial": 1,
             "doc_id": "advisory_opinions_2016-01",
             "name": "An AO name3",
             "summary": "An AO summary3",
@@ -401,13 +413,13 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         self.create_ao(3, expected_ao3)
 
         gen = get_advisory_opinions(None)
-        assert (next(gen)) == expected_ao1
-        assert (next(gen)) == expected_ao2
         assert (next(gen)) == expected_ao3
+        assert (next(gen)) == expected_ao2
+        assert (next(gen)) == expected_ao1
 
         gen = get_advisory_opinions('2015-02')
-        assert (next(gen)) == expected_ao2
         assert (next(gen)) == expected_ao3
+        assert (next(gen)) == expected_ao2
 
     def create_document(self, ao_id, document, filename='201801_C.pdf'):
         self.connection.execute(

--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -32,6 +32,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_1',
+            'case_serial': 1,
             'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
@@ -66,6 +67,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_101',
+            'case_serial': 101,
             'published_flg': False,
             'participants': [],
             'subjects': [mur_subject],
@@ -100,6 +102,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'name': 'Simple ADR',
             'election_cycles': [2016],
             'doc_id': 'adr_1',
+            'case_serial': 1,
             'published_flg': True,
             'participants': [],
             'non_monetary_terms': [],
@@ -186,6 +189,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'no': '1',
             'name': 'Big Admin Fine',
             'doc_id': 'af_1',
+            'case_serial': 1,
             'published_flg': True,
             'documents': [],
             'commission_votes': [{'action': None, 'vote_date': None}],
@@ -268,6 +272,7 @@ class TestLoadCurrentCases(BaseTestCase):
         expected_mur = {
             "type": "murs",
             'no': '1',
+            'case_serial': 1,
             'name': 'MUR with participants',
             'mur_type': 'current',
             'published_flg': True,
@@ -446,6 +451,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'participants': [],
             'no': '1',
             'doc_id': 'mur_1',
+            'case_serial': 1,
             'published_flg': True,
             'mur_type': 'current',
             'name': 'Open Elections LLC',
@@ -468,6 +474,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_1',
+            'case_serial': 1,
             'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
@@ -488,6 +495,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_2',
+            'case_serial': 2,
             'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
@@ -508,6 +516,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'mur_type': 'current',
             'election_cycles': [2016],
             'doc_id': 'mur_3',
+            'case_serial': 3,
             'published_flg': True,
             'participants': [],
             'subjects': [mur_subject],
@@ -544,9 +553,9 @@ class TestLoadCurrentCases(BaseTestCase):
         )
 
         gen = get_cases('MUR')
-        assert (next(gen)) == expected_mur1
-        assert (next(gen)) == expected_mur2
         assert (next(gen)) == expected_mur3
+        assert (next(gen)) == expected_mur2
+        assert (next(gen)) == expected_mur1
 
         actual_murs = [mur for mur in get_cases('MUR', '2')]
         assert actual_murs == [expected_mur2]

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -193,7 +193,7 @@ def make_multi_sort_args(default=None, validator=None, default_hide_null=False,
         default_nulls_only=False, default_sort_nulls_last=False):
     args = make_sort_args(default, validator, default_hide_null, default_nulls_only, default_sort_nulls_last)
     args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True,
-        description='Provide a field to sort by. Use - for descending order.',)
+        description=docs.SORT)
     return args
 
 
@@ -264,6 +264,7 @@ legal_universal_search = {
     'af_min_fd_date': fields.Date(required=False, description=docs.AF_MIN_FD_DATE),
     'af_max_fd_date': fields.Date(required=False, description=docs.AF_MAX_FD_DATE),
     'af_fd_fine_amount': fields.Int(IStr, required=False, description=docs.AF_FD_FINE_AMOUNT),
+    'sort':fields.Str(IStr, required=False, description=docs.SORT),
 }
 
 candidate_detail = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -49,6 +49,11 @@ PAGES = '''
 Number of pages in the document
 '''
 
+SORT = '''
+Provide a field to sort by. Use `-` for descending order. \
+ex: `-case_no`
+'''
+
 # ======== candidate start ===========
 CANDIDATE_TAG = '''
 Candidate endpoints give you access to information about the people running for office.

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -21,13 +21,15 @@ logger = logging.getLogger(__name__)
 
 ALL_AOS = """
     SELECT
-        ao_parsed.ao_id,
-        ao_parsed.ao_no,
-        ao_parsed.name,
-        ao_parsed.summary,
-        ao_parsed.req_date,
-        ao_parsed.issue_date,
-        ao.stage
+        ao_parsed.ao_id as ao_id,
+        ao_parsed.ao_no as ao_no,
+        ao_parsed.ao_year as ao_year,
+        ao_parsed.ao_serial as ao_serial,
+        ao_parsed.name as name,
+        ao_parsed.summary as summary,
+        ao_parsed.req_date as req_date,
+        ao_parsed.issue_date as issue_date,
+        ao.stage as stage
     FROM aouser.aos_with_parsed_numbers ao_parsed
     INNER JOIN aouser.ao ao
         ON ao_parsed.ao_id = ao.ao_id
@@ -36,7 +38,7 @@ ALL_AOS = """
         OR
         (ao_parsed.ao_year > %s)
     )
-    ORDER BY ao_parsed.ao_year, ao_parsed.ao_serial
+    ORDER BY ao_parsed.ao_year desc, ao_parsed.ao_serial desc
 """
 
 AO_ENTITIES = """
@@ -173,6 +175,9 @@ def get_advisory_opinions(from_ao_no):
             ao = {
                 "type": AO_DOC_TYPE,
                 "no": row["ao_no"],
+                "ao_no": row["ao_no"],
+                "ao_year": row["ao_year"],
+                "ao_serial": row["ao_serial"],
                 "doc_id": "{0}_{1}".format(AO_DOC_TYPE, row["ao_no"]),
                 "name": row["name"],
                 "summary": row["summary"],

--- a/webservices/legal_docs/archived_murs.py
+++ b/webservices/legal_docs/archived_murs.py
@@ -23,15 +23,17 @@ logger = logging.getLogger(__name__)
 ALL_ARCHIVED_MURS = """
     SELECT DISTINCT
         mur_id,
-        mur_number as mur_no
+        mur_number as mur_no,
+        mur_id as case_serial
     FROM MUR_ARCH.ARCHIVED_MURS
-    ORDER BY mur_id
+    ORDER BY mur_id desc
 """
 
 SINGLE_MUR = """
     SELECT DISTINCT
         mur_number as mur_no,
         mur_id,
+        mur_id as case_serial,
         mur_name,
         open_date,
         close_date
@@ -172,6 +174,7 @@ def get_single_mur(mur_no):
                 "type": get_es_type(),
                 "doc_id": "mur_{0}".format(row["mur_no"]),
                 "no": row["mur_no"],
+                "case_serial": row["mur_id"],
                 "url": "/legal/matter-under-review/{0}/".format(row["mur_no"]),
                 "mur_type": "archived",
                 "mur_name": row["mur_name"],

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -25,18 +25,20 @@ ALL_CASES = """
     SELECT
         case_id,
         case_no,
+        case_serial,
         name,
         case_type,
         published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE case_type = %s
-    ORDER BY case_serial
+    ORDER BY case_serial desc
 """
 
 SINGLE_CASE = """
     SELECT DISTINCT
         case_id,
         case_no,
+        case_serial,
         name,
         case_type,
         published_flg
@@ -237,10 +239,10 @@ AF_COMMISSION_VOTES = """
 
 """ For ADR's populate case_status based on event_name""" 
 adr_case_status_map = {
-    'Dismissed': 'Case Dismissed',
-    'Settlement Agreement - Complaint Unsubstantiated': 'Negotiated Settlement Approved',
-    'Dismissed - Agreement Rejected': 'Negotiated Settlement Rejected by Commission',
-    'Dismissed - Failed to Approve': 'Case Dismissed'
+    "Dismissed": "Case Dismissed",
+    "Settlement Agreement - Complaint Unsubstantiated": "Negotiated Settlement Approved",
+    "Dismissed - Agreement Rejected": "Negotiated Settlement Rejected by Commission",
+    "Dismissed - Failed to Approve": "Case Dismissed"
 }
 
 STATUTE_REGEX = re.compile(r"(?<!\(|\d)(?P<section>\d+([a-z](-1)?)?)")
@@ -364,6 +366,7 @@ def get_single_case(case_type, case_no, bucket):
                 "type": get_es_type(case_type),
                 "doc_id": "{0}_{1}".format(case_type.lower(), row["case_no"]),
                 "no": row["case_no"],
+                "case_serial": row["case_serial"],
                 "name": row["name"],
                 "published_flg": row["published_flg"],
                 "sort1": sort1,

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -56,6 +56,7 @@ ADMIN_FINES = {
     "type": {"type": "keyword"},
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
+    "case_serial": {"type": "integer"},
     "name": {"type": "text", "analyzer": "english"},
     "published_flg": {"type": "boolean"},
     "commission_votes": {
@@ -127,6 +128,9 @@ ADMIN_FINES = {
 ADVISORY_OPINIONS = {
     "type": {"type": "keyword"},
     "no": {"type": "keyword"},
+    "ao_no": {"type": "keyword"},
+    "ao_serial": {"type": "integer"},
+    "ao_year": {"type": "integer"},
     "doc_id": {"type": "keyword"},
     "name": {"type": "text", "analyzer": "english"},
     "summary": {"type": "text", "analyzer": "english"},
@@ -198,6 +202,7 @@ MUR_MAPPINGS = {
     "type": {"type": "keyword"},
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
+    "case_serial": {"type": "integer"},
     "name": {"type": "text", "analyzer": "english"},
     "published_flg": {"type": "boolean"},
     "commission_votes": {
@@ -244,6 +249,7 @@ ADR_MAPPINGS = {
     "type": {"type": "keyword"},
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
+    "case_serial": {"type": "integer"},
     "name": {"type": "text", "analyzer": "english"},
     "published_flg": {"type": "boolean"},
     "complainant": {"type": "text"},
@@ -363,6 +369,7 @@ ARCH_MUR_MAPPINGS = {
         "type": {"type": "keyword"},
         "doc_id": {"type": "keyword"},
         "no": {"type": "keyword"},
+        "case_serial": {"type": "integer"},
         "mur_name": {"type": "text"},
         "mur_type": {"type": "keyword"},
         "open_date": {"type": "date", "format": "dateOptionalTime"},


### PR DESCRIPTION
## Summary (required)
This PR will add sorting by `case_no` (MUR/AF/ADR) number. The default setting is descending. 
This PR also add sorting by `ao_no` (advisory opinions) number. The default setting is descending. 

**Action item(s):**
- [x] Add `case_serial` column in three cases (MUR/AF/ADR) return, load to ES
- [x] Add `ao_no`, `ao_serial`, `ao_year` columns in three cases advisory opinions return, load to ES
- [x] Add sorting feature in endpoint legal/search
- [x] Update auto test
- [x] Reindex all legal data ( case, ao, arch-mur) on Elasticsearch on dev
- [ ] Reindex all legal data ( case, ao, arch-mur) on Elasticsearch on stage(after cut)
- [ ] Reindex all legal data ( case, ao, arch-mur) on Elasticsearch on prod(after release)

Some cf task commands when reload to ES:
```
cf run-task api --command "python cli.py display_index_alias" -m 2G --name display_index_alias
cf run-task api --command "python cli.py delete_index archived_murs" -m 2G --name delete_archived_murs
cf run-task api --command "python cli.py create_index archived_murs" -m 2G --name create_archmur_index
cf run-task api --command "python cli.py load_archived_murs" -m 2G --name upload_all_arch_mur
cf run-task api --command "python cli.py display_mappings" -m 2G --name display_mappings
cf run-task api --command "python cli.py refresh_current_legal_docs_zero_downtime" -m 4G --name refresh_data
cf run-task api --command "python cli.py initialize_current_legal_docs" -m 4G --name initialize_docs_data
```

- Resolves #5152 

### Required reviewers
1-2 devs

## Impacted areas of the application
legal/search resource

## How to test
Local or deploy on dev.
==Local
- Follow wiki to [setup local Elasticsearch](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally)

- Some basic commands:
`python cli.py display_index_alias`
`python cli.py delete_index docs`
`python cli.py create_index`
`python cli.py delete_index archived_murs`
`python cli.py create_index archived_murs`

- upload sample data

upload current murs:
`python cli.py load_current_murs 7212`
`python cli.py load_current_murs 4633`
`python cli.py load_current_murs 2314`  
`python cli.py load_current_murs 3620`  
`python cli.py load_current_murs 3774`  
`python cli.py load_current_murs 3987`  
`python cli.py load_current_murs 2804R`

upload archived murs:
`python cli.py load_archived_murs 101`
`python cli.py load_archived_murs 103`
`python cli.py load_archived_murs 179`
`python cli.py load_archived_murs 9`
`python cli.py load_archived_murs 99`

upload admin_fines:
`python cli.py load_admin_fines 3726`
`python cli.py load_admin_fines 3571`
`python cli.py load_admin_fines 3314`

upload advisory opinions : (from 2022-08 to 2022-25)
`python cli.py load_advisory_opinions 2022-08`

- test urls on local
1)murs: descending
http://127.0.0.1:5000/v1/legal/search/?type=murs
http://127.0.0.1:5000/v1/legal/search/?type=murs&sort=-case_no
2)murs: ascending 
http://127.0.0.1:5000/v1/legal/search/?type=murs&sort=case_no
3)admin fine: descending
http://127.0.0.1:5000/v1/legal/search/?type=admin_fines
http://127.0.0.1:5000/v1/legal/search/?type=admin_fines&sort=-case_no
4)admin fine: ascending
http://127.0.0.1:5000/v1/legal/search/?type=admin_fines&sort=case_no
5)adr: descending
http://127.0.0.1:5000/v1/legal/search/?type=adrs
http://127.0.0.1:5000/v1/legal/search/?type=adrs&sort=-case_no
6)adr: ascending 
http://127.0.0.1:5000/v1/legal/search/?type=murs&sort=case_no
7)advisory opinion descending
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&sort=-ao_no
8)advisory opinion ascending
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&sort=ao_no

-deploy branch and test urls on dev
1)murs: descending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&sort=-case_no
2)murs: ascending 
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&sort=case_no
3)admin fine: descending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=admin_fines
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=admin_fines&sort=-case_no
4)admin fine: ascending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=admin_fines&sort=case_no
5)adr: descending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=adrs
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=adrs&sort=-case_no
6)adr: ascending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=adrs&sort=case_no
7)advisory opinion: descending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=-case_no
8)advisory opinion: ascending
https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=case_no
