### PR TITLE
Create model CommitteeHistoryProfile and Refactor CommitteeHistory join 

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -113,6 +113,13 @@ class CommitteeHistoryFactory(BaseCommitteeFactory):
     cycle = 2016
 
 
+class CommitteeHistoryProfileFactory(CommitteeHistoryFactory):
+    class Meta:
+        model = models.CommitteeHistoryProfile
+
+    cycle = 2016
+
+
 class CommitteeTotalsHouseSenateFactory(BaseCommitteeFactory):
     class Meta:
         model = models.CommitteeTotalsHouseSenate

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -6,7 +6,7 @@ import manage
 from tests.common import BaseTestCase
 from webservices import rest, __API_VERSION__
 from webservices.rest import db
-from webservices.resources.committees import CommitteeHistoryView
+from webservices.resources.committees import CommitteeHistoryProfileView
 
 
 @pytest.mark.usefixtures("migrate_db")
@@ -104,7 +104,7 @@ class CommitteeTestCase(BaseTestCase):
         }
 
         committee_api = self._results(
-            rest.api.url_for(CommitteeHistoryView, **params_cmte)
+            rest.api.url_for(CommitteeHistoryProfileView, **params_cmte)
         )
         self.check_nulls_in_array_column(committee_api, array_column='cycles')
         self.check_nulls_in_array_column(

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -10,7 +10,7 @@ from webservices.rest import db
 from webservices.rest import api
 from webservices.resources.committees import CommitteeList
 from webservices.resources.committees import CommitteeView
-from webservices.resources.committees import CommitteeHistoryView
+from webservices.resources.committees import CommitteeHistoryProfileView
 from webservices.resources.candidates import CandidateView
 
 
@@ -456,32 +456,32 @@ class CommitteeFormatTest(ApiBaseTest):
 #  '/committee/<string:committee_id>/history/<int:cycle>/',
 #  '/candidate/<string:candidate_id>/committees/history/',
 #  '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
-class TestCommitteeHistory(ApiBaseTest):
+class TestCommitteeHistoryProfile(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateDetailFactory()
         self.committees = [factories.CommitteeDetailFactory() for _ in range(8)]
         self.histories = [
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[0].committee_id,
                 cycle=2010,
                 designation="P",
                 is_active=True,
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[1].committee_id,
                 cycle=2012,
                 designation="P",
                 is_active=True,
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
                 designation="P",
                 is_active=True,
             ),
             # Candidate PCC converted to PAC in 2016
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[2].committee_id,
                 cycle=2016,
                 designation="P",
@@ -491,20 +491,20 @@ class TestCommitteeHistory(ApiBaseTest):
                 former_candidate_election_year=2016,
                 former_committee_name="Used to be PCC but I'm a PAC now committeee"
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[3].committee_id,
                 cycle=2014,
                 designation="A",
                 is_active=False,
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
                 designation="J",
                 is_active=False,
             ),
             # test leadership pac with same committees[5], different cycle.
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[5].committee_id,
                 cycle=2006,
                 committee_type="P",
@@ -512,21 +512,21 @@ class TestCommitteeHistory(ApiBaseTest):
                 is_active=True,
             ),
             # test leadership pac with same committees[5], different cycle.
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[5].committee_id,
                 cycle=2008,
                 committee_type="P",
                 designation="D",
                 is_active=True,
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[6].committee_id,
                 cycle=2020,
                 designation="D",
                 is_active=True,
                 sponsor_candidate_ids=["H003", "H004"]
             ),
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[7].committee_id,
                 cycle=2022,
                 designation="J",
@@ -608,7 +608,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_is_active(self):
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
                 election_full=False,
@@ -619,7 +619,7 @@ class TestCommitteeHistory(ApiBaseTest):
 
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
                 election_full=False,
@@ -631,7 +631,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_candidate_cycle(self):
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2012,
                 election_full=False,
@@ -644,7 +644,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_election_full(self):
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2012,
                 election_full=True,
@@ -660,7 +660,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_designation(self):
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id=self.candidate.candidate_id,
                 designation=["P", "A"],
             )
@@ -671,7 +671,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_ledership_pac_committees(self):
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2008,
                 election_full=True,
@@ -687,7 +687,7 @@ class TestCommitteeHistory(ApiBaseTest):
         """Where PCC converted to PAC in 2016, still show committee history."""
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id=self.candidate.candidate_id,
                 cycle=2016,
                 election_full=True
