### PR TITLE
Increase memory

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 1.5G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 10
-    memory: 1.5G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 1.5G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:


### PR DESCRIPTION
## Summary (required)

- Partially resolves #5267

Increases api memory to 2G in dev, stage, and prod

### Required reviewers

1 dev


## Screenshots

![image](https://user-images.githubusercontent.com/66386084/198096527-3eba1b9e-08a7-4163-b32f-1b77427f12d6.png)

## How to test
test the requests on dev and prod that are getting the 502 errors
I tested https://fec-dev-api.app.cloud.gov/v1/committee/C00075820/reports/?api_key=DEMO_KEY&sort_null_only=false&per_page=100&page=1&sort_hide_null=false&sort=-coverage_end_date&sort_nulls_last=false
I got 502 errors after per_page=98
- deploy to dev 
- re-ran https://fec-dev-api.app.cloud.gov/v1/committee/C00075820/reports/?api_key=DEMO_KEY&sort_null_only=false&per_page=100&page=1&sort_hide_null=false&sort=-coverage_end_date&sort_nulls_last=false
No longer getting the 502
-`cf app api` (shows 2G memory)
