### PR TITLE
Add report info to debts endpoint

### DIFF
--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -41,18 +41,17 @@ class TestScheduleDView(ApiBaseTest):
         self.assertEqual(results[0]['creditor_debtor_name'], 'OFFICE MAX')
 
     def test_filter_match_field(self):
-        names = ['DUES', 'PRINTING', 'ENTERTAIMENT']
+        names = ['DUES', 'PRINTING', 'ENTERTAINMENT']
         [factories.ScheduleDViewFactory(nature_of_debt=name) for name in names]
         results = self._results(
-            api.url_for(ScheduleDView, nature_of_debt='ENTERTAIMENT')
+            api.url_for(ScheduleDView, nature_of_debt='ENTERTAINMENT')
         )
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]['nature_of_debt'], 'ENTERTAIMENT')
+        self.assertEqual(results[0]['nature_of_debt'], 'ENTERTAINMENT')
 
     def test_filter_range(self):
         [
             factories.ScheduleDViewFactory(
-                load_date=datetime.date(2012, 1, 1),
                 amount_incurred_period=1,
                 outstanding_balance_beginning_of_period=1,
                 outstanding_balance_close_of_period=1,
@@ -60,7 +59,6 @@ class TestScheduleDView(ApiBaseTest):
                 coverage_end_date=datetime.date(2011, 8, 27)
             ),
             factories.ScheduleDViewFactory(
-                load_date=datetime.date(2013, 1, 1),
                 amount_incurred_period=2,
                 outstanding_balance_beginning_of_period=2,
                 outstanding_balance_close_of_period=2,
@@ -68,7 +66,6 @@ class TestScheduleDView(ApiBaseTest):
                 coverage_end_date=datetime.date(2012, 2, 27)
             ),
             factories.ScheduleDViewFactory(
-                load_date=datetime.date(2014, 1, 1),
                 amount_incurred_period=3,
                 outstanding_balance_beginning_of_period=3,
                 outstanding_balance_close_of_period=3,
@@ -76,7 +73,6 @@ class TestScheduleDView(ApiBaseTest):
                 coverage_end_date=datetime.date(2013, 5, 5)
             ),
             factories.ScheduleDViewFactory(
-                load_date=datetime.date(2015, 1, 1),
                 amount_incurred_period=4,
                 outstanding_balance_beginning_of_period=3,
                 outstanding_balance_close_of_period=4,
@@ -86,13 +82,7 @@ class TestScheduleDView(ApiBaseTest):
         ]
         # load_date min, max
         min_date = datetime.date(2013, 1, 1)
-        results = self._results(api.url_for(ScheduleDView, min_date=min_date))
-        self.assertTrue(
-            all(
-                each['load_date'] >= min_date.isoformat()
-                for each in results
-            )
-        )
+
         results = self._results(api.url_for(ScheduleDView, min_coverage_start_date=min_date))
         self.assertTrue(
             all(
@@ -108,10 +98,7 @@ class TestScheduleDView(ApiBaseTest):
             )
         )
         max_date = datetime.date(2014, 1, 1)
-        results = self._results(api.url_for(ScheduleDView, max_date=max_date))
-        self.assertTrue(
-            all(each['load_date'] <= max_date.isoformat() for each in results)
-        )
+
         results = self._results(api.url_for(ScheduleDView, max_coverage_start_date=min_date))
         self.assertTrue(
             all(
@@ -126,15 +113,7 @@ class TestScheduleDView(ApiBaseTest):
                 for each in results
             )
         )
-        results = self._results(
-            api.url_for(ScheduleDView, min_date=min_date, max_date=max_date)
-        )
-        self.assertTrue(
-            all(
-                min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
-                for each in results
-            )
-        )
+
         results = self._results(
             api.url_for(ScheduleDView, min_coverage_end_date=min_date, max_coverage_end_date=max_date)
         )
@@ -193,17 +172,17 @@ class TestScheduleDView(ApiBaseTest):
 
     def test_sort_ascending(self):
         [
-            factories.ScheduleDViewFactory(sub_id=1, load_date='2017-01-02'),
-            factories.ScheduleDViewFactory(sub_id=2, load_date='2017-01-01'),
+            factories.ScheduleDViewFactory(sub_id=1, coverage_end_date='2017-01-02'),
+            factories.ScheduleDViewFactory(sub_id=2, coverage_end_date='2017-01-01'),
         ]
-        results = self._results(api.url_for(ScheduleDView, sort=['load_date']))
-        self.assertEqual(results[0]['load_date'], '2017-01-01')
-        self.assertEqual(results[1]['load_date'], '2017-01-02')
+        results = self._results(api.url_for(ScheduleDView, sort=['coverage_end_date']))
+        self.assertEqual(results[0]['coverage_end_date'], '2017-01-01')
+        self.assertEqual(results[1]['coverage_end_date'], '2017-01-02')
 
     def test_sort_descending(self):
         [
-            factories.ScheduleDViewFactory(sub_id=1, load_date='2017-01-02'),
-            factories.ScheduleDViewFactory(sub_id=2, load_date='2017-01-01'),
+            factories.ScheduleDViewFactory(sub_id=1),
+            factories.ScheduleDViewFactory(sub_id=2),
         ]
         results = self._results(api.url_for(ScheduleDView, sort=['-sub_id']))
         self.assertEqual(results[0]['sub_id'], '2')

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -22,6 +22,8 @@ class TestScheduleDView(ApiBaseTest):
             ('image_number', ScheduleD.image_number, ['123', '456']),
             ('committee_id', ScheduleD.committee_id, ['C01', 'C02']),
             ('candidate_id', ScheduleD.candidate_id, ['S01', 'S02']),
+            ('report_year', ScheduleD.report_year, [2023, 2019]),
+            ('report_type', ScheduleD.report_type, ['60D', 'Q3'])
         ]
         for label, column, values in filters:
             [factories.ScheduleDViewFactory(**{column.key: value}) for value in values]
