### PR TITLE
5294 -upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.4.1
 gevent==21.12.0
 gunicorn==19.10.0
-GitPython==3.1.27
+GitPython==3.1.30
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary (required)

- Resolves #5294 
GitPython is in maintenance mode. I did some research and as we use Gitpython for our automated releases it will be challenging to switch over to Pygit2 or Dulwich, but we will probably need to do it in the future. Currently, GitPython is most widely used and have releases/patches pretty fast. 

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  Interaction with git libraries, automated release process

## Screenshots
Before:
<img width="886" alt="Screen Shot 2023-01-03 at 8 47 56 AM" src="https://user-images.githubusercontent.com/66386084/210380496-2a7a1ca8-7bca-442b-8109-f2430ff481f1.png">

After:
<img width="886" alt="Screen Shot 2023-01-03 at 8 50 26 AM" src="https://user-images.githubusercontent.com/66386084/210380980-011b1925-520d-4c04-b14c-99f9953860ca.png">

## How to test
- checkout and pull the latest `develop` branch
- run `snyk test --all-projects`. Shows vulnerability. 
- `gh pr checkout 5309`
- 'pyenv virtualenv 3.9.14 api'
- 'pyenv activate api'
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `snyk test --all-projects`
- run `pytest`
- `flask run`