### PR TITLE
Refactor filter_fulltext 

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -358,6 +358,37 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_employer'], 'Vandelay Industries')
 
+    def test_schedule_a_filter_fulltext_employer_with_null(self):
+        receipts = [  # noqa
+            factories.ScheduleAFactory(
+                contribution_receipt_date=datetime.date(2016, 6, 1),
+                two_year_transaction_period=2016,
+                contributor_employer='Vandelay Industries',
+            ),
+            factories.ScheduleAFactory(
+                contribution_receipt_date=datetime.date(2016, 4, 1),
+                two_year_transaction_period=2016,
+                contributor_employer='Thomas Null LLC',
+            ),
+            factories.ScheduleAFactory(
+                contribution_receipt_date=datetime.date(2016, 1, 1),
+                two_year_transaction_period=2016,
+                contributor_employer=None,
+            )
+        ]
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='vandelay', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['contributor_employer'], 'Vandelay Industries')
+
+        results = self._results(
+            api.url_for(ScheduleAView, contributor_employer='null', sort='contribution_receipt_date', **self.kwargs)
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]['contributor_employer'], None)
+        self.assertEqual(results[1]['contributor_employer'], 'Thomas Null LLC')
+
     def test_schedule_a_filter_fulltext_employer_and(self):
         employers = ['Test&Test', 'Test & Test', 'Test& Test', 'Test &Test']
         [

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -91,10 +91,11 @@ def filter_fulltext(query, kwargs, fields):
                 ]
                 query = query.filter(sa.and_(*filters))
             if include_list:
-                filters = [
-                    column.match(utils.parse_fulltext(value))
-                    for value in include_list
-                ]
+                filters = []
+                for value in include_list:
+                    filters.append(column.match(utils.parse_fulltext(value)))
+                    if value.upper() == 'NULL':
+                        filters.append(column.is_(None))
                 query = query.filter(sa.or_(*filters))
     return query
 


### PR DESCRIPTION
## Summary (required)
Resolves #5135 

When filtering for an employer with null value, the endpoint returns rows with string null or just null.

### Required reviewers
2 developers

### Impacted areas of the application
[This worksheet](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=676443644) lists all the endpoints that use this filter

