### PR TITLE
[MERGE WITH GITFLOW] Release/public 20230110

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.4.1
 gevent==21.12.0
 gunicorn==19.10.0
-GitPython==3.1.27
+GitPython==3.1.30
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
This is for the sprint (20.2) release.
@fec-jli  will deploy this 1/10