### PR TITLE
Add coalesce to committee_name in ts_vector column

### DIFF
--- a/data/migrations/V0273__ofec_filings_all_mv_add_coalesce
+++ b/data/migrations/V0273__ofec_filings_all_mv_add_coalesce
@@ -1,0 +1,256 @@
+/*
+For issue #5416
+Add coalesce to cmte_name in tsvector column
+Previous version is V0258
+*/
+-- ----------
+-- ofec_filings_all_mv_tmp
+-- ----------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_filings_all_mv_tmp 
+AS
+SELECT row_number() OVER () AS idx,
+    CASE
+		WHEN upper(substr(filing_history.cand_cmte_id,1,1)) IN ('H','S','P') THEN filing_history.cand_cmte_id
+		ELSE NULL
+	END AS candidate_id,
+	cand.name AS candidate_name,
+    filing_history.cand_cmte_id AS committee_id,
+    com.name AS committee_name,
+    filing_history.sub_id,
+    filing_history.cvg_start_dt::text::date::timestamp without time zone AS coverage_start_date,
+    filing_history.cvg_end_dt::text::date::timestamp without time zone AS coverage_end_date,
+    filing_history.receipt_dt::text::date::timestamp without time zone AS receipt_date,
+    filing_history.election_yr AS election_year,
+    filing_history.form_tp AS form_type,
+    filing_history.rpt_yr AS report_year,
+    get_cycle(filing_history.rpt_yr) AS cycle,
+    filing_history.rpt_tp AS report_type,
+    filing_history.to_from_ind AS document_type,
+    expand_document(filing_history.to_from_ind::text) AS document_type_full,
+    filing_history.begin_image_num::bigint AS beginning_image_number,
+    filing_history.end_image_num AS ending_image_number,
+    filing_history.pages,
+    filing_history.ttl_receipts AS total_receipts,
+    filing_history.ttl_indt_contb AS total_individual_contributions,
+    filing_history.net_dons AS net_donations,
+    filing_history.ttl_disb AS total_disbursements,
+    filing_history.ttl_indt_exp AS total_independent_expenditures,
+    filing_history.ttl_communication_cost AS total_communication_cost,
+    filing_history.coh_bop AS cash_on_hand_beginning_period,
+    filing_history.coh_cop AS cash_on_hand_end_period,
+    filing_history.debts_owed_by_cmte AS debts_owed_by_committee,
+    filing_history.debts_owed_to_cmte AS debts_owed_to_committee,
+    filing_history.hse_pers_funds_amt AS house_personal_funds,
+    filing_history.sen_pers_funds_amt AS senate_personal_funds,
+    filing_history.oppos_pers_fund_amt AS opposition_personal_funds,
+    filing_history.tres_nm AS treasurer_name,
+    filing_history.file_num AS file_number,
+	CASE
+		WHEN upper(filing_history.form_tp) IN ('FRQ', 'F99') THEN 0
+		ELSE filing_history.prev_file_num
+	END AS previous_file_number,
+    report.rpt_tp_desc AS report_type_full,
+    filing_history.rpt_pgi AS primary_general_indicator,
+	filing_history.request_tp AS request_type,
+	filing_history.amndt_ind AS amendment_indicator,
+	filing_history.lst_updt_dt AS update_date,
+	report_pdf_url_or_null(filing_history.begin_image_num::text, filing_history.rpt_yr, com.committee_type::text, filing_history.cand_cmte_id::text, filing_history.form_tp::text) AS pdf_url,
+	means_filed(filing_history.begin_image_num::text) AS means_filed,
+	report_html_url(means_filed(filing_history.begin_image_num::text), filing_history.cand_cmte_id::text, filing_history.file_num::text) AS html_url,
+	report_fec_url(filing_history.begin_image_num::text, filing_history.file_num::integer) AS fec_url,
+	amendments.amendment_chain,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN filing_history.file_num
+		WHEN upper(filing_history.form_tp::text) IN ('F1'::text, 'F1M'::text, 'F2'::text) THEN v1.mst_rct_file_num 
+		WHEN vs.orig_sub_id IS NOT NULL THEN vs.file_num
+		ELSE amendments.mst_rct_file_num
+	END AS most_recent_file_number,
+	is_amended(amendments.mst_rct_file_num::integer, amendments.file_num::integer, filing_history.form_tp::text) AS is_amended,
+	CASE
+		WHEN upper(filing_history.form_tp::text) IN ('FRQ', 'F99') THEN true
+		WHEN upper(filing_history.form_tp::text) IN ('F1', 'F1M', 'F2') THEN
+	    	CASE 
+				WHEN filing_history.file_num = v1.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != v1.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN upper(filing_history.form_tp::text) = 'F5'::text AND filing_history.rpt_tp::text IN ('24'::text, '48'::text) THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F6'::text THEN NULL
+		WHEN upper(filing_history.form_tp::text) = 'F24' THEN 
+	    	CASE 
+				WHEN filing_history.file_num = amendments.mst_rct_file_num THEN true
+				WHEN filing_history.file_num != amendments.mst_rct_file_num THEN false
+				ELSE NULL
+	    	END
+		WHEN vs.orig_sub_id IS NOT NULL THEN true
+		WHEN vs.orig_sub_id IS NULL THEN false
+		ELSE NULL
+	END AS most_recent,
+	CASE
+		WHEN upper(filing_history.form_tp::text) = 'FRQ'::text THEN 0
+		WHEN upper(filing_history.form_tp::text) = 'F99'::text THEN 0
+		ELSE array_length(amendments.amendment_chain, 1) - 1
+	END AS amendment_version,
+	cand.state,
+	cand.office,
+	cand.district,
+	cand.party,
+	cmte_valid_fec_yr.cmte_tp,
+	get_office_cmte_tp(cand.office, cmte_valid_fec_yr.cmte_tp) AS office_cmte_tp,
+	CASE
+		WHEN (upper(filing_history.form_tp::text) in ('F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) not in ('24', '48')) THEN 'REPORT'::varchar(10)    
+		WHEN (upper(filing_history.form_tp::text) in ('F24', 'F6', 'F9', 'F10', 'F11')) or (upper(filing_history.form_tp::text) = 'F5' and upper(filing_history.rpt_tp::text) in ('24', '48')) THEN 'NOTICE'::varchar(10)    
+		WHEN upper(filing_history.form_tp::text) in ('F1','F2') THEN 'STATEMENT'::varchar(10)        
+		WHEN upper(filing_history.form_tp::text) in ('F1M', 'F8', 'F99', 'F12', 'FRQ') THEN 'OTHER'::varchar(10)    
+	END AS form_category,
+	cb.bank_depository_nm,
+    cb.bank_depository_st1,
+    cb.bank_depository_st2,
+    cb.bank_depository_city,
+    cb.bank_depository_st,
+    cb.bank_depository_zip,
+    cb.additional_bank_names,
+    to_tsvector(parse_fulltext(coalesce(com.name)||' '||filing_history.cand_cmte_id)) AS filer_name_text
+FROM disclosure.f_rpt_or_form_sub filing_history
+LEFT JOIN disclosure.cmte_valid_fec_yr cmte_valid_fec_yr ON filing_history.cand_cmte_id::text = cmte_valid_fec_yr.cmte_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cmte_valid_fec_yr.fec_election_yr
+LEFT JOIN ofec_committee_history_vw com ON filing_history.cand_cmte_id::text = com.committee_id::text AND get_cycle(filing_history.rpt_yr)::numeric = com.cycle
+LEFT JOIN ofec_candidate_history_vw cand ON filing_history.cand_cmte_id::text = cand.candidate_id::text AND get_cycle(filing_history.rpt_yr)::numeric = cand.two_year_period
+LEFT JOIN staging.ref_rpt_tp report ON filing_history.rpt_tp::text = report.rpt_tp_cd::text
+LEFT JOIN ofec_filings_amendments_all_vw amendments ON filing_history.file_num = amendments.file_num
+LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON filing_history.sub_id = vs.orig_sub_id
+LEFT JOIN ofec_non_financial_amendment_chain_vw v1 ON filing_history.sub_id = v1.sub_id
+LEFT JOIN ofec_committee_bank_vw cb ON filing_history.sub_id = cb.sub_id
+WHERE filing_history.rpt_yr >= 1979 AND filing_history.form_tp::text <> 'SL'::text AND filing_history.form_tp::text <> 'SI'::text
+WITH DATA;
+
+
+
+ALTER TABLE public.ofec_filings_all_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_filings_all_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_filings_all_mv_tmp_idx
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (idx);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_amend_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (amendment_indicator);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_beg_img_num
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (beginning_image_number);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cand_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (candidate_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_committee_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_end_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_end_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cvg_start_dt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (coverage_start_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_cycle_cmte_id
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (cycle, committee_id );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_district
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (district );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_type
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_office_cmte_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (office_cmte_tp );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_party
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (party );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_pri_gnrl_ind
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (primary_general_indicator );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_receipt_date
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (receipt_date);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_req_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (request_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_tp_full
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_type_full );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_rpt_yr
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (report_year);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_disb
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_disbursements);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_independent_expenditures);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_ttl_rcpt
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (total_receipts);
+CREATE INDEX idx_ofec_filings_all_mv_tmp_state
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (state );
+CREATE INDEX idx_ofec_filings_all_mv_tmp_form_category
+    ON public.ofec_filings_all_mv_tmp USING btree
+    (form_category);  
+CREATE INDEX idx_ofec_filings_all_mv_tmp_filer_name_text
+    ON public.ofec_filings_all_mv_tmp USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_filings_all_vw AS 
+SELECT * FROM public.ofec_filings_all_mv_tmp;
+
+ALTER TABLE public.ofec_filings_all_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_filings_all_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_filings_all_vw TO fec_read;
+
+-- drop old MV
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_filings_all_mv;
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW public.ofec_filings_all_mv_tmp RENAME TO ofec_filings_all_mv;
+
+-- rename indexes
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_idx RENAME TO idx_ofec_filings_all_mv_idx;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_amend_ind RENAME TO idx_ofec_filings_all_mv_amend_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_beg_img_num RENAME TO idx_ofec_filings_all_mv_beg_img_num;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cand_id RENAME TO idx_ofec_filings_all_mv_cand_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_committee_id RENAME TO idx_ofec_filings_all_mv_committee_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_end_dt RENAME TO idx_ofec_filings_all_mv_cvg_end_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cvg_start_dt RENAME TO idx_ofec_filings_all_mv_cvg_start_dt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle RENAME TO idx_ofec_filings_all_mv_cycle;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_cycle_cmte_id RENAME TO idx_ofec_filings_all_mv_cycle_cmte_id;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_district RENAME TO idx_ofec_filings_all_mv_district;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_type RENAME TO idx_ofec_filings_all_mv_form_type;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office RENAME TO idx_ofec_filings_all_mv_office;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_office_cmte_tp RENAME TO idx_ofec_filings_all_mv_office_cmte_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_party RENAME TO idx_ofec_filings_all_mv_party;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_pri_gnrl_ind RENAME TO idx_ofec_filings_all_mv_pri_gnrl_ind;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_receipt_date RENAME TO idx_ofec_filings_all_mv_receipt_date;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_req_tp RENAME TO idx_ofec_filings_all_mv_req_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp RENAME TO idx_ofec_filings_all_mv_rpt_tp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_tp_full RENAME TO idx_ofec_filings_all_mv_rpt_tp_full;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_rpt_yr RENAME TO idx_ofec_filings_all_mv_rpt_yr;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_disb RENAME TO idx_ofec_filings_all_mv_ttl_disb;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_indpndnt_exp RENAME TO idx_ofec_filings_all_mv_ttl_indpndnt_exp;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_ttl_rcpt RENAME TO idx_ofec_filings_all_mv_ttl_rcpt;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_state RENAME TO idx_ofec_filings_all_mv_state;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_form_category RENAME TO idx_ofec_filings_all_mv_form_category;
+ALTER INDEX IF EXISTS idx_ofec_filings_all_mv_tmp_filer_name_text RENAME TO idx_ofec_filings_all_mv_filer_name_text;

--- a/data/migrations/V0274__ofec_reports_presidential_mv_add_coalesce
+++ b/data/migrations/V0274__ofec_reports_presidential_mv_add_coalesce
@@ -1,0 +1,241 @@
+-- ---------public.ofec_reports_presidential_mv---------
+/*
+This migration is for issue #5416
+Add coalesce to cmte_name in tsvector column
+Previous mv is V0258
+*/
+-- -----------------------------------------------------
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_reports_presidential_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3p.cmte_id AS committee_id,
+    f3p.rpt_yr + f3p.rpt_yr % 2::numeric AS cycle,
+    f3p.cvg_start_dt AS coverage_start_date,
+    f3p.cvg_end_dt AS coverage_end_date,
+    f3p.begin_image_num AS beginning_image_number,
+    f3p.cand_contb_per AS candidate_contribution_period,
+    f3p.cand_contb_ytd AS candidate_contribution_ytd,
+    f3p.coh_bop AS cash_on_hand_beginning_period,
+    f3p.coh_cop AS cash_on_hand_end_period,
+    f3p.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3p.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3p.end_image_num AS end_image_number,
+    f3p.exempt_legal_acctg_disb_per AS exempt_legal_accounting_disbursement_period,
+    f3p.exempt_legal_acctg_disb_ytd AS exempt_legal_accounting_disbursement_ytd,
+    f3p.exp_subject_limits AS expenditure_subject_to_limits,
+    f3p.fed_funds_per AS federal_funds_period,
+    f3p.fed_funds_ytd AS federal_funds_ytd,
+    f3p.fndrsg_disb_per AS fundraising_disbursements_period,
+    f3p.fndrsg_disb_ytd AS fundraising_disbursements_ytd,
+    f3p.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3p.indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3p.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3p.indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3p.indv_contb_per AS total_individual_contributions_period,
+    f3p.indv_contb_ytd AS total_individual_contributions_ytd,
+    f3p.items_on_hand_liquidated,
+    f3p.loans_received_from_cand_per AS loans_received_from_candidate_period,
+    f3p.loans_received_from_cand_ytd AS loans_received_from_candidate_ytd,
+    f3p.net_contb_sum_page_per AS net_contributions_cycle_to_date,
+    f3p.net_op_exp_sum_page_per AS net_operating_expenditures_cycle_to_date,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_exp_ytd,
+    f3p.offsets_to_fndrsg_exp_per AS offsets_to_fundraising_expenditures_period,
+    f3p.offsets_to_fndrsg_exp_ytd AS offsets_to_fundraising_expenditures_ytd,
+    f3p.offsets_to_legal_acctg_per AS offsets_to_legal_accounting_period,
+    f3p.offsets_to_legal_acctg_ytd AS offsets_to_legal_accounting_ytd,
+    f3p.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3p.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3p.op_exp_per AS operating_expenditures_period,
+    f3p.op_exp_ytd AS operating_expenditures_ytd,
+    f3p.other_disb_per AS other_disbursements_period,
+    f3p.other_disb_ytd AS other_disbursements_ytd,
+    f3p.other_loans_received_per AS other_loans_received_period,
+    f3p.other_loans_received_ytd,
+    f3p.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3p.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3p.other_receipts_per AS other_receipts_period,
+    f3p.other_receipts_ytd,
+    f3p.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3p.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3p.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3p.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3p.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3p.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3p.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3p.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3p.repymts_loans_made_by_cand_per AS repayments_loans_made_by_candidate_period,
+    f3p.repymts_loans_made_cand_ytd AS repayments_loans_made_candidate_ytd,
+    f3p.repymts_other_loans_per AS repayments_other_loans_period,
+    f3p.repymts_other_loans_ytd AS repayments_other_loans_ytd,
+    f3p.rpt_yr AS report_year,
+    f3p.subttl_sum_page_per AS subtotal_summary_period,
+    f3p.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3p.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3p.ttl_contb_per AS total_contributions_period,
+    f3p.ttl_contb_ytd AS total_contributions_ytd,
+    f3p.ttl_disb_per AS total_disbursements_period,
+    f3p.ttl_disb_ytd AS total_disbursements_ytd,
+    f3p.ttl_loan_repymts_made_per AS total_loan_repayments_made_period,
+    f3p.ttl_loan_repymts_made_ytd AS total_loan_repayments_made_ytd,
+    f3p.ttl_loans_received_per AS total_loans_received_period,
+    f3p.ttl_loans_received_ytd AS total_loans_received_ytd,
+    f3p.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3p.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3p.ttl_per AS total_period,
+    f3p.ttl_receipts_per AS total_receipts_period,
+    f3p.ttl_receipts_ytd AS total_receipts_ytd,
+    f3p.ttl_ytd AS total_ytd,
+    f3p.tranf_from_affilated_cmte_per AS transfers_from_affiliated_committee_period,
+    f3p.tranf_from_affiliated_cmte_ytd AS transfers_from_affiliated_committee_ytd,
+    f3p.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3p.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3p.rpt_tp AS report_type,
+    f3p.rpt_tp_desc AS report_type_full,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3p.receipt_dt AS receipt_date,
+    f3p.file_num AS file_number,
+    f3p.amndt_ind AS amendment_indicator,
+    f3p.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3p.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3p.begin_image_num::text), f3p.cmte_id::text, f3p.file_num::text) AS html_url,
+    report_fec_url(f3p.begin_image_num::text, f3p.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3p.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name,
+    to_tsvector(parse_fulltext(coalesce(cmte.cmte_nm,'')||' '||f3p.cmte_id)) AS filer_name_text
+  FROM disclosure.nml_form_3p f3p
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3p.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3p.rpt_yr + f3p.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3p.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3p.file_num = amendments.file_num
+  WHERE f3p.rpt_yr >= 1979::numeric AND f3p.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_presidential_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_presidential_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_presidential_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_presidential_mv_tmp_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+ 
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_cyc_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (cycle, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_is_amen_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (is_amended, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (receipt_date, idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_presidential_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+    
+CREATE INDEX idx_ofec_reports_presidential_mv_tmp_filer_name_text
+    ON public.ofec_reports_presidential_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_presidential_vw AS 
+SELECT * FROM public.ofec_reports_presidential_mv_tmp;
+
+ALTER TABLE public.ofec_reports_presidential_vw OWNER TO fec;
+GRANT ALL ON TABLE public.ofec_reports_presidential_vw TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_presidential_vw TO fec_read;
+
+
+-- drop old MV:ofec_reports_presidential_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_presidential_mv_tmp 
+  RENAME TO ofec_reports_presidential_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_idx RENAME TO idx_ofec_reports_presidential_mv_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_disb_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_presidential_mv_beg_image_num_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_presidential_mv_cmte_id_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_end_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_presidential_mv_cvg_start_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_presidential_mv_cyc_cmte_id;
+ 
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_presidential_mv_cyc_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_presidential_mv_is_amen_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_presidential_mv_rcpt_date_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_type_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_presidential_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_presidential_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_presidential_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_presidential_mv_filer_name_text;

--- a/data/migrations/V0275__ofec_reports_house_senate_mv_add_coalesce
+++ b/data/migrations/V0275__ofec_reports_house_senate_mv_add_coalesce
@@ -1,0 +1,229 @@
+/*
+This migration is for issue #5416
+Add coalesce to cmte_name in tsvector column
+Previous mv is V0259
+*/
+-- -----------------------------------------------------
+-- --------public.ofec_reports_house_senate_mv--------------
+DROP MATERIALIZED VIEW IF EXISTS public.oofec_reports_house_senate_mv_tmp;
+
+CREATE MATERIALIZED VIEW public.ofec_reports_house_senate_mv_tmp AS
+  SELECT row_number() OVER () AS idx,
+    f3.cmte_id AS committee_id,
+    f3.rpt_yr + f3.rpt_yr % 2::numeric AS cycle,
+    f3.cvg_start_dt AS coverage_start_date,
+    f3.cvg_end_dt AS coverage_end_date,
+    f3.agr_amt_pers_contrib_gen AS aggregate_amount_personal_contributions_general,
+    f3.agr_amt_contrib_pers_fund_prim AS aggregate_contributions_personal_funds_primary,
+    f3.all_other_loans_per AS all_other_loans_period,
+    f3.all_other_loans_ytd,
+    f3.begin_image_num AS beginning_image_number,
+    f3.cand_contb_per AS candidate_contribution_period,
+    f3.cand_contb_ytd AS candidate_contribution_ytd,
+    f3.coh_bop AS cash_on_hand_beginning_period,
+    GREATEST(f3.coh_cop_i, f3.coh_cop_ii) AS cash_on_hand_end_period,
+    f3.debts_owed_by_cmte AS debts_owed_by_committee,
+    f3.debts_owed_to_cmte AS debts_owed_to_committee,
+    f3.end_image_num AS end_image_number,
+    f3.grs_rcpt_auth_cmte_gen AS gross_receipt_authorized_committee_general,
+    f3.grs_rcpt_auth_cmte_prim AS gross_receipt_authorized_committee_primary,
+    f3.grs_rcpt_min_pers_contrib_gen AS gross_receipt_minus_personal_contribution_general,
+    f3.grs_rcpt_min_pers_contrib_prim AS gross_receipt_minus_personal_contributions_primary,
+    f3.indv_item_contb_per AS individual_itemized_contributions_period,
+    f3.indv_unitem_contb_per AS individual_unitemized_contributions_period,
+    f3.loan_repymts_cand_loans_per AS loan_repayments_candidate_loans_period,
+    f3.loan_repymts_cand_loans_ytd AS loan_repayments_candidate_loans_ytd,
+    f3.loan_repymts_other_loans_per AS loan_repayments_other_loans_period,
+    f3.loan_repymts_other_loans_ytd AS loan_repayments_other_loans_ytd,
+    f3.loans_made_by_cand_per AS loans_made_by_candidate_period,
+    f3.loans_made_by_cand_ytd AS loans_made_by_candidate_ytd,
+    f3.net_contb_per AS net_contributions_period,
+    f3.net_contb_ytd AS net_contributions_ytd,
+    f3.net_op_exp_per AS net_operating_expenditures_period,
+    f3.net_op_exp_ytd AS net_operating_expenditures_ytd,
+    f3.offsets_to_op_exp_per AS offsets_to_operating_expenditures_period,
+    f3.offsets_to_op_exp_ytd AS offsets_to_operating_expenditures_ytd,
+    f3.op_exp_per AS operating_expenditures_period,
+    f3.op_exp_ytd AS operating_expenditures_ytd,
+    f3.other_disb_per AS other_disbursements_period,
+    f3.other_disb_ytd AS other_disbursements_ytd,
+    f3.other_pol_cmte_contb_per AS other_political_committee_contributions_period,
+    f3.other_pol_cmte_contb_ytd AS other_political_committee_contributions_ytd,
+    f3.other_receipts_per AS other_receipts_period,
+    f3.other_receipts_ytd,
+    f3.pol_pty_cmte_contb_per AS political_party_committee_contributions_period,
+    f3.pol_pty_cmte_contb_ytd AS political_party_committee_contributions_ytd,
+    f3.ref_indv_contb_per AS refunded_individual_contributions_period,
+    f3.ref_indv_contb_ytd AS refunded_individual_contributions_ytd,
+    f3.ref_other_pol_cmte_contb_per AS refunded_other_political_committee_contributions_period,
+    f3.ref_other_pol_cmte_contb_ytd AS refunded_other_political_committee_contributions_ytd,
+    f3.ref_pol_pty_cmte_contb_per AS refunded_political_party_committee_contributions_period,
+    f3.ref_pol_pty_cmte_contb_ytd AS refunded_political_party_committee_contributions_ytd,
+    f3.ref_ttl_contb_col_ttl_ytd AS refunds_total_contributions_col_total_ytd,
+    f3.subttl_per AS subtotal_period,
+    f3.ttl_contb_ref_col_ttl_per AS total_contribution_refunds_col_total_period,
+    f3.ttl_contb_ref_per AS total_contribution_refunds_period,
+    f3.ttl_contb_ref_ytd AS total_contribution_refunds_ytd,
+    f3.ttl_contb_column_ttl_per AS total_contributions_column_total_period,
+    f3.ttl_contb_per AS total_contributions_period,
+    f3.ttl_contb_ytd AS total_contributions_ytd,
+    GREATEST(f3.ttl_disb_per_i, f3.ttl_disb_per_ii) AS total_disbursements_period,
+    f3.ttl_disb_ytd AS total_disbursements_ytd,
+    f3.ttl_indv_contb_per AS total_individual_contributions_period,
+    f3.ttl_indv_contb_ytd AS total_individual_contributions_ytd,
+    f3.ttl_indv_item_contb_ytd AS individual_itemized_contributions_ytd,
+    f3.ttl_indv_unitem_contb_ytd AS individual_unitemized_contributions_ytd,
+    f3.ttl_loan_repymts_per AS total_loan_repayments_made_period,
+    f3.ttl_loan_repymts_ytd AS total_loan_repayments_made_ytd,
+    f3.ttl_loans_per AS total_loans_received_period,
+    f3.ttl_loans_ytd AS total_loans_received_ytd,
+    f3.ttl_offsets_to_op_exp_per AS total_offsets_to_operating_expenditures_period,
+    f3.ttl_offsets_to_op_exp_ytd AS total_offsets_to_operating_expenditures_ytd,
+    f3.ttl_op_exp_per AS total_operating_expenditures_period,
+    f3.ttl_op_exp_ytd AS total_operating_expenditures_ytd,
+    GREATEST(f3.ttl_receipts_per_i, f3.ttl_receipts_ii) AS total_receipts_period,
+    f3.ttl_receipts_ytd AS total_receipts_ytd,
+    f3.tranf_from_other_auth_cmte_per AS transfers_from_other_authorized_committee_period,
+    f3.tranf_from_other_auth_cmte_ytd AS transfers_from_other_authorized_committee_ytd,
+    f3.tranf_to_other_auth_cmte_per AS transfers_to_other_authorized_committee_period,
+    f3.tranf_to_other_auth_cmte_ytd AS transfers_to_other_authorized_committee_ytd,
+    f3.rpt_tp AS report_type,
+    f3.rpt_tp_desc AS report_type_full,
+    f3.rpt_yr AS report_year,
+    CASE
+      WHEN vs.orig_sub_id IS NOT NULL THEN 'Y'::text
+      ELSE 'N'::text
+    END ~~ 'N'::text AS is_amended,
+    f3.receipt_dt AS receipt_date,
+    f3.file_num AS file_number,
+    f3.amndt_ind AS amendment_indicator,
+    f3.amndt_ind_desc AS amendment_indicator_full,
+    means_filed(f3.begin_image_num::text) AS means_filed,
+    report_html_url(means_filed(f3.begin_image_num::text), f3.cmte_id::text, f3.file_num::text) AS html_url,
+    report_fec_url(f3.begin_image_num::text, f3.file_num::integer) AS fec_url,
+    amendments.amendment_chain,
+    amendments.prev_file_num AS previous_file_number,
+    amendments.mst_rct_file_num AS most_recent_file_number,
+    is_most_recent(f3.file_num::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+    cmte.cmte_nm AS committee_name,
+    to_tsvector(parse_fulltext(coalesce(cmte.cmte_nm,'')||' '||f3.cmte_id)) AS filer_name_text
+  FROM disclosure.nml_form_3 f3
+  LEFT JOIN disclosure.v_sum_and_det_sum_report vs ON f3.sub_id = vs.orig_sub_id
+  LEFT JOIN disclosure.cmte_valid_fec_yr cmte ON (f3.rpt_yr + f3.rpt_yr % 2::numeric) = cmte.fec_election_yr AND f3.cmte_id::text = cmte.cmte_id::text
+  LEFT JOIN ofec_filings_amendments_all_vw amendments ON f3.file_num = amendments.file_num
+  WHERE f3.rpt_yr >= 1979::numeric AND f3.delete_ind IS NULL
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_house_senate_mv_tmp
+    OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_house_senate_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_house_senate_mv_tmp_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_cyc_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_is_amen_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+CREATE INDEX idx_ofec_reports_house_senate_mv_tmp_filer_name_text
+    ON public.ofec_reports_house_senate_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_house_senate_vw AS 
+  SELECT * FROM public.ofec_reports_house_senate_mv_tmp;
+
+
+-- drop old MV:ofec_reports_house_senate_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_house_senate_mv_tmp 
+  RENAME TO ofec_reports_house_senate_mv;
+
+
+-- rename all indexes
+
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_idx RENAME TO idx_ofec_reports_house_senate_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_disb_period_id_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_disb_period_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_house_senate_mv_beg_image_num_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_house_senate_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_house_senate_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_house_senate_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_house_senate_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_house_senate_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_house_senate_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_house_senate_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_house_senate_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_house_senate_mv_filer_name_text;

--- a/data/migrations/V0276__ofec_reports_pac_party_mv_add_coalesce
+++ b/data/migrations/V0276__ofec_reports_pac_party_mv_add_coalesce
@@ -1,0 +1,256 @@
+/*
+This migration is for issue #5416
+Add coalesce to cmte_name in tsvector column 
+Previous mv is V0260
+*/
+-- -----------------------------------------------------
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp;
+CREATE MATERIALIZED VIEW public.ofec_reports_pac_party_mv_tmp AS
+    SELECT row_number() OVER () AS idx,
+        rpt.committee_id,
+        rpt.cycle,
+        rpt.coverage_start_date,
+        rpt.coverage_end_date,
+        rpt.all_loans_received_period,
+        rpt.all_loans_received_ytd,
+        rpt.allocated_federal_election_levin_share_period,
+        rpt.beginning_image_number,
+        rpt.calendar_ytd,
+        rpt.cash_on_hand_beginning_calendar_ytd,
+        rpt.cash_on_hand_beginning_period,
+        rpt.cash_on_hand_close_ytd,
+        rpt.cash_on_hand_end_period,
+        rpt.coordinated_expenditures_by_party_committee_period,
+        rpt.coordinated_expenditures_by_party_committee_ytd,
+        rpt.debts_owed_by_committee,
+        rpt.debts_owed_to_committee,
+        rpt.end_image_number,
+        rpt.fed_candidate_committee_contribution_refunds_ytd,
+        rpt.fed_candidate_committee_contributions_period,
+        rpt.fed_candidate_committee_contributions_ytd,
+        rpt.fed_candidate_contribution_refunds_period,
+        rpt.independent_expenditures_period,
+        rpt.independent_expenditures_ytd,
+        rpt.refunded_individual_contributions_period,
+        rpt.refunded_individual_contributions_ytd,
+        rpt.individual_itemized_contributions_period,
+        rpt.individual_itemized_contributions_ytd,
+        rpt.individual_unitemized_contributions_period,
+        rpt.individual_unitemized_contributions_ytd,
+        rpt.loan_repayments_made_period,
+        rpt.loan_repayments_made_ytd,
+        rpt.loan_repayments_received_period,
+        rpt.loan_repayments_received_ytd,
+        rpt.loans_made_period,
+        rpt.loans_made_ytd,
+        rpt.net_contributions_period,
+        rpt.net_contributions_ytd,
+        rpt.net_operating_expenditures_period,
+        rpt.net_operating_expenditures_ytd,
+        rpt.non_allocated_fed_election_activity_period,
+        rpt.non_allocated_fed_election_activity_ytd,
+        rpt.nonfed_share_allocated_disbursements_period,
+        rpt.offsets_to_operating_expenditures_period,
+        rpt.offsets_to_operating_expenditures_ytd,
+        rpt.other_disbursements_period,
+        rpt.other_disbursements_ytd,
+        rpt.other_fed_operating_expenditures_period,
+        rpt.other_fed_operating_expenditures_ytd,
+        rpt.other_fed_receipts_period,
+        rpt.other_fed_receipts_ytd,
+        rpt.refunded_other_political_committee_contributions_period,
+        rpt.refunded_other_political_committee_contributions_ytd,
+        rpt.other_political_committee_contributions_period,
+        rpt.other_political_committee_contributions_ytd,
+        rpt.refunded_political_party_committee_contributions_period,
+        rpt.refunded_political_party_committee_contributions_ytd,
+        rpt.political_party_committee_contributions_period,
+        rpt.political_party_committee_contributions_ytd,
+        rpt.report_year,
+        rpt.shared_fed_activity_nonfed_ytd,
+        rpt.shared_fed_activity_period,
+        rpt.shared_fed_activity_ytd,
+        rpt.shared_fed_operating_expenditures_period,
+        rpt.shared_fed_operating_expenditures_ytd,
+        rpt.shared_nonfed_operating_expenditures_period,
+        rpt.shared_nonfed_operating_expenditures_ytd,
+        rpt.subtotal_summary_page_period,
+        rpt.subtotal_summary_ytd,
+        rpt.total_contribution_refunds_period,
+        rpt.total_contribution_refunds_ytd,
+        rpt.total_contributions_period,
+        rpt.total_contributions_ytd,
+        rpt.total_disbursements_period,
+        rpt.total_disbursements_ytd,
+        rpt.total_fed_disbursements_period,
+        rpt.total_fed_disbursements_ytd,
+        rpt.total_fed_election_activity_period,
+        rpt.total_fed_election_activity_ytd,
+        rpt.total_fed_operating_expenditures_period,
+        rpt.total_fed_operating_expenditures_ytd,
+        rpt.total_fed_receipts_period,
+        rpt.total_fed_receipts_ytd,
+        rpt.total_individual_contributions_period,
+        rpt.total_individual_contributions_ytd,
+        rpt.total_nonfed_transfers_period,
+        rpt.total_nonfed_transfers_ytd,
+        rpt.total_operating_expenditures_period,
+        rpt.total_operating_expenditures_ytd,
+        rpt.total_receipts_period,
+        rpt.total_receipts_ytd,
+        rpt.transfers_from_affiliated_party_period,
+        rpt.transfers_from_affiliated_party_ytd,
+        rpt.transfers_from_nonfed_account_period,
+        rpt.transfers_from_nonfed_account_ytd,
+        rpt.transfers_from_nonfed_levin_period,
+        rpt.transfers_from_nonfed_levin_ytd,
+        rpt.transfers_to_affiliated_committee_period,
+        rpt.transfers_to_affilitated_committees_ytd,
+        rpt.form_tp,
+        rpt.report_type,
+        rpt.report_type_full,
+        rpt.is_amended,
+        rpt.receipt_date,
+        rpt.file_number,
+        rpt.amendment_indicator,
+        rpt.amendment_indicator_full,
+        rpt.means_filed,
+        rpt.html_url,
+        rpt.fec_url,
+        amendments.amendment_chain,
+        amendments.prev_file_num AS previous_file_number,
+        amendments.mst_rct_file_num AS most_recent_file_number,
+        is_most_recent(rpt.file_number::integer, amendments.mst_rct_file_num::integer) AS most_recent,
+        rpt.committee_name,
+        to_tsvector(parse_fulltext(coalesce(rpt.committee_name,'')||' '||rpt.committee_id)) AS filer_name_text    
+    FROM ofec_pac_party_report_vw rpt
+    LEFT JOIN ofec_filings_amendments_all_vw amendments ON rpt.file_number = amendments.file_num
+WITH DATA;
+
+ALTER TABLE public.ofec_reports_pac_party_mv_tmp
+    OWNER TO fec; 
+
+GRANT ALL ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec;
+GRANT SELECT ON TABLE public.ofec_reports_pac_party_mv_tmp TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_reports_pac_party_mv_tmp_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (beginning_image_number COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (committee_id COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_end_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (coverage_start_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, committee_id COLLATE pg_catalog."default");
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_cyc_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (cycle, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_ie_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (independent_expenditures_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_is_amen_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (is_amended, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (receipt_date, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_type COLLATE pg_catalog."default", idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (report_year, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_disbursements_period, idx);
+    
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING btree
+    (total_receipts_period, idx);
+
+CREATE INDEX idx_ofec_reports_pac_party_mv_tmp_filer_name_text
+    ON public.ofec_reports_pac_party_mv_tmp
+    USING gin (filer_name_text);
+
+-- ------------
+-- point the view to the _mv_tmp    
+-- ------------
+CREATE OR REPLACE VIEW public.ofec_reports_pac_party_vw AS 
+  SELECT * FROM public.ofec_reports_pac_party_mv_tmp;
+
+
+-- drop old MV:ofec_reports_pac_party_mv
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv;
+
+
+-- rename _tmp mv to mv
+ALTER MATERIALIZED VIEW IF EXISTS public.ofec_reports_pac_party_mv_tmp 
+  RENAME TO ofec_reports_pac_party_mv;
+
+
+-- rename all indexes
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_idx RENAME TO idx_ofec_reports_pac_party_mv_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_beg_image_num_idx RENAME TO idx_ofec_reports_pac_party_mv_beg_image_num_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cmte_id_idx RENAME TO idx_ofec_reports_pac_party_mv_cmte_id_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_end_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_end_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cvg_start_date_idx RENAME TO idx_ofec_reports_pac_party_mv_cvg_start_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_cmte_id RENAME TO idx_ofec_reports_pac_party_mv_cyc_cmte_id;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_cyc_idx RENAME TO idx_ofec_reports_pac_party_mv_cyc_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_ie_period_idx RENAME TO idx_ofec_reports_pac_party_mv_ie_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_is_amen_idx RENAME TO idx_ofec_reports_pac_party_mv_is_amen_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rcpt_date_idx RENAME TO idx_ofec_reports_pac_party_mv_rcpt_date_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_type_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_type_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_rpt_year_idx RENAME TO idx_ofec_reports_pac_party_mv_rpt_year_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_disb_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_disb_period_idx;
+    
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_tot_rcpt_period_idx RENAME TO idx_ofec_reports_pac_party_mv_tot_rcpt_period_idx;
+
+ALTER INDEX public.idx_ofec_reports_pac_party_mv_tmp_filer_name_text RENAME TO idx_ofec_reports_pac_party_mv_filer_name_text;


### PR DESCRIPTION
## Summary (required)

- Resolves #5416 

When committee name is null, the concatenation that includes committee name will return null.  Coalesce function is added to handle this scenario.

### Required reviewers

1 developer

## How to test
1. Download feature branch
2. Run pytest
3. Run `flyway migrate`
4. Test **filings endpoint** on local by switching model to tmp mv
In common/models/filings.py, set 
> class Filings(FecFileNumberMixin, CsvMixin, db.Model):
    __tablename__ = 'ofec_filings_all_mv_tmp_hc'

**Before change, no rows returned**
https://api.open.fec.gov/v1/filings/?sort=-receipt_date&sort_hide_null=false&sort_nulls_last=false&per_page=20&page=1&sort_null_only=false&q_filer=C00780197&api_key=DEMO_KEY
**After change, 9 rows returned**
http://127.0.0.1:5000/v1/filings/?page=1&sort_nulls_last=false&q_filer=C00780197&sort=-receipt_date&sort_hide_null=false&per_page=20&sort_null_only=false

5. Test **reports endpoints** on local by switching models to tmp mv
     In common/models/reports.py, set:
       
`__tablename__ = 'ofec_reports_house_senate_mv_tmp_hc'`

**Before change, 107 rows returned**
https://api.open.fec.gov/v1/reports/house-senate/?per_page=20&q_filer=C00281840&page=1&sort_hide_null=false&sort=cycle&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
**After change, 108 rows returned including 1992 YE**
http://127.0.0.1:5000/v1/reports/house-senate/?page=1&sort_nulls_last=false&q_filer=C00281840&sort=cycle&sort_hide_null=false&per_page=20&sort_null_only=false

`__tablename__ = 'ofec_reports_pac_party_mv_tmp_hc'`

**Before change, 31 rows returned**
https://api.open.fec.gov/v1/reports/pac-party/?per_page=20&q_filer=C00288647&page=1&sort_hide_null=false&sort=cycle&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
**After change, 32 rows returned including 1992 YE**
http://127.0.0.1:5000/v1/reports/pac-party/?page=1&sort_nulls_last=false&q_filer=C00288647&sort=cycle&sort_hide_null=false&per_page=20&sort_null_only=false

`__tablename__ = 'ofec_reports_presidential_mv_tmp_hc'`

**Before change, 0 row returned**
https://api.open.fec.gov/v1/reports/presidential/?per_page=20&q_filer=C00219170&page=1&sort_hide_null=false&sort=-coverage_end_date&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
**After change, 1 row returned **
http://127.0.0.1:5000/v1/reports/presidential/?page=1&sort_nulls_last=false&q_filer=C00219170&sort=-coverage_end_date&sort_hide_null=false&per_page=20&sort_null_only=false

**Before change, 4 row returned**
https://www.fec.gov/data/reports/presidential/?is_amended=false&data_type=processed&q_filer=C00184572
**After change, 5 row returned including TERMINATION REPORT 1985**
http://127.0.0.1:5000/v1/reports/presidential/?page=1&sort_nulls_last=false&q_filer=C00184572&sort=-coverage_end_date&sort_hide_null=false&per_page=20&sort_null_only=false

