### PR TITLE
5266 & 5262 Upgrade flyway 9.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.2.0/flyway-commandline-9.2.0-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-9.2.0:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.7.0/flyway-commandline-9.7.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-9.7.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 9.2.0 ([download](https://flywaydb.org/documentation/usage/commandline/))
-		* After downloading, open `flyway-9.2.0/conf/flyway.conf` and set
+    * Flyway 9.7.0 ([download](https://flywaydb.org/documentation/usage/commandline/))
+		* After downloading, open `flyway-9.7.0/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -698,9 +698,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.2.0.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.2.0-macosx-x64.tar.gz`, `flyway-commandline-9.2.0-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.7.0.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.7.0-macosx-x64.tar.gz`, `flyway-commandline-9.7.0-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.2.0` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.7.0` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.2.0"
-    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.2.0") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.7.0"
+    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.7.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-9.2.0.jar:app/gradle/lib/flyway-core-9.2.0.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-9.7.0.jar:app/gradle/lib/flyway-core-9.7.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5266 
- Resolves #5262

Upgrades flyway to most recent version. (Does not remove final DOS moderate vulnerability)

### Required reviewers

1-2 devs

## Impacted areas of the application

-  DB migrations

## Screenshots
Before:
<img width="1385" alt="Screen Shot 2022-11-04 at 2 42 04 PM" src="https://user-images.githubusercontent.com/66386084/200051421-7e0fe4ee-93d4-4b71-b6fe-ed12c3238fe9.png">


After:
![image](https://user-images.githubusercontent.com/66386084/200049689-e3e05982-ca28-40b7-a8c8-935f3007b1cf.png)


## How to test
- checkout and pull the latest `develop` branch
- run `snyk test --all-projects`. Shows vulnerability. 
- `gh pr checkout 5276`
- upgrade flyway however you prefer (I use `brew upgrade flyway`)
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `snyk test --all-projects`.  One vulnerability left (jackson.build)
- `dropdb cfdm_test`
- `createdb cfdm_test`
- run `invoke create_sample_db`. All 256 migrations should run OK against `cfdm_test` db 
- run `pytest`
- `flask run`
