### PR TITLE
Add coverage_date to schedule_d endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,17 @@ jobs:
             pytest
 
       - run:
-          name: Perform post-test checks
+          name: Upload coverage report to codecov
           command: |
             . .env/bin/activate
-            codecov
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -t ${CODECOV_TOKEN} -v
 
       - store_artifacts:
           path: test-reports

--- a/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
+++ b/data/migrations/V0270__add_fec_fitem_sched_ab_2023_2024.sql
@@ -1,0 +1,145 @@
+/*
+This is for issue #5376
+The tables were already created so we will not miss any incoming data.
+However, official migration script is need to add these to the version controlled base of the database structure.
+*/
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_a_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_a_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_a)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_a_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_a_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_a_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_a_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_a_2023_2024 TO openfec_read;
+
+
+
+-- -----------------------------------------------------
+-- create table disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+        EXECUTE format('CREATE TABLE disclosure.fec_fitem_sched_b_2023_2024
+(
+  CONSTRAINT fec_fitem_sched_b_2023_2024_pkey PRIMARY KEY (sub_id),
+  CONSTRAINT check_two_year_transaction_period CHECK (two_year_transaction_period = ANY (ARRAY[2023, 2024]::numeric[]))
+)
+INHERITS (disclosure.fec_fitem_sched_b)
+WITH (
+  OIDS=FALSE
+)');
+    EXCEPTION
+             WHEN duplicate_table THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+DO $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER tri_fec_fitem_sched_b_2023_2024
+  BEFORE INSERT
+  ON disclosure.fec_fitem_sched_b_2023_2024
+  FOR EACH ROW
+  EXECUTE PROCEDURE disclosure.fec_fitem_sched_b_insert()');
+    EXCEPTION
+             WHEN duplicate_object THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+
+ALTER TABLE disclosure.fec_fitem_sched_b_2023_2024
+  OWNER TO fec;
+GRANT ALL ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO fec_read;
+GRANT SELECT ON TABLE disclosure.fec_fitem_sched_b_2023_2024 TO openfec_read;
+
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_a_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_a_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+-- -----------------------------------------------------
+-- Add indexes to disclosure.fec_fitem_sched_b_2023_2024
+-- -----------------------------------------------------
+DO $$
+BEGIN
+    EXECUTE format('select disclosure.finalize_itemized_schedule_b_tables (2024, 2024)');
+
+
+        EXCEPTION
+             WHEN duplicate_table THEN
+        null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+
+
+/*
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+order by 1
+
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2023_2024'
+except
+select substring(indexname, 23)
+from pg_indexes
+where tablename like 'fec_fitem_sched_b_2021_2022'
+order by 1
+*/

--- a/data/migrations/V0271__h4_mv_create.sql
+++ b/data/migrations/V0271__h4_mv_create.sql
@@ -1,0 +1,89 @@
+/*
+This migration file is for issue #5361. 
+It creates a new view and materialized view pair for the H4 endpoint
+*/
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_sched_h4_mv;
+
+CREATE MATERIALIZED VIEW public.ofec_sched_h4_mv AS
+SELECT h4.filer_cmte_id AS cmte_id,
+h4.evt_purpose_dt AS event_purpose_date,
+h4.ttl_amt_disb AS disbursement_amount,
+h4.fed_share AS fed_share,
+h4.nonfed_share AS nonfed_share,
+h4.pye_st1 AS payee_st1,
+h4.pye_st2 AS payee_st2,
+h4.pye_city AS payee_city,
+h4.pye_st AS payee_state,
+h4.pye_zip AS payee_zip,
+h4.admin_voter_drive_acty_ind AS admin_voter_drive_acty_ind,
+h4.fndrsg_acty_ind AS fndrsg_acty_ind,
+h4.exempt_acty_ind AS exempt_acty_ind,
+h4.direct_cand_supp_acty_ind AS direct_cand_supp_acty_ind,
+h4.evt_amt_ytd AS event_amount_ytd,
+h4.add_desc AS activity_or_event,
+h4.admin_acty_ind AS admin_acty_ind,
+h4.gen_voter_drive_acty_ind AS gen_voter_drive_acty_ind,
+h4.catg_cd AS catg_cd,
+h4.catg_cd_desc AS catg_cd_desc,
+h4.pub_comm_ref_pty_chk AS public_comm_indicator,
+h4.memo_cd AS memo_cd,
+h4.memo_text AS memo_text,
+h4.image_num AS image_num,
+h4.tran_id AS tran_id,
+h4.election_cycle AS election_cycle, 
+h4.rpt_tp AS rpt_tp,
+h4.rpt_yr AS rpt_yr,
+h4.sub_id AS sub_id,
+h4.link_id AS link_id,
+h4.schedule_type AS schedule_type,
+h4.schedule_type_desc AS schedule_type_desc,
+h4.orig_sub_id AS orig_sub_id,
+h4.back_ref_tran_id AS back_ref_tran_id,
+h4.back_ref_sched_id AS back_ref_sched_id,
+h4.filing_form AS filing_form,
+h4.line_num AS line_num,
+h4.file_num AS file_num,
+h4.pye_nm AS payee_name,
+h4.evt_purpose_nm AS disbursement_purpose,
+to_tsvector(parse_fulltext(h4.evt_purpose_nm)) as disbursement_purpose_text,
+to_tsvector(parse_fulltext(h4.pye_nm)) as payee_name_text
+FROM disclosure.fec_fitem_sched_h4 h4;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_h4_mv
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_h4_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_h4_mv TO fec_read;
+
+-- create index on the ofec_sched_h4_mv (should support sort by cmte_id, event_purpose_date, & disbursement_amount)
+CREATE UNIQUE INDEX idx_ofec_sched_h4_mv_cmte_id_date_cycle_sub ON public.ofec_sched_h4_mv USING btree (cmte_id, event_purpose_date, election_cycle, sub_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_cmte_id ON public.ofec_sched_h4_mv USING btree (cmte_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_event_purpose_date ON public.ofec_sched_h4_mv USING btree (event_purpose_date);
+
+CREATE INDEX idx_ofec_sched_h4_mv_cycle ON public.ofec_sched_h4_mv USING btree (election_cycle);
+
+CREATE INDEX idx_ofec_sched_h4_mv_sub_id ON public.ofec_sched_h4_mv USING btree (sub_id);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_city ON public.ofec_sched_h4_mv USING btree (payee_city);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_state ON public.ofec_sched_h4_mv USING btree (payee_state);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_zip ON public.ofec_sched_h4_mv USING btree (payee_zip);
+
+CREATE INDEX idx_ofec_sched_h4_mv_disbursement_purpose_text ON public.ofec_sched_h4_mv USING gin (disbursement_purpose);
+
+CREATE INDEX idx_ofec_sched_h4_mv_payee_name_text ON public.ofec_sched_h4_mv USING gin (payee_name);
+
+
+-- update the interface VW to point to the updated ofec_sched_h4_mv
+-- ---------------
+CREATE OR REPLACE VIEW public.ofec_sched_h4_vw AS
+SELECT * FROM public.ofec_sched_h4_mv;
+
+-- grant correct ownership/permission
+ALTER TABLE public.ofec_sched_h4_vw
+  OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_sched_h4_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_sched_h4_vw TO fec_read;

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ celery-once==3.0.0
 redis==4.5.4
 
 # testing and build in circle
-codecov==2.1.7
+coverage==7.0.3
 factory_boy==2.8.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ smart_open==1.8.0
 # Task queue
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
-redis==4.2.2
+redis==4.5.4
 
 # testing and build in circle
 codecov==2.1.7

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -53,25 +53,33 @@ class TestScheduleDView(ApiBaseTest):
                 load_date=datetime.date(2012, 1, 1),
                 amount_incurred_period=1,
                 outstanding_balance_beginning_of_period=1,
-                outstanding_balance_close_of_period=1
+                outstanding_balance_close_of_period=1,
+                coverage_start_date=datetime.date(2011, 1, 1),
+                coverage_end_date=datetime.date(2011, 8, 27)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2013, 1, 1),
                 amount_incurred_period=2,
                 outstanding_balance_beginning_of_period=2,
-                outstanding_balance_close_of_period=2
+                outstanding_balance_close_of_period=2,
+                coverage_start_date=datetime.date(2012, 1, 1),
+                coverage_end_date=datetime.date(2012, 2, 27)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2014, 1, 1),
                 amount_incurred_period=3,
                 outstanding_balance_beginning_of_period=3,
-                outstanding_balance_close_of_period=3
+                outstanding_balance_close_of_period=3,
+                coverage_start_date=datetime.date(2013, 1, 1),
+                coverage_end_date=datetime.date(2013, 5, 5)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2015, 1, 1),
                 amount_incurred_period=4,
                 outstanding_balance_beginning_of_period=3,
