### PR TITLE
5286-Unpin setuptools, upgrade certifi and deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 apispec==0.39.0
-certifi==2020.11.8
+certifi==2022.12.7
 cfenv==0.5.2
 defusedxml==0.6.0
 elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
 Flask==2.1.2
-Flask-Cors==3.0.9
+Flask-Cors==3.0.10
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.4.1
-gevent==21.12.0
+gevent==22.10.2
 gunicorn==19.10.0
 GitPython==3.1.30
 icalendar==4.0.2
@@ -21,7 +21,6 @@ python-dateutil==2.8.1
 python-dotenv>=0.20.0 # Sets variable defaults in .flaskenv file
 requests==2.25.1
 requests-aws4auth==1.0
-setuptools==65.1.1 # Pinned to fix the deploy errors caused by the latest setuptool version 65.3.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported


### PR DESCRIPTION
## Summary

- Resolves #5286 
- Resolves #5298 

Removes two snyk vulnerabilities by un-pinning setuptools and upgrading gevent. 

Locust (formerly locustio) needs to be upgraded with gevent and certifi. I added a ticket for this change (two major versions + a lot of syntax changes) 

### Required reviewers
1-2 devs

## Impacted areas of the application
-  Gevent library

## Screenshots

Before:
![Screen Shot 2023-01-11 at 6 34 49 PM](https://user-images.githubusercontent.com/66386084/211940797-3aa61bea-e3fc-430f-bfd5-77384b1ad349.png)


After:
![Screen Shot 2023-01-11 at 6 11 57 PM](https://user-images.githubusercontent.com/66386084/211938034-fe50dcd2-607f-4423-ba75-50bf4568e3dd.png)


## Related PRs

Related PRs against other branches:


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- checkout and pull the latest `develop` branch
- run `snyk test --all-projects`. Shows vulnerability. 
- `gh pr checkout 5320`
- 'pyenv virtualenv 3.9.16 api'
- 'pyenv activate api'
- run `pip install -r requirements.txt` 
- run `snyk test --all-projects`
- run `pytest`
- `flask run`
