### PR TITLE
[MERGE WITH GITFLOW] Increase api memory to 2.5G

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 2G
+    memory: 2.5G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 2.5G
+    memory: 1G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 10
-    memory: 2G
+    memory: 2.5G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 2G
+    memory: 2.5G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 2.5G
+    memory: 1G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:


### PR DESCRIPTION
## Summary (required)
App metrics: https://logs.fr.cloud.gov/goto/03634cc2122630e2a86cad813ddefe52
Booting workers still a bit high: https://logs.fr.cloud.gov/goto/67b5912713e2588c523b63597baa54e8

- Partially resolves #5267

Increases api memory to 2.5G in dev, stage, and prod

### Required reviewers

1 dev


## Screenshots

## How to test
Make sure api work well.