### PR TITLE
update werkzeug and flask-sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ elasticsearch-dsl==7.3.0
 Flask==2.1.2
 Flask-Cors==3.0.10
 Flask-RESTful==0.3.9
-Flask-SQLAlchemy==2.4.1
+Flask-SQLAlchemy==2.5.1
 gevent==22.10.2
 gunicorn==19.10.0
 GitPython==3.1.30
@@ -26,7 +26,7 @@ SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==5.5.3
-werkzeug==2.0.0
+werkzeug==2.2.3
 
 # Marshalling
 flask-apispec==0.7.0


### PR DESCRIPTION
## Summary (required)

- Resolves #5349 and #5350

This ticket upgrades werkzeug to remove a vulnerability. I also had to upgrade flask-sqlalchemy from version 2.4.1 because is was not compatible with werkzeug 2.2.3. 

### Required reviewers 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  requirements.txt
- webservices

## Screenshots

Before upgrade:
![image](https://user-images.githubusercontent.com/121631201/223157133-124d2cdd-3183-48ce-9cc3-99ec003f002e.png)

After upgrade: 
![image](https://user-images.githubusercontent.com/121631201/223157158-9872bb11-834e-4ecf-9880-8b80e568fb23.png)


## How to test

1. Checkout this branch 
2. `pip install -r requirements.txt`
3. `snyk test --file=requirements.txt --package-manager=pip`
4. `pytest`
5. `flask run`