-                outstanding_balance_close_of_period=4
+                outstanding_balance_close_of_period=4,
+                coverage_start_date=datetime.date(2014, 1, 1),
+                coverage_end_date=datetime.date(2014, 6, 6)
             ),
         ]
         # load_date min, max
@@ -83,10 +91,38 @@ class TestScheduleDView(ApiBaseTest):
                 for each in results
             )
         )
+        results = self._results(api.url_for(ScheduleDView, min_coverage_start_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_start_date'] >= min_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(api.url_for(ScheduleDView, min_coverage_end_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_end_date'] >= min_date.isoformat()
+                for each in results
+            )
+        )
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(ScheduleDView, max_date=max_date))
         self.assertTrue(
             all(each['load_date'] <= max_date.isoformat() for each in results)
+        )
+        results = self._results(api.url_for(ScheduleDView, max_coverage_start_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_start_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(api.url_for(ScheduleDView, max_coverage_end_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_end_date'] <= max_date.isoformat()
+                for each in results
+            )
         )
         results = self._results(
             api.url_for(ScheduleDView, min_date=min_date, max_date=max_date)
@@ -94,6 +130,25 @@ class TestScheduleDView(ApiBaseTest):
         self.assertTrue(
             all(
                 min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(
+            api.url_for(ScheduleDView, min_coverage_end_date=min_date, max_coverage_end_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                min_date.isoformat() <= each['coverage_end_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(
+            api.url_for(ScheduleDView, min_coverage_start_date=min_date, max_coverage_start_date=max_date)
+        )
+
+        self.assertTrue(
+            all(
+                min_date.isoformat() <= each['coverage_start_date'] <= max_date.isoformat()
                 for each in results
             )
         )

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -22,6 +22,8 @@ class TestScheduleDView(ApiBaseTest):
             ('image_number', ScheduleD.image_number, ['123', '456']),
             ('committee_id', ScheduleD.committee_id, ['C01', 'C02']),
             ('candidate_id', ScheduleD.candidate_id, ['S01', 'S02']),
+            ('report_year', ScheduleD.report_year, [2023, 2019]),
+            ('report_type', ScheduleD.report_type, ['60D', 'Q3'])
         ]
         for label, column, values in filters:
             [factories.ScheduleDViewFactory(**{column.key: value}) for value in values]

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -762,7 +762,9 @@ schedule_d = {
     'min_coverage_end_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_END_DATE),
     'max_coverage_end_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_END_DATE),
     'min_coverage_start_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
-    'max_coverage_start_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_START_DATE)
+    'max_coverage_start_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
+    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
+    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE)
 }
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -759,6 +759,10 @@ schedule_d = {
     'creditor_debtor_name': fields.List(fields.Str),
     'nature_of_debt': fields.Str(),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'min_coverage_end_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_END_DATE),
+    'max_coverage_end_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_END_DATE),
+    'min_coverage_start_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
+    'max_coverage_start_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_START_DATE)
 }
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -490,8 +490,7 @@ class ScheduleC(PdfMixin, BaseItemized):
 
 
 class ScheduleD(PdfMixin, BaseItemized):
-    __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'fec_fitem_sched_d'
+    __tablename__ = 'ofec_sched_d_mv'
 
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
@@ -535,6 +534,8 @@ class ScheduleD(PdfMixin, BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     election_cycle = db.Column(db.Integer)
     load_date = db.Column('pg_date', db.Date)
+    coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
+    coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
 
     committee = db.relationship(
         'CommitteeHistory',

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -536,6 +536,8 @@ class ScheduleD(PdfMixin, BaseItemized):
     load_date = db.Column('pg_date', db.Date)
     coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
+    report_year = db.Column('rpt_yr', db.Integer,  index=True, doc=docs.REPORT_YEAR)
+    report_type = db.Column('rpt_tp', db.String, index=True, doc=docs.REPORT_TYPE)
 
     committee = db.relationship(
         'CommitteeHistory',

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1852,6 +1852,14 @@ MAX_COVERAGE_END_DATE = '''
 Ending date of the reporting period before this date(MM/DD/YYYY or YYYY-MM-DD)
 '''
 
+MIN_COVERAGE_START_DATE = '''
+Starting date of the reporting period after this date(MM/DD/YYYY or YYYY-MM-DD)
+'''
+
+MAX_COVERAGE_START_DATE = '''
+Starting date of the reporting period before this date(MM/DD/YYYY or YYYY-MM-DD)
+'''
+
 MIN_TRANSACTION_DATA_COMPLETE_DATE = '''
 Select all filings processed completely after this date(MM/DD/YYYY or YYYY-MM-DD)
 '''

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -26,6 +26,8 @@ class ScheduleDView(ApiResource):
         ('image_number', models.ScheduleD.image_number),
         ('committee_id', models.ScheduleD.committee_id),
         ('candidate_id', models.ScheduleD.candidate_id),
+        ('report_year', models.ScheduleD.report_year),
+        ('report_type', models.ScheduleD.report_type)
     ]
 
     filter_range_fields = [

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -35,6 +35,9 @@ class ScheduleDView(ApiResource):
         (('min_image_number', 'max_image_number'), models.ScheduleD.image_number),
         (('min_amount_outstanding_beginning', 'max_amount_outstanding_beginning'), models.ScheduleD.outstanding_balance_beginning_of_period),
         (('min_amount_outstanding_close', 'max_amount_outstanding_close'), models.ScheduleD.outstanding_balance_close_of_period),
+        (('min_coverage_start_date', 'max_coverage_start_date'), models.ScheduleD.coverage_start_date),
+        (('min_coverage_end_date', 'max_coverage_end_date'), models.ScheduleD.coverage_end_date)
+
     ]
 
     filter_match_fields = [


### PR DESCRIPTION
## Summary (required)

- Resolves #4758 

This ticket adds coverage_start_date and coverage_end_date to the debts endpoint and creates a filter for both of these fields (`min_coverage_end_date` `max_coverage_end_date` `min_coverage_start_date` `max_coverage_start_date`).  The ticket mentions that report year, and report type should also be added, but these values are already in the endpoint. 

### Required reviewers - 2 Developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  debts endpoint 


## Related PRs

Related PRs against other branches:

#5392 - database portion, must be merged in first. 

## How to test

1. Checkout this branch 
2. `pytest`
3. `flask run`
4.  Test the endpoint

Sample URLS: 
http://127.0.0.1:5000/developers/#/debts/get_schedules_schedule_d_

sort by coverage_end_date: 
http://127.0.0.1:5000/v1/schedules/schedule_d/?sort_hide_null=false&page=1&sort_null_only=false&per_page=20&sort=-coverage_end_date&sort_nulls_last=false

max_coverage_end_date=2020-01-01:
http://127.0.0.1:5000/v1/schedules/schedule_d/?sort_hide_null=false&page=1&sort_null_only=false&per_page=20&sort=-coverage_end_date&sort_nulls_last=false&max_coverage_end_date=2020-01-01