### PR TITLE
5295-upgrade flyway to 9.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.7.0/flyway-commandline-9.7.0-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-9.7.0:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.10.1/flyway-commandline-9.10.1-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-9.10.1:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ We are always trying to improve our documentation. If you have suggestions or ru
          * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-    * Flyway 9.7.0 ([download](https://flywaydb.org/documentation/usage/commandline/))
-		* After downloading, open `flyway-9.7.0/conf/flyway.conf` and set
+    * Flyway 9.10.1 ([download](https://flywaydb.org/documentation/usage/commandline/))
+		* After downloading, open `flyway-9.10.1/conf/flyway.conf` and set
            the flyway environment variables `flyway.url` and
            `flyway.locations` as
 
@@ -698,9 +698,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 #### Installing `flyway`
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.7.0.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.7.0-macosx-x64.tar.gz`, `flyway-commandline-9.7.0-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.10.1.tar.gz` from [Flyway downloads](https://flywaydb.org/getstarted/download). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.10.1-macosx-x64.tar.gz`, `flyway-commandline-9.10.1-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.7.0` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.10.1` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 All database schema modification code is checked into version control in the directory `data/migrations` in the form of SQL files that follow a strict naming convention - `V<version_number>__<descriptive_name>.sql`. `flyway` also maintains a table in the target database called `flyway_schema_history` which tracks the migration versions that have already been applied.

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.7.0"
-    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.7.0") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.10.1"
+    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.10.1") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
   command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
   path: build/distributions/flyway.zip
   env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-9.7.0.jar:app/gradle/lib/flyway-core-9.7.0.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-9.10.1.jar:app/gradle/lib/flyway-core-9.10.1.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
   services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #5295 
Upgrades flyway to most recent version, removes all the vulnerabilities found in the CLI, might not remove netty

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  local migrations

## Screenshots
Before:
<img width="885" alt="Screen Shot 2022-12-16 at 5 58 39 PM" src="https://user-images.githubusercontent.com/66386084/208202307-8254c377-8b8f-4a3d-a9d2-7511e9f1f0ae.png">



After:
<img width="880" alt="Screen Shot 2022-12-16 at 5 55 52 PM" src="https://user-images.githubusercontent.com/66386084/208202049-73a71817-04cb-46f8-8f8f-40c4f68ac2a9.png">


## How to test
- checkout and pull the latest `develop` branch
- run `snyk test --all-projects`. Shows vulnerability. 
- `gh pr checkout 5301`
- upgrade flyway however you prefer (I use `brew upgrade flyway`) (make sure to re-set your flyway.url and flyway.locations in the conf file)
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `snyk test --all-projects`
- `dropdb cfdm_test`
- `createdb cfdm_test`
- run `invoke create_sample_db`. All 256 migrations should run OK against `cfdm_test` db 
- run `pytest`
- `flask run`

NOTE: THE CLI does not find the most recent high security vulnerability for me. I upgraded to the most recent version and it's still not showing up. I decided it would be still valuable to remove the current vulnerability and upgrade to the most recent version, but we may need to wait until the next version is released for the netty vulnerability to be addressed. 


Also if you're doing the brew method flyway is located in the Cellar  /usr/local/Cellar/flyway