### PR TITLE
setup pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: [--line-length=120]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,9 @@ git+https://github.com/18F/rdbms-subsetter
 # Testing
 pdbpp==0.9.1
 click==8.1.3
+pre-commit==2.21.0 #client-side hook triggered by operations like git commit
 
 # requirements.txt generation (pip-compile)
 pip-tools==4.2.0
 #locust
 locustio==0.14.6 #upgrade locustio to python 3.8 compatible version
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,11 +46,9 @@ redis==4.2.2
 # testing and build in circle
 codecov==2.1.7
 factory_boy==2.8.1
-flake8==4.0.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
 nplusone==0.8.0
 pytest==5.2.0
 pytest-cov==2.5.1
-pytest-flake8==1.0.6
 webtest==2.0.34

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
 [tool:pytest]
-addopts=--cov webservices --cov-report term-missing --flake8
+addopts=--cov webservices --cov-report term-missing
 testpaths=tests
-
-[flake8]
-ignore = E127,E128,W503
-max-line-length = 120


### PR DESCRIPTION
## Summary (required)

 pre-commit hook is run first, before you even type in a commit message. 
-  inspect the snapshot that's about to be committed
-  to make sure tests run
-  inspect in the code

- Resolves #5217 

pre-commit scripts run automatically every time a file is changes event occurs in a Git repository

### Required reviewers

2 or more developers

## How to test

- checkout branch: `git checkout feature/5217-setup-precommit-hook`
- create new python virtualenv: `pyenv virtualenv 3.9.14 venv-api`
- install requirements and requirements-dev : `pip install -r requirements.txt` ; `pip install -r requirements-dev.txt`
- run: `pre-commit install`
- update a python file (ex:remove new line at the end of the file)
- stage the changes: `git add -p`
- commit changes:  `git commit` (this is when pre-commit hook will flag changes made to python file and prevent from committing the changes to the branch)
- fix the syntax, stage the file and commit the changes.
