### PR TITLE
[MERGE WITH GIT FLOW] Hotfix/use new codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,17 @@ jobs:
             pytest
 
       - run:
-          name: Perform post-test checks
+          name: Upload coverage report to codecov
           command: |
             . .env/bin/activate
-            codecov
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+            ./codecov -t ${CODECOV_TOKEN} -v
 
       - store_artifacts:
           path: test-reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ celery-once==3.0.0
 redis==4.5.4
 
 # testing and build in circle
-codecov==2.1.7
+coverage==7.0.3
 factory_boy==2.8.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py


### PR DESCRIPTION
## Summary 

- Resolves #5400 

Our deploys are failing because codecov removed/deprecated their uploader package. To fix this, we have to move to their new [universal uploader](https://docs.codecov.com/docs/codecov-uploader).

### Required reviewers - 1-2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci pipeline 
- requirements.txt


## How to test

- view pipeline on circleCI: https://app.circleci.com/pipelines/github/fecgov/openFEC/1888/workflows/666a4921-526a-4717-9734-93cd5a949cd4/jobs/4495

- view codecov report: https://app.codecov.io/gh/fecgov/openFEC/commit/b567acce9527b21bd65c4e05474c4333ff70035b

Other way to test: 

1. Create new branch based off of this branch : `git branch <new-branch-name> hotfix/use-new-codecov-uploader` 
2. Make any change to the code
3. Commit changes and push branch 
4. View pipeline in circle ci and ensure that the step "Upload coverage report to codecov" is successful 
5. Check that report is successfully uploaded to codecov 
6. Create a test pull request, ensure that codecov bot leaves a comment 