@@ -53,25 +55,33 @@ class TestScheduleDView(ApiBaseTest):
                 load_date=datetime.date(2012, 1, 1),
                 amount_incurred_period=1,
                 outstanding_balance_beginning_of_period=1,
-                outstanding_balance_close_of_period=1
+                outstanding_balance_close_of_period=1,
+                coverage_start_date=datetime.date(2011, 1, 1),
+                coverage_end_date=datetime.date(2011, 8, 27)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2013, 1, 1),
                 amount_incurred_period=2,
                 outstanding_balance_beginning_of_period=2,
-                outstanding_balance_close_of_period=2
+                outstanding_balance_close_of_period=2,
+                coverage_start_date=datetime.date(2012, 1, 1),
+                coverage_end_date=datetime.date(2012, 2, 27)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2014, 1, 1),
                 amount_incurred_period=3,
                 outstanding_balance_beginning_of_period=3,
-                outstanding_balance_close_of_period=3
+                outstanding_balance_close_of_period=3,
+                coverage_start_date=datetime.date(2013, 1, 1),
+                coverage_end_date=datetime.date(2013, 5, 5)
             ),
             factories.ScheduleDViewFactory(
                 load_date=datetime.date(2015, 1, 1),
                 amount_incurred_period=4,
                 outstanding_balance_beginning_of_period=3,
-                outstanding_balance_close_of_period=4
+                outstanding_balance_close_of_period=4,
+                coverage_start_date=datetime.date(2014, 1, 1),
+                coverage_end_date=datetime.date(2014, 6, 6)
             ),
         ]
         # load_date min, max
@@ -83,10 +93,38 @@ class TestScheduleDView(ApiBaseTest):
                 for each in results
             )
         )
