### PR TITLE
5453-Add jmetev1's build script fix and add prettier to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
 
--   repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
-    -   id: flake8
+      - id: flake8
         args: [--max-line-length=120]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: 'v3.0.0-alpha.9-for-vscode' # Use the sha / tag you want to point at
+    hooks:
+      - id: prettier

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,9 @@
 {
-	"singleQuote": true,
-	"semi": true,
-	"jsxBracketSameLine": false,
-	"tabWidth": 2,
-	"useTabs": false,
-	"printWidth": 80,
-	"trailingComma": "es5",
-	"arrowParens": "always"
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 80,
+  "trailingComma": "es5",
+  "arrowParens": "always"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "file-loader": "^1.1.11",
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.21",
-        "prettier": "^1.12.1",
+        "prettier": "^2.8.8",
         "react-hot-loader": "^4.1.0",
         "style-loader": "^0.21.0",
         "terser-webpack-plugin": "^2.3.5",
@@ -7460,15 +7460,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/private": {
@@ -17486,9 +17489,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "private": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/fecgov/openFEC.git"
   },
   "scripts": {
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider && npm run format:lint && webpack --config webpack.production.config.js --colors",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && npm run lint && webpack --config webpack.production.config.js --colors",
     "develop": "export NODE_OPTIONS=--openssl-legacy-provider && webpack-dev-server --config webpack.config.js --mode development",
     "format": "prettier --write 'src/**/*.js'",
     "lint": "eslint ./src/**/*.js",
@@ -16,11 +16,11 @@
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
     "immutable": "^3.8.2",
-    "minimist":"^1.2.6",
+    "minimist": "^1.2.6",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "async":"^2.6.4",
+    "async": "^2.6.4",
     "swagger-ui-dist": "4.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "file-loader": "^1.1.11",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.21",
-    "prettier": "^1.12.1",
+    "prettier": "^2.8.8",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^0.21.0",
     "terser-webpack-plugin": "^2.3.5",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -38,7 +38,8 @@ const Footer = () => (
         </ul>
 
         <p>
-          1050 First Street, NE<br /> Washington, DC 20463
+          1050 First Street, NE
+          <br /> Washington, DC 20463
         </p>
 
         <a href="mailto:apiinfo@fec.gov">


### PR DESCRIPTION
## Summary (required)

- Resolves #5453 
@jmetev1 found an issue in our build scripts. He noticed we were running format before lint during npm run build which allows us to ignore issues as they are being fixed, but not committed. I used his code changes and then also added prettier to our pre-commit hooks and upgraded prettier. 

Thank you @jmetev1, for your contribution and for catching this issue for us!


### Required reviewers
2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  npm run build, pre-commit hooks


## Related PRs

(https://github.com/fecgov/openFEC/pull/5451)

## How to test

- start your virtualenv
- pull recent develop
- rm -rf node_modules
- npm i && npm run develop
-  (should see footer issue) 
- npm run build 
- (should see footer change is made but not committed) 
- pull this branch
- rm -rf node_modules
- npm i && npm run develop
- npm run build

Then try testing out committing a change that would break prettier's  rules like removing the new line in the footer