### PR TITLE
upgrade redis to 4.5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ smart_open==1.8.0
 # Task queue
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
-redis==4.2.2
+redis==4.5.4
 
 # testing and build in circle
 codecov==2.1.7


### PR DESCRIPTION
## Summary (required)

- Resolves #5381 

This ticket upgrades Redis to the latest version to get rid of a vulnerability in requirements.txt. 

### Required reviewers - 1 Developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  webservices/tasks
- requirements.txt 

## How to test

1. Checkout this branch
2. `pip install -r requirements.txt`
3. `snyk test`
4. Test downloads and celery tasks on local by following the [wiki instructions](https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks)

Optional: 
5. Deploy this PR to dev 
6. Test export/downloads

Example URL: https://dev.fec.gov/data/candidates/?has_raised_funds=true&is_active_candidate=true