### Screenshots
```
SELECT disclosure.fec_fitem_sched_a.cmte_id AS disclosure_fec_fitem_sched_a_cmte_id, disclosure.fec_fitem_sched_a.rpt_yr AS disclosure_fec_fitem_sched_a_rpt_yr, disclosure.fec_fitem_sched_a.rpt_tp AS disclosure_fec_fitem_sched_a_rpt_tp, disclosure.fec_fitem_sched_a.image_num AS disclosure_fec_fitem_sched_a_image_num, disclosure.fec_fitem_sched_a.line_num AS disclosure_fec_fitem_sched_a_line_num, disclosure.fec_fitem_sched_a.tran_id AS disclosure_fec_fitem_sched_a_tran_id, disclosure.fec_fitem_sched_a.file_num AS disclosure_fec_fitem_sched_a_file_num, disclosure.fec_fitem_sched_a.cmte_nm AS disclosure_fec_fitem_sched_a_cmte_nm, disclosure.fec_fitem_sched_a.entity_tp AS disclosure_fec_fitem_sched_a_entity_tp, disclosure.fec_fitem_sched_a.entity_tp_desc AS disclosure_fec_fitem_sched_a_entity_tp_desc, disclosure.fec_fitem_sched_a.contbr_id AS disclosure_fec_fitem_sched_a_contbr_id, disclosure.fec_fitem_sched_a.contbr_prefix AS disclosure_fec_fitem_sched_a_contbr_prefix, disclosure.fec_fitem_sched_a.contbr_nm AS disclosure_fec_fitem_sched_a_contbr_nm, disclosure.fec_fitem_sched_a.cmte_tp AS disclosure_fec_fitem_sched_a_cmte_tp, disclosure.fec_fitem_sched_a.org_tp AS disclosure_fec_fitem_sched_a_org_tp, disclosure.fec_fitem_sched_a.cmte_dsgn AS disclosure_fec_fitem_sched_a_cmte_dsgn, disclosure.fec_fitem_sched_a.contbr_nm_first AS disclosure_fec_fitem_sched_a_contbr_nm_first, disclosure.fec_fitem_sched_a.contbr_m_nm AS disclosure_fec_fitem_sched_a_contbr_m_nm, disclosure.fec_fitem_sched_a.contbr_nm_last AS disclosure_fec_fitem_sched_a_contbr_nm_last, disclosure.fec_fitem_sched_a.contbr_suffix AS disclosure_fec_fitem_sched_a_contbr_suffix, disclosure.fec_fitem_sched_a.contbr_st1 AS disclosure_fec_fitem_sched_a_contbr_st1, disclosure.fec_fitem_sched_a.contbr_st2 AS disclosure_fec_fitem_sched_a_contbr_st2, disclosure.fec_fitem_sched_a.contbr_city AS disclosure_fec_fitem_sched_a_contbr_city, disclosure.fec_fitem_sched_a.contbr_st AS disclosure_fec_fitem_sched_a_contbr_st, disclosure.fec_fitem_sched_a.contbr_zip AS disclosure_fec_fitem_sched_a_contbr_zip, disclosure.fec_fitem_sched_a.contbr_employer AS disclosure_fec_fitem_sched_a_contbr_employer, disclosure.fec_fitem_sched_a.contbr_occupation AS disclosure_fec_fitem_sched_a_contbr_occupation, disclosure.fec_fitem_sched_a.clean_contbr_id AS disclosure_fec_fitem_sched_a_clean_contbr_id, disclosure.fec_fitem_sched_a.receipt_tp AS disclosure_fec_fitem_sched_a_receipt_tp, disclosure.fec_fitem_sched_a.receipt_tp_desc AS disclosure_fec_fitem_sched_a_receipt_tp_desc, disclosure.fec_fitem_sched_a.receipt_desc AS disclosure_fec_fitem_sched_a_receipt_desc, disclosure.fec_fitem_sched_a.memo_cd AS disclosure_fec_fitem_sched_a_memo_cd, disclosure.fec_fitem_sched_a.memo_cd_desc AS disclosure_fec_fitem_sched_a_memo_cd_desc, disclosure.fec_fitem_sched_a.contb_receipt_dt AS disclosure_fec_fitem_sched_a_contb_receipt_dt, disclosure.fec_fitem_sched_a.contb_receipt_amt AS disclosure_fec_fitem_sched_a_contb_receipt_amt, disclosure.fec_fitem_sched_a.contb_aggregate_ytd AS disclosure_fec_fitem_sched_a_contb_aggregate_ytd, disclosure.fec_fitem_sched_a.cand_id AS disclosure_fec_fitem_sched_a_cand_id, disclosure.fec_fitem_sched_a.cand_nm AS disclosure_fec_fitem_sched_a_cand_nm, disclosure.fec_fitem_sched_a.cand_nm_first AS disclosure_fec_fitem_sched_a_cand_nm_first, disclosure.fec_fitem_sched_a.cand_nm_last AS disclosure_fec_fitem_sched_a_cand_nm_last, disclosure.fec_fitem_sched_a.cand_m_nm AS disclosure_fec_fitem_sched_a_cand_m_nm, disclosure.fec_fitem_sched_a.cand_prefix AS disclosure_fec_fitem_sched_a_cand_prefix, disclosure.fec_fitem_sched_a.cand_suffix AS disclosure_fec_fitem_sched_a_cand_suffix, disclosure.fec_fitem_sched_a.cand_office AS disclosure_fec_fitem_sched_a_cand_office, disclosure.fec_fitem_sched_a.cand_office_desc AS disclosure_fec_fitem_sched_a_cand_office_desc, disclosure.fec_fitem_sched_a.cand_office_st AS disclosure_fec_fitem_sched_a_cand_office_st, disclosure.fec_fitem_sched_a.cand_office_st_desc AS disclosure_fec_fitem_sched_a_cand_office_st_desc, disclosure.fec_fitem_sched_a.cand_office_district AS disclosure_fec_fitem_sched_a_cand_office_district, disclosure.fec_fitem_sched_a.conduit_cmte_id AS disclosure_fec_fitem_sched_a_conduit_cmte_id, disclosure.fec_fitem_sched_a.conduit_cmte_nm AS disclosure_fec_fitem_sched_a_conduit_cmte_nm, disclosure.fec_fitem_sched_a.conduit_cmte_st1 AS disclosure_fec_fitem_sched_a_conduit_cmte_st1, disclosure.fec_fitem_sched_a.conduit_cmte_st2 AS disclosure_fec_fitem_sched_a_conduit_cmte_st2, disclosure.fec_fitem_sched_a.conduit_cmte_city AS disclosure_fec_fitem_sched_a_conduit_cmte_city, disclosure.fec_fitem_sched_a.conduit_cmte_st AS disclosure_fec_fitem_sched_a_conduit_cmte_st, disclosure.fec_fitem_sched_a.conduit_cmte_zip AS disclosure_fec_fitem_sched_a_conduit_cmte_zip, disclosure.fec_fitem_sched_a.donor_cmte_nm AS disclosure_fec_fitem_sched_a_donor_cmte_nm, disclosure.fec_fitem_sched_a.national_cmte_nonfed_acct AS disclosure_fec_fitem_sched_a_national_cmte_nonfed_acct, disclosure.fec_fitem_sched_a.election_tp AS disclosure_fec_fitem_sched_a_election_tp, disclosure.fec_fitem_sched_a.election_tp_desc AS disclosure_fec_fitem_sched_a_election_tp_desc, disclosure.fec_fitem_sched_a.fec_election_tp_desc AS disclosure_fec_fitem_sched_a_fec_election_tp_desc, disclosure.fec_fitem_sched_a.fec_election_yr AS disclosure_fec_fitem_sched_a_fec_election_yr, disclosure.fec_fitem_sched_a.action_cd AS disclosure_fec_fitem_sched_a_action_cd, disclosure.fec_fitem_sched_a.action_cd_desc AS disclosure_fec_fitem_sched_a_action_cd_desc, disclosure.fec_fitem_sched_a.schedule_type_desc AS disclosure_fec_fitem_sched_a_schedule_type_desc, disclosure.fec_fitem_sched_a.pg_date AS disclosure_fec_fitem_sched_a_pg_date, disclosure.fec_fitem_sched_a.orig_sub_id AS disclosure_fec_fitem_sched_a_orig_sub_id, disclosure.fec_fitem_sched_a.back_ref_tran_id AS disclosure_fec_fitem_sched_a_back_ref_tran_id, disclosure.fec_fitem_sched_a.back_ref_sched_nm AS disclosure_fec_fitem_sched_a_back_ref_sched_nm, disclosure.fec_fitem_sched_a.filing_form AS disclosure_fec_fitem_sched_a_filing_form, disclosure.fec_fitem_sched_a.link_id AS disclosure_fec_fitem_sched_a_link_id, disclosure.fec_fitem_sched_a.contributor_name_text AS disclosure_fec_fitem_sched_a_contributor_name_text, disclosure.fec_fitem_sched_a.contributor_employer_text AS disclosure_fec_fitem_sched_a_contributor_employer_text, disclosure.fec_fitem_sched_a.contributor_occupation_text AS disclosure_fec_fitem_sched_a_contributor_occupation_text, disclosure.fec_fitem_sched_a.is_individual AS disclosure_fec_fitem_sched_a_is_individual, disclosure.fec_fitem_sched_a.memo_text AS disclosure_fec_fitem_sched_a_memo_text, disclosure.fec_fitem_sched_a.two_year_transaction_period AS disclosure_fec_fitem_sched_a_two_year_transaction_period, disclosure.fec_fitem_sched_a.schedule_type AS disclosure_fec_fitem_sched_a_schedule_type, disclosure.fec_fitem_sched_a.increased_limit AS disclosure_fec_fitem_sched_a_increased_limit, disclosure.fec_fitem_sched_a.sub_id AS disclosure_fec_fitem_sched_a_sub_id, disclosure.fec_fitem_sched_a.pdf_url AS disclosure_fec_fitem_sched_a_pdf_url, disclosure.fec_fitem_sched_a.line_number_label AS disclosure_fec_fitem_sched_a_line_number_label 
FROM disclosure.fec_fitem_sched_a 
WHERE disclosure.fec_fitem_sched_a.is_individual = true AND disclosure.fec_fitem_sched_a.cmte_id IN (%(cmte_id_1)s) 
AND disclosure.fec_fitem_sched_a.contbr_st IN (%(contbr_st_1)s) 
AND disclosure.fec_fitem_sched_a.two_year_transaction_period IN (%(two_year_transaction_period_1)s) 
AND (disclosure.fec_fitem_sched_a.contributor_employer_text @@ to_tsquery(%(contributor_employer_text_1)s) OR disclosure.fec_fitem_sched_a.contributor_employer_text IS NULL)
```

