### PR TITLE
Remove cached python env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
+            sudo rm -rf .env
             python3 -m venv .env
             . .env/bin/activate
             pip install -r requirements.txt


### PR DESCRIPTION
## Summary (required)

- Resolves #5251

This PR removes the old virtual environments before creating a new one and downloading the dependencies. This will prevent future issues with the venv cache. 

### Required reviewers

1-2 devs

## How to test

- Merge branch to develop, builds should now succeed. Old failing branches will need to be re-based to add change. 

