### PR TITLE
Fix description fulltext filter in /electioneering/

### DIFF
--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -71,6 +71,6 @@ class TestElectioneering(ApiBaseTest):
     def test_filter_fulltext(self):
         factories.ElectioneeringFactory()
         factories.ElectioneeringFactory(purpose_description='fitter happier')
-        results = self._results(api.url_for(ElectioneeringView, description='happier'))
+        results = self._results(api.url_for(ElectioneeringView, disbursement_description='happier'))
         assert len(results) == 1
         assert results[0]['purpose_description'] == 'fitter happier'

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -810,11 +810,11 @@ electioneering = {
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'min_amount': Currency(description='Filter for all amounts greater than a value.'),
-    'max_amount': Currency(description='Filter for all amounts less than a value.'),
-    'min_date': fields.Date(description='Minimum disbursement date'),
-    'max_date': fields.Date(description='Maximum disbursement date'),
-    'description': fields.Str('Disbursement description'),
+    'min_amount': Currency(description=docs.ELECTIONEERING_MIN_AMOUNT),
+    'max_amount': Currency(description=docs.ELECTIONEERING_MAX_AMOUNT),
+    'min_date': fields.Date(description=docs.ELECTIONEERING_MIN_DATE),
+    'max_date': fields.Date(description=docs.ELECTIONEERING_MAX_DATE),
+    'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
 }
 
 electioneering_by_candidate = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1328,6 +1328,14 @@ Total electioneering communications spent on candidates by cycle
 or candidate election year
 '''
 
+ELECTIONEERING_MIN_AMOUNT = 'Filter for all amounts greater than a value'
+
+ELECTIONEERING_MAX_AMOUNT = 'Filter for all amounts less than a value'
+
+ELECTIONEERING_MIN_DATE = 'Minimum disbursement date'
+
+ELECTIONEERING_MAX_DATE = 'Maximum disbursement date'
+
 COMMUNICATION_COST = '''
 52 U.S.C. 30118 allows "communications by a corporation to its stockholders and executive \
 or administrative personnel and their families or by a labor organization to its members \

--- a/webservices/resources/costs.py
+++ b/webservices/resources/costs.py
@@ -58,7 +58,7 @@ class ElectioneeringView(ApiResource):
     page_schema = schemas.ElectioneeringPageSchema
 
     filter_fulltext_fields = [
-        ('description', models.Electioneering.purpose_description_text),
+        ('disbursement_description', models.Electioneering.purpose_description_text),
     ]
 
     @property


### PR DESCRIPTION
## Summary (required)
When filtering for description in endpoint /electioneering/, it does not filter correctly. This PR will fix the issue and change filter name `description` to `disbursement_description`.
(because no api user use filter `description` so far, so we don't need send email to user.

- Resolves #5441 

### Required reviewers
1 dev

## Impacted areas of the application
/electioneering/

## How to test
1) checkout branch
2) pytest
3) test and compare endpoint /electioneering/  on local and prod.
Test urls:

(1) return 29 rows
http://127.0.0.1:5000/v1/electioneering/?per_page=20&disbursement_description=house&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false

return 1055 rows
https://api.open.fec.gov/v1/electioneering/?per_page=20&description=house&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false&api_key=DEMO_KEY

(2) return 41 rows
http://127.0.0.1:5000/v1/electioneering/?per_page=20&disbursement_description=hou&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false

return 490 rows
https://api.open.fec.gov/v1/electioneering/?per_page=20&description=hou&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false&api_key=DEMO_KEY

(3) return: Invalid keyword
http://127.0.0.1:5000/v1/electioneering/?per_page=20&disbursement_description=ho&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false

return 450 rows
https://api.open.fec.gov/v1/electioneering/?per_page=20&description=ho&sort_hide_null=false&sort_nulls_last=false&page=1&sort_null_only=false&api_key=DEMO_KEY