## How to test
- Download feature branch and run `pytest`
- Start api locally and compare these endpoints between prod and local

**API: /schedules​/schedule_a​/**
Before change:  return 3 rows with string Null value
https://api.open.fec.gov/v1/schedules/schedule_a/?api_key=DEMO_KEY&contributor_state=ND&sort_hide_null=false&sort_nulls_last=false&contributor_employer=null&committee_id=C00431445&two_year_transaction_period=2012&sort=-contribution_receipt_date&per_page=30&is_individual=true

After change: return 33 rows 
http://127.0.0.1:5000/v1/schedules/schedule_a/?api_key=DEMO_KEY&contributor_state=ND&sort_hide_null=false&sort_nulls_last=false&contributor_employer=null&committee_id=C00431445&two_year_transaction_period=2012&sort=-contribution_receipt_date&per_page=30&is_individual=true

Before change: 370 rows returned
https://api.open.fec.gov/v1/schedules/schedule_a/?per_page=20&sort_null_only=false&contributor_occupation=null&api_key=DEMO_KEY&sort=-contribution_receipt_date&sort_hide_null=false&two_year_transaction_period=2012

After change: 687206 rows returned
http://127.0.0.1:5000/v1/schedules/schedule_a/?per_page=20&sort_null_only=false&contributor_occupation=null&api_key=DEMO_KEY&sort=-contribution_receipt_date&sort_hide_null=false&two_year_transaction_period=2012

**API: /names/committees/**
Before change:
https://api.open.fec.gov/v1/names/committees/?api_key=DEMO_KEY&q=null
After change:
http://127.0.0.1:5000/v1/names/committees/?api_key=DEMO_KEY&q=null