### PR TITLE
Upgrade prance to version 0.22.11.4.0 and unpin jsonschema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x
 networkx==2.6.2
-prance[osv]>=0.19
+prance[osv]==0.22.11.4.0
 psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 python-dotenv>=0.20.0 # Sets variable defaults in .flaskenv file
@@ -46,7 +46,6 @@ redis==4.5.4
 coverage==7.0.3
 factory_boy==2.8.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
-jsonschema==3.2.0 #pinned to fix the pytest deprecation warning inside jsonschema/validators.py
 nplusone==0.8.0
 pytest==5.2.0
 pytest-cov==2.5.1


### PR DESCRIPTION
## Summary (required)

- Resolves #5393 

This ticket upgrades prance to get rid of the the warning from `pytest`. 

Version [0.22.11.4.0](https://prance.readthedocs.io/en/latest/) of prance replaces distutils.version with packaging.version which is what was causing the warning. I had to unpin jsonschema because prance requires jsonschema >= 4.0.0 

### Required reviewers - 1 Developer

## Impacted areas of the application

General components of the application that this PR will affect:

-  pytest

## How to test

1. Checkout this branch 
2. Activate your virtual environment
3. `pip install -r requirements.txt`
4. `pytest`