### PR TITLE
Fix invalid districts in /candidates/totals/aggregates/

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1498,7 +1498,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             party="DEM",
         )
         factories.CandidateTotalFactory(
-            candidate_id="S11",
+            candidate_id="S119",
             is_election=False,  # data for two-year period (not candidate election year)
             cycle=2014,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=400,
@@ -1516,7 +1516,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             party="DEM",
         )
         factories.CandidateTotalFactory(
-            candidate_id="S11",
+            candidate_id="S119",
             is_election=False,  # data for two-year period (not candidate election year)
             cycle=2016,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=600,
@@ -1585,6 +1585,22 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="00",
             party="REP",
+        )
+
+        factories.ElectionsListFactory(
+            office='H', state='CA', district='01', incumbent_id='H11', cycle=2016
+        )
+
+        factories.ElectionsListFactory(
+            office='H', state='CA', district='02', incumbent_id='H22', cycle=2016
+        )
+
+        factories.ElectionsListFactory(
+            office='H', state='VA', district='01', incumbent_id='H33', cycle=2016
+        )
+
+        factories.ElectionsListFactory(
+            office='S', state='CA', district='00', incumbent_id='S11', cycle=2016
         )
 
     def test_base(self):

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -14,6 +14,7 @@ from webservices.common.models import (
     CandidateCommitteeLink,
     ScheduleABySize,
     ScheduleAByState,
+    ElectionsList,
     db,
 )
 
@@ -506,6 +507,12 @@ class CandidateTotalAggregateView(ApiResource):
 
             # remove district=null
             query = query.filter(~total.district.is_(None))
+            query = query.filter(
+                models.ElectionsList.cycle == total.election_year,
+                models.ElectionsList.state == total.state,
+                models.ElectionsList.office == total.office,
+                models.ElectionsList.district == total.district, 
+            )
             query = query.group_by(
                 total.election_year, total.office, total.state, total.district,
             )


### PR DESCRIPTION
## Summary (required)

- Resolves #5164
- Invalid districts are removed from /candidates/totals/aggregates/  when "aggregate_by=office-state-district".  Districts were cross referenced with the same data source used for "elections/search/" endpoint.

### Required reviewers

1 developer

## How to test
- Download feature branch, run `pytest`
- Start api page on local, and run these endpoints

**2022 Alabama House**
**Before change**: invalid districts 12, 13
https://api.open.fec.gov/v1/candidates/totals/aggregates/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&state=AL&sort=state&per_page=10&page=1&aggregate_by=office-state-district&election_year=2022&office=H&election_full=true&is_active_candidate=true

**After change:** not showing 12, 13
http://127.0.0.1:5000/v1/candidates/totals/aggregates/?election_year=2022&per_page=20&is_active_candidate=true&office=H&state=AL&sort_nulls_last=false&sort_null_only=false&aggregate_by=office-state-district&sort=-election_year&page=1&election_full=true&sort_hide_null=false

**2022 West Virginia House, holds two districts after losing one congressional seat**
**Before change**: showing district 01, 02 and 03
https://api.open.fec.gov/v1/candidates/totals/aggregates/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=true&state=WV&sort=state&per_page=10&page=1&aggregate_by=office-state-district&election_year=2022&office=H&election_full=true&is_active_candidate=true

**After change**: showing district 01 and 02
http://127.0.0.1:5000/v1/candidates/totals/aggregates/?election_year=2022&per_page=20&is_active_candidate=true&office=H&state=WV&sort_nulls_last=false&sort_null_only=false&aggregate_by=office-state-district&sort=-election_year&page=1&election_full=true&sort_hide_null=false
