### PR TITLE
Add interpretation for candidate_id

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -71,6 +71,12 @@ The candidate endpoints primarily use data from FEC registration
 CANDIDATE_ID = '''
 A unique identifier assigned to each candidate registered with the FEC.
 If a person runs for several offices, that person will have separate candidate IDs for each office.
+First character indicates office - [P]residential, [H]ouse, [S]enate].
+Second character is the last digit of the two-year period the ID was created.
+Third and fourth is the candidate state. Presidential IDs don't have state.
+Fifth and sixth is the district when the candidate first ran. This does not change if the
+candidate/member's district changes during re-districting. Presidential IDs don't have districts.
+The rest is sequence.
 '''
 
 CANDIDATE_INACTIVE = '''


### PR DESCRIPTION
## Summary (required)

- Resolves #5296 

Add interpretation for candidate_id to help users to understand more of its composition.

### Required reviewers

1 developer

## How to test
Download feature branch and run pytest.
Review the text next to candidate_id.

http://127.0.0.1:5000/developers/#/candidate/get_candidate__candidate_id__

<img width="1358" alt="Screen Shot 2023-02-23 at 2 13 56 PM" src="https://user-images.githubusercontent.com/24396726/221007648-916eebb9-2354-46d7-a6b1-a3cc7fbb4c05.png">

