### PR TITLE
Remove union all in schedule A, B and E endpoints

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -86,9 +86,6 @@ class ScheduleAView(ItemizedResource):
         'contributor_employer',
         'contributor_occupation',
     ]
-    union_all_fields = [
-        'committee_id',
-    ]
     secondary_index_options = [
         'committee_id',
         'contributor_id',

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -64,9 +64,6 @@ class ScheduleBView(ItemizedResource):
         'recipient_name',
         'recipient_city',
     ]
-    union_all_fields = [
-        'committee_id',
-    ]
     use_pk_for_count = True
     query_options = [
         sa.orm.joinedload(models.ScheduleB.committee),

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -69,9 +69,6 @@ class ScheduleEView(ItemizedResource):
         'committee_id',
         'candidate_id',
     ]
-    union_all_fields = [
-        'committee_id'
-    ]
     use_pk_for_count = True
     query_options = [
         sa.orm.joinedload(models.ScheduleE.candidate),


### PR DESCRIPTION
## Summary (required)

- Resolves #5198 

In this PR, union all mechanism that was added to schedules endpoint are removed.  This change fixes the exclude issue. 

Locust testing was conducted to test the performance. Locust testing was applied same endpoints by comparing before vs after.   Test results shows there is no decreasing performance before and after change. Test result is here:
[Locust test result](https://docs.google.com/spreadsheets/d/1Od3u4iqRp5Y4MGNwf9AyDtJb7-vGNvksIkC8tYSJ9C8/edit#gid=1699862915)

<img width="500" alt="Screen Shot 2023-01-17 at 9 52 49 AM" src="https://user-images.githubusercontent.com/24396726/212931155-71ee9e3c-9676-4eca-954d-f4554a9284e3.png">
### Required reviewers
1 -2 developers

## Impacted areas of the application
/schedules​/schedule_a​/
/schedules​/schedule_b​/
/schedules​/schedule_e​/

## How to test
- Download feature branch
- Run `pytest`
- Start api on local, and run these apis

Data example for testing.  This individual has 18 contributions to 9 committees in 2018.  Here is the list of each committee and the counts of contribution to the committee. 
"C00075820":	1
"C00126789":	1
"C00215905":	1
"C00330894":	2
"C00333427":        2
"C00401224":	7
"C00446906":	1
"C00545947":	2
"C00548180":	1

Test endpoint by excluding "committee_id=-C00446906&committee_id=-C00401224".  **10 rows are expected.**
**Before the change, endpoint returns 28 rows**
https://api.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_name=sohn+richard&two_year_transaction_period=2018&sort=-contribution_receipt_date&per_page=30&is_individual=true&committee_id=-C00446906&committee_id=-C00401224

**After change**. --- 10 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&sort_hide_null=false&sort_nulls_last=false&contributor_name=sohn+richard&two_year_transaction_period=2018&sort=-contribution_receipt_date&per_page=30&is_individual=true&committee_id=-C00446906&committee_id=-C00401224


Schedule B:
Same results returned after taking out union all, 36 rows
https://api.open.fec.gov/v1/schedules/schedule_b/?sort_null_only=false&api_key=DEMO_KEY&two_year_transaction_period=2022&per_page=20&sort=-disbursement_date&sort_hide_null=false&committee_id=C00582858&committee_id=C00808030

http://127.0.0.1:5000/v1/schedules/schedule_b/?sort_null_only=false&two_year_transaction_period=2022&per_page=20&sort=-disbursement_date&sort_hide_null=false&committee_id=C00582858&committee_id=C00808030

Schedule E:
Same results returned after taking out union all, 140 rows
https://api.open.fec.gov/v1/schedules/schedule_e/?api_key=DEMO_KEY&sort_null_only=false&per_page=20&sort_nulls_last=false&sort=-expenditure_date&sort_hide_null=false&committee_id=C00658815&committee_id=C00010363

http://127.0.0.1:5000/v1/schedules/schedule_e/?sort_null_only=false&per_page=20&sort_nulls_last=false&sort=-expenditure_date&sort_hide_null=false&committee_id=C00658815&committee_id=C00010363