### PR TITLE
Create MV for schedule_d endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,17 @@ jobs:
             pytest
 
       - run:
-          name: Perform post-test checks
+          name: Upload coverage report to codecov
           command: |
             . .env/bin/activate
-            codecov
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -t ${CODECOV_TOKEN} -v
 
       - store_artifacts:
           path: test-reports

--- a/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
+++ b/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
@@ -1,0 +1,145 @@
+/*
+This is for issue #5376
+The tables were already created so we will not miss any incoming data.
+However, official migration script is need to add these to the version controlled base of the database structure.
+*/
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_a_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_a_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_a)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_a_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_a_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_a_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_a_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO openfec_read;
+
+
+
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+        EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_b_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_b_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_b)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_b_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_b_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_b_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_b_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO openfec_read;
+
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_a_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_b_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+/*
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+order by 1
+
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+order by 1
+*/

--- a/data/migrations/V0271__h4_mv_create.sql
+++ b/data/migrations/V0271__h4_mv_create.sql
@@ -1,0 +1,89 @@
+/*
+This migration file is for issue #5361. 
+It creates a new view and materialized view pair for the H4 endpoint
+*/
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_h4_mv;
+
+CREATE MATERIALIZED VIEW public.ofec_sched_h4_mv AS
+SELECT h4.filer_cmte_id AS cmte_id,
+h4.evt_purpose_dt AS event_purpose_date,
+h4.ttl_amt_disb AS disbursement_amount,
+h4.fed_share AS fed_share,
+h4.nonfed_share AS nonfed_share,
+h4.pye_st1 AS payee_st1,
+h4.pye_st2 AS payee_st2,
+h4.pye_city AS payee_city,
+h4.pye_st AS payee_state,
+h4.pye_zip AS payee_zip,
+h4.admin_voter_drive_acty_ind AS admin_voter_drive_acty_ind,
+h4.fndrsg_acty_ind AS fndrsg_acty_ind,
+h4.exempt_acty_ind AS exempt_acty_ind,
+h4.direct_cand_supp_acty_ind AS direct_cand_supp_acty_ind,
+h4.evt_amt_ytd AS event_amount_ytd,
+h4.add_desc AS activity_or_event,
+h4.admin_acty_ind AS admin_acty_ind,
+h4.gen_voter_drive_acty_ind AS gen_voter_drive_acty_ind,
+h4.catg_cd AS catg_cd,
+h4.catg_cd_desc AS catg_cd_desc,
+h4.pub_comm_ref_pty_chk AS public_comm_indicator,
+h4.memo_cd AS memo_cd,
+h4.memo_text AS memo_text,
+h4.image_num AS image_num,
+h4.tran_id AS tran_id,
+h4.election_cycle AS election_cycle, 
+h4.rpt_tp AS rpt_tp,
+h4.rpt_yr AS rpt_yr,
+h4.sub_id AS sub_id,
+h4.link_id AS link_id,
+h4.schedule_type AS schedule_type,
+h4.schedule_type_desc AS schedule_type_desc,
+h4.orig_sub_id AS orig_sub_id,
+h4.back_ref_tran_id AS back_ref_tran_id,
+h4.back_ref_sched_id AS back_ref_sched_id,
+h4.filing_form AS filing_form,
+h4.line_num AS line_num,
+h4.file_num AS file_num,
+h4.pye_nm AS payee_name,
+h4.evt_purpose_nm AS disbursement_purpose,
+to_tsvector(parse_fulltext(h4.evt_purpose_nm)) as disbursement_purpose_text,
+to_tsvector(parse_fulltext(h4.pye_nm)) as payee_name_text
+FROM disclosure.fec_fitem_sched_h4 h4;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_h4_mv
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_h4_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_h4_mv TO fec_read;
+
+-- create index on the ofec_sched_h4_mv (should support sort by cmte_id, event_purpose_date, & disbursement_amount)
+CREATE UNIQUE INDEX idx_ofec_sched_h4_mv_cmte_id_date_cycle_sub ON public.ofec_sched_h4_mv USING btree (cmte_id, event_purpose_date, election_cycle, sub_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_cmte_id ON public.ofec_sched_h4_mv USING btree (cmte_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_event_purpose_date ON public.ofec_sched_h4_mv USING btree (event_purpose_date);
+
+CREATE INDEX idx_ofec_sched_h4_mv_cycle ON public.ofec_sched_h4_mv USING btree (election_cycle);
+
+CREATE INDEX idx_ofec_sched_h4_mv_sub_id ON public.ofec_sched_h4_mv USING btree (sub_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_city ON public.ofec_sched_h4_mv USING btree (payee_city);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_state ON public.ofec_sched_h4_mv USING btree (payee_state);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_zip ON public.ofec_sched_h4_mv USING btree (payee_zip);
+
+CREATE INDEX idx_ofec_sched_h4_mv_disbursement_purpose_text ON public.ofec_sched_h4_mv USING gin (disbursement_purpose);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_name_text ON public.ofec_sched_h4_mv USING gin (payee_name);
+
+
+-- update the interface VW to point to the updated ofec_sched_h4_mv
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_sched_h4_vw AS
+SELECT * FROM public.ofec_sched_h4_mv;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_h4_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_h4_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_h4_vw TO fec_read;

--- a/data/migrations/V0272__add_ofec_schedule_d_report.sql
+++ b/data/migrations/V0272__add_ofec_schedule_d_report.sql
@@ -1,0 +1,102 @@
+/*
+This migration file will create a materialized view for the schedule D endpoint with
+added report information 
+issue #4758 (Add report-level information to the debts endpoint)
+*/
+
+-- ---------------
+-- ofec_sched_d_mv
+-- ---------------
+CREATE MATERIALIZED VIEW public.ofec_sched_d_mv AS
+    SELECT
+        sd.sub_id,
+        sd.cmte_id,
+        sd.image_num,
+        sd.filing_form,
+        sd.link_id,
+        sd.line_num,
+        sd.tran_id,
+        sd.file_num,
+        sd.orig_sub_id,
+        sd.cmte_nm,
+        sd.cred_dbtr_id,
+        sd.cred_dbtr_nm,
+        sd.cred_dbtr_l_nm,
+        sd.cred_dbtr_f_nm,
+        sd.cred_dbtr_m_nm,
+        sd.cred_dbtr_prefix,
+        sd.cred_dbtr_suffix,
+        sd.cred_dbtr_st1,
+        sd.cred_dbtr_st2,
+        sd.cred_dbtr_city,
+        sd.cred_dbtr_st,
+        sd.creditor_debtor_name_text,
+        sd.entity_tp,
+        sd.nature_debt_purpose,
+        sd.outstg_bal_bop,
+        sd.outstg_bal_cop,
+        sd.amt_incurred_per,
+        sd.pymt_per,
+        sd.cand_id,
+        sd.cand_nm,
+        sd.cand_nm_first,
+        sd.cand_nm_last,
+        sd.cand_office,
+        sd.cand_office_st,
+        sd.cand_office_st_desc,
+        sd.cand_office_district,
+        sd.conduit_cmte_id,
+        sd.conduit_cmte_nm,
+        sd.conduit_cmte_st1,
+        sd.conduit_cmte_st2,
+        sd.conduit_cmte_city,
+        sd.conduit_cmte_st,
+        sd.conduit_cmte_zip,
+        sd.action_cd,
+        sd.action_cd_desc,
+        sd.schedule_type,
+        sd.schedule_type_desc,
+        sd.election_cycle,
+        sd.pg_date,
+        sd.rpt_tp,
+        sd.rpt_yr,
+        public.date_or_null(fr.cvg_start_dt::integer) as coverage_start_date,
+        public.date_or_null(fr.cvg_end_dt::integer) as coverage_end_date
+    FROM disclosure.fec_fitem_sched_d sd
+    LEFT JOIN disclosure.f_rpt_or_form_sub fr
+        ON sd.link_id = fr.sub_id
+WITH DATA;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_d_mv
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_d_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_d_mv TO fec_read;
+
+-- create unique index on the  MV
+CREATE UNIQUE INDEX idx_ofec_sched_d_mv_sub_id ON public.ofec_sched_d_mv USING btree (sub_id);
+
+-- Create indices on filtered columns
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_cand_id on ofec_sched_d_mv USING btree (cand_id);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_pg_date on ofec_sched_d_mv USING btree (pg_date);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_pymt_per on ofec_sched_d_mv USING btree (pymt_per);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_amt_incurred_per on ofec_sched_d_mv USING btree (amt_incurred_per);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_outstg_bal_bop on ofec_sched_d_mv USING btree (outstg_bal_bop);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_outstg_bal_cop on ofec_sched_d_mv USING btree (outstg_bal_cop);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_nature_debt_purpose on ofec_sched_d_mv USING btree (nature_debt_purpose);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_cred_dbtr_nm on ofec_sched_d_mv USING btree (cred_dbtr_nm);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_coverage_start_date on ofec_sched_d_mv USING btree (coverage_start_date);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_coverage_end_date on ofec_sched_d_mv USING btree (coverage_end_date);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_rpt_tp on ofec_sched_d_mv USING btree (rpt_tp);
+CREATE INDEX IF NOT EXISTS idx_ofec_sched_d_mv_rpt_yr on ofec_sched_d_mv USING btree (rpt_yr);
+
+-- update the interface VW to point to the updated MV
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_sched_d_vw AS
+SELECT * FROM public.ofec_sched_d_mv;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_d_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_d_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_d_vw TO fec_read;

--- a/manage.py
+++ b/manage.py
@@ -110,7 +110,8 @@ def refresh_materialized(concurrent=True):
         "totals_ie": ["ofec_totals_ie_only_mv"],
         "totals_presidential": ["ofec_totals_presidential_mv"],
         "sched_b_by_recipient": ["ofec_sched_b_aggregate_recipient_mv"],
-        "totals_inaugural_donations": ["ofec_totals_inaugural_donations_mv"]
+        "totals_inaugural_donations": ["ofec_totals_inaugural_donations_mv"],
+        "schedule_d": ["ofec_sched_d_mv"]
     }
 
     graph = flow.get_graph()

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ celery-once==3.0.0
 redis==4.5.4
 
 # testing and build in circle
-codecov==2.1.7
+coverage==7.0.3
 factory_boy==2.8.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -47,7 +47,8 @@ def get_graph():
         'totals_ie',
         'totals_presidential',
         'sched_b_by_recipient',
-        'totals_inaugural_donations'
+        'totals_inaugural_donations',
+        'schedule_d'
     ]
     graph.add_nodes_from(MATERIALIZED_VIEWS)
 


### PR DESCRIPTION
## Summary (required)

- Partially Resolves #4758 

This ticket creates a new MV using `disclosure.fec_fitem_schedule_d` and  `disclosure.f_rpt_or_form_sub` to add report level information to the debts endpoint. 

### Required reviewers - 1 Developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  data/migrations

## How to test

1. `dropdb cfdm_test`
2. `createdb cfdm_test`
3. `invoke create_sample_db`