@@ -701,7 +701,7 @@ class TestCommitteeHistory(ApiBaseTest):
         lower_candidate = factories.CandidateDetailFactory(candidate_id="H01")
         lower_committee_1 = factories.CommitteeDetailFactory(committee_id="ID01")
         [
-            factories.CommitteeHistoryFactory(
+            factories.CommitteeHistoryProfileFactory(
                 committee_id=lower_committee_1.committee_id,
                 cycle=2014,
                 designation="J",
@@ -733,7 +733,7 @@ class TestCommitteeHistory(ApiBaseTest):
 
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 committee_id="id01",
                 cycle=2014,
                 election_full=False,
@@ -744,7 +744,7 @@ class TestCommitteeHistory(ApiBaseTest):
 
         results = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 candidate_id="h01",
                 cycle=2014,
                 election_full=False,
@@ -756,7 +756,7 @@ class TestCommitteeHistory(ApiBaseTest):
     def test_sponsor_candidate_ids(self):
         result = self._results(
             api.url_for(
-                CommitteeHistoryView,
+                CommitteeHistoryProfileView,
                 committee_id=self.committees[6].committee_id,
             )
         )
@@ -768,19 +768,22 @@ class TestCommitteeHistory(ApiBaseTest):
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_001",
             most_recent_filing_flag='Y',
+            joint_committee_id="C009",
         )
         factories.JFCCommitteeFactory(
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_old",
             most_recent_filing_flag='N',
+            joint_committee_id="C009",
         )
         factories.JFCCommitteeFactory(
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_002",
             most_recent_filing_flag='Y',
+            joint_committee_id="C009",
         )
         results = self._results(
-            api.url_for(CommitteeHistoryView, committee_id=self.committees[7].committee_id)
+            api.url_for(CommitteeHistoryProfileView, committee_id=self.committees[7].committee_id)
         )
 
         self.assertEqual(len(results), 1)

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -31,6 +31,9 @@ class CandidateNameSearch(utils.Resource):
         return {'results': query.all()}
 
 
+# search committee full text name
+# model class: CommitteeSearch
+# use for endpoint:'/names/committees/'
 @doc(
     tags=['search'],
     description=docs.NAME_SEARCH,

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -318,7 +318,7 @@ api.add_resource(
     '/candidate/<string:candidate_id>/committees/',
 )
 api.add_resource(
-    committees.CommitteeHistoryView,
+    committees.CommitteeHistoryProfileView,
     '/committee/<string:committee_id>/history/',
     '/committee/<string:committee_id>/history/<int:cycle>/',
     '/candidate/<string:candidate_id>/committees/history/',
@@ -466,7 +466,7 @@ apidoc.register(candidates.CandidateSearch, blueprint='v1')
 apidoc.register(candidates.CandidateHistoryView, blueprint='v1')
 apidoc.register(committees.CommitteeView, blueprint='v1')
 apidoc.register(committees.CommitteeList, blueprint='v1')
-apidoc.register(committees.CommitteeHistoryView, blueprint='v1')
+apidoc.register(committees.CommitteeHistoryProfileView, blueprint='v1')
 apidoc.register(reports.ReportsView, blueprint='v1')
 apidoc.register(reports.CommitteeReportsView, blueprint='v1')
 apidoc.register(reports.EFilingHouseSenateSummaryView, blueprint='v1')

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -404,6 +404,7 @@ register_schema(CommitteePageSchema)
 # create JFC committee schema
 JFCCommitteeSchema = make_schema(
     models.JFCCommittee,
+    class_name='JFCCommitteeSchema',
     options={'exclude': ('idx', 'committee_id', 'most_recent_filing_flag', )},
 )
 # End create JFC committee schema
@@ -420,6 +421,7 @@ augment_models(
     make_committees_schema,
     models.CommitteeHistory,
     models.CommitteeDetail,
+    models.CommitteeHistoryProfile,
 )
 
 


### PR DESCRIPTION
## Summary (required)
In order to improve the api performance, this PR will 
1)Remove join `JFCCommittee` model from `CommitteeHistory` model that are used by these endpoints:
/schedules/schedule_a/
/schedules/schedule_b/
/schedules/schedule_c/
/schedules/schedule_d/
/schedules/schedule_e/
/schedules/schedule_f/
/schedules/schedule_h4/
/reports/presidential/
/reports/house-senate/
/reports/pac-party/
/filings/
/totals/
....

2)Create new model `CommitteeHistoryProfile` join `JFCCommittee` model that are used by these 4 endpoints: (resource class: CommitteeHistoryProfileView)
/committee/<string:committee_id>/history/
/committee/<string:committee_id>/history/<int:cycle>/
/candidate/<string:candidate_id>/committees/history/
/candidate/<string:candidate_id>/committees/history/<int:cycle>/

- Resolves [https://github.com/fecgov/openFEC/issues/5270](https://github.com/fecgov/openFEC/issues/5270)
- partial of #5267

3)Reference Google Drive doc: [Endpoint Information](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=700639845)
[Committee Model & endpoints relation](https://docs.google.com/drawings/d/1KEBYJiscDxoLQbwqKCMV89KNII-9itUuF1poMNnRDZ8/edit)


### Required reviewers
2 developers
John is must on front-end.

## Impacted areas of the application
<img width="642" alt="committee_model_relation" src="https://user-images.githubusercontent.com/24395751/200075087-42613f8e-5d44-48ba-a61d-3d97b87bcd63.png">


General components of the application that this PR will affect:
Most of endpoints except endpoints under tags: audit, legal, dates, presidential and filer resources.

## Related PRs [https://github.com/fecgov/openFEC/pull/5167](https://github.com/fecgov/openFEC/pull/5167)

## How to test
1)checkout branch
2)pytest
3)test endpoints on local or dev space and compare with prod api.
http://127.0.0.1:5000/v1/
https://fec-dev-api.app.cloud.gov/v1/
https://api.open.fec.gov/v1/

