### PR TITLE
add state_full to candidates/totals/aggregates endpoint

### DIFF
--- a/data/migrations/V0265__add_state_full_ofec_candidate_totals_mv.sql
+++ b/data/migrations/V0265__add_state_full_ofec_candidate_totals_mv.sql
@@ -1,0 +1,303 @@
+/*
+Issue #5163.
+
+This migration will add state_full as a column
+
+Previous file: V0245__add_state_district_ofec_candidate_totals_mv.sql
+*/
+
+-- ----------------------
+-- ofec_candidate_totals_mv_tmp
+-- ----------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_candidate_totals_mv_tmp AS
+WITH totals AS (
+         SELECT ofec_totals_combined_vw.committee_id,
+            ofec_totals_combined_vw.cycle,
+            ofec_totals_combined_vw.receipts,
+            ofec_totals_combined_vw.disbursements,
+            ofec_totals_combined_vw.last_cash_on_hand_end_period,
+            ofec_totals_combined_vw.last_debts_owed_by_committee,
+            ofec_totals_combined_vw.coverage_start_date,
+            ofec_totals_combined_vw.coverage_end_date,
+            ofec_totals_combined_vw.federal_funds_flag,
+            ofec_totals_combined_vw.individual_itemized_contributions,
+            ofec_totals_combined_vw.transfers_from_other_authorized_committee,
+            ofec_totals_combined_vw.other_political_committee_contributions
+           FROM ofec_totals_combined_vw
+           WHERE form_type in ('F3', 'F3P', 'F3X')
+           AND committee_type in ('H','P','S')
+           AND committee_designation in ('P','A')
+        ), link AS (
+         SELECT ofec_cand_cmte_linkage_vw.cand_id,
+            ofec_cand_cmte_linkage_vw.election_yr_to_be_included + ofec_cand_cmte_linkage_vw.election_yr_to_be_included % 2::numeric AS election_yr_to_be_included,
+            ofec_cand_cmte_linkage_vw.fec_election_yr,
+            ofec_cand_cmte_linkage_vw.cmte_id
+           FROM ofec_cand_cmte_linkage_vw
+          WHERE ofec_cand_cmte_linkage_vw.cmte_dsgn in ('P','A')
+          -- should only include candidate committees
+          AND ofec_cand_cmte_linkage_vw.cmte_tp in ('H','P','S')
+          --
+          GROUP BY ofec_cand_cmte_linkage_vw.cand_id, ofec_cand_cmte_linkage_vw.election_yr_to_be_included, ofec_cand_cmte_linkage_vw.fec_election_yr, ofec_cand_cmte_linkage_vw.cmte_id
+        ), cycle_cmte_totals_basic AS (
+         SELECT link.cand_id,
+            link.cmte_id,
+            link.election_yr_to_be_included,
+            totals_1.cycle,
+            false AS is_election,
+            totals_1.receipts,
+            totals_1.disbursements,
+            first_value(totals_1.last_cash_on_hand_end_period) OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_cash_on_hand_end_period,
+            first_value(totals_1.last_debts_owed_by_committee) OVER (PARTITION BY link.cand_id, link.election_yr_to_be_included, totals_1.cycle, link.cmte_id ORDER BY totals_1.coverage_end_date DESC NULLS LAST) AS last_debts_owed_by_committee,
+            totals_1.coverage_start_date,
+            totals_1.coverage_end_date,
+            totals_1.federal_funds_flag,
+            totals_1.individual_itemized_contributions,
+            totals_1.transfers_from_other_authorized_committee,
+            totals_1.other_political_committee_contributions
+           FROM link
+           -- --
+             JOIN totals totals_1 ON link.cmte_id::text = totals_1.committee_id::text AND link.fec_election_yr = totals_1.cycle::numeric
+        ), cycle_cmte_totals AS (
+         SELECT cycle_cmte_totals_basic.cand_id AS candidate_id,
+            cycle_cmte_totals_basic.cmte_id,
+            cycle_cmte_totals_basic.election_yr_to_be_included AS election_year,
+            cycle_cmte_totals_basic.cycle,
+            sum(cycle_cmte_totals_basic.receipts) AS receipts,
+            sum(cycle_cmte_totals_basic.disbursements) AS disbursements,
+            max(cycle_cmte_totals_basic.last_cash_on_hand_end_period) AS cash_on_hand_end_period_per_cmte,
+            max(cycle_cmte_totals_basic.last_debts_owed_by_committee) AS debts_owed_by_committee_per_cmte,
+            min(cycle_cmte_totals_basic.coverage_start_date) AS coverage_start_date,
+            max(cycle_cmte_totals_basic.coverage_end_date) AS coverage_end_date,
+            array_agg(cycle_cmte_totals_basic.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag,
+            sum(cycle_cmte_totals_basic.individual_itemized_contributions) AS individual_itemized_contributions,
+            sum(cycle_cmte_totals_basic.transfers_from_other_authorized_committee) AS transfers_from_other_authorized_committee,
+            sum(cycle_cmte_totals_basic.other_political_committee_contributions) AS other_political_committee_contributions
+           FROM cycle_cmte_totals_basic
+          GROUP BY cycle_cmte_totals_basic.cand_id, cycle_cmte_totals_basic.election_yr_to_be_included, cycle_cmte_totals_basic.cycle, cycle_cmte_totals_basic.cmte_id
+        ), cycle_totals AS (
+         SELECT cycle_cmte_totals.candidate_id,
+            cycle_cmte_totals.election_year,
+            cycle_cmte_totals.cycle,
+            false AS is_election,
+            sum(cycle_cmte_totals.receipts) AS receipts,
+            sum(cycle_cmte_totals.disbursements) AS disbursements,
+            sum(cycle_cmte_totals.receipts) > 0::numeric AS has_raised_funds,
+            sum(cycle_cmte_totals.cash_on_hand_end_period_per_cmte) AS cash_on_hand_end_period,
+            sum(cycle_cmte_totals.debts_owed_by_committee_per_cmte) AS debts_owed_by_committee,
+            min(cycle_cmte_totals.coverage_start_date) AS coverage_start_date,
+            max(cycle_cmte_totals.coverage_end_date) AS coverage_end_date,
+            array_agg(cycle_cmte_totals.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag,
+            sum(cycle_cmte_totals.individual_itemized_contributions) AS individual_itemized_contributions,
+            sum(cycle_cmte_totals.transfers_from_other_authorized_committee) AS transfers_from_other_authorized_committee,
+            sum(cycle_cmte_totals.other_political_committee_contributions) AS other_political_committee_contributions
+           FROM cycle_cmte_totals
+          GROUP BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cycle
+        ), election_cmte_totals_basic AS (
+         SELECT cycle_cmte_totals.candidate_id,
+            cycle_cmte_totals.cmte_id,
+            cycle_cmte_totals.cycle,
+            cycle_cmte_totals.election_year,
+            cycle_cmte_totals.receipts,
+            cycle_cmte_totals.disbursements,
+            first_value(cycle_cmte_totals.cash_on_hand_end_period_per_cmte) OVER (PARTITION BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cmte_id ORDER BY cycle_cmte_totals.cycle DESC NULLS LAST) AS last_cash_on_hand_end_period,
+            first_value(cycle_cmte_totals.debts_owed_by_committee_per_cmte) OVER (PARTITION BY cycle_cmte_totals.candidate_id, cycle_cmte_totals.election_year, cycle_cmte_totals.cmte_id ORDER BY cycle_cmte_totals.cycle DESC NULLS LAST) AS last_debts_owed_by_committee,
+            cycle_cmte_totals.coverage_start_date,
+            cycle_cmte_totals.coverage_end_date,
+            cycle_cmte_totals.federal_funds_flag,
+            cycle_cmte_totals.individual_itemized_contributions,
+            cycle_cmte_totals.transfers_from_other_authorized_committee,
+            cycle_cmte_totals.other_political_committee_contributions
+           FROM cycle_cmte_totals
+        ), election_cmte_totals AS (
+         SELECT election_cmte_totals_basic.candidate_id,
+            election_cmte_totals_basic.cmte_id,
+            election_cmte_totals_basic.election_year,
+            sum(election_cmte_totals_basic.receipts) AS receipts,
+            sum(election_cmte_totals_basic.disbursements) AS disbursements,
+            max(election_cmte_totals_basic.last_cash_on_hand_end_period) AS last_cash_on_hand_end_period,
+            max(election_cmte_totals_basic.last_debts_owed_by_committee) AS last_debts_owed_by_committee,
+            min(election_cmte_totals_basic.coverage_start_date) AS coverage_start_date,
+            max(election_cmte_totals_basic.coverage_end_date) AS coverage_end_date,
+            array_agg(election_cmte_totals_basic.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag,
+            sum(election_cmte_totals_basic.individual_itemized_contributions) AS individual_itemized_contributions,
+            sum(election_cmte_totals_basic.transfers_from_other_authorized_committee) AS transfers_from_other_authorized_committee,
+            sum(election_cmte_totals_basic.other_political_committee_contributions) AS other_political_committee_contributions
+           FROM election_cmte_totals_basic
+          GROUP BY election_cmte_totals_basic.candidate_id, election_cmte_totals_basic.election_year, election_cmte_totals_basic.cmte_id
+        ), combined_totals AS (
+         SELECT election_cmte_totals.candidate_id,
+            election_cmte_totals.election_year,
+            election_cmte_totals.election_year AS cycle,
+            true AS is_election,
+            sum(election_cmte_totals.receipts) AS receipts,
+            sum(election_cmte_totals.disbursements) AS disbursements,
+            sum(election_cmte_totals.receipts) > 0::numeric AS has_raised_funds,
+            sum(election_cmte_totals.last_cash_on_hand_end_period) AS cash_on_hand_end_period,
+            sum(election_cmte_totals.last_debts_owed_by_committee) AS debts_owed_by_committee,
+            min(election_cmte_totals.coverage_start_date) AS coverage_start_date,
+            max(election_cmte_totals.coverage_end_date) AS coverage_end_date,
+            array_agg(election_cmte_totals.federal_funds_flag) @> ARRAY[true] AS federal_funds_flag,
+            sum(election_cmte_totals.individual_itemized_contributions) AS individual_itemized_contributions,
+            sum(election_cmte_totals.transfers_from_other_authorized_committee) AS transfers_from_other_authorized_committee,
+            sum(election_cmte_totals.other_political_committee_contributions) AS other_political_committee_contributions
+           FROM election_cmte_totals
+           --
+           WHERE election_cmte_totals.election_year is not null
+           --
+          GROUP BY election_cmte_totals.candidate_id, election_cmte_totals.election_year
+        UNION ALL
+         (
+         SELECT
+         --
+         DISTINCT ON (candidate_id, cycle)
+         --
+         cycle_totals.candidate_id,
+            cycle_totals.election_year,
+            cycle_totals.cycle,
+            false AS is_election,
+            cycle_totals.receipts,
+            cycle_totals.disbursements,
+            cycle_totals.has_raised_funds,
+            cycle_totals.cash_on_hand_end_period,
+            cycle_totals.debts_owed_by_committee,
+            cycle_totals.coverage_start_date,
+            cycle_totals.coverage_end_date,
+            cycle_totals.federal_funds_flag,
+            cycle_totals.individual_itemized_contributions,
+            cycle_totals.transfers_from_other_authorized_committee,
+            cycle_totals.other_political_committee_contributions
+           FROM cycle_totals
+           --
+	   ORDER BY candidate_id, cycle, election_year NULLS LAST
+	   --
+	   )
+        )
+ SELECT cand.candidate_id,
+ -- --
+    candidate_election_year AS election_year,
+    cand.two_year_period AS cycle,
+    COALESCE(totals.is_election,
+        CASE
+        -- --
+            WHEN cand.candidate_election_year = cand.two_year_period THEN true
+            ELSE false
+        END) AS is_election,
+    COALESCE(totals.receipts, 0::numeric) AS receipts,
+    COALESCE(totals.disbursements, 0::numeric) AS disbursements,
+    COALESCE(totals.has_raised_funds, false) AS has_raised_funds,
+    COALESCE(totals.cash_on_hand_end_period, 0::numeric) AS cash_on_hand_end_period,
+    COALESCE(totals.debts_owed_by_committee, 0::numeric) AS debts_owed_by_committee,
+    totals.coverage_start_date,
+    totals.coverage_end_date,
+    COALESCE(totals.federal_funds_flag, false) AS federal_funds_flag,
+    cand.party,
+    cand.office,
+    cand.candidate_inactive,
+    COALESCE(totals.individual_itemized_contributions, 0::numeric) AS individual_itemized_contributions,
+    COALESCE(totals.transfers_from_other_authorized_committee, 0::numeric) AS transfers_from_other_authorized_committee,
+    COALESCE(totals.other_political_committee_contributions, 0::numeric) AS other_political_committee_contributions,
+    cand.state,
+    cand.district,
+    cand.district_number,
+    COALESCE(expand_state(cand.state::text), 'Other') AS state_full
+   FROM ofec_candidate_history_with_future_election_vw cand
+     LEFT JOIN combined_totals totals ON cand.candidate_id::text = totals.candidate_id::text AND cand.two_year_period = totals.cycle
+WITH DATA;
+
+--Permissions
+ALTER TABLE public.ofec_candidate_totals_mv_tmp OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_totals_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_totals_mv_tmp TO fec_read;
+
+--Indexes
+CREATE UNIQUE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id, election_year, cycle, is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cand_id ON public.ofec_candidate_totals_mv_tmp USING btree (candidate_id);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_cycle ON public.ofec_candidate_totals_mv_tmp USING btree (cycle);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_is_election ON public.ofec_candidate_totals_mv_tmp USING btree (is_election);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_receipts ON public.ofec_candidate_totals_mv_tmp USING btree (receipts);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_disbursements ON public.ofec_candidate_totals_mv_tmp USING btree (disbursements);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_election_year ON public.ofec_candidate_totals_mv_tmp USING btree (election_year);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_federal_funds_flag ON public.ofec_candidate_totals_mv_tmp USING btree (federal_funds_flag);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_has_raised_funds ON public.ofec_candidate_totals_mv_tmp USING btree (has_raised_funds);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_office ON public.ofec_candidate_totals_mv_tmp USING btree (office);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_party ON public.ofec_candidate_totals_mv_tmp USING btree (party);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_individual_itemized_contributions ON public.ofec_candidate_totals_mv_tmp USING btree (individual_itemized_contributions);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_transfers_from_other_authorized_cmte ON public.ofec_candidate_totals_mv_tmp USING btree (transfers_from_other_authorized_committee);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_other_political_committee_cont ON public.ofec_candidate_totals_mv_tmp USING btree (other_political_committee_contributions);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_state ON public.ofec_candidate_totals_mv_tmp USING btree (state);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_state_full ON public.ofec_candidate_totals_mv_tmp USING btree (state_full);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_district ON public.ofec_candidate_totals_mv_tmp USING btree (district);
+
+CREATE INDEX idx_ofec_candidate_totals_mv_tmp_district_number ON public.ofec_candidate_totals_mv_tmp USING btree (district_number);
+
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_candidate_totals_vw AS
+SELECT * FROM public.ofec_candidate_totals_mv_tmp;
+-- ---------------
+ALTER TABLE public.ofec_candidate_totals_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_candidate_totals_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_candidate_totals_vw TO fec_read;
+
+
+-- drop old MV
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_candidate_totals_mv_tmp RENAME TO ofec_candidate_totals_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id_elec_yr_cycle_is_elect RENAME TO idx_ofec_candidate_totals_mv_cand_id_elec_yr_cycle_is_elect;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cand_id RENAME TO idx_ofec_candidate_totals_mv_cand_id;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_cycle RENAME TO idx_ofec_candidate_totals_mv_cycle;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_is_election RENAME TO idx_ofec_candidate_totals_mv_is_election;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_receipts RENAME TO idx_ofec_candidate_totals_mv_receipts;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_disbursements RENAME TO idx_ofec_candidate_totals_mv_disbursements;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_election_year RENAME TO idx_ofec_candidate_totals_mv_election_year;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_federal_funds_flag RENAME TO idx_ofec_candidate_totals_mv_federal_funds_flag;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_has_raised_funds RENAME TO idx_ofec_candidate_totals_mv_has_raised_funds;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_office RENAME TO idx_ofec_candidate_totals_mv_office;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_party RENAME TO idx_ofec_candidate_totals_mv_party;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_individual_itemized_contributions RENAME TO idx_ofec_candidate_totals_mv_individual_itemized_contributions;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_transfers_from_other_authorized_cmte RENAME TO idx_ofec_candidate_totals_mv_transfers_from_other_authorized_cmte;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_other_political_committee_cont RENAME TO idx_ofec_candidate_totals_mv_other_political_committee_cont;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_state RENAME TO idx_ofec_candidate_totals_mv_state;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_state_full RENAME TO idx_ofec_candidate_totals_mv_state_full;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_district RENAME TO idx_ofec_candidate_totals_mv_district;
+
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_district_number RENAME TO idx_ofec_candidate_totals_mv_district_number;
+ALTER INDEX IF EXISTS idx_ofec_candidate_totals_mv_tmp_district_number RENAME TO idx_ofec_candidate_totals_mv_district_number;

--- a/locustfile.py
+++ b/locustfile.py
@@ -17,8 +17,7 @@ import os
 import random
 import resource
 
-import locust
-from locust import between
+from locust import between, HttpUser, task, TaskSet, user
 
 
 # Avoid "Too many open files" error
@@ -217,7 +216,7 @@ def get_random_date():
     return "{y}-{m}-{d}".format(y=str(year), m=str(month), d=str(date))
 
 
-class Tasks(locust.TaskSet):
+class Tasks(TaskSet):
     def on_start(self):
         self.candidates = self.fetch_ids("candidates", "candidate_id")
         self.committees = self.fetch_ids("committees", "committee_id")
@@ -228,12 +227,12 @@ class Tasks(locust.TaskSet):
         print("*********fetch_ids response:{}".format(resp))
         return [result[key] for result in resp.json()["results"]]
 
-    @locust.task
+    @task
     def load_home(self):
         params = {"api_key": API_KEY}
         self.client.get("", name="home", params=params)
 
-    @locust.task
+    @task
     def test_download(self):
         """
         a quick test on downlaod api. this test need to generate a aynamic query
@@ -262,19 +261,19 @@ class Tasks(locust.TaskSet):
             json=payload,
         )
 
-    @locust.task
+    @task
     def load_candidates_search(self, term=None):
         term = term or random.choice(CANDIDATES)
         params = {"api_key": API_KEY, "sort": "-receipts", "q": term}
         self.client.get("candidates/search", name="candidate_search", params=params)
 
-    @locust.task
+    @task
     def load_committees_search(self, term=None):
         term = term or random.choice(CANDIDATES)
         params = {"api_key": API_KEY, "sort": "-receipts", "q": term}
         self.client.get("committees", name="committee_search", params=params)
 
-    @locust.task
+    @task
     def load_candidates_table(self):
         params = {
             "cycle": [random.choice(CYCLES) for _ in range(3)],
@@ -282,7 +281,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get("candidates", name="candidates_table", params=params)
 
-    @locust.task
+    @task
     def load_committees_table(self):
         params = {
             "cycle": [random.choice(CYCLES) for _ in range(3)],
@@ -290,7 +289,7 @@ class Tasks(locust.TaskSet):
         }
         self.client.get("committees", name="committees_table", params=params)
 
-    @locust.task
+    @task
     def load_candidate_detail(self, candidate_id=None):
         params = {"api_key": API_KEY}
         candidate_id = candidate_id or random.choice(self.candidates)
@@ -300,7 +299,7 @@ class Tasks(locust.TaskSet):
             params=params,
         )
 
-    @locust.task
+    @task
     def load_committee_detail(self, committee_id=None):
         params = {"api_key": API_KEY}
         committee_id = committee_id or random.choice(self.committees)
@@ -310,7 +309,7 @@ class Tasks(locust.TaskSet):
             params=params,
         )
 
-    @locust.task
+    @task
     def load_candidate_totals(self, candidate_id=None):
         params = {"api_key": API_KEY}
         candidate_id = candidate_id or random.choice(self.candidates)
@@ -320,7 +319,7 @@ class Tasks(locust.TaskSet):
             params=params,
         )
 
-    @locust.task
+    @task
     def load_committee_totals(self, committee_id=None):
         params = {"api_key": API_KEY}
         committee_id = committee_id or random.choice(self.committees)
@@ -330,13 +329,13 @@ class Tasks(locust.TaskSet):
             params=params,
         )
 
-    @locust.task
+    @task
     def load_schedule_a_small(self):
         params = random.choice(small_records_sched_a)
         params["api_key"] = API_KEY
         self.client.get("schedules/schedule_a/", name="schedule_a_small", params=params)
 
-    @locust.task
+    @task
     def load_schedule_a_medium(self):
         params = random.choice(medium_records_sched_a)
         params["api_key"] = API_KEY
@@ -344,7 +343,7 @@ class Tasks(locust.TaskSet):
             "schedules/schedule_a/", name="schedule_a_medium", params=params
         )
 
-    @locust.task
+    @task
     def load_schedule_a_large(self):
         params = random.choice(large_records_sched_a)
         params["api_key"] = API_KEY
@@ -352,7 +351,7 @@ class Tasks(locust.TaskSet):
             "schedules/schedule_a/", name="load_schedule_a_large", params=params
         )
 
-    @locust.task
+    @task
     def load_schedule_a_problematic(self):
         params = random.choice(poor_performance_a)
         params["api_key"] = API_KEY
@@ -360,7 +359,7 @@ class Tasks(locust.TaskSet):
             "schedules/schedule_a/", name="load_schedule_a_problematic", params=params
         )
 
-    @locust.task
+    @task
     def load_schedule_b_problematic(self):
         params = random.choice(poor_performance_b)
         params["api_key"] = API_KEY
@@ -368,42 +367,42 @@ class Tasks(locust.TaskSet):
             "schedules/schedule_b/", name="load_schedule_b_problematic", params=params
         )
 
-    @locust.task
+    @task
     def load_audit_category(self):
         params = {"api_key": API_KEY}
         self.client.get("audit-category/", name="load_audit_category", params=params)
 
-    @locust.task
+    @task
     def load_filings(self):
         params = {"api_key": API_KEY}
         self.client.get("filings/", name="load_filings", params=params)
 
-    @locust.task
+    @task
     def load_totals(self):
         params = {"api_key": API_KEY}
         self.client.get("totals/P/", name="load_totals", params=params)
 
-    @locust.task
+    @task
     def load_reports(self):
         params = {"api_key": API_KEY}
         self.client.get("reports/P/", name="load_reports", params=params)
 
-    @locust.task
+    @task
     def load_legal_documents_search(self, term=None):
         params = {"q": term, "api_key": API_KEY}
         self.client.get("legal/search", name="legal_search", params=params)
 
-    @locust.task
+    @task
     def get_docs_mur(self):
         params = {"api_key": API_KEY}
         self.client.get("legal/docs/murs/7074", name="get_docs_mur", params=params)
 
-    @locust.task
+    @task
     def get_docs_adr(self):
         params = {"api_key": API_KEY}
         self.client.get("legal/docs/adrs/668", name="get_docs_adr", params=params)
 
-    @locust.task
+    @task
     def get_docs_admin_fine(self):
         params = {"api_key": API_KEY}
         self.client.get(
@@ -411,14 +410,14 @@ class Tasks(locust.TaskSet):
         )
 
     # archived mur #179
-    @locust.task
+    @task
     def get_docs_archived_mur(self):
         params = {"api_key": API_KEY}
         self.client.get(
             "legal/docs/murs/179", name="get_docs_archived_mur", params=params
         )
 
-    @locust.task
+    @task
     def get_docs_advisory_opinions(self):
         params = {"api_key": API_KEY}
         self.client.get(
@@ -426,6 +425,6 @@ class Tasks(locust.TaskSet):
         )
 
 
-class Swarm(locust.HttpLocust):
-    task_set = Tasks
+class Swarm(user.HttpUser):
+    tasks = [Tasks]
     wait_time = between(5000, 50000)

--- a/locustfile.py
+++ b/locustfile.py
@@ -224,7 +224,6 @@ class Tasks(TaskSet):
     def fetch_ids(self, endpoint, key):
         params = {"api_key": API_KEY}
         resp = self.client.get(endpoint, name="preload_ids", params=params)
-        print("*********fetch_ids response:{}".format(resp))
         return [result[key] for result in resp.json()["results"]]
 
     @task

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ pre-commit==2.21.0 #client-side hook triggered by operations like git commit
 # requirements.txt generation (pip-compile)
 pip-tools==4.2.0
 #locust
-locustio==0.14.6 #upgrade locustio to python 3.8 compatible version
+locust==2.14.2

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1412,6 +1412,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="01",
             party="DEM",
+            state_full='California'
         )
         factories.CandidateTotalFactory(
             candidate_id="HCA01",
@@ -1430,6 +1431,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="01",
             party="DEM",
+            state_full='California'
         )
         factories.CandidateTotalFactory(
             candidate_id="HCA02",
@@ -1448,6 +1450,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="02",
             party="DEM",
+            state_full='California'
         )
         factories.CandidateTotalFactory(
             candidate_id="HNY01",
@@ -1465,6 +1468,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="NY",
             district="01",
             party="REP",
+            state_full='New York'
         )
         factories.CandidateTotalFactory(
             candidate_id="HNY13",
@@ -1482,6 +1486,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="NY",
             district="13",
             party="REP",
+            state_full='New York'
         )
 
         factories.CandidateTotalFactory(
@@ -1500,6 +1505,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="00",
             party="DEM",
+            state_full='California'
         )
         factories.CandidateTotalFactory(
             candidate_id="SCA01",
@@ -1518,6 +1524,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="00",
             party="DEM",
+            state_full='California'
         )
         factories.CandidateTotalFactory(
             candidate_id="SNY01",
@@ -1536,6 +1543,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="NY",
             district="00",
             party="DEM",
+            state_full='New York'
         )
         factories.CandidateTotalFactory(
             candidate_id="SNY01",
@@ -1554,6 +1562,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="NY",
             district="00",
             party="DEM",
+            state_full='New York'
         )
         factories.CandidateTotalFactory(
             candidate_id="SNY01",
@@ -1572,6 +1581,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="NY",
             district="00",
             party="DEM",
+            state_full='New York'
         )
         factories.CandidateTotalFactory(
             candidate_id="SVA02",  # not exist in election list
@@ -1590,6 +1600,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="VA",
             district="00",
             party="REP",
+            state_full='Virginia'
         )
 
         factories.CandidateTotalFactory(
@@ -1609,6 +1620,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="00",
             party="REP",
+            state_full='California'
         )
 
         factories.CandidateTotalFactory(
@@ -1628,6 +1640,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             state="CA",
             district="00",
             party="REP",
+            state_full='California'
         )
 
     def test_base(self):
@@ -1729,6 +1742,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "election_year": 2022,
                 "office": "S",
                 "state": "CA",
+                "state_full": "California",
                 "total_receipts": 90,
                 "total_disbursements": 90,
                 "total_individual_itemized_contributions": 90,
@@ -1744,6 +1758,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "election_year": 2016,
                 "office": "S",
                 "state": "CA",
+                "state_full": "California",
                 "total_receipts": 100,
                 "total_disbursements": 100,
                 "total_individual_itemized_contributions": 100,
@@ -1759,6 +1774,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "election_year": 2016,
                 "office": "S",
                 "state": "NY",
+                "state_full": "New York",
                 "total_receipts": 1000,
                 "total_disbursements": 1000,
                 "total_individual_itemized_contributions": 1000,
@@ -1903,6 +1919,72 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
             },
         )
 
+    def test_sort_by_state_full(self):
+        # aggregate_by="office-state", office=S, is_active_candidate=True, election_full default=true
+        # return rows: (2016/S/NY, 2016/S/CA, 2022/S/CA)
+        # row 1: 2016/total=1000
+        # row 2: 2016/total=100
+        # row 3: 2022/total=90
+
+        results = self._results(api.url_for(
+            CandidateTotalAggregateView,
+            aggregate_by="office-state",
+            office="S",
+            is_active_candidate=True,
+            sort="-state_full")
+        )
+        assert len(results) == 3
+        assert_dicts_subset(
+            results[0],
+            {
+                "election_year": 2016,
+                "office": "S",
+                "state": "NY",
+                "state_full": "New York",
+                "total_receipts": 1000,
+                "total_disbursements": 1000,
+                "total_individual_itemized_contributions": 1000,
+                "total_transfers_from_other_authorized_committee": 1000,
+                "total_other_political_committee_contributions": 1000,
+                "total_cash_on_hand_end_period": 1000,
+                "total_debts_owed_by_committee": 1000,
+
+            },
+        )
+        assert_dicts_subset(
+            results[1],
+            {
+                "election_year": 2016,
+                "office": "S",
+                "state": "CA",
+                "state_full": "California",
+                "total_receipts": 100,
+                "total_disbursements": 100,
+                "total_individual_itemized_contributions": 100,
+                "total_transfers_from_other_authorized_committee": 100,
+                "total_other_political_committee_contributions": 100,
+                "total_cash_on_hand_end_period": 100,
+                "total_debts_owed_by_committee": 100,
+            },
+        )
+        assert_dicts_subset(
+            results[2],
+            {
+                "election_year": 2022,
+                "office": "S",
+                "state": "CA",
+                "state_full": "California",
+                "total_receipts": 90,
+                "total_disbursements": 90,
+                "total_individual_itemized_contributions": 90,
+                "total_transfers_from_other_authorized_committee": 90,
+                "total_other_political_committee_contributions": 90,
+                "total_cash_on_hand_end_period": 90,
+                "total_debts_owed_by_committee": 90,
+
+            },
+        )
+
     def test_filter_by_min_max_election_cycle(self):
         # case1: aggregate_by=office, office=S, election_full default=true,
         # is_active_candidate=true, min_election_cycle=2016
@@ -1974,6 +2056,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "total_cash_on_hand_end_period": 3000,
                 "total_debts_owed_by_committee": 3000,
                 "state": "CA",
+                "state_full": "California"
             },
         )
 
@@ -2004,6 +2087,7 @@ class TestCandidatesTotalsAggregates(ApiBaseTest):
                 "total_cash_on_hand_end_period": 1000,
                 "total_debts_owed_by_committee": 1000,
                 "state": "CA",
+                "state_full": "California",
                 "district": "01",
             },
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -160,9 +160,11 @@ class IndicesValidator(IndexValidator):
                 )
 
 
-def make_sort_args(default=None, validator=None, default_hide_null=False,
+def make_sort_args(
+    default=None, validator=None, default_hide_null=False,
         default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True,
         additional_description=''):
+
     args = {
         'sort': fields.Str(
             missing=default,
@@ -189,10 +191,13 @@ def make_sort_args(default=None, validator=None, default_hide_null=False,
     return args
 
 
-def make_multi_sort_args(default=None, validator=None, default_hide_null=False,
+def make_multi_sort_args(
+    default=None, validator=None, default_hide_null=False,
         default_nulls_only=False, default_sort_nulls_last=False):
+
     args = make_sort_args(default, validator, default_hide_null, default_nulls_only, default_sort_nulls_last)
-    args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True,
+    args['sort'] = fields.List(
+        fields.Str, missing=default, validate=validator, required=False, allow_none=True,
         description=docs.SORT)
     return args
 
@@ -217,7 +222,10 @@ legal_universal_search = {
     'q': fields.Str(required=False, description=docs.TEXT_SEARCH),
     'from_hit': fields.Int(required=False, description=docs.FROM_HIT),
     'hits_returned': fields.Int(required=False, description=docs.HITS_RETURNED),
-    'type': fields.Str(required=False, description=docs.LEGAL_DOC_TYPE),
+    'type': fields.Str(
+            validate=validate.OneOf(["admin_fines", "adrs", "advisory_opinions",
+                                     "murs", "regulations", "statutes"]),
+            description=docs.LEGAL_DOC_TYPE),
 
     'ao_no': fields.List(IStr, required=False, description=docs.AO_NUMBER),
     'ao_name': fields.List(IStr, required=False, description=docs.AO_NAME),
@@ -225,13 +233,15 @@ legal_universal_search = {
     'ao_max_issue_date': fields.Date(description=docs.AO_MAX_ISSUE_DATE),
     'ao_min_request_date': fields.Date(description=docs.AO_MIN_REQUEST_DATE),
     'ao_max_request_date': fields.Date(description=docs.AO_MAX_REQUEST_DATE),
-    'ao_category': fields.List(IStr(validate=validate.OneOf(['F', 'V', 'D', 'R', 'W', 'C', 'S'])),
-                                    description=docs.AO_CATEGORY),
+    'ao_category': fields.List(
+        IStr(validate=validate.OneOf(['F', 'V', 'D', 'R', 'W', 'C', 'S'])),
+        description=docs.AO_CATEGORY),
     'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
     'ao_status': fields.Str(description=docs.AO_STATUS),
     'ao_requestor': fields.Str(description=docs.AO_REQUESTOR),
-    'ao_requestor_type': fields.List(fields.Integer(validate=validate.OneOf(range(1, 17))),
-                                            description=docs.AO_REQUESTOR_TYPE),
+    'ao_requestor_type': fields.List(
+        fields.Integer(validate=validate.OneOf(range(1, 17))),
+        description=docs.AO_REQUESTOR_TYPE),
     'ao_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'ao_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'ao_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
@@ -250,10 +260,13 @@ legal_universal_search = {
     'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
 
     # case_doc_category_id is the key of case_document_category
-    'case_doc_category_id': fields.List(IStr(validate=validate.OneOf(['1', '2', '3', '4', '5', '6'])),
-                                    description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
+    'case_doc_category_id': fields.List(IStr(
+        validate=validate.OneOf(
+            ['1', '2', '3', '4', '5', '6', '1001', '1002', '1003', '1004', '1005', '1006', '2001'])),
+        description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
 
-    'mur_type': fields.Str(required=False, description=docs.MUR_TYPE),
+    'mur_type': fields.Str(
+        required=False, validate=validate.OneOf(["archived", "current"]), description=docs.MUR_TYPE),
 
     'af_name': fields.List(IStr, required=False, description=docs.AF_NAME),
     'af_committee_id': fields.Str(IStr, required=False, description=docs.AF_COMMITTEE_ID),
@@ -264,7 +277,7 @@ legal_universal_search = {
     'af_min_fd_date': fields.Date(required=False, description=docs.AF_MIN_FD_DATE),
     'af_max_fd_date': fields.Date(required=False, description=docs.AF_MAX_FD_DATE),
     'af_fd_fine_amount': fields.Int(IStr, required=False, description=docs.AF_FD_FINE_AMOUNT),
-    'sort':fields.Str(IStr, required=False, description=docs.SORT),
+    'sort': fields.Str(IStr, required=False, description=docs.SORT),
 }
 
 candidate_detail = {
@@ -897,7 +910,8 @@ entities = {
 }
 
 schedule_e = {
-    'candidate_office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])),
+    'candidate_office': fields.List(fields.Str(
+        validate=validate.OneOf(['', 'H', 'S', 'P'])),
         description=docs.OFFICE),
     'candidate_party': fields.List(IStr, description=docs.PARTY),
     'candidate_office_state': fields.List(IStr, description=docs.STATE_GENERIC),
@@ -906,17 +920,21 @@ schedule_e = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
-    'last_expenditure_date': fields.Date(missing=None,
+    'last_expenditure_date': fields.Date(
+        missing=None,
         description=docs.LAST_EXPENDITURE_DATE),
-    'last_expenditure_amount': fields.Float(missing=None,
+    'last_expenditure_amount': fields.Float(
+        missing=None,
         description=docs.LAST_EXPENDITURE_AMOUNT),
-    'last_office_total_ytd': fields.Float(missing=None,
+    'last_office_total_ytd': fields.Float(
+        missing=None,
         description=docs.LAST_OFFICE_TOTAL_YTD),
     'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
         description=docs.SUPPORT_OPPOSE_INDICATOR),
-    'last_support_oppose_indicator': fields.Str(missing=None,
+    'last_support_oppose_indicator': fields.Str(
+        missing=None,
         description=docs.LAST_SUPPOSE_OPPOSE_INDICATOR),
     'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
     'min_dissemination_date': fields.Date(description=docs.DISSEMINATION_MIN_DATE),

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -207,6 +207,7 @@ class CandidateTotal(db.Model):
     state = db.Column(db.String(2), index=True, doc=docs.STATE)
     district = db.Column(db.String(2), index=True, doc=docs.DISTRICT)
     district_number = db.Column(db.Integer, index=True, doc=docs.DISTRICT)
+    state_full = db.Column(db.String(50), index=True, doc=docs.STATE)
 
 
 class CandidateElection(db.Model):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1,4 +1,3 @@
-from webservices.env import env
 
 
 """Narrative API documentation."""
@@ -72,6 +71,12 @@ The candidate endpoints primarily use data from FEC registration
 CANDIDATE_ID = '''
 A unique identifier assigned to each candidate registered with the FEC.
 If a person runs for several offices, that person will have separate candidate IDs for each office.
+First character indicates office - [P]residential, [H]ouse, [S]enate].
+Second character is the last digit of the two-year period the ID was created.
+Third and fourth is the candidate state. Presidential IDs don't have state.
+Fifth and sixth is the district when the candidate first ran. This does not change if the
+candidate/member's district changes during re-districting. Presidential IDs don't have districts.
+The rest is sequence.
 '''
 
 CANDIDATE_INACTIVE = '''
@@ -258,8 +263,9 @@ filer. Use the `committee_id` to find the most recent information about the comm
 '''
 
 COMMITTEE_HISTORY = '''
-Explore a filer's characteristics over time. This can be particularly useful if the
-committees change treasurers, designation, or `committee_type`.
+Explore a filer's characteristics over time. This can \
+be particularly useful if the committees change \
+treasurers, designation, or `committee_type`.
 '''
 
 COMMITTEE_CYCLE = '''
@@ -558,8 +564,9 @@ True indicates that a committee is active.
 '''
 
 SPONSOR_CANDIDATE_ID = '''
-A unique identifier assigned to each candidate registered with the FEC.
-If a person runs for several offices, that person will have separate candidate IDs for each office. This is a filter for Leadership PAC sponsor.
+A unique identifier assigned to each candidate registered with the FEC. \
+If a person runs for several offices, that person will have separate \
+candidate IDs for each office. This is a filter for Leadership PAC sponsor.
 '''
 
 PREVIOUS_FILE_NUMBER = '''
@@ -571,7 +578,8 @@ Amendment version
 '''
 
 BANK_DEPOSITORY_NM = '''
-Primary bank or depository in which the committee deposits funds, holds accounts, rents safety deposit boxes or maintains funds.
+Primary bank or depository in which the committee deposits funds,\
+holds accounts, rents safety deposit boxes or maintains funds.
 '''
 
 BANK_DEPOSITORY_ST1 = '''
@@ -595,7 +603,8 @@ Zip code of bank or depository as reported on the Form 1
 '''
 
 ADDITIONAL_BANK_NAMES = '''
-Additional banks or depositories in which the committee deposits funds, holds accounts, rents safety deposit boxes or maintains funds.
+Additional banks or depositories in which the committee deposits funds,\
+ holds accounts, rents safety deposit boxes or maintains funds.
 '''
 
 FILER_NAME_TEXT = '''
@@ -797,16 +806,18 @@ SCHEDULE_A_TAG = '''
 This collection of endpoints includes Schedule A records reported by a committee. \
 Schedule A records describe itemized receipts, including contributions from individuals. \
 If you are interested in contributions from individuals, use the /schedules/schedule_a/ endpoint. \
-For a more complete description of all Schedule A records visit
+For a more complete description of all Schedule A records visit \
 [About receipts data](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/). \
-If you are interested in our "is_individual" methodology visit
+If you are interested in our "is_individual" methodology visit \
 our [methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/).\n
 
 
 Schedule A is also available as a database dump file that is updated weekly on Sunday.
-The database dump files are here: https://www.fec.gov/files/bulk-downloads/index.html?prefix=bulk-downloads/data-dump/schedules/.
-The instructions are here: https://www.fec.gov/files//bulk-downloads/data-dump/schedules/README.txt.
-We cannot provide help with restoring the database dump files, but you can refer to this community led [group](https://groups.google.com/forum/#!forum/fec-data) for discussion.
+The database dump files are \
+here: https://www.fec.gov/files/bulk-downloads/index.html?prefix=bulk-downloads/data-dump/schedules/. \
+The instructions are here: https://www.fec.gov/files//bulk-downloads/data-dump/schedules/README.txt. \
+We cannot provide help with restoring the database dump files, but you can refer to \
+this community led [group](https://groups.google.com/forum/#!forum/fec-data) for discussion.
 '''
 
 SCHEDULE_A = '''
@@ -815,8 +826,10 @@ This description is for both ​`/schedules​/schedule_a​/` and ​ `/schedul
 This endpoint provides itemized receipts. Schedule A records describe itemized receipts, \
 including contributions from individuals. If you are interested in contributions from an \
 individual, use the `/schedules/schedule_a/` endpoint. For a more complete description of all \
-Schedule A records visit [About receipts data](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/). \
-If you are interested in our "is_individual" methodology visit our [methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/).
+Schedule A records visit \
+[About receipts data](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/about-receipts-data/). \
+If you are interested in our "is_individual" methodology visit our \
+[methodology page](https://www.fec.gov/campaign-finance-data/about-campaign-finance-data/methodology/). \
 
 ​The `/schedules​/schedule_a​/` endpoint is not paginated by page number. This endpoint uses keyset \
 pagination to improve query performance and these indices are required to properly page through \
@@ -1421,7 +1434,8 @@ REPORT_TYPE = BASE_REPORT_TYPE + '\
     - MSY Monthly Semi-Annual (YE)\n\
 '
 
-REQUEST_TYPE = 'Requests for additional information (RFAIs) sent to filers. The request type is based on the type of document filed:\n\
+REQUEST_TYPE = '''
+Requests for additional information (RFAIs) sent to filers. The request type is based on the type of document filed:\n\
     - 1 Statement of Organization\n\
     - 2 Report of Receipts and Expenditures (Form 3 and 3X)\n\
     - 3 Second Notice - Reports\n\
@@ -1431,7 +1445,7 @@ REQUEST_TYPE = 'Requests for additional information (RFAIs) sent to filers. The 
     - 7 Failure to File\n\
     - 8 From Public Disclosure\n\
     - 9 From Multi Candidate Status\n\
-'
+'''
 
 REPORT_TYPE_W_EXCLUDE = 'Report type; prefix with "-" to exclude. ' + REPORT_TYPE
 
@@ -1459,10 +1473,6 @@ CANDIDATE_MAX_FIRST_FILE_DATE = 'Selects all candidates whose first filing was r
 
 # schedules
 MEMO_CODE = "'X' indicates that the amount is NOT to be included in the itemization total."
-
-
-
-
 
 # schedule A
 CONTRIBUTOR_ID = 'The FEC identifier should be represented here if the contributor is registered with the FEC.'
@@ -1963,13 +1973,9 @@ LEGAL_DOC_NO = '''
 Document number to fetch
 '''
 
-LEGAL_DOC_TYPE = 'Legal Document type to refine search by\n\
-    - statutes\n\
-    - regulations\n\
-    - advisory_opinions\n\
-    - murs\n\
-    - admin_fines\n\
-'
+LEGAL_DOC_TYPE = '''
+Choose a legal document type
+'''
 
 TEXT_SEARCH = '''
 Text to search legal documents for
@@ -2079,14 +2085,22 @@ CASE_MAX_CLOSE_DATE = '''
 The latest date closed of case
 '''
 
-CASE_DOCUMENT_CATEGORY_DESCRIPTION = 'Select one or more case_doc_category_id to filter by corresponding CASE_DOCUMENT_CATEGORY:\n\
-        - 1 - Conciliation Agreements\n\
-        - 2 - Complaint, Responses, Designation of Counsel and Extensions of Timee\n\
+CASE_DOCUMENT_CATEGORY_DESCRIPTION = '''
+Select one or more case_doc_category_id to filter by corresponding CASE_DOCUMENT_CATEGORY:\n\
+        - 1 - Conciliation and Settlement Agreements\n\
+        - 2 - Complaint, Responses, Designation of Counsel and Extensions of Time\n\
         - 3 - General Counsel Reports, Briefs, Notifications and Responses\n\
         - 4 - Certifications\n\
-        - 5 - Civil Penalties, Disgorgements and Other Payments\n\
-        - 6 - Statements of Reasons \n\
-'
+        - 5 - Civil Penalties, Disgorgements, Other Payments and Letters of Compliance\n\
+        - 6 - Statement of Reasons \n\
+        - 1001 - ADR Settlement Agreements\n\
+        - 1002 - Complaint, Responses, Designation of Counsel and Extensions of Time\n\
+        - 1003 - ADR Memoranda, Notifications and Responses\n\
+        - 1004 - Certifications\n\
+        - 1005 - Civil Penalties, Disgorgements, Other Payments and Letters of Compliance\n\
+        - 1006 - Statement of Reasons \n\
+        - 2001 - Administrative Fine Case\n\
+'''
 
 MUR_TYPE = '''
 Type of MUR : current or archived

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -493,10 +493,12 @@ class CandidateTotalAggregateView(ApiResource):
             query = query.add_columns(
                 total.state.label("state")
             )
-            query = query.group_by(
-                total.election_year, total.office, total.state
+            query = query.add_columns(
+                total.state_full.label("state_full")
             )
-
+            query = query.group_by(
+                total.election_year, total.office, total.state, total.state_full
+            )
         # aggregate by election_year, office, state, district
         elif kwargs.get("aggregate_by") and "office-state-district" == kwargs.get("aggregate_by"):
             query = query.add_columns(
@@ -506,13 +508,16 @@ class CandidateTotalAggregateView(ApiResource):
                 total.state.label("state")
             )
             query = query.add_columns(
+                total.state_full.label("state_full")
+            )
+            query = query.add_columns(
                 total.district.label("district")
             )
 
             # remove district=null
             query = query.filter(total.district.isnot(None))
             query = query.group_by(
-                total.election_year, total.office, total.state, total.district,
+                total.election_year, total.office, total.state, total.district, total.state_full
             )
 
         # aggregate by election_year, office, party

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -172,9 +172,9 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&sort=case_no
     if kwargs.get("sort"):
         if kwargs.get("sort").upper() == "CASE_NO":
-            query = query.sort({"case_serial" : {"order" : "asc"}})
+            query = query.sort({"case_serial": {"order": "asc"}})
         else:
-            query = query.sort({"case_serial" : {"order" : "desc"}})
+            query = query.sort({"case_serial": {"order": "desc"}})
 
     should_query = [
         get_case_document_query(q, **kwargs),
@@ -185,6 +185,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     must_clauses = []
     if kwargs.get("case_no"):
         must_clauses.append(Q("terms", no=kwargs.get("case_no")))
+
     if kwargs.get("case_document_category"):
         must_clauses = [
             Q("terms", documents__category=kwargs.get("case_document_category"))
@@ -201,12 +202,23 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         return apply_adr_specific_query_params(query, **kwargs)
 
 # Select one or more case_doc_category_id to filter by corresponding case_document_category
-# - 1 - Conciliation Agreements
-# - 2 - Complaint, Responses, Designation of Counsel and Extensions of Timee
+# - 1 - Conciliation and Settlement Agreements
+# - 2 - Complaint, Responses, Designation of Counsel and Extensions of Time
 # - 3 - General Counsel Reports, Briefs, Notifications and Responses
 # - 4 - Certifications
-# - 5 - Civil Penalties, Disgorgements and Other Payments
-# - 6 - Statements of Reasons
+# - 5 - Civil Penalties, Disgorgements, Other Payments and Letters of Compliance
+# - 6 - Statement of Reasons
+# ADR document categories
+# - 1001 - ADR Settlement Agreements
+# - 1002 - Complaint, Responses, Designation of Counsel and Extensions of Time
+# - 1003 - ADR Memoranda, Notifications and Responses
+# - 1004 - Certifications
+# - 1005 - Civil Penalties, Disgorgements, Other Payments and Letters of Compliance
+# - 1006 - Statement of Reasons
+# AF document category
+# - 2001 - Administrative Fine Case
+
+
 def get_case_document_query(q, **kwargs):
     combined_query = []
     category_queries = []
@@ -311,7 +323,8 @@ def apply_mur_specific_query_params(query, **kwargs):
     logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     if kwargs.get("case_regulatory_citation") or kwargs.get("case_statutory_citation"):
-        return case_apply_citation_params(query,
+        return case_apply_citation_params(
+            query,
             kwargs.get("case_regulatory_citation"),
             kwargs.get("case_statutory_citation"),
             kwargs.get("case_citation_require_all"), **kwargs)
@@ -457,9 +470,9 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
     if kwargs.get("sort"):
         if kwargs.get("sort").upper() == "AO_NO":
-            query = query.sort({"ao_no" : {"order" : "asc"}})
+            query = query.sort({"ao_no": {"order": "asc"}})
         else:
-            query = query.sort({"ao_no" : {"order" : "desc"}})
+            query = query.sort({"ao_no": {"order": "desc"}})
 
     should_query = [
         get_ao_document_query(q, **kwargs),

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1369,6 +1369,7 @@ class CandidateTotalAggregateSchema(ma.Schema):
     state = ma.fields.Str()
     district = ma.fields.Str()
     district_number = ma.fields.Int()
+    state_full = ma.fields.Str()
 
 
 augment_schemas(CandidateTotalAggregateSchema)


### PR DESCRIPTION
## Summary (required)

- Resolves #5163 

This ticket adds state_full to the candidates/totals/aggregates endpoint. 

### Required reviewers 1-2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

-  candidates/totals/aggregates endpoint, aggregate by office-state and office-state-district 


## Related PRs

Related PRs against other branches: 
#5345 - database portion, needs to be merged in first

## How to test
1. Check out this branch
2. `pytest`
3. Test candidates/totals/aggregates endpoint on local 

Sample URLS: 
office-state sorted by state-full:
 
local:
http://127.0.0.1:5000/v1/candidates/totals/aggregates/?election_full=true&sort_hide_null=false&page=1&election_year=2022&aggregate_by=office-state&sort_nulls_last=false&sort_null_only=false&sort=state_full&per_page=20

compare to:
https://api.open.fec.gov/v1/candidates/totals/aggregates/?sort_nulls_last=false&election_year=2022&election_full=true&per_page=20&api_key=DEMO_KEY&sort_null_only=false&page=1&sort=-election_year&sort_hide_null=false&aggregate_by=office-state

office-state-district: 

local:
http://127.0.0.1:5000/v1/candidates/totals/aggregates/?election_full=true&sort_hide_null=false&min_election_cycle=2012&page=1&max_election_cycle=2022&aggregate_by=office-state-district&sort_nulls_last=false&sort_null_only=false&sort=-election_year&per_page=20

compare to: 
https://api.open.fec.gov/v1/candidates/totals/aggregates/?sort_nulls_last=false&election_full=true&max_election_cycle=2022&per_page=20&min_election_cycle=2012&api_key=DEMO_KEY&sort_null_only=false&page=1&sort=-election_year&sort_hide_null=false&aggregate_by=office-state-district






