### PR TITLE
Feature/4718 replace http with https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ static/swagger-ui/js
 
 # Pytest cache
 .pytest_cache/
+
+# Pycharm
+.idea

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
     * The latest long term support (LTS) or stable release of Node.js (which includes npm)
     * PostgreSQL (the latest 10 release).
          * Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
-         * Read a [Windows tutorial](http://www.postgresqltutorial.com/install-postgresql/)
+         * Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
          * Read a [Linux tutorial](https://www.postgresql.org/docs/9.4/static/installation.html) (or follow your OS package manager)
     * Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
     * Flyway 9.10.1 ([download](https://flywaydb.org/documentation/usage/commandline/))
@@ -228,7 +228,7 @@ Navigate to the installation folder (eg., `elasticsearch-7.4`) and run:
 3. View your local version of the site at [http://localhost:5000](http://localhost:5000).
 
 #### Task queue
-We use [Celery](http://www.celeryproject.org/) to schedule periodic tasks— for example, refreshing materialized views and updating incremental aggregates. We use [Redis](https://redis.io/) as the Celery message broker.
+We use [Celery](https://www.celeryproject.org/) to schedule periodic tasks— for example, refreshing materialized views and updating incremental aggregates. We use [Redis](https://redis.io/) as the Celery message broker.
 
 To work with Celery and Redis locally, install Redis and start a Redis server. By default,
 we connect to Redis at `redis://localhost:6379`; if Redis is running at a different URL,
@@ -335,7 +335,7 @@ To deploy to Cloud Foundry, run:
 invoke deploy
 ```
 
-[Learn more about Invoke](http://www.pyinvoke.org/).
+[Learn more about Invoke](https://www.pyinvoke.org/).
 
 The `deploy` task will detect the appropriate Cloud Foundry space based the current branch. You can override this with the optional `--space` flag. For example:
 

--- a/data/notes.md
+++ b/data/notes.md
@@ -3,14 +3,14 @@
 * Zip codes to congressional districts
     * data/natl_zccd_delim.csv
     * https://www2.census.gov/geo/relfiles/cdsld13/natl/natl_zccd_delim.txt
-    * DC https://www.zipcodesdirectory.com/zip-codes/washington-dc.php
-    * Puerto Rico https://www.topuertorico.org/reference/zipcodes.shtml
-    * Guam https://www.zipcodelist.org/home/guam-zip-code-list
-    * American Samoa https://www.zipcodelist.org/home/american-samoa-zip-code-list
+    * DC https://www.unitedstateszipcodes.org/dc/
+    * Puerto Rico https://welcome.topuertorico.org/reference/zipcodes.shtml
+    * Guam https://www.zip-codes.com/state/gu.asp
+    * American Samoa https://www.zip-codes.com/state/as.asp
 
 * FIPS state codes
     * data/fips_stats.csv
-    * https://www.census.gov/geo/reference/ansi_statetables.html
+    * https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html
     * Added Guam and American Samoa to enable results
 
 * Election years and Senate classes

--- a/data/notes.md
+++ b/data/notes.md
@@ -2,11 +2,11 @@
 
 * Zip codes to congressional districts
     * data/natl_zccd_delim.csv
-    * http://www2.census.gov/geo/relfiles/cdsld13/natl/natl_zccd_delim.txt
-    * DC http://www.zipcodesdirectory.com/zip-codes/washington-dc.php
-    * Puerto Rico http://www.topuertorico.org/reference/zipcodes.shtml
-    * Guam http://www.zipcodelist.org/home/guam-zip-code-list
-    * American Samoa http://www.zipcodelist.org/home/american-samoa-zip-code-list
+    * https://www2.census.gov/geo/relfiles/cdsld13/natl/natl_zccd_delim.txt
+    * DC https://www.zipcodesdirectory.com/zip-codes/washington-dc.php
+    * Puerto Rico https://www.topuertorico.org/reference/zipcodes.shtml
+    * Guam https://www.zipcodelist.org/home/guam-zip-code-list
+    * American Samoa https://www.zipcodelist.org/home/american-samoa-zip-code-list
 
 * FIPS state codes
     * data/fips_stats.csv

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -38,8 +38,7 @@ const Footer = () => (
         </ul>
 
         <p>
-          1050 First Street, NE
-          <br /> Washington, DC 20463
+          1050 First Street, NE<br /> Washington, DC 20463
         </p>
 
         <a href="mailto:apiinfo@fec.gov">

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -38,7 +38,8 @@ const Footer = () => (
         </ul>
 
         <p>
-          1050 First Street, NE<br /> Washington, DC 20463
+          1050 First Street, NE
+          <br /> Washington, DC 20463
         </p>
 
         <a href="mailto:apiinfo@fec.gov">

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -6,7 +6,6 @@ from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
 from webservices import exceptions
 
-
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
 
@@ -173,11 +172,11 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     @property
     def pdf_url(self):
         image_number = str(self.beginning_image_number)
-        return 'https://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(image_number[-3:], image_number)
+        return utils.DOCQUERY_URL + '/pdf/{0}/{1}/{1}.pdf'.format(image_number[-3:], image_number)
 
     @property
     def html_url(self):
-        return 'https://docquery.fec.gov/cgi-bin/forms/{0}/{1}/'.format(self.committee_id, self.file_number)
+        return utils.DOCQUERY_URL + '/cgi-bin/forms/{0}/{1}/'.format(self.committee_id, self.file_number)
 
 
 # TODO: add index on committee id and filed_date

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -126,8 +126,8 @@ stays the same. If the same person runs for multiple offices — for example, a 
 candidate runs for a Senate office — that candidate will get a unique ID for each office.
 
 The candidate endpoints primarily use data from FEC registration
-[Form 1](http://www.fec.gov/pdf/forms/fecfrm1.pdf) for committee information and
-[Form 2](http://www.fec.gov/pdf/forms/fecfrm2.pdf) for candidate information.
+[Form 1](https://www.fec.gov/pdf/forms/fecfrm1.pdf) for committee information and
+[Form 2](https://www.fec.gov/pdf/forms/fecfrm2.pdf) for candidate information.
 '''
 
 CANDIDATE_DETAIL = '''
@@ -702,11 +702,11 @@ also incorporate any changes made by committees, if any report covering the peri
 Information is made available on the API as soon as it's processed. Keep in mind, complex
 paper filings take longer to process.
 
-The financial endpoints use data from FEC [form 5](http://www.fec.gov/pdf/forms/fecfrm5.pdf),
+The financial endpoints use data from FEC [form 5](https://www.fec.gov/pdf/forms/fecfrm5.pdf),
 for independent expenditors; or the summary and detailed summary pages of the FEC
-[Form 3](http://www.fec.gov/pdf/forms/fecfrm3.pdf), for House and Senate committees;
-[Form 3X](http://www.fec.gov/pdf/forms/fecfrm3x.pdf), for PACs and parties;
-and [Form 3P](http://www.fec.gov/pdf/forms/fecfrm3p.pdf), for presidential committees.
+[Form 3](https://www.fec.gov/pdf/forms/fecfrm3.pdf), for House and Senate committees;
+[Form 3X](https://www.fec.gov/pdf/forms/fecfrm3x.pdf), for PACs and parties;
+and [Form 3P](https://www.fec.gov/pdf/forms/fecfrm3p.pdf), for presidential committees.
 '''
 
 WIP_TAG = '''
@@ -1278,7 +1278,7 @@ The maximum date the report is due.(MM/DD/YYYY or YYYY-MM-DD)
 
 COMMUNICATION_TAG = '''
 Reports of communication costs by corporations and membership organizations
-from the FEC [F7 forms](http://www.fec.gov/pdf/forms/fecform7.pdf).
+from the FEC [F7 forms](https://www.fec.gov/pdf/forms/fecform7.pdf).
 '''
 ELECTIONEERING = '''
 An electioneering communication is any broadcast, cable or satellite communication that fulfills \

--- a/webservices/legal_docs/statutes.py
+++ b/webservices/legal_docs/statutes.py
@@ -38,7 +38,7 @@ def get_title_52_statutes():
         "https://uscode.house.gov/download/"
         "releasepoints/us/pl/114/219/xml_usc52@114-219.zip"
     )
-    tag_name = "{{https://xml.house.gov/schemas/uslm/1.0}}{0}"
+    tag_name = "{{http://xml.house.gov/schemas/uslm/1.0}}{0}"
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format("subtitle")):
         if subtitle.attrib["identifier"] == "/us/usc/t52/stIII":
@@ -85,7 +85,7 @@ def get_title_26_statutes():
         "https://uscode.house.gov/download/"
         "releasepoints/us/pl/114/219/xml_usc26@114-219.zip"
     )
-    tag_name = "{{https://xml.house.gov/schemas/uslm/1.0}}{0}"
+    tag_name = "{{http://xml.house.gov/schemas/uslm/1.0}}{0}"
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format("subtitle")):
         if subtitle.attrib["identifier"] == "/us/usc/t26/stH":

--- a/webservices/legal_docs/statutes.py
+++ b/webservices/legal_docs/statutes.py
@@ -35,10 +35,10 @@ def get_title_52_statutes():
 
     # TO DO: check if DOCS_ALIAS exist before uploading.
     title_parsed = get_xml_tree_from_url(
-        "http://uscode.house.gov/download/"
+        "https://uscode.house.gov/download/"
         "releasepoints/us/pl/114/219/xml_usc52@114-219.zip"
     )
-    tag_name = "{{http://xml.house.gov/schemas/uslm/1.0}}{0}"
+    tag_name = "{{https://xml.house.gov/schemas/uslm/1.0}}{0}"
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format("subtitle")):
         if subtitle.attrib["identifier"] == "/us/usc/t52/stIII":
@@ -82,10 +82,10 @@ def get_title_26_statutes():
 
     # TO DO: check if DOCS_ALIAS exist before uploading.
     title_parsed = get_xml_tree_from_url(
-        "http://uscode.house.gov/download/"
+        "https://uscode.house.gov/download/"
         "releasepoints/us/pl/114/219/xml_usc26@114-219.zip"
     )
-    tag_name = "{{http://xml.house.gov/schemas/uslm/1.0}}{0}"
+    tag_name = "{{https://xml.house.gov/schemas/uslm/1.0}}{0}"
     section_count = 0
     for subtitle in title_parsed.iter(tag_name.format("subtitle")):
         if subtitle.attrib["identifier"] == "/us/usc/t26/stH":

--- a/webservices/templates/swagger-ui.html
+++ b/webservices/templates/swagger-ui.html
@@ -127,7 +127,7 @@
       sendWelcomeEmail: true,
     };
   </script>
-  <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
+  <noscript>Please enable JavaScript to signup for an <a href="https://api.data.gov/">api.data.gov</a> API key.</noscript>
 
   <script src="{{ swagger_static('dist/swagger-layout.js') }}"></script>
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 
 use_kwargs = functools.partial(use_kwargs_original, locations=("query",))
 
+DOCQUERY_URL = 'https://docquery.fec.gov'
+
 
 class Resource(six.with_metaclass(MethodResourceMeta, restful.Resource)):
     pass
@@ -47,9 +49,9 @@ API_KEY_ARG = fields.Str(
 if env.get_credential("PRODUCTION"):
     Resource = use_kwargs({"api_key": API_KEY_ARG})(Resource)
 
-fec_url_map = {'9': 'https://docquery.fec.gov/dcdev/posted/{0}.fec'}
+fec_url_map = {'9': DOCQUERY_URL + '/dcdev/posted/{0}.fec'}
 fec_url_map = defaultdict(
-    lambda: 'https://docquery.fec.gov/paper/posted/{0}.fec', fec_url_map
+    lambda: DOCQUERY_URL + '/paper/posted/{0}.fec', fec_url_map
 
 )
 
@@ -393,7 +395,7 @@ def document_description(
 
 def make_report_pdf_url(image_number):
     if image_number:
-        return 'https://docquery.fec.gov/pdf/{0}/{1}/{1}.pdf'.format(
+        return DOCQUERY_URL + '/pdf/{0}/{1}/{1}.pdf'.format(
             str(image_number)[-3:], image_number,
         )
     else:
@@ -402,15 +404,15 @@ def make_report_pdf_url(image_number):
 
 def make_schedule_pdf_url(image_number):
     if image_number:
-        return 'https://docquery.fec.gov/cgi-bin/fecimg/?' + image_number
+        return DOCQUERY_URL + '/cgi-bin/fecimg/?' + image_number
 
 
 def make_csv_url(file_num):
     file_number = str(file_num)
     if file_num > -1 and file_num < 100:
-        return 'https://docquery.fec.gov/csv/000/{0}.csv'.format(file_number)
+        return DOCQUERY_URL + '/csv/000/{0}.csv'.format(file_number)
     elif file_num >= 100:
-        return 'https://docquery.fec.gov/csv/{0}/{1}.csv'.format(
+        return DOCQUERY_URL + '/csv/{0}/{1}.csv'.format(
             file_number[-3:], file_number
         )
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4718 

This PR changes all applicable links from HTTP to HTTPS. It also creates a constant variable for the docquery URL. 

Finally, it adds .idea to the .gitignore file (Comes from using pycharm as your IDE which is my favorite 😀) 
  
### Required reviewers 1 developer 

## Impacted areas of the application

General components of the application that this PR will affect:

-  /data/notes.md
-  /README.md
-  /filings 
- /legal_docs/statutes
- /schedules

## How to test
Before Changes are Applied: 

For changes in statutes.py:
1. Ensure that elastic search is running locally 
2. Run command: `python cli.py load_statutes`
3. Confirm that 57 statute sections are uploaded 
![image](https://user-images.githubusercontent.com/121631201/213787645-dc6482bb-f8dc-4627-9274-17693eb1dc36.png)


After Changes are Applied: 

For changes in README.md: 
1. Click the following links on the readme to ensure they work: 
- Windows tutorial 
- Celery 
- Learn more about Invoke

For changes in data/notes.md:
1. Click all links within notes.md to ensure they work 

Note: Some links were to websites that do not exist anymore, I replaced them with links to a different websites with similar information. 

For changes in utils.py: 
1. Go to the following links and open the html_url, csv_url, fec_url, and pdf_url links to ensure they work

http://127.0.0.1:5000/v1/schedules/schedule_a/efile/?sort=-contribution_receipt_date&page=1&per_page=20&sort_null_only=false&sort_nulls_last=false&sort_hide_null=false

http://127.0.0.1:5000/v1/schedules/schedule_c/?sort=-incurred_date&page=1&per_page=20&sort_null_only=false&sort_nulls_last=true&sort_hide_null=false

http://127.0.0.1:5000/v1/filings/?sort=-receipt_date&page=1&per_page=20&sort_null_only=false&sort_nulls_last=false&sort_hide_null=false

For changes in filings.py: 
1. Go to the following link and open pdf_url and html_url and ensure they work

http://127.0.0.1:5000/v1/efile/filings/

For changes in statutes.py:
1. Ensure that elastic search is running locally 
2. Run command: `python cli.py load_statutes`
3. Confirm that 57 statute sections are still uploaded 
![image](https://user-images.githubusercontent.com/121631201/213787645-dc6482bb-f8dc-4627-9274-17693eb1dc36.png)

For changes to docs.py: 
1. Go to the get candidates search section - http://127.0.0.1:5000/developers/#/candidate/get_candidates_search_ 
2. Click on the link for form 1 and ensure it works 
3. Click on the link for form 2 and ensure it works 
4. Go to the financial section - http://127.0.0.1:5000/developers/#/financial 
5. Click on the link for form 5 and ensure it works 
6. Click on the link for form 3 and ensure it works 
7. Click on the link for form 3X and ensure it works 
8. Click on the link for form 3P and ensure it works 
9. Go to the communication_cost section - http://127.0.0.1:5000/developers/#/communication%20cost 
10. Click on the link for form F7 and ensure it works 

For changes to swagger-ui.html: 
1. Disable Javascript in your browser
 - In firefox type about:config in the address bar and hit enter 
 - Accept the risk and continue 
 - Find javascript.enabled and set it to false by clicking the toggle button
2. Go to the homepage which should have the following message: 
![image](https://user-images.githubusercontent.com/121631201/213794292-1e082be1-5a1f-491c-baf6-971cd63f096e.png)
3. Click the link and ensure that it works 