4)sample urls (committee object without join JFCcommittee)
**/schedules/schedule_a/**
(search `contributor` and `committee`, you will see two sub-object)
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2022&sort_hide_null=false&sort_null_only=false&sort=-contribution_receipt_date&per_page=20&committee_id=C00750166

https://api.open.fec.gov/v1/schedules/schedule_a/?two_year_transaction_period=2022&sort_hide_null=false&sort_null_only=false&sort=-contribution_receipt_date&per_page=20&committee_id=C00750166&api_key=DEMO_KEY
(jfc_committee sub-object inside `contributor` and `committee`)

**/schedules/schedule_b/**
(search `recipient_committee` and `committee`, you will see two sub-object)

https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_b/?two_year_transaction_period=2022&committee_id=C00750166&sort_null_only=false&sort=-disbursement_date&sort_hide_null=false&per_page=20

http://127.0.0.1:5000/v1/schedules/schedule_b/?two_year_transaction_period=2022&committee_id=C00750166&sort_null_only=false&sort=-disbursement_date&sort_hide_null=false&per_page=20

https://api.open.fec.gov/v1/schedules/schedule_b/?two_year_transaction_period=2022&committee_id=C00750166&sort_null_only=false&sort=-disbursement_date&sort_hide_null=false&per_page=20&api_key=DEMO_KEY
(jfc_committee sub-object inside `recipient_committee` and `committee`)

**/schedules/schedule_c/**
http://127.0.0.1:5000/v1/schedules/schedule_c/?sort_nulls_last=true&page=1&sort_null_only=false&sort_hide_null=false&sort=-incurred_date&per_page=20

https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_c/?sort_nulls_last=true&page=1&sort_null_only=false&sort_hide_null=false&sort=-incurred_date&per_page=20

https://api.open.fec.gov/v1/schedules/schedule_c/?sort_nulls_last=true&page=1&sort_null_only=false&sort_hide_null=false&sort=-incurred_date&per_page=20&api_key=DEMO_KEY

**/schedules/schedule_d/**
http://127.0.0.1:5000/v1/schedules/schedule_d/?sort_nulls_last=false&page=1&sort_null_only=false&sort=load_date&sort_hide_null=false&per_page=20

https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_d/?sort_nulls_last=false&page=1&sort_null_only=false&sort=load_date&sort_hide_null=false&per_page=20

https://api.open.fec.gov/v1/schedules/schedule_d/?sort_nulls_last=false&page=1&sort_null_only=false&sort=load_date&sort_hide_null=false&per_page=20&api_key=DEMO_KEY

**/schedules/schedule_e/**
http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_nulls_last=false&most_recent=true&committee_id=C00331454&sort_null_only=false&sort=-expenditure_date&sort_hide_null=false&per_page=20

https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_e/?sort_nulls_last=false&most_recent=true&committee_id=C00331454&sort_null_only=false&sort=-expenditure_date&sort_hide_null=false&per_page=20

https://api.open.fec.gov/v1/schedules/schedule_e/?sort_nulls_last=false&most_recent=true&committee_id=C00331454&sort_null_only=false&sort=-expenditure_date&sort_hide_null=false&per_page=20&api_key=DEMO_KEY

**/schedules/schedule_f/**
http://127.0.0.1:5000/v1/schedules/schedule_f/?sort_nulls_last=false&sort_null_only=false&page=1&per_page=20&sort_hide_null=false&sort=expenditure_date

https://fec-dev-api.app.cloud.gov/v1/schedules/schedule_f/?sort_nulls_last=false&sort_null_only=false&page=1&per_page=20&sort_hide_null=false&sort=expenditure_date

https://api.open.fec.gov/v1/schedules/schedule_f/?sort_nulls_last=false&sort_null_only=false&page=1&per_page=20&sort_hide_null=false&sort=expenditure_date&api_key=DEMO_KEY

**/schedules/schedule_h4/**


**/reports/:**
http://127.0.0.1:5000/v1/reports/pac-party/?per_page=20&committee_id=C00750166&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-coverage_end_date&page=1

