### PR TITLE
Adjust API memory for all environments to 2G

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 1G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 10
-    memory: 2.5G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -2,7 +2,7 @@
 applications:
   - name: api
     instances: 1
-    memory: 1G
+    memory: 2G
     disk_quota: 1G
     stack: cflinuxfs3
     buildpacks:


### PR DESCRIPTION
## Summary

Our memory usage has decreased significantly to about 1.5GB. We can now adjust to 2GB for all environments.

### Required reviewers

1 backend developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  API app