+        results = self._results(api.url_for(ScheduleDView, min_coverage_start_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_start_date'] >= min_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(api.url_for(ScheduleDView, min_coverage_end_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_end_date'] >= min_date.isoformat()
+                for each in results
+            )
+        )
         max_date = datetime.date(2014, 1, 1)
         results = self._results(api.url_for(ScheduleDView, max_date=max_date))
         self.assertTrue(
             all(each['load_date'] <= max_date.isoformat() for each in results)
+        )
+        results = self._results(api.url_for(ScheduleDView, max_coverage_start_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_start_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(api.url_for(ScheduleDView, max_coverage_end_date=min_date))
+        self.assertTrue(
+            all(
+                each['coverage_end_date'] <= max_date.isoformat()
+                for each in results
+            )
         )
         results = self._results(
             api.url_for(ScheduleDView, min_date=min_date, max_date=max_date)
@@ -94,6 +132,25 @@ class TestScheduleDView(ApiBaseTest):
         self.assertTrue(
             all(
                 min_date.isoformat() <= each['load_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(
+            api.url_for(ScheduleDView, min_coverage_end_date=min_date, max_coverage_end_date=max_date)
+        )
+        self.assertTrue(
+            all(
+                min_date.isoformat() <= each['coverage_end_date'] <= max_date.isoformat()
+                for each in results
+            )
+        )
+        results = self._results(
+            api.url_for(ScheduleDView, min_coverage_start_date=min_date, max_coverage_start_date=max_date)
+        )
+
+        self.assertTrue(
+            all(
+                min_date.isoformat() <= each['coverage_start_date'] <= max_date.isoformat()
                 for each in results
             )
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -745,8 +745,6 @@ schedule_d = {
     'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
     'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
     'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
-    'min_date': fields.Date(description='Minimum load date'),
-    'max_date': fields.Date(description='Maximum load date'),
     'min_payment_period': fields.Float(),
     'max_payment_period': fields.Float(),
     'min_amount_incurred': fields.Float(),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -759,6 +759,12 @@ schedule_d = {
     'creditor_debtor_name': fields.List(fields.Str),
     'nature_of_debt': fields.Str(),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'min_coverage_end_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_END_DATE),
+    'max_coverage_end_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_END_DATE),
+    'min_coverage_start_date': fields.Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
+    'max_coverage_start_date': fields.Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
+    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
+    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE)
 }
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -533,7 +533,6 @@ class ScheduleD(PdfMixin, BaseItemized):
     schedule_type = db.Column(db.String)
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     election_cycle = db.Column(db.Integer)
-    load_date = db.Column('pg_date', db.Date)
     coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
     report_year = db.Column('rpt_yr', db.Integer, index=True, doc=docs.REPORT_YEAR)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -490,8 +490,7 @@ class ScheduleC(PdfMixin, BaseItemized):
 
 
 class ScheduleD(PdfMixin, BaseItemized):
-    __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'fec_fitem_sched_d'
+    __tablename__ = 'ofec_sched_d_mv'
 
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
@@ -535,6 +534,10 @@ class ScheduleD(PdfMixin, BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     election_cycle = db.Column(db.Integer)
     load_date = db.Column('pg_date', db.Date)
+    coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
+    coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
+    report_year = db.Column('rpt_yr', db.Integer, index=True, doc=docs.REPORT_YEAR)
+    report_type = db.Column('rpt_tp', db.String, index=True, doc=docs.REPORT_TYPE)
 
     committee = db.relationship(
         'CommitteeHistory',

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1852,6 +1852,14 @@ MAX_COVERAGE_END_DATE = '''
 Ending date of the reporting period before this date(MM/DD/YYYY or YYYY-MM-DD)
 '''
 
+MIN_COVERAGE_START_DATE = '''
+Starting date of the reporting period after this date(MM/DD/YYYY or YYYY-MM-DD)
+'''
+
+MAX_COVERAGE_START_DATE = '''
+Starting date of the reporting period before this date(MM/DD/YYYY or YYYY-MM-DD)
+'''
+
 MIN_TRANSACTION_DATA_COMPLETE_DATE = '''
 Select all filings processed completely after this date(MM/DD/YYYY or YYYY-MM-DD)
 '''

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -31,7 +31,6 @@ class ScheduleDView(ApiResource):
     ]
 
     filter_range_fields = [
-        (('min_date', 'max_date'), models.ScheduleD.load_date),
         (('min_payment_period', 'max_payment_period'), models.ScheduleD.payment_period),
         (('min_amount_incurred', 'max_amount_incurred'), models.ScheduleD.amount_incurred_period),
         (('min_image_number', 'max_image_number'), models.ScheduleD.image_number),
@@ -57,7 +56,7 @@ class ScheduleDView(ApiResource):
             args.schedule_d,
             args.paging,
             args.make_sort_args(
-                default='load_date',
+                default='-coverage_end_date',
             )
         )
 
@@ -91,6 +90,6 @@ class ScheduleDViewBySubId(ApiResource):
         return utils.extend(
             args.paging,
             args.make_sort_args(
-                default='load_date',
+                default='-coverage_end_date',
             )
         )

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -26,6 +26,8 @@ class ScheduleDView(ApiResource):
         ('image_number', models.ScheduleD.image_number),
         ('committee_id', models.ScheduleD.committee_id),
         ('candidate_id', models.ScheduleD.candidate_id),
+        ('report_year', models.ScheduleD.report_year),
+        ('report_type', models.ScheduleD.report_type)
     ]
 
     filter_range_fields = [
@@ -35,6 +37,10 @@ class ScheduleDView(ApiResource):
         (('min_image_number', 'max_image_number'), models.ScheduleD.image_number),
         (('min_amount_outstanding_beginning', 'max_amount_outstanding_beginning'), models.ScheduleD.outstanding_balance_beginning_of_period),
         (('min_amount_outstanding_close', 'max_amount_outstanding_close'), models.ScheduleD.outstanding_balance_close_of_period),
+        (('min_amount_outstanding_close', 'max_amount_outstanding_close'),
+         models.ScheduleD.outstanding_balance_close_of_period),
+        (('min_coverage_start_date', 'max_coverage_start_date'), models.ScheduleD.coverage_start_date),
+        (('min_coverage_end_date', 'max_coverage_end_date'), models.ScheduleD.coverage_end_date)
     ]
 
     filter_match_fields = [


### PR DESCRIPTION
## Summary (required)

- Resolves #4758 

This ticket adds coverage_start_date and coverage_end_date to the debts endpoint and creates a filter for both of these fields (`min_coverage_end_date` `max_coverage_end_date` `min_coverage_start_date` `max_coverage_start_date`).  The ticket mentions that report year, and report type should also be added, but these values are already in the endpoint. 

### Required reviewers - 2 Developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  debts endpoint 


## Related PRs

Related PRs against other branches:

#5392 - database portion, must be merged in first. 

## How to test 

1. Checkout this branch 
2. `pytest`
3. `flask run`
4.  Test the endpoint

Sample URLS: 
http://127.0.0.1:5000/developers/#/debts/get_schedules_schedule_d_

sort by coverage_end_date: 
http://127.0.0.1:5000/v1/schedules/schedule_d/?sort_hide_null=false&page=1&sort_null_only=false&per_page=20&sort=-coverage_end_date&sort_nulls_last=false

max_coverage_end_date=2020-01-01:
http://127.0.0.1:5000/v1/schedules/schedule_d/?sort_hide_null=false&page=1&sort_null_only=false&per_page=20&sort=-coverage_end_date&sort_nulls_last=false&max_coverage_end_date=2020-01-01