### PR TITLE
Remove schedule A routing logic

### DIFF
--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -1,7 +1,6 @@
 import random
 import celery
 from sqlalchemy import orm
-from flask import request
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
 from flask_sqlalchemy import SignallingSession
 
@@ -41,24 +40,8 @@ class RoutingSession(SignallingSession):
 
         return use_follower
 
-    @property
-    def route_schedule_a(self):
-        """If we have more than 1 replica, separate Schedule A traffic. """
-        return (
-            self.app.config['SQLALCHEMY_ROUTE_SCHEDULE_A'] and len(self.followers) > 1
-        )
-
     def get_bind(self, mapper=None, clause=None):
         if self.use_follower:
-            # Celery worker doesn't have request context
-            if request and self.route_schedule_a:
-                if '/schedule_a/' not in request.path:
-                    # Route all non-schedule A traffic to replica 1
-                    return self.followers[0]
-                else:
-                    # Split out Schedule A to remaining replicas
-                    return random.choice(self.followers[1:])
-
             return random.choice(self.followers)
 
         return super().get_bind(mapper=mapper, clause=clause)

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -88,9 +88,6 @@ app.config['SQLALCHEMY_FOLLOWERS'] = [
     for follower in utils.split_env_var(env.get_credential('SQLA_FOLLOWERS', ''))
     if follower.strip()
 ]
-app.config['SQLALCHEMY_ROUTE_SCHEDULE_A'] = bool(
-    env.get_credential('SQLA_ROUTE_SCHEDULE_A', '')
-)
 app.config['PROPAGATE_EXCEPTIONS'] = True
 
 # app.config['SQLALCHEMY_ECHO'] = True


### PR DESCRIPTION
## Summary (required)

- Resolves #4843

Remove schedule A routing replica logic. I'm also removing the old SQLA_FOLLOWER variable that was added to our environments. 


### Required reviewers

3 reviewers ---This specific issue caused a[ production incident](https://docs.google.com/document/d/1zcOJt-hZa5SdwPvDJJafSEj0ylsba_f4DJDp_dYLfX8/edit#) so I would love as many eyes as possible 

## Impacted areas of the application

General components of the application that this PR will affect:

-  RO replicas/ Schedule A routing 


## Related PRs
https://github.com/fecgov/openFEC/pull/4855/files
https://github.com/fecgov/openFEC/pull/4844

## How to test

This has been locust tested on dev. Once this is reviewed and merged, I will remove the SQLA_FOLLOWER variable using [this method ](https://github.com/fecgov/openFEC/wiki/Switch-out-cf-environment-variables) Then I will re-test. If anyone has any further ideas on how to prevent issues I'd very open to them

If someone wants to pair on testing on stage as well just let me know. 


- [x] SQLA_FOLLOWER has been removed from dev
- [x] SQLA_FOLLOWER has been changed to SQLA_FOLLOWERS in stage (for some reason FOLLOWER is the only one on stage, when both dev and prod have both
- [ ] SQLA_FOLLOWER has been removed from prod (I will wait to do this after this PR has been approved)