http://127.0.0.1:5000/v1/reports/house-senate/?per_page=20&committee_id=C00715722&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-coverage_end_date&page=1

http://127.0.0.1:5000/v1/reports/presidential/?per_page=20&committee_id=C00703975&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-coverage_end_date&page=1

(exclude `committee` object output, but still join JFCCommittee)
https://api.open.fec.gov/v1/reports/pac-party/?per_page=20&committee_id=C00750166&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-coverage_end_date&page=1&api_key=DEMO_KEY


**/filings/**
http://127.0.0.1:5000/v1/filings/?per_page=20&committee_id=C00750166&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-receipt_date&page=1

http://127.0.0.1:5000/v1/committee/C00750166/filings/?per_page=20&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&sort=-receipt_date&page=1

**Aggregates**
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?per_page=20&sort_null_only=false&committee_id=C00750166&sort_nulls_last=false&sort_hide_null=false&page=1

http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?per_page=20&sort_null_only=false&committee_id=C00750166&sort_nulls_last=false&sort_hide_null=false&page=1

**Totals**
http://127.0.0.1:5000/v1/totals/pac-party/?sort_null_only=false&sort_nulls_last=false&per_page=20&committee_id=C00750166&sort=-cycle&sort_hide_null=false&page=1

http://127.0.0.1:5000/v1/committee/C00750166/totals/?sort=-cycle&per_page=20&sort_nulls_last=false&page=1&sort_null_only=false&sort_hide_null=false



The following 4 endpoints should join JFCCommittee and return jfc_committee object.
**/committee/<string:committee_id>/history/**
(return 10 rows in jfc_committee)
http://127.0.0.1:5000/v1/committee/C00750166/history/?sort_null_only=false&per_page=20&sort=-cycle&sort_nulls_last=false&election_full=true&sort_hide_null=false&page=1

(return empty[ ],  has 8 rows in fec_form_1s_vw and join_cmte_id = null)
http://127.0.0.1:5000/v1/committee/C00433615/history/?sort_null_only=false&per_page=20&sort=-cycle&sort_nulls_last=false&election_full=true&sort_hide_null=false&page=1

(on prod, return 8 empty{null } )
https://api.open.fec.gov/v1/committee/C00433615/history/?sort_null_only=false&per_page=20&sort=-cycle&sort_nulls_last=false&election_full=true&sort_hide_null=false&page=1&api_key=DEMO_KEY

(return empty[ ], no record in fec_form_1s_vw)
http://127.0.0.1:5000/v1/committee/C00827659/history/?sort_null_only=false&per_page=20&sort=-cycle&sort_nulls_last=false&election_full=true&sort_hide_null=false&page=1

**/committee/<string:committee_id>/history/<int:cycle>/**
https://fec-dev-api.app.cloud.gov/v1/committee/C00750166/history/2022/?sort_nulls_last=false&page=1&election_full=true&sort_hide_null=false&sort=-cycle&sort_null_only=false&per_page=20

**/candidate/<string:candidate_id>/committees/history/**
https://fec-dev-api.app.cloud.gov/v1/candidate/H2IL20042/committees/history/?sort_nulls_last=false&page=1&election_full=true&sort_hide_null=false&sort=-cycle&sort_null_only=false&per_page=20

**/candidate/<string:candidate_id>/committees/history/<int:cycle>/**
https://fec-dev-api.app.cloud.gov/v1/candidate/H2IL20042/committees/history/2020/?sort_nulls_last=false&page=1&election_full=true&sort_hide_null=false&sort=-cycle&sort_null_only=false&per_page=20
