### PR TITLE
Fix broken reports_ie_only endpoint

### DIFF
--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -61,7 +61,7 @@ class TestReports(ApiBaseTest):
             ('house-senate', factories.ReportsHouseSenateFactory),
             ('presidential', factories.ReportsPresidentialFactory),
             ('pac-party', factories.ReportsPacPartyFactory),
-            # TODO after finish CommitteeReportsIEOnly, add baack('ie-only', factories.ReportsIEOnlyFactory),
+            ('ie-only', factories.ReportsIEOnlyFactory),
         ]
 
         for category, factory in params:
@@ -110,26 +110,25 @@ class TestReports(ApiBaseTest):
             [presidential_report_2012, house_report_2016],
         )
 
-    # TODO: After finish add filer_name_text filter in to CommitteeReportsIEOnly
-    # def test_ie_only(self):
-    #     number = 12345678902
-    #     report = factories.ReportsIEOnlyFactory(
-    #         beginning_image_number=number,
-    #         independent_contributions_period=200,
-    #         independent_expenditures_period=100,
-    #     )
-    #     results = self._results(
-    #         api.url_for(
-    #             ReportsView, entity_type='ie-only', beginning_image_number=number,
-    #         )
-    #     )
-    #     result = results[0]
-    #     for key in [
-    #         'report_form',
-    #         'independent_contributions_period',
-    #         'independent_expenditures_period',
-    #     ]:
-    #         self.assertEqual(result[key], getattr(report, key))
+    def test_ie_only(self):
+        number = 12345678902
+        report = factories.ReportsIEOnlyFactory(
+            beginning_image_number=number,
+            independent_contributions_period=200,
+            independent_expenditures_period=100,
+        )
+        results = self._results(
+            api.url_for(
+                ReportsView, entity_type='ie-only', beginning_image_number=number,
+            )
+        )
+        result = results[0]
+        for key in [
+            'report_form',
+            'independent_contributions_period',
+            'independent_expenditures_period',
+        ]:
+            self.assertEqual(result[key], getattr(report, key))
 
 
 # Test endpoint:

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -419,6 +419,7 @@ reports = {
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
     'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+    'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
 }
 
 committee_reports = {

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -468,6 +468,7 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
 
     beginning_image_number = db.Column(db.BigInteger)
     committee_id = db.Column(db.String)
+    committee_name = db.Column(db.String)
     cycle = db.Column(db.Integer)
     coverage_start_date = db.Column(db.DateTime(), index=True)
     coverage_end_date = db.Column(db.DateTime(), index=True)
@@ -483,6 +484,7 @@ class CommitteeReportsIEOnly(PdfMixin, BaseModel):
     receipt_date = db.Column(db.Date, doc=docs.RECEIPT_DATE)
     means_filed = db.Column(db.String, doc=docs.MEANS_FILED)
     fec_url = db.Column(db.String)
+    spender_name_text = db.Column(TSVECTOR, doc=docs.SPENDER_NAME_TEXT)
 
 
 class BaseFilingSummary(db.Model):

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -126,10 +126,10 @@ def get_match_filters():
 
 # Use for endpoint '/reports/<string:entity_type>/' under tag:'financial'
 # Sample urls:
-# http://127.0.0.1:5000/v1/reports/presidential/?filer_name_text=bid
-# http://127.0.0.1:5000/v1/reports/house-senate/?filer_name_text=bid
-# http://127.0.0.1:5000/v1/reports/pac-party/filer_name_text=bid
-# TODO http://127.0.0.1:5000/v1/reports/ie-only/filer_name_text=bid
+# http://127.0.0.1:5000/v1/reports/presidential/?q_filer=bid
+# http://127.0.0.1:5000/v1/reports/house-senate/?q_filer=bid
+# http://127.0.0.1:5000/v1/reports/pac-party/q_filer=bid
+# http://127.0.0.1:5000/v1/reports/ie-only/q_spender=bid
 @doc(
     tags=['financial'],
     description=docs.REPORTS,
@@ -172,7 +172,10 @@ class ReportsView(views.ApiResource):
             ('beginning_image_number', reports_class.beginning_image_number),
         ]
 
-        filter_fulltext_fields = [("q_filer", reports_class.filer_name_text), ]
+        if entity_type == 'ie-only':
+            filter_fulltext_fields = [("q_spender", reports_class.spender_name_text), ]
+        else:
+            filter_fulltext_fields = [("q_filer", reports_class.filer_name_text), ]
 
         if hasattr(reports_class, 'committee'):
             query = reports_class.query.outerjoin(reports_class.committee).options(

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -482,7 +482,7 @@ make_reports_schema = functools.partial(
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('idx', 'committee', 'filer_name_text')},
+    options={'exclude': ('idx', 'committee', 'filer_name_text', 'spender_name_text')},
 )
 
 augment_models(


### PR DESCRIPTION
## Summary (required)
Fix 500 error in reports/ie-only/ endpoint
- Resolves #5232 
- Ref PR #5255 #5257 
Add two column: spender_name_text and committee_name in endpoint return


### Required reviewers
1 dev

## Impacted areas of the application

## How to test
- Download feature branch , point to dev db
- `pytest`
- `python cli.py run`
- test local api
- Sample urls:
on prod api, you will get `Internal Server Error`
https://api.open.fec.gov/v1/reports/ie-only/?q_spender=c007&sort=-coverage_end_date&api_key=DEMO_KEY

on local, you can filter by q_spender (committee_id or committee_name)
http://127.0.0.1:5000/v1/reports/ie-only/?q_spender=c007&sort=-coverage_end_date
http://127.0.0.1:5000/v1/reports/ie-only/?q_spender=bid&sort=-coverage_end_date


