### PR TITLE
add fec_fitem_sched_ab_2023_2024 tables

### DIFF
--- a/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
+++ b/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
@@ -1,0 +1,145 @@
+/*
+This is for issue #5376
+The tables were already created so we will not miss any incoming data.
+However, official migration script is need to add these to the version controlled base of the database structure.
+*/
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_a_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_a_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_a)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_a_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_a_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_a_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_a_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO openfec_read;
+
+
+
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+        EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_b_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_b_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_b)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_b_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_b_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_b_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_b_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO openfec_read;
+
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_a_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_b_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+/*
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+order by 1
+
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+order by 1
+*/


### PR DESCRIPTION
## Summary (required)

- Resolves #5376 
create fec_fitem_sched_a_2023_2024 and fec_fitem_sched_b_2023_2024 partition tables and related objects.

### Required reviewers
This is database work. Only requires database team to review.

## Impacted areas of the application
None


## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test
- download the branch to local machine, either invoke create_sample_db process or run flyway migrate. Make sure migration executed successfully.
- Connect to local_db, verify fec_fitem_sched_a_2023_2024 and fec_fitem_sched_b_2023_2024 tables and the indexes created successfully.

select tablename
from pg_tables
where tablename like 'fec_fitem_sched_%_2023_2024'
order by tablename;

there should be 2 rows returned

select tablename, indexname
from pg_indexes
where tablename like 'fec_fitem_sched_%_2023_2024'
order by tablename, indexname;

there should be 66 rows returned (35 indexes for fec_fitem_sched_a_2023_2024 and 31 indexes for fec_fitem_sched_b_2023_2024)

The tables had already been added to the Aurora database, the syntax in this migration file should allow the migration file to run without causing error. To test this:
delete from flyway_schema_history where version = '0270';
Then run flyway migration again. Flyway migration should execute successfully without error.

## System architecture updates (if applicable)

(If this pull request changes our [current system diagram](https://github.com/fecgov/FEC/wiki/2.-FEC-system-diagram), include a description of those changes here and create a new ticket to update the system diagram)
