### PR TITLE
 Flask upgrade to 2.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ static/swagger-ui/js
 
 # Pycharm
 .idea
+.vscode/launch.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-apispec==0.39.0
+apispec==4.0.0
 certifi==2022.12.7
 cfenv==0.5.2
 defusedxml==0.6.0
 elasticsearch==7.6.0
 elasticsearch-dsl==7.3.0
-Flask==2.1.2
+Flask==2.2.5
 Flask-Cors==3.0.10
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
@@ -25,14 +25,14 @@ sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
-webargs==5.5.3
+webargs==7.0.0
 werkzeug==2.2.3
 
 # Marshalling
-flask-apispec==0.7.0
-git+https://github.com/fecgov/marshmallow-pagination@master
-marshmallow==2.16.3
-marshmallow-sqlalchemy==0.15.0
+flask-apispec==0.11.4
+git+https://github.com/fecgov/marshmallow-pagination.git@feature/upgrade-to-marshmallow-v3
+marshmallow==3.0.0
+marshmallow-sqlalchemy==0.23.1
 
 # Data export
 smart_open==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ werkzeug==2.2.3
 
 # Marshalling
 flask-apispec==0.11.4
-git+https://github.com/fecgov/marshmallow-pagination.git@feature/upgrade-to-marshmallow-v3
+git+https://github.com/fecgov/marshmallow-pagination@develop
 marshmallow==3.0.0
 marshmallow-sqlalchemy==0.23.1
 

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -125,19 +125,33 @@ class CandidatesTestCase(common.BaseTestCase):
             )
         )
         results_tab = self.connection.execute(sql_extract).fetchall()
-        params = {
+        candidate_params = {
             'election_year': election_year,
+            'cycle': election_year,
+            'district': '01',
+            'state': 'MD',
+        }
+
+        election_params = {
             'cycle': election_year,
             'election_full': True,
             'district': '01',
             'state': 'MD',
         }
-        candidates_api = self._results(rest.api.url_for(CandidateList, **params))
+
+        total_params = {
+            'cycle': election_year,
+            'election_full': True,
+            'district': '01',
+            'state': 'MD',
+            'election_year': election_year,
+        }
+        candidates_api = self._results(rest.api.url_for(CandidateList, **candidate_params))
         candidates_totals_api = self._results(
-            rest.api.url_for(TotalsCandidateView, **params)
+            rest.api.url_for(TotalsCandidateView, **total_params)
         )
         elections_api = self._results(
-            rest.api.url_for(ElectionView, office='house', **params)
+            rest.api.url_for(ElectionView, office='house', **election_params)
         )
         assert (
             len(results_tab)

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -477,12 +477,12 @@ class TriggerTestCase(common.BaseTestCase):
             connection.execute(insert, data)
         manage.refresh_materialized(concurrent=False)
         results = self._results(
-            api.url_for(ScheduleBView, contributor_employer='ést-lou')
+            api.url_for(ScheduleBView, recipient_name='ést-lou')
         )
         contbr_employer_list = {r['recipient_name'] for r in results}
         assert names.issubset(contbr_employer_list)
         results = self._results(
-            api.url_for(ScheduleBView, contributor_employer='est lou')
+            api.url_for(ScheduleBView, recipient_name='est lou')
         )
         contbr_employer_list = {r['recipient_name'] for r in results}
         assert names.issubset(contbr_employer_list)

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -250,7 +250,7 @@ class TestAggregates(ApiBaseTest):
             results = self._results(
                 api.url_for(
                     resource,
-                    candidate_id=self.candidate.candidate_id,
+                    committee_id=self.committee.committee_id,
                     cycle=2012,
                     office='president',
                     election_full=False,

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -250,14 +250,14 @@ class TestAggregates(ApiBaseTest):
             results = self._results(
                 api.url_for(
                     resource,
-                    committee_id=self.committee.committee_id,
+                    candidate_id=self.candidate.candidate_id,
                     cycle=2012,
                     office='president',
                     election_full=False,
                 )
             )
             assert len(results) == 1
-            serialized = schema().dump(aggregates[0]).data
+            serialized = schema().dump(aggregates[0])
             serialized.update(
                 {
                     'committee_name': self.committee.name,
@@ -278,14 +278,13 @@ class TestAggregates(ApiBaseTest):
                 api.url_for(
                     resource,
                     candidate_id=self.candidate.candidate_id,
-                    committee_id=self.committee.committee_id,
                     cycle=2012,
                     office='president',
                     election_full='true',
                 )
             )
             assert len(results) == 1
-            serialized = schema().dump(aggregates[0]).data
+            serialized = schema().dump(aggregates[0])
             serialized.update(
                 {
                     'committee_name': self.committee.name,

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -386,13 +386,12 @@ class CommitteeFormatTest(ApiBaseTest):
                 for each in results
             )
         )
-        results = self._results(
-            api.url_for(
-                CommitteeList,
-                **{min_date_field: datetime.date.fromisoformat(values[1]),
-                max_date_field: datetime.date.fromisoformat(values[2])}
-            )
-        )
+        results = self._results(api.url_for(
+            CommitteeList,
+            **{min_date_field: datetime.date.fromisoformat(values[1]),
+               max_date_field: datetime.date.fromisoformat(values[2])}
+                                            )
+                                )
         self.assertTrue(
             all(
                 datetime.date.fromisoformat(values[1]).isoformat()
@@ -618,6 +617,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
             )
         )
         assert len(results) == 1
+        self.assertFalse(results[0]["is_active"])
 
         results = self._results(
             api.url_for(
@@ -628,6 +628,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
             )
         )
         assert len(results) == 1
+        self.assertTrue(results[0]["is_active"])
 
     def test_candidate_cycle(self):
         results = self._results(

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -297,8 +297,8 @@ class CommitteeFormatTest(ApiBaseTest):
 
     def test_first_f1_date_sort(self):
         committees = [
-            factories.CommitteeFactory(first_f1_date="2003-10-12"),
-            factories.CommitteeFactory(first_f1_date="2017-05-14"),
+            factories.CommitteeFactory(first_f1_date=datetime.date.fromisoformat("2003-10-12")),
+            factories.CommitteeFactory(first_f1_date=datetime.date.fromisoformat("2017-05-14")),
         ]
         committee_ids = [each.committee_id for each in committees]
         results = self._results(api.url_for(CommitteeList, sort="first_f1_date"))
@@ -614,8 +614,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
                 CommitteeHistoryProfileView,
                 committee_id=self.committees[4].committee_id,
                 cycle=2014,
-                election_full=False,
-                is_active=False,
+                election_full=False
             )
         )
         assert len(results) == 1
@@ -625,8 +624,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
                 CommitteeHistoryProfileView,
                 committee_id=self.committees[2].committee_id,
                 cycle=2014,
-                election_full=False,
-                is_active=True,
+                election_full=False
             )
         )
         assert len(results) == 1
@@ -739,8 +737,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
                 CommitteeHistoryProfileView,
                 committee_id="id01",
                 cycle=2014,
-                election_full=False,
-                is_active=False,
+                election_full=False
             )
         )
         assert len(results) == 1
@@ -750,8 +747,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
                 CommitteeHistoryProfileView,
                 candidate_id="h01",
                 cycle=2014,
-                election_full=False,
-                is_active=False,
+                election_full=False
             )
         )
         assert len(results) == 1

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -30,7 +30,7 @@ class TestReportingDates(ApiBaseTest):
         factories.ReportDateFactory(update_date=datetime.datetime(2014, 4, 2))
 
         filter_fields = (
-            ('due_date', '2014-01-02'),
+            ('min_due_date', '2014-01-02'),
             ('report_year', 2015),
             ('report_type', 'YE'),
             ('min_create_date', '2014-03-02'),

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -617,7 +617,6 @@ class TestScheduleA(ApiBaseTest):
             api.url_for(
                 ScheduleAView,
                 sort='-contribution_receipt_date',
-                sort_reverse_nulls='true',
                 **self.kwargs
             )
         )
@@ -681,7 +680,6 @@ class TestScheduleA(ApiBaseTest):
             api.url_for(
                 ScheduleAView,
                 sort='contribution_receipt_date',
-                sort_reverse_nulls='true',
                 **self.kwargs
             )
         )
@@ -969,7 +967,6 @@ class TestScheduleB(ApiBaseTest):
             api.url_for(
                 ScheduleBView,
                 sort='-disbursement_date',
-                sort_nulls_last=True,
                 **self.kwargs
             )
         )
@@ -1151,15 +1148,15 @@ class TestScheduleE(ApiBaseTest):
             ),
         ]
         results = self._results(
-            api.url_for(ScheduleEView, q_spender='action', **self.kwargs)
+            api.url_for(ScheduleEView, q_spender='action')
         )
         self.assertEqual(len(results), 2)
         results = self._results(
-            api.url_for(ScheduleEView, q_spender='abc', **self.kwargs)
+            api.url_for(ScheduleEView, q_spender='abc')
         )
         self.assertEqual(len(results), 1)
         results = self._results(
-            api.url_for(ScheduleEView, q_spender='C001', **self.kwargs)
+            api.url_for(ScheduleEView, q_spender='C001')
         )
         self.assertEqual(len(results), 1)
 
@@ -1196,7 +1193,7 @@ class TestScheduleE(ApiBaseTest):
     def test_schedule_e_expenditure_description_field(self):
         factories.ScheduleEFactory(committee_id='C001', expenditure_description='Advertising Costs')
         results = self._results(
-            api.url_for(ScheduleEView, **self.kwargs)
+            api.url_for(ScheduleEView)
         )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['expenditure_description'], 'Advertising Costs')
@@ -1322,7 +1319,7 @@ class TestScheduleE(ApiBaseTest):
             factories.ScheduleEFactory(committee_id='C006', filing_form='F3X'),
         ]
         results = self._results(
-            api.url_for(ScheduleEView, most_recent=True, **self.kwargs)
+            api.url_for(ScheduleEView, most_recent=True)
         )
         # Most recent should include null values
         self.assertEqual(len(results), 5)
@@ -1347,7 +1344,7 @@ class TestScheduleE(ApiBaseTest):
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
         results = self._results(
-            api.url_for(ScheduleEEfileView, most_recent=True, **self.kwargs)
+            api.url_for(ScheduleEEfileView, most_recent=True)
         )
         # Most recent should include null values
         self.assertEqual(len(results), 5)
@@ -1396,21 +1393,21 @@ class TestScheduleH4(ApiBaseTest):
             for purpose in purposes
         ]
         results = self._results(
-            api.url_for(ScheduleH4View, disbursement_purpose='Test&Test', **self.kwargs)
+            api.url_for(ScheduleH4View, q_disbursement_purpose='Test&Test')
         )
         self.assertIn(results[0]['disbursement_purpose'], purposes)
         results = self._results(
             api.url_for(
-                ScheduleH4View, disbursement_purpose='Test & Test', **self.kwargs
+                ScheduleH4View, q_disbursement_purpose='Test & Test'
             )
         )
         self.assertIn(results[0]['disbursement_purpose'], purposes)
         results = self._results(
-            api.url_for(ScheduleH4View, disbursement_purpose='Test& Test', **self.kwargs)
+            api.url_for(ScheduleH4View, q_disbursement_purpose='Test& Test')
         )
         self.assertIn(results[0]['disbursement_purpose'], purposes)
         results = self._results(
-            api.url_for(ScheduleH4View, disbursement_purpose='Test &Test', **self.kwargs)
+            api.url_for(ScheduleH4View, q_disbursement_purpose='Test &Test')
         )
         self.assertIn(results[0]['disbursement_purpose'], purposes)
 
@@ -1420,12 +1417,12 @@ class TestScheduleH4(ApiBaseTest):
             'Test com',
             'Testerosa',
             'Test#com',
-            'Not.com',
+            'Not.com',  # this should not be a result
             'Test.com and Test.com',
         ]
         [factories.ScheduleH4Factory(payee_name=payee) for payee in payee_names]
-        results = self._results(api.url_for(ScheduleH4View, payee_name='test'))
-        self.assertEqual(len(results), len(payee_names))
+        results = self._results(api.url_for(ScheduleH4View, q_payee_name='test'))
+        self.assertEqual(len(results), 5)
 
     def test_schedule_h4_efile_event_purpose_date_range(self):
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -425,7 +425,6 @@ class TestEFileReports(ApiBaseTest):
         results = self._results(
             api.url_for(
                 EFilingPresidentialSummaryView,
-                entity_type='presidential',
                 committee_id=committee_id,
             )
         )
@@ -463,7 +462,6 @@ class TestEFileReports(ApiBaseTest):
         results = self._results(
             api.url_for(
                 EFilingHouseSenateSummaryView,
-                entity_type='house-senate',
                 committee_id=committee_id,
             )
         )

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -35,7 +35,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
-            cycle=2014,
+            cycle=2010,
             candidate_id='S002',
             support_oppose_indicator='S',
         ),

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -11,17 +11,20 @@ class TestScheduleEByCandidateView(ApiBaseTest):
     def test_fields(self):
         candidate_id = 'S001'
         support_oppose_indicator = 'S'
-        factories.ScheduleEByCandidateFactory(candidate_id=candidate_id,
-            support_oppose_indicator=support_oppose_indicator, cycle=2018)
+        factories.ScheduleEByCandidateFactory(
+            candidate_id=candidate_id,
+            support_oppose_indicator=support_oppose_indicator,
+            cycle=2018)
         factories.CandidateElectionFactory(candidate_id=candidate_id,
-            cand_election_year=2018)
-        results = self._results(api.url_for(ScheduleEByCandidateView, candidate_id='S001'))
+                                           cand_election_year=2018)
+        results = self._results(api.url_for(ScheduleEByCandidateView,
+                                            candidate_id='S001'))
         assert len(results) == 1
         assert results[0].keys() == ScheduleEByCandidateSchema().fields.keys()
 
     def test_sched_e_filter_match(self):
         factories.CandidateElectionFactory(candidate_id='S002',
-            cand_election_year=2014)
+                                           cand_election_year=2014)
         factories.ScheduleEByCandidateFactory(
             total=50000,
             count=10,
@@ -32,19 +35,20 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
-            cycle=2010,
+            cycle=2014,
             candidate_id='S002',
-            support_oppose_indicator='O',
+            support_oppose_indicator='S',
         ),
 
         results = self._results(
             api.url_for(ScheduleEByCandidateView, candidate_id='S002',
-            cycle=2014, support_oppose_indicator='S')
+                        cycle=2014, support_oppose='S')
         )
         self.assertEqual(len(results), 1)
 
     def test_sort_bad_column(self):
-        response = self.app.get(api.url_for(ScheduleEByCandidateView, sort='candidate'))
+        response = self.app.get(api.url_for(ScheduleEByCandidateView,
+                                            sort='candidate'))
         self.assertEqual(response.status_code, 422)
         self.assertIn(b'Cannot sort on value', response.data)
 
@@ -106,7 +110,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         ),
         response = self._results(
             api.url_for(ScheduleEByCandidateView, sort='-candidate_id',
-                office='senate', state='NY', cycle=2012))
+                        office='senate', state='NY', cycle=2012))
         self.assertEqual(len(response), 3)
         self.assertEqual(response[0]['candidate_id'], 'S003')
         self.assertEqual(response[0]['support_oppose_indicator'], 'S')
@@ -154,8 +158,11 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             support_oppose_indicator='S',
         ),
 
-        response = self._results(api.url_for(ScheduleEByCandidateView, cycle=2010,
-            office='senate', state='NY', sort='-candidate_name'))
+        response = self._results(api.url_for(ScheduleEByCandidateView,
+                                             cycle=2010,
+                                             office='senate',
+                                             state='NY',
+                                             sort='-candidate_name'))
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
         self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
@@ -212,8 +219,11 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             committee_id='C006',
         ),
 
-        response = self._results(api.url_for(ScheduleEByCandidateView, sort='-committee_id',
-            office='senate', cycle=2010, state='NY'))
+        response = self._results(api.url_for(ScheduleEByCandidateView,
+                                             sort='-committee_id',
+                                             office='senate',
+                                             cycle=2010,
+                                             state='NY'))
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['committee_id'], 'C006')
         self.assertEqual(response[1]['committee_id'], 'C005')
@@ -270,8 +280,11 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             committee_id='C006',
         ),
 
-        response = self._results(api.url_for(ScheduleEByCandidateView, sort='-committee_name',
-            office='senate', cycle=2010, state='NY'))
+        response = self._results(api.url_for(ScheduleEByCandidateView,
+                                             sort='-committee_name',
+                                             office='senate',
+                                             cycle=2010,
+                                             state='NY'))
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['committee_name'], 'Warner for America')
         self.assertEqual(response[1]['committee_name'], 'Ritche for America')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,7 +309,7 @@ class TestSort(ApiBaseTest):
 class TestArgs(TestCase):
     def test_currency(self):
         with rest.app.test_request_context('?dollars=$24.50'):
-            parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request)
+            parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request, location='query')
             self.assertEqual(parsed, {'dollars': 24.50})
 
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -73,7 +73,7 @@ class Date(fields.Str):
                 datetime.datetime.strptime(value, '%m/%d/%Y')
             except (TypeError, ValueError):
                 raise exceptions.ApiError(
-                    'Date must be formatted as MM/DD/YYYY or YYYY-MM-DD',
+                    exceptions.DATE_ERROR,
                     status_code=422)
 
 

--- a/webservices/common/models/dates.py
+++ b/webservices/common/models/dates.py
@@ -55,7 +55,7 @@ class ElectionDate(db.Model, FecAppMixin):
 
     trc_election_id = db.Column(db.Integer, primary_key=True)
     election_state = db.Column(db.String, index=True, doc=docs.STATE)
-    election_district = db.Column(db.Integer, index=True, doc=docs.DISTRICT)
+    election_district = db.Column(db.String, index=True, doc=docs.DISTRICT)
     election_party = db.Column(db.String, index=True, doc=docs.PARTY)
     office_sought = db.Column(db.String, index=True, doc=docs.OFFICE)
     election_date = db.Column(db.Date, index=True, doc=docs.ELECTION_DATE)

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -18,7 +18,7 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     sub_id = db.Column(db.BigInteger, index=True, primary_key=True, doc=docs.SUB_ID)
     coverage_start_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_START_DATE)
     coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
-    receipt_date = db.Column(db.Date, index=True, doc=docs.RECEIPT_DATE)
+    receipt_date = db.Column(db.DateTime, index=True, doc=docs.RECEIPT_DATE)
     election_year = db.Column(db.Integer, doc=docs.ELECTION_YEAR)
     form_type = db.Column(db.String, index=True, doc=docs.FORM_TYPE)
     report_year = db.Column(db.Integer, index=True, doc=docs.REPORT_YEAR)

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -456,7 +456,7 @@ class ScheduleC(PdfMixin, BaseItemized):
     due_date_terms = db.Column('due_dt_terms', db.String)
     interest_rate_terms = db.Column(db.String)
     secured_ind = db.Column(db.String)
-    schedule_a_line_number = db.Column('sched_a_line_num', db.Integer)
+    schedule_a_line_number = db.Column('sched_a_line_num', db.String)
     personally_funded = db.Column('pers_fund_yes_no', db.String)
     memo_code = db.Column('memo_cd', db.String)
     memo_text = db.Column(db.String)

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -13,6 +13,9 @@ KEYWORD_LENGTH_ERROR = """Invalid keyword. The keyword must be at least 3 charac
 NEXT_IN_CHAIN_DATA_ERROR = """next_in_chain data error, please contact apiinfo@fec.gov.\
 """
 
+DATE_ERROR = """Invalid date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD.\
+"""
+
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -71,7 +71,6 @@ class CalendarDatesExport(CalendarDatesView):
         'ics': (calendar.ICalEventSchema, calendar.render_ical, 'text/calendar'),
     }
 
-    @use_kwargs(args.calendar_dates)
     @use_kwargs({
         'renderer': fields.Str(missing='ics', validate=validate.OneOf(['ics', 'csv'])),
     })
@@ -85,7 +84,7 @@ class CalendarDatesExport(CalendarDatesView):
         schema_type, renderer, mimetype = self.renderers[kwargs['renderer']]
         schema = schema_type(many=True)
         return Response(
-            renderer(schema.dump(query).data, schema),
+            renderer(schema.dump(query), schema),
             mimetype=mimetype,
         )
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -154,7 +154,7 @@ class ReportsView(views.ApiResource):
             validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
         page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
-        return reports_schema().dump(page).data
+        return reports_schema().dump(page)
 
     def build_query(self, entity_type=None, **kwargs):
         # For this endpoint we now enforce the enpoint specified to map the right model.
@@ -219,7 +219,7 @@ class CommitteeReportsView(views.ApiResource):
             validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
         page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
-        return reports_schema().dump(page).data
+        return reports_schema().dump(page)
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         reports_class, reports_schema = reports_schema_map.get(

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -89,7 +89,7 @@ class TotalsByEntityTypeView(ApiResource):
             committee_id=committee_id, entity_type=entity_type, **kwargs
         )
         page = utils.fetch_page(query, kwargs, model=totals_class)
-        return totals_schema().dump(page).data
+        return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, entity_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
@@ -240,7 +240,7 @@ class TotalsCommitteeView(ApiResource):
             committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
         )
         page = utils.fetch_page(query, kwargs, model=totals_class)
-        return totals_schema().dump(page).data
+        return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
         totals_class, totals_schema = totals_schema_map.get(
@@ -285,7 +285,7 @@ class CandidateTotalsView(utils.Resource):
             validator = args.IndexValidator(totals_class)
             validator(kwargs['sort'])
         page = utils.fetch_page(query, kwargs, model=totals_class)
-        return totals_schema().dump(page).data
+        return totals_schema().dump(page)
 
     def build_query(self, candidate_id=None, **kwargs):
         totals_class, totals_schema = candidate_totals_schema_map.get(
@@ -347,6 +347,7 @@ class ScheduleAByStateRecipientTotalsView(ApiResource):
     @property
     def index_column(self):
         return self.model.idx
+
 
 @doc(
     tags=['financial'], description=docs.TOTALS_INAUGURAL_DONATIONS

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -6,6 +6,7 @@ full documentation visit: https://api.open.fec.gov/developers.
 import http
 import logging
 import os
+from marshmallow import EXCLUDE
 import ujson
 import sqlalchemy as sa
 import flask_cors as cors
@@ -102,8 +103,9 @@ cors.CORS(app)
 
 
 class FlaskRestParser(FlaskParser):
+    DEFAULT_UNKNOWN_BY_LOCATION = {"query": EXCLUDE}
 
-    def handle_error(self, error, req, schema, status_code, error_headers):
+    def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         message = error.messages
         status_code = getattr(error, 'status_code', 422)
         raise exceptions.ApiError(message, status_code)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -4,7 +4,7 @@ import functools
 from collections import namedtuple
 
 import marshmallow as ma
-from marshmallow_sqlalchemy import ModelSchema
+from marshmallow_sqlalchemy import SQLAlchemySchema, SQLAlchemyAutoSchema
 from marshmallow_pagination import schemas as paging_schemas
 
 from webservices import utils, decoders
@@ -14,22 +14,21 @@ from webservices import __API_VERSION__
 from webservices.calendar import format_start_date, format_end_date
 from marshmallow import post_dump
 
-
-spec.definition('OffsetInfo', schema=paging_schemas.OffsetInfoSchema)
-spec.definition('SeekInfo', schema=paging_schemas.SeekInfoSchema)
+spec.components.schema('OffsetInfo', schema=paging_schemas.OffsetInfoSchema)
+spec.components.schema('SeekInfo', schema=paging_schemas.SeekInfoSchema)
 
 # A namedtuple used to help capture any additional columns that should be
 # included with exported data:
-# field: the field object definining the relationship on a model, e.g.,
+# field: the field object definining the relationship on a model,e.g.,
 #   models.ScheduleA.committee (an object)
-# column: the column object found in the related model, e.g.,
+# column: the column object found in the related model,e.g.,
 #   models.CommitteeHistory.name (an object)
 # label: the label to use for the column in the query that will appear in the
-# header row of the output, e.g.,
+# header row of the output,e.g.,
 #   'committee_name' (a string)
 # position: the spot within the list of columns that this should be inserted
-# at; defaults to -1 (end of the list), e.g.,
-#   1 (an integer, in this case the second spot in a list)
+# at; defaults to -1 (end of the list),e.g.,
+#   1 (an integer,in this case the second spot in a list)
 
 # Usage:  Define a custom attribute in a schema's Meta options object called
 # 'relationships' and set to a list of one or more relationships.
@@ -50,15 +49,33 @@ class Relationship(namedtuple('Relationship', 'field column label position')):
         )
 
 
-class BaseSchema(ModelSchema):
+class BaseSchema(SQLAlchemySchema):
+    class Meta:
+        sqla_session = models.db.session
+        load_instance = True
+        include_relationships = True
+        include_fk = True
 
-    def get_attribute(self, attr, obj, default):
+    def get_attribute(self, obj, attr, default):
         if '.' in attr:
-            return super().get_attribute(attr, obj, default)
+            return super().get_attribute(obj, attr, default)
         return getattr(obj, attr, default)
 
 
-class BaseEfileSchema(BaseSchema):
+class BaseAutoSchema(SQLAlchemyAutoSchema):
+    def get_attribute(self, obj, attr, default):
+        if '.' in attr:
+            return super().get_attribute(obj, attr, default)
+        return getattr(obj, attr, default)
+
+
+class BaseEfileSchema(BaseAutoSchema):
+    class Meta:
+        sqla_session = models.db.session
+        load_instance = True
+        include_relationships = True
+        include_fk = True
+
     summary_lines = ma.fields.Method("parse_summary_rows")
     report_year = ma.fields.Int()
     pdf_url = ma.fields.Str()
@@ -74,7 +91,7 @@ class BaseEfileSchema(BaseSchema):
     fec_file_id = ma.fields.Str()
 
     @post_dump
-    def extract_summary_rows(self, obj):
+    def extract_summary_rows(self, obj, **kwargs):
         if obj.get('summary_lines'):
             for key, value in obj.get('summary_lines').items():
                 # may be a way to pull these out using pandas?
@@ -84,6 +101,7 @@ class BaseEfileSchema(BaseSchema):
             obj.pop('summary_lines')
         if obj.get('amendment'):
             obj.pop('amendment')
+        return obj
 
 
 def extract_columns(obj, column_a, column_b, descriptions):
@@ -110,10 +128,14 @@ def make_period_string(per_string=None):
     return per_string
 
 
-class EFilingF3PSchema(BaseEfileSchema):
+class BaseF3PFilingSchema(BaseEfileSchema):
+    class Meta(BaseEfileSchema.Meta):
+        model = models.BaseF3PFiling
+        exclude = ('total_disbursements', 'total_receipts')
+
     treasurer_name = ma.fields.Str()
 
-    def parse_summary_rows(self, obj):
+    def parse_summary_rows(self, obj, **kwargs):
         line_list = {}
         state_map = {}
 
@@ -150,73 +172,83 @@ class EFilingF3PSchema(BaseEfileSchema):
             return line_list
 
 
-class EFilingF3Schema(BaseEfileSchema):
+class BaseF3FilingSchema(BaseEfileSchema):
+    class Meta(BaseEfileSchema.Meta):
+        model = models.BaseF3Filing
+
     candidate_name = ma.fields.Str()
     treasurer_name = ma.fields.Str()
 
-    def parse_summary_rows(self, obj):
+    def parse_summary_rows(self, obj, **kwargs):
         descriptions = decoders.f3_description
         line_list = extract_columns(obj, decoders.f3_col_a, decoders.f3_col_b, descriptions)
         # final bit of data cleaning before json marshalling
-        # If values are None, fall back to 0 to prevent errors
-        coh_cop_i = line_list.get('coh_cop_i') if line_list.get('coh_cop_i') else 0
-        coh_cop_ii = line_list.get('coh_cop_ii') if line_list.get('coh_cop_ii') else 0
-        cash = max(coh_cop_i, coh_cop_ii)
-        line_list["cash_on_hand_end_period"] = cash
-        # i and ii should always be the same but data can be wrong
-        line_list.pop('coh_cop_ii')
-        line_list.pop('coh_cop_i')
-        coh_bop = line_list.get('coh_bop') if line_list.get('coh_bop') else 0
-        cash_on_hand_beginning_period = (
-            obj.cash_on_hand_beginning_period
-            if obj.cash_on_hand_beginning_period
-            else 0
-        )
-        cash = max(cash_on_hand_beginning_period, coh_bop)
-        obj.cash_on_hand_beginning_period = None
-        line_list.pop('coh_bop')
-        line_list["cash_on_hand_beginning_period"] = cash
-        cash = max(line_list.get('total_disbursements_per_i'), line_list.get('total_disbursements_per_ii'))
-        line_list["total_disbursements_period"] = cash
-        line_list.pop('total_disbursements_per_i')
-        line_list.pop('total_disbursements_per_ii')
-        cash = max(line_list.get('total_receipts_per_i'), line_list.get('ttl_receipts_ii'))
-        line_list["total_receipts_period"] = cash
-        line_list.pop('total_receipts_per_i')
-        line_list.pop('ttl_receipts_ii')
+        # If values are None,fall back to 0 to prevent errors
+        if line_list:
+            coh_cop_i = line_list.get('coh_cop_i') if line_list.get('coh_cop_i') else 0
+            coh_cop_ii = line_list.get('coh_cop_ii') if line_list.get('coh_cop_ii') else 0
+            cash = max(coh_cop_i, coh_cop_ii)
+            line_list["cash_on_hand_end_period"] = cash
+            # i and ii should always be the same but data can be wrong
+            line_list.pop('coh_cop_ii')
+            line_list.pop('coh_cop_i')
+            coh_bop = line_list.get('coh_bop') if line_list.get('coh_bop') else 0
+            cash_on_hand_beginning_period = (
+                obj.cash_on_hand_beginning_period
+                if obj.cash_on_hand_beginning_period
+                else 0
+            )
+            cash = max(cash_on_hand_beginning_period, coh_bop)
+            obj.cash_on_hand_beginning_period = None
+            line_list.pop('coh_bop')
+            line_list["cash_on_hand_beginning_period"] = cash
+            cash = max(line_list.get('total_disbursements_per_i'), line_list.get('total_disbursements_per_ii'))
+            line_list["total_disbursements_period"] = cash
+            line_list.pop('total_disbursements_per_i')
+            line_list.pop('total_disbursements_per_ii')
+            cash = max(line_list.get('total_receipts_per_i'), line_list.get('ttl_receipts_ii'))
+            line_list["total_receipts_period"] = cash
+            line_list.pop('total_receipts_per_i')
+            line_list.pop('ttl_receipts_ii')
         return line_list
 
 
-class EFilingF3XSchema(BaseEfileSchema):
-    def parse_summary_rows(self, obj):
+class BaseF3XFilingSchema(BaseEfileSchema):
+    class Meta(BaseEfileSchema.Meta):
+        model = models.BaseF3XFiling
+
+    def parse_summary_rows(self, obj, **kwargsj):
         descriptions = decoders.f3x_description
         line_list = extract_columns(obj, decoders.f3x_col_a, decoders.f3x_col_b, descriptions)
-        line_list['cash_on_hand_beginning_calendar_ytd'] = line_list.pop('coh_begin_calendar_yr')
-        line_list['cash_on_hand_beginning_period'] = line_list.pop('coh_bop')
+        if line_list:
+            line_list['cash_on_hand_beginning_calendar_ytd'] = line_list.pop('coh_begin_calendar_yr')
+            line_list['cash_on_hand_beginning_period'] = line_list.pop('coh_bop')
         return line_list
 
 
 schema_map = {}
-schema_map["BaseF3XFiling"] = EFilingF3XSchema
-schema_map["BaseF3Filing"] = EFilingF3Schema
-schema_map["BaseF3PFiling"] = EFilingF3PSchema
+schema_map["BaseF3XFiling"] = BaseF3XFilingSchema
+schema_map["BaseF3Filing"] = BaseF3FilingSchema
+schema_map["BaseF3PFiling"] = BaseF3PFilingSchema
 
 
 def register_schema(schema, definition_name=None):
     definition_name = definition_name or re.sub(r'Schema$', '', schema.__name__)
-    spec.definition(definition_name, schema=schema)
+    spec.components.schema(definition_name, schema=schema)
 
 
-def make_schema(model, class_name=None, fields=None, options=None):
+def make_schema(model, class_name=None, fields=None, options=None, BaseSchema=BaseAutoSchema):
     class_name = class_name or '{0}Schema'.format(model.__name__)
     Meta = type(
         'Meta',
-        (object, ),
+        (object,),
         utils.extend(
             {
                 'model': model,
                 'sqla_session': models.db.session,
-                'exclude': ('idx', ),
+                'load_instance': True,
+                'include_relationships': True,
+                'include_fk': True
             },
             options or {},
         )
@@ -225,11 +257,10 @@ def make_schema(model, class_name=None, fields=None, options=None):
         BaseSchema
         if not schema_map.get(model.__name__)
         else schema_map.get(model.__name__)
-
     )
     return type(
         class_name,
-        (mapped_schema, ),
+        (mapped_schema,),
         utils.extend({'Meta': Meta}, fields or {}),
     )
 
@@ -288,7 +319,8 @@ def augment_itemized_aggregate_models(factory, committee_model, *models, namespa
 
 
 class ApiSchema(ma.Schema):
-    def _postprocess(self, data, many, obj):
+    @post_dump
+    def _postprocess(self, data, **kwargs):
         ret = {'api_version': __API_VERSION__}
         ret.update(data)
         return ret
@@ -299,7 +331,7 @@ class BaseSearchSchema(ma.Schema):
     name = ma.fields.Str()
 
 
-class CandidateSearchSchema(BaseSearchSchema):
+class CandidateSearchBaseSchema(BaseSearchSchema):
     office_sought = ma.fields.Str()
 
 
@@ -309,7 +341,7 @@ class CommitteeSearchSchema(BaseSearchSchema):
 
 class CandidateSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
-        CandidateSearchSchema,
+        CandidateSearchBaseSchema,
         ref='#/definitions/CandidateSearch',
         many=True,
     )
@@ -323,8 +355,8 @@ class CommitteeSearchListSchema(ApiSchema):
     )
 
 
-register_schema(CandidateSearchSchema)
-register_schema(CandidateSearchListSchema)
+register_schema(CandidateSearchBaseSchema, 'CandidateSearchBaseSchema')
+register_schema(CandidateSearchListSchema, 'CandidateSearchListSchema')
 register_schema(CommitteeSearchSchema)
 register_schema(CommitteeSearchListSchema)
 
@@ -358,27 +390,12 @@ register_schema(AuditCandidateSearchListSchema)
 register_schema(AuditCommitteeSearchSchema)
 register_schema(AuditCommitteeSearchListSchema)
 
-
-make_efiling_schema = functools.partial(
-    make_schema,
-    options={'exclude': ('idx', 'total_disbursements', 'total_receipts')},
-    fields={
-        'pdf_url': ma.fields.Str(),
-        'report_year': ma.fields.Int(),
-    }
-)
-
-augment_models(
-    make_efiling_schema,
-    models.BaseF3PFiling,
-    models.BaseF3XFiling,
-    models.BaseF3Filing,
-)
+augment_schemas(BaseF3PFilingSchema, BaseF3FilingSchema, BaseF3XFilingSchema)
 
 # create pac sponsor candidate schema
 PacSponsorCandidateschema = make_schema(
     models.PacSponsorCandidate,
-    options={'exclude': ('idx', 'committee_id', )},
+    options={'exclude': ('idx', 'committee_id',)},
 )
 # End create pac sponsor candidate schema
 
@@ -392,10 +409,14 @@ PrincipalCommitteeSchema = make_schema(
 
 CommitteeSchema = make_schema(
     models.Committee,
-    options={'exclude': ('idx', 'treasurer_text', )},
     fields={
         'sponsor_candidate_list': ma.fields.Nested(PacSponsorCandidateschema, many=True),
+        'first_f1_date': ma.fields.Date(),
+        'first_file_date': ma.fields.Date(),
+        'last_f1_date': ma.fields.Date(),
+        'last_file_date': ma.fields.Date()
     },
+    options={'exclude': ('idx', 'treasurer_text',)},
 )
 CommitteePageSchema = make_page_schema(CommitteeSchema)
 register_schema(CommitteeSchema)
@@ -405,16 +426,16 @@ register_schema(CommitteePageSchema)
 JFCCommitteeSchema = make_schema(
     models.JFCCommittee,
     class_name='JFCCommitteeSchema',
-    options={'exclude': ('idx', 'committee_id', 'most_recent_filing_flag', )},
-)
+    options={'exclude': ('idx', 'committee_id',  'most_recent_filing_flag',)},
+    )
 # End create JFC committee schema
 
 make_committees_schema = functools.partial(
     make_schema,
-    options={'exclude': ('idx', 'treasurer_text', )},
     fields={
         'jfc_committee': ma.fields.Nested(JFCCommitteeSchema, many=True),
-    }
+    },
+    options={'exclude': ('idx', 'treasurer_text',)},
 )
 
 augment_models(
@@ -427,26 +448,53 @@ augment_models(
 
 make_candidate_schema = functools.partial(
     make_schema,
-    options={'exclude': ('idx', 'principal_committees')},
     fields={
         'federal_funds_flag': ma.fields.Boolean(attribute='flags.federal_funds_flag'),
         'has_raised_funds': ma.fields.Boolean(attribute='flags.has_raised_funds'),
-    }
+    },
+    options={'exclude': ('idx', 'principal_committees', 'flags')},
 )
 
 augment_models(
     make_candidate_schema,
-    models.Candidate,
-    models.CandidateDetail,
-
+    models.Candidate
 )
-# built these schemas without make_candidate_schema, as it was filtering out the flags
+
+candidate_detail_schema = make_schema(
+    models.CandidateDetail,
+    fields={
+        'federal_funds_flag': ma.fields.Boolean(attribute='flags.federal_funds_flag'),
+        'has_raised_funds': ma.fields.Boolean(attribute='flags.has_raised_funds'),
+    },
+    options={'exclude': ('idx',)},
+)
+
+augment_schemas(candidate_detail_schema)
+
+# built these schemas without make_candidate_schema,as it was filtering out the flags
+make_candidate_total_schema = make_schema(
+    models.CandidateTotal,
+    fields={
+        'receipts': ma.fields.Float(),
+        'disbursements': ma.fields.Float(),
+        'individual_itemized_contributions': ma.fields.Float(),
+        'transfers_from_other_authorized_committee': ma.fields.Float(),
+        'other_political_committee_contributions': ma.fields.Float()
+    }
+)
+
+augment_schemas(make_candidate_total_schema)
+
+make_candidate_history_schema = make_schema(
+    models.CandidateHistory,
+    options={'exclude': ('idx',)}
+)
+
+augment_schemas(make_candidate_history_schema)
+
 augment_models(
     make_schema,
-    models.CandidateHistory,
-    models.CandidateTotal,
     models.CandidateFlags
-
 )
 
 
@@ -460,20 +508,229 @@ augment_schemas(CandidateHistoryTotalSchema)
 
 CandidateSearchSchema = make_schema(
     models.Candidate,
-    options={'exclude': ('idx', 'flags')},
     fields={
         'principal_committees': ma.fields.Nested('PrincipalCommitteeSchema', many=True),
         'federal_funds_flag': ma.fields.Boolean(attribute='flags.federal_funds_flag'),
         'has_raised_funds': ma.fields.Boolean(attribute='flags.has_raised_funds'),
     },
+    options={'exclude': ('idx', 'flags')},
 )
 CandidateSearchPageSchema = make_page_schema(CandidateSearchSchema)
-register_schema(CandidateSearchSchema)
-register_schema(CandidateSearchPageSchema)
+register_schema(CandidateSearchSchema, 'CandidateSearch')
+register_schema(CandidateSearchPageSchema, 'CandidateSearchPage')
 
+committee_fields = {
+        'pdf_url': ma.fields.Str(),
+        'csv_url': ma.fields.Str(),
+        'fec_url': ma.fields.Str(),
+        'report_form': ma.fields.Str(),
+        'document_description': ma.fields.Str(),
+        'committee_type': ma.fields.Str(attribute='committee.committee_type'),
+        'beginning_image_number': ma.fields.Str(),
+        'end_image_number': ma.fields.Str(),
+        'fec_file_id': ma.fields.Str(),
+        'total_receipts_period': ma.fields.Float(),
+        'total_disbursements_ytd': ma.fields.Float(),
+        'total_disbursements_period': ma.fields.Float(),
+        'total_contributions_ytd': ma.fields.Float(),
+        'total_contributions_period': ma.fields.Float(),
+        'refunded_political_party_committee_contributions_ytd': ma.fields.Float(),
+        'total_contribution_refunds_period': ma.fields.Float(),
+        'total_contribution_refunds_ytd': ma.fields.Float(),
+        'refunded_individual_contributions_period': ma.fields.Float(),
+        'refunded_individual_contributions_ytd': ma.fields.Float(),
+        'refunded_other_political_committee_contributions_period': ma.fields.Float(),
+        'refunded_other_political_committee_contributions_ytd': ma.fields.Float(),
+        'refunded_political_party_committee_contributions_period': ma.fields.Float(),
+        'previous_file_number': ma.fields.Float(),
+        'most_recent_file_number': ma.fields.Float(),
+        'cash_on_hand_beginning_period': ma.fields.Float(),
+        'cash_on_hand_end_period': ma.fields.Float(),
+        'debts_owed_by_committee': ma.fields.Float(),
+        'debts_owed_to_committee': ma.fields.Float(),
+        'other_disbursements_period': ma.fields.Float(),
+        'other_disbursements_ytd': ma.fields.Float(),
+        'other_political_committee_contributions_period': ma.fields.Float(),
+        'other_political_committee_contributions_ytd': ma.fields.Float(),
+        'political_party_committee_contributions_period': ma.fields.Float(),
+        'political_party_committee_contributions_ytd': ma.fields.Float()
+    }
 
-make_reports_schema = functools.partial(
-    make_schema,
+committee_reports_presidential_schema = make_schema(
+        models.CommitteeReportsPresidential,
+        fields=utils.extend(
+            committee_fields,
+            {
+                'candidate_contribution_period': ma.fields.Float(),
+                'candidate_contribution_ytd': ma.fields.Float(),
+                'exempt_legal_accounting_disbursement_period': ma.fields.Float(),
+                'exempt_legal_accounting_disbursement_ytd': ma.fields.Float(),
+                'expenditure_subject_to_limits': ma.fields.Float(),
+                'federal_funds_period': ma.fields.Float(),
+                'federal_funds_ytd': ma.fields.Float(),
+                'fundraising_disbursements_period': ma.fields.Float(),
+                'fundraising_disbursements_ytd': ma.fields.Float(),
+                'items_on_hand_liquidated': ma.fields.Float(),
+                'loans_received_from_candidate_period': ma.fields.Float(),
+                'loans_received_from_candidate_ytd': ma.fields.Float(),
+                'offsets_to_fundraising_expenditures_ytd': ma.fields.Float(),
+                'offsets_to_fundraising_expenditures_period': ma.fields.Float(),
+                'offsets_to_legal_accounting_period': ma.fields.Float(),
+                'offsets_to_legal_accounting_ytd': ma.fields.Float(),
+                'operating_expenditures_period': ma.fields.Float(),
+                'operating_expenditures_ytd': ma.fields.Float(),
+                'other_loans_received_period': ma.fields.Float(),
+                'other_loans_received_ytd': ma.fields.Float(),
+                'other_receipts_period': ma.fields.Float(),
+                'other_receipts_ytd': ma.fields.Float(),
+                'repayments_loans_made_by_candidate_period': ma.fields.Float(),
+                'repayments_loans_made_candidate_ytd': ma.fields.Float(),
+                'repayments_other_loans_period': ma.fields.Float(),
+                'repayments_other_loans_ytd': ma.fields.Float(),
+                'subtotal_summary_period': ma.fields.Float(),
+                'total_loan_repayments_made_period': ma.fields.Float(),
+                'total_loan_repayments_made_ytd': ma.fields.Float(),
+                'total_loans_received_period': ma.fields.Float(),
+                'total_loans_received_ytd': ma.fields.Float(),
+                'total_offsets_to_operating_expenditures_period': ma.fields.Float(),
+                'total_offsets_to_operating_expenditures_ytd': ma.fields.Float(),
+                'total_period': ma.fields.Float(),
+                'total_ytd': ma.fields.Float(),
+                'transfers_from_affiliated_committee_period': ma.fields.Float(),
+                'transfers_from_affiliated_committee_ytd': ma.fields.Float(),
+                'transfers_to_other_authorized_committee_period': ma.fields.Float(),
+                'transfers_to_other_authorized_committee_ytd': ma.fields.Float(),
+                'net_contributions_cycle_to_date': ma.fields.Float(),
+                'net_operating_expenditures_cycle_to_date': ma.fields.Float()
+            }),
+        options={'exclude': ('idx', 'committee', 'filer_name_text')}
+)
+
+augment_schemas(committee_reports_presidential_schema)
+
+committee_reports_hs_schema = make_schema(
+    models.CommitteeReportsHouseSenate,
+    fields=utils.extend(
+        committee_fields,
+        {
+            'aggregate_amount_personal_contributions_general': ma.fields.Float(),
+            'aggregate_contributions_personal_funds_primary': ma.fields.Float(),
+            'all_other_loans_period': ma.fields.Float(),
+            'all_other_loans_ytd': ma.fields.Float(),
+            'candidate_contribution_period': ma.fields.Float(),
+            'candidate_contribution_ytd': ma.fields.Float(),
+            'gross_receipt_authorized_committee_general': ma.fields.Float(),  # missing
+            'gross_receipt_authorized_committee_primary': ma.fields.Float(),  # missing
+            'gross_receipt_minus_personal_contribution_general': ma.fields.Float(),
+            'gross_receipt_minus_personal_contributions_primary': ma.fields.Float(),
+            'loan_repayments_candidate_loans_period': ma.fields.Float(),
+            'loan_repayments_candidate_loans_ytd': ma.fields.Float(),
+            'loan_repayments_other_loans_period': ma.fields.Float(),
+            'loan_repayments_other_loans_ytd': ma.fields.Float(),
+            'loans_made_by_candidate_period': ma.fields.Float(),
+            'loans_made_by_candidate_ytd': ma.fields.Float(),
+            'net_contributions_ytd': ma.fields.Float(),
+            'net_contributions_period': ma.fields.Float(),
+            'net_operating_expenditures_period': ma.fields.Float(),
+            'net_operating_expenditures_ytd': ma.fields.Float(),
+            'operating_expenditures_period': ma.fields.Float(),
+            'operating_expenditures_ytd': ma.fields.Float(),
+            'other_receipts_period': ma.fields.Float(),
+            'other_receipts_ytd': ma.fields.Float(),
+            'refunds_total_contributions_col_total_ytd': ma.fields.Float(),
+            'subtotal_period': ma.fields.Float(),
+            'total_contribution_refunds_col_total_period': ma.fields.Float(),
+            'total_contributions_column_total_period': ma.fields.Float(),  # missing
+            'total_loan_repayments_made_period': ma.fields.Float(),
+            'total_loan_repayments_made_ytd': ma.fields.Float(),
+            'total_loans_received_period': ma.fields.Float(),
+            'total_loans_received_ytd': ma.fields.Float(),
+            'total_offsets_to_operating_expenditures_period': ma.fields.Float(),
+            'total_offsets_to_operating_expenditures_ytd': ma.fields.Float(),
+            'total_operating_expenditures_period': ma.fields.Float(),
+            'total_operating_expenditures_ytd': ma.fields.Float(),
+            'transfers_from_other_authorized_committee_period': ma.fields.Float(),
+            'transfers_from_other_authorized_committee_ytd': ma.fields.Float(),
+            'transfers_to_other_authorized_committee_period': ma.fields.Float(),
+            'transfers_to_other_authorized_committee_ytd': ma.fields.Float(),
+        }),
+    options={'exclude': ('idx', 'committee', 'filer_name_text')}
+    )
+
+augment_schemas(committee_reports_hs_schema)
+
+committee_reports_pac_schema = make_schema(
+        models.CommitteeReportsPacParty,
+        fields=utils.extend(
+            committee_fields,
+            {
+                'all_loans_received_period': ma.fields.Float(),
+                'all_loans_received_ytd': ma.fields.Float(),
+                'allocated_federal_election_levin_share_period': ma.fields.Float(),
+                'cash_on_hand_beginning_calendar_ytd': ma.fields.Float(),
+                'cash_on_hand_close_ytd': ma.fields.Float(),
+                'coordinated_expenditures_by_party_committee_period': ma.fields.Float(),
+                'coordinated_expenditures_by_party_committee_ytd': ma.fields.Float(),
+                'fed_candidate_committee_contribution_refunds_ytd': ma.fields.Float(),
+                'fed_candidate_committee_contributions_period': ma.fields.Float(),
+                'fed_candidate_committee_contributions_ytd': ma.fields.Float(),
+                'fed_candidate_contribution_refunds_period': ma.fields.Float(),
+                'independent_expenditures_period': ma.fields.Float(),
+                'independent_expenditures_ytd': ma.fields.Float(),
+                'loan_repayments_made_period': ma.fields.Float(),
+                'loan_repayments_made_ytd': ma.fields.Float(),
+                'loan_repayments_received_period': ma.fields.Float(),
+                'loan_repayments_received_ytd': ma.fields.Float(),
+                'loans_made_period': ma.fields.Float(),
+                'loans_made_ytd': ma.fields.Float(),
+                'net_contributions_period': ma.fields.Float(),
+                'net_contributions_ytd': ma.fields.Float(),
+                'net_operating_expenditures_period': ma.fields.Float(),
+                'net_operating_expenditures_ytd': ma.fields.Float(),
+                'non_allocated_fed_election_activity_period': ma.fields.Float(),
+                'non_allocated_fed_election_activity_ytd': ma.fields.Float(),
+                'nonfed_share_allocated_disbursements_period': ma.fields.Float(),
+                'other_fed_operating_expenditures_period': ma.fields.Float(),
+                'other_fed_operating_expenditures_ytd': ma.fields.Float(),
+                'other_fed_receipts_period': ma.fields.Float(),
+                'other_fed_receipts_ytd': ma.fields.Float(),
+                'shared_fed_activity_nonfed_ytd': ma.fields.Float(),
+                'shared_fed_activity_period': ma.fields.Float(),
+                'shared_fed_activity_ytd': ma.fields.Float(),
+                'shared_fed_operating_expenditures_period': ma.fields.Float(),
+                'shared_fed_operating_expenditures_ytd': ma.fields.Float(),
+                'shared_nonfed_operating_expenditures_period': ma.fields.Float(),
+                'shared_nonfed_operating_expenditures_ytd': ma.fields.Float(),
+                'subtotal_summary_page_period': ma.fields.Float(),
+                'subtotal_summary_ytd': ma.fields.Float(),
+                'total_fed_disbursements_period': ma.fields.Float(),
+                'total_fed_disbursements_ytd': ma.fields.Float(),
+                'total_fed_election_activity_period': ma.fields.Float(),
+                'total_fed_election_activity_ytd': ma.fields.Float(),
+                'total_fed_operating_expenditures_period': ma.fields.Float(),
+                'total_fed_operating_expenditures_ytd': ma.fields.Float(),
+                'total_fed_receipts_period': ma.fields.Float(),
+                'total_fed_receipts_ytd': ma.fields.Float(),
+                'total_nonfed_transfers_period': ma.fields.Float(),
+                'total_nonfed_transfers_ytd': ma.fields.Float(),
+                'total_operating_expenditures_period': ma.fields.Float(),
+                'total_operating_expenditures_ytd': ma.fields.Float(),
+                'transfers_from_affiliated_party_period': ma.fields.Float(),
+                'transfers_from_affiliated_party_ytd': ma.fields.Float(),
+                'transfers_from_nonfed_account_period': ma.fields.Float(),
+                'transfers_from_nonfed_account_ytd': ma.fields.Float(),
+                'transfers_from_nonfed_levin_period': ma.fields.Float(),
+                'transfers_from_nonfed_levin_ytd': ma.fields.Float(),
+                'transfers_to_affiliated_committee_period': ma.fields.Float(),
+                'transfers_to_affilitated_committees_ytd': ma.fields.Float()
+            }),
+        options={'exclude': ('idx', 'committee', 'filer_name_text')}
+)
+
+augment_schemas(committee_reports_pac_schema)
+
+committee_reports_ie_schema = make_schema(
+    models.CommitteeReportsIEOnly,
     fields={
         'pdf_url': ma.fields.Str(),
         'csv_url': ma.fields.Str(),
@@ -484,17 +741,13 @@ make_reports_schema = functools.partial(
         'beginning_image_number': ma.fields.Str(),
         'end_image_number': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
+        'independent_contributions_period': ma.fields.Float(),
+        'independent_expenditures_period': ma.fields.Float()
     },
-    options={'exclude': ('idx', 'committee', 'filer_name_text', 'spender_name_text')},
+    options={'exclude': ('idx', 'spender_name_text')},
 )
 
-augment_models(
-    make_reports_schema,
-    models.CommitteeReportsPresidential,
-    models.CommitteeReportsHouseSenate,
-    models.CommitteeReportsPacParty,
-    models.CommitteeReportsIEOnly,
-)
+augment_schemas(committee_reports_ie_schema)
 
 reports_schemas = (
     schemas['CommitteeReportsPresidentialSchema'],
@@ -508,68 +761,288 @@ CommitteeReportsPageSchema = make_page_schema(CommitteeReportsSchema)
 entity_fields = {
     'pdf_url': ma.fields.Str(),
     'report_form': ma.fields.Str(),
-    'last_cash_on_hand_end_period': ma.fields.Decimal(places=2),
+    'last_cash_on_hand_end_period': ma.fields.Float(),
     'last_beginning_image_number': ma.fields.Str(),
     'transaction_coverage_date': ma.fields.Date(
         attribute='transaction_coverage.transaction_coverage_date',
         default=None),
-    'individual_contributions_percent': ma.fields.Decimal(places=2),
-    'party_and_other_committee_contributions_percent': ma.fields.Decimal(places=2),
-    'contributions_ie_and_party_expenditures_made_percent': ma.fields.Decimal(places=2),
-    'operating_expenditures_percent': ma.fields.Decimal(places=2),
+    'individual_contributions_percent': ma.fields.Float(),
+    'party_and_other_committee_contributions_percent': ma.fields.Float(),
+    'contributions_ie_and_party_expenditures_made_percent': ma.fields.Float(),
+    'operating_expenditures_percent': ma.fields.Float(),
 }
-# All /totals/entity_type/except 'pac', 'party', 'pac-party'
+# All /totals/entity_type/except 'pac','party','pac-party'
 make_totals_schema = functools.partial(
     make_schema,
-    fields=entity_fields,
-    options={
+    fields=utils.extend(
+        entity_fields,
+        {'cash_on_hand_beginning_period': ma.fields.Float()},
+        {'all_other_loans': ma.fields.Float()},
+        {'candidate_contribution': ma.fields.Float()},
+        {'disbursements': ma.fields.Float()},
+        {'individual_contributions': ma.fields.Float()},
+        {'individual_itemized_contributions': ma.fields.Float()},
+        {'individual_unitemized_contributions': ma.fields.Float()},
+        {'last_cash_on_hand_end_period': ma.fields.Float()},
+        {'last_debts_owed_by_committee': ma.fields.Float()},
+        {'last_debts_owed_to_committee': ma.fields.Float()},
+        {'loan_repayments': ma.fields.Float()},
+        {'loan_repayments_candidate_loans': ma.fields.Float()},
+        {'loan_repayments_other_loans': ma.fields.Float()},
+        {'loans': ma.fields.Float()},
+        {'loans_made_by_candidate': ma.fields.Float()},
+        {'net_contributions': ma.fields.Float()},
+        {'net_operating_expenditures': ma.fields.Float()},
+        {'offsets_to_operating_expenditures': ma.fields.Float()},
+        {'operating_expenditures': ma.fields.Float()},
+        {'other_political_committee_contributions': ma.fields.Float()},
+        {'other_receipts': ma.fields.Float()},
+        {'political_party_committee_contributions': ma.fields.Float()},
+        {'receipts': ma.fields.Float()},
+        {'refunded_individual_contributions': ma.fields.Float()},
+        {'refunded_other_political_committee_contributions': ma.fields.Float()},
+        {'refunded_political_party_committee_contributions': ma.fields.Float()},
+        {'transfers_from_other_authorized_committee': ma.fields.Float()},
+        {'transfers_to_other_authorized_committee': ma.fields.Float()},
+        {'other_disbursements': ma.fields.Float()},
+        {'contribution_refunds': ma.fields.Float()},
+        {'contributions': ma.fields.Float()},
+    ), options={
         'exclude': (
             'transaction_coverage',
             'idx',
             'treasurer_text',
-            'sponsor_candidate_list',
-            'sponsor_candidate_ids'
         )
-    },
+    }
 )
 augment_models(
     make_totals_schema,
-    models.CommitteeTotalsHouseSenate,
-    models.CommitteeTotalsIEOnly,
-    models.CommitteeTotalsPerCycle,
+    models.CommitteeTotalsHouseSenate
 )
-# /totals/entity_type/ 'pac', 'party', 'pac-party'
+
+make_totals_per_cycle_schema = functools.partial(
+    make_schema,
+    fields=utils.extend(
+        entity_fields,
+        {'cash_on_hand_beginning_period': ma.fields.Float()},
+        {'all_other_loans': ma.fields.Float()},
+        {'candidate_contribution': ma.fields.Float()},
+        {'disbursements': ma.fields.Float()},
+        {'individual_contributions': ma.fields.Float()},
+        {'individual_itemized_contributions': ma.fields.Float()},
+        {'individual_unitemized_contributions': ma.fields.Float()},
+        {'last_cash_on_hand_end_period': ma.fields.Float()},
+        {'last_debts_owed_by_committee': ma.fields.Float()},
+        {'last_debts_owed_to_committee': ma.fields.Float()},
+        {'loan_repayments': ma.fields.Float()},
+        {'loan_repayments_candidate_loans': ma.fields.Float()},
+        {'loan_repayments_other_loans': ma.fields.Float()},
+        {'loans': ma.fields.Float()},
+        {'loans_made_by_candidate': ma.fields.Float()},
+        {'net_contributions': ma.fields.Float()},
+        {'net_operating_expenditures': ma.fields.Float()},
+        {'offsets_to_operating_expenditures': ma.fields.Float()},
+        {'operating_expenditures': ma.fields.Float()},
+        {'other_political_committee_contributions': ma.fields.Float()},
+        {'other_receipts': ma.fields.Float()},
+        {'political_party_committee_contributions': ma.fields.Float()},
+        {'receipts': ma.fields.Float()},
+        {'refunded_individual_contributions': ma.fields.Float()},
+        {'refunded_other_political_committee_contributions': ma.fields.Float()},
+        {'refunded_political_party_committee_contributions': ma.fields.Float()},
+        {'transfers_from_other_authorized_committee': ma.fields.Float()},
+        {'transfers_to_other_authorized_committee': ma.fields.Float()},
+        {'other_disbursements': ma.fields.Float()},
+        {'contribution_refunds': ma.fields.Float()},
+        {'contributions': ma.fields.Float()},
+        {'exempt_legal_accounting_disbursement': ma.fields.Float()},
+        {'federal_funds': ma.fields.Float()},
+        {'fundraising_disbursements': ma.fields.Float()},
+        {'loan_repayments_made': ma.fields.Float()},
+        {'loans_received': ma.fields.Float()},
+        {'loans_received_from_candidate': ma.fields.Float()},
+        {'offsets_to_fundraising_expenditures': ma.fields.Float()},
+        {'offsets_to_legal_accounting': ma.fields.Float()},
+        {'other_loans_received': ma.fields.Float()},
+        {'repayments_loans_made_by_candidate': ma.fields.Float()},
+        {'repayments_other_loans': ma.fields.Float()},
+        {'total_offsets_to_operating_expenditures': ma.fields.Float()},
+        {'transfers_from_affiliated_committee': ma.fields.Float()}
+    ), options={
+        'exclude': (
+            'transaction_coverage',
+            'idx',
+            'treasurer_text',
+        )
+    }
+)
+
+augment_models(
+    make_totals_per_cycle_schema,
+    models.CommitteeTotalsPerCycle
+)
+
+make_committee_totals_ie_only = make_schema(
+    models.CommitteeTotalsIEOnly,
+    fields=utils.extend(
+        entity_fields,
+        {'total_independent_contributions': ma.fields.Float()},
+        {'total_independent_expenditures': ma.fields.Float()}
+    ), options={
+        'exclude': (
+            'transaction_coverage',
+            'idx',
+        )
+    }
+)
+
+augment_schemas(make_committee_totals_ie_only)
+
+# /totals/entity_type/ 'pac','party','pac-party'
 make_pac_party_totals_schema = functools.partial(
     make_schema,
     fields=utils.extend(
         entity_fields,
-        {'sponsor_candidate_list': ma.fields.Nested(PacSponsorCandidateschema, many=True)}
+        {'sponsor_candidate_list': ma.fields.Nested(PacSponsorCandidateschema, many=True)},
+        {'all_loans_received': ma.fields.Float()},
+        {'allocated_federal_election_levin_share': ma.fields.Float()},
+        {'disbursements': ma.fields.Float()},
+        {'convention_exp': ma.fields.Float()},
+        {'coordinated_expenditures_by_party_committee': ma.fields.Float()},
+        {'exp_prior_years_subject_limits': ma.fields.Float()},
+        {'exp_subject_limits': ma.fields.Float()},
+        {'fed_candidate_committee_contributions': ma.fields.Float()},
+        {'fed_candidate_contribution_refunds': ma.fields.Float()},
+        {'fed_disbursements': ma.fields.Float()},
+        {'fed_election_activity': ma.fields.Float()},
+        {'fed_operating_expenditures': ma.fields.Float()},
+        {'fed_receipts': ma.fields.Float()},
+        {'independent_expenditures': ma.fields.Float()},
+        {'cash_on_hand_beginning_period': ma.fields.Float()},
+        {'contribution_refunds': ma.fields.Float()},
+        {'individual_contributions': ma.fields.Float()},
+        {'individual_itemized_contributions': ma.fields.Float()},
+        {'individual_unitemized_contributions': ma.fields.Float()},
+        {'itemized_convention_exp': ma.fields.Float()},
+        {'itemized_other_disb': ma.fields.Float()},
+        {'itemized_other_income': ma.fields.Float()},
+        {'itemized_other_refunds': ma.fields.Float()},
+        {'itemized_refunds_relating_convention_exp': ma.fields.Float()},
+        {'last_debts_owed_by_committee': ma.fields.Float()},
+        {'last_debts_owed_to_committee': ma.fields.Float()},
+        {'loan_repayments_made': ma.fields.Float()},
+        {'loan_repayments_received': ma.fields.Float()},
+        {'loans_and_loan_repayments_made': ma.fields.Float()},
+        {'loans_and_loan_repayments_received': ma.fields.Float()},
+        {'loans_made': ma.fields.Float()},
+        {'net_contributions': ma.fields.Float()},
+        {'net_operating_expenditures': ma.fields.Float()},
+        {'non_allocated_fed_election_activity': ma.fields.Float()},
+        {'offsets_to_operating_expenditures': ma.fields.Float()},
+        {'operating_expenditures': ma.fields.Float()},
+        {'other_disbursements': ma.fields.Float()},
+        {'other_fed_operating_expenditures': ma.fields.Float()},
+        {'other_fed_receipts': ma.fields.Float()},
+        {'other_political_committee_contributions': ma.fields.Float()},
+        {'other_refunds': ma.fields.Float()},
+        {'political_party_committee_contributions': ma.fields.Float()},
+        {'refunded_individual_contributions': ma.fields.Float()},
+        {'refunded_other_political_committee_contributions': ma.fields.Float()},
+        {'refunded_political_party_committee_contributions': ma.fields.Float()},
+        {'refunds_relating_convention_exp': ma.fields.Float()},
+        {'shared_fed_activity': ma.fields.Float()},
+        {'shared_fed_activity_nonfed': ma.fields.Float()},
+        {'shared_fed_operating_expenditures': ma.fields.Float()},
+        {'shared_nonfed_operating_expenditures': ma.fields.Float()},
+        {'total_exp_subject_limits': ma.fields.Float()},
+        {'total_transfers': ma.fields.Float()},
+        {'transfers_from_affiliated_party': ma.fields.Float()},
+        {'transfers_from_nonfed_account': ma.fields.Float()},
+        {'transfers_from_nonfed_levin': ma.fields.Float()},
+        {'transfers_to_affiliated_committee': ma.fields.Float()},
+        {'unitemized_convention_exp': ma.fields.Float()},
+        {'unitemized_other_disb': ma.fields.Float()},
+        {'unitemized_other_income': ma.fields.Float()},
+        {'unitemized_other_refunds': ma.fields.Float()},
+        {'unitemized_refunds_relating_convention_exp': ma.fields.Float()},
+        {'contributions': ma.fields.Float()},
+        {'federal_funds': ma.fields.Float()},
+        {'receipts': ma.fields.Float()}
     ),
-    options={
-        'exclude': (
-            'transaction_coverage',
-            'idx',
-            'treasurer_text',
-        )
-    },
+    options={'exclude': ('idx', 'treasurer_text', 'transaction_coverage')}
 )
 augment_models(
     make_pac_party_totals_schema,
     models.CommitteeTotalsPacParty,
 )
 
-make_candidate_totals_schema = functools.partial(
-    make_schema,
-    fields={
-        'last_cash_on_hand_end_period': ma.fields.Decimal(places=2),
+candidate_committee_fields = {
+        'last_cash_on_hand_end_period': ma.fields.Float(),
         'last_beginning_image_number': ma.fields.Str(),
-    },
-)
-augment_models(
-    make_candidate_totals_schema,
+        'receipts': ma.fields.Float(),
+        'candidate_contribution': ma.fields.Float(),
+        'offsets_to_operating_expenditures': ma.fields.Float(),
+        'political_party_committee_contributions': ma.fields.Float(),
+        'other_disbursements': ma.fields.Float(),
+        'other_political_committee_contributions': ma.fields.Float(),
+        'individual_itemized_contributions': ma.fields.Float(),
+        'individual_unitemized_contributions': ma.fields.Float(),
+        'disbursements': ma.fields.Float(),
+        'contributions': ma.fields.Float(),
+        'individual_contributions': ma.fields.Float(),
+        'contribution_refunds': ma.fields.Float(),
+        'operating_expenditures': ma.fields.Float(),
+        'refunded_individual_contributions': ma.fields.Float(),
+        'refunded_other_political_committee_contributions': ma.fields.Float(),
+        'refunded_political_party_committee_contributions': ma.fields.Float(),
+        'last_debts_owed_by_committee': ma.fields.Float(),
+        'last_debts_owed_to_committee': ma.fields.Float()
+
+}
+
+make_candidate_totals_schema = make_schema(
     models.CandidateCommitteeTotalsPresidential,
-    models.CandidateCommitteeTotalsHouseSenate,
+    fields=utils.extend({
+        'exempt_legal_accounting_disbursement': ma.fields.Float(),
+        'federal_funds': ma.fields.Float(),
+        'fundraising_disbursements': ma.fields.Float(),
+        'loan_repayments_made': ma.fields.Float(),
+        'loans_received': ma.fields.Float(),
+        'loans_received_from_candidate': ma.fields.Float(),
+        'offsets_to_fundraising_expenditures': ma.fields.Float(),
+        'offsets_to_legal_accounting': ma.fields.Float(),
+        'total_offsets_to_operating_expenditures': ma.fields.Float(),
+        'other_loans_received': ma.fields.Float(),
+        'other_receipts': ma.fields.Float(),
+        'repayments_loans_made_by_candidate': ma.fields.Float(),
+        'repayments_other_loans': ma.fields.Float(),
+        'transfers_from_affiliated_committee': ma.fields.Float(),
+        'transfers_to_other_authorized_committee': ma.fields.Float(),
+        'net_operating_expenditures': ma.fields.Float(),
+        'net_contributions': ma.fields.Float(),
+        'disbursements': ma.fields.Float()
+    }, candidate_committee_fields)
 )
+augment_schemas(make_candidate_totals_schema)
+
+candidate_committee_totals_hs = make_schema(
+    models.CandidateCommitteeTotalsHouseSenate,
+    fields=utils.extend({
+        'all_other_loans': ma.fields.Float(),
+        'candidate_contribution': ma.fields.Float(),
+        'loan_repayments': ma.fields.Float(),
+        'loan_repayments_candidate_loans': ma.fields.Float(),
+        'loan_repayments_other_loans': ma.fields.Float(),
+        'loans': ma.fields.Float(),
+        'loans_made_by_candidate': ma.fields.Float(),
+        'other_receipts': ma.fields.Float(),
+        'transfers_from_other_authorized_committee': ma.fields.Float(),
+        'transfers_to_other_authorized_committee': ma.fields.Float(),
+        'net_operating_expenditures': ma.fields.Float(),
+        'net_contributions': ma.fields.Float()
+    }, candidate_committee_fields)
+)
+augment_schemas(candidate_committee_totals_hs)
 
 register_schema(CommitteeReportsSchema)
 register_schema(CommitteeReportsPageSchema)
@@ -593,29 +1066,27 @@ ScheduleASchema = make_schema(
         'memoed_subtotal': ma.fields.Boolean(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'contributor': ma.fields.Nested(schemas['CommitteeHistorySchema']),
-        'contribution_receipt_amount': ma.fields.Decimal(places=2),
-        'contributor_aggregate_ytd': ma.fields.Decimal(places=2),
+        'contribution_receipt_amount': ma.fields.Float(),
+        'contributor_aggregate_ytd': ma.fields.Float(),
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'report_year': ma.fields.Int()
     },
     options={
-        'exclude': (
+         'exclude': (
             'contributor_name_text',
             'contributor_employer_text',
             'contributor_occupation_text',
-            'recipient_street_1',
-            'recipient_street_2',
-        ),
-        'relationships': [
+            ),
+         'relationships': [
             Relationship(
                 models.ScheduleA.committee,
                 models.CommitteeHistory.name,
                 'committee_name',
                 1
-            ),
-        ],
-
+                ),
+            ],
     }
 )
 
@@ -629,15 +1100,9 @@ ScheduleCSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
-
     },
-    options={
-        'exclude': (
-            'loan_source_name_text',
-            'candidate_name_text',
-        )
-    },
-)
+    options={'exclude': ('loan_source_name_text', 'candidate_name_text',)}
+    )
 ScheduleCPageSchema = make_page_schema(
     ScheduleCSchema,
 )
@@ -647,10 +1112,10 @@ ScheduleBByRecipientIDSchema = make_schema(
     fields={
         'committee_name': ma.fields.Str(),
         'recipient_name': ma.fields.Str(),
+        'total': ma.fields.Float(),
+        'memo_total': ma.fields.Float()
     },
-    options={
-        'exclude': ('idx', 'committee', 'recipient')
-    },
+    options={'exclude': ('idx', 'committee', 'recipient')}
 )
 augment_schemas(ScheduleBByRecipientIDSchema)
 
@@ -659,11 +1124,12 @@ augment_schemas(ScheduleBByRecipientIDSchema)
 ScheduleBByRecipientSchema = make_schema(
     models.ScheduleBByRecipient,
     fields={
-        'recipient_disbursement_percent': ma.fields.Decimal(places=2),
+        'recipient_disbursement_percent': ma.fields.Float(),
+        'committee_total_disbursements': ma.fields.Float(),
+        'total': ma.fields.Float(),
+        'memo_total': ma.fields.Float()
     },
-    options={
-        'exclude': ('idx', 'committee')
-    },
+    options={'exclude': ('idx', 'committee')}
 )
 
 ScheduleBByRecipientPageSchema = make_page_schema(ScheduleBByRecipientSchema, page_type=paging_schemas.SeekPageSchema)
@@ -688,9 +1154,10 @@ make_aggregate_schema = functools.partial(
         'candidate_id': ma.fields.Str(),
         'committee_name': ma.fields.Str(),
         'candidate_name': ma.fields.Str(),
+        'total': ma.fields.Float()
     },
-    options={'exclude': ('idx', 'committee', 'candidate')},
-)
+    options={'exclude': ('idx', 'committee', 'candidate')}
+    )
 
 ScheduleEByCandidateSchema = make_aggregate_schema(models.ScheduleEByCandidate)
 augment_schemas(ScheduleEByCandidateSchema)
@@ -702,9 +1169,7 @@ ScheduleDSchema = make_schema(
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
     },
-    options={
-        'exclude': ('creditor_debtor_name_text',)
-    },
+    options={'exclude': ('creditor_debtor_name_text',)}
 )
 ScheduleDPageSchema = make_page_schema(
     ScheduleDSchema
@@ -718,10 +1183,8 @@ ScheduleFSchema = make_schema(
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
     },
-    options={'exclude': ('payee_name_text',)
-             },
-
-)
+    options={'exclude': ('payee_name_text',)}
+    )
 ScheduleFPageSchema = make_page_schema(
     ScheduleFSchema
 )
@@ -741,6 +1204,7 @@ ScheduleBSchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'disbursement_amount': ma.fields.Float()
     },
     options={
         'exclude': (
@@ -770,6 +1234,12 @@ ScheduleH4Schema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'cycle': ma.fields.Int(),
+        'disbursement_amount': ma.fields.Float(),
+        'federal_share': ma.fields.Float(),
+        'nonfederal_share': ma.fields.Float(),
+        'event_amount_year_to_date': ma.fields.Float(),
+
     },
     options={
         'exclude': (
@@ -795,8 +1265,8 @@ ScheduleESchema = make_schema(
     fields={
         'memoed_subtotal': ma.fields.Boolean(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
-        'expenditure_amount': ma.fields.Decimal(places=2),
-        'office_total_ytd': ma.fields.Decimal(places=2),
+        'expenditure_amount': ma.fields.Float(),
+        'office_total_ytd': ma.fields.Float(),
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
@@ -820,9 +1290,7 @@ ScheduleEPageSchema = make_page_schema(ScheduleESchema, page_type=paging_schemas
 register_schema(ScheduleESchema)
 register_schema(ScheduleEPageSchema)
 
-CommunicationCostSchema = make_schema(
-    models.CommunicationCost,
-)
+CommunicationCostSchema = make_schema(models.CommunicationCost, fields={'transaction_amount': ma.fields.Float()})
 CommunicationCostPageSchema = make_page_schema(
     CommunicationCostSchema,
     page_type=paging_schemas.OffsetPageSchema
@@ -839,18 +1307,24 @@ CCAggregatesSchema = make_schema(
         'candidate_name': ma.fields.Str(),
         'cycle': ma.fields.Int(),
         'count': ma.fields.Int(),
-        'total': ma.fields.Decimal(places=2),
+        'total': ma.fields.Float(),
     },
+    options={'exclude': ('idx',)}
 )
 CCAggregatesPageSchema = make_page_schema(CCAggregatesSchema)
-register_schema(CCAggregatesSchema)
-register_schema(CCAggregatesPageSchema)
+register_schema(CCAggregatesSchema, 'CCAggregates')
+register_schema(CCAggregatesPageSchema, 'CCAggregatesPage')
 
 ElectioneeringSchema = make_schema(
     models.Electioneering,
-    fields={'election_type': ma.fields.Str()},
-    options={'exclude': ('idx', 'purpose_description_text', 'election_type_raw')},
+    fields={'election_type': ma.fields.Str(),
+            'number_of_candidates': ma.fields.Float(),
+            'calculated_candidate_share': ma.fields.Float(),
+            'disbursement_amount': ma.fields.Float(),
+            },
+    options={'exclude': ('idx', 'purpose_description_text', 'election_type_raw')}
 )
+
 ElectioneeringPageSchema = make_page_schema(ElectioneeringSchema, page_type=paging_schemas.SeekPageSchema)
 register_schema(ElectioneeringSchema)
 register_schema(ElectioneeringPageSchema)
@@ -864,12 +1338,13 @@ ECAggregatesSchema = make_schema(
         'candidate_name': ma.fields.Str(),
         'cycle': ma.fields.Int(),
         'count': ma.fields.Int(),
-        'total': ma.fields.Decimal(places=2),
+        'total': ma.fields.Float(),
     },
+    options={'exclude': ('idx',)}
 )
 ECAggregatesPageSchema = make_page_schema(ECAggregatesSchema)
-register_schema(ECAggregatesSchema)
-register_schema(ECAggregatesPageSchema)
+register_schema(ECAggregatesSchema, 'ECAggregates')
+register_schema(ECAggregatesPageSchema, 'ECAggregatesPage')
 
 BaseFilingsSchema = make_schema(
     models.Filings,
@@ -882,22 +1357,46 @@ BaseFilingsSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'fec_file_id': ma.fields.Str(),
         'report_type_full': ma.fields.Str(),
+        'amendment_chain': ma.fields.List(ma.fields.Int()),
+        'total_receipts': ma.fields.Float(),
+        'total_individual_contributions': ma.fields.Float(),
+        'net_donations': ma.fields.Float(),
+        'total_disbursements': ma.fields.Float(),
+        'total_independent_expenditures': ma.fields.Float(),
+        'total_communication_cost': ma.fields.Float(),
+        'cash_on_hand_beginning_period': ma.fields.Float(),
+        'cash_on_hand_end_period': ma.fields.Float(),
+        'debts_owed_by_committee': ma.fields.Float(),
+        'debts_owed_to_committee': ma.fields.Float(),
+        'house_personal_funds': ma.fields.Float(),
+        'senate_personal_funds': ma.fields.Float(),
+        'opposition_personal_funds': ma.fields.Float()
     },
-    options={'exclude': ('committee', 'filer_name_text', 'report_type_full_original',)},
+    options={'exclude': ('committee', 'filer_name_text', 'report_type_full_original', )}
 )
 
 
 class FilingsSchema(BaseFilingsSchema):
     @post_dump
-    def remove_fec_url(self, obj):
+    def remove_fec_url(self, obj, **kwargs):
         if not obj.get('fec_url'):
             obj.pop('fec_url')
+
+        return obj
 
 
 augment_schemas(FilingsSchema)
 
 EfilingsAmendmentsSchema = make_schema(
     models.EfilingsAmendments,
+    fields={
+        'amendment_chain': ma.fields.List(ma.fields.Int()),
+        'longest_chain': ma.fields.Float(),
+        'most_recent_filing': ma.fields.Float(),
+        'depth': ma.fields.Float(),
+        'last': ma.fields.Float(),
+        'previous_file_number': ma.fields.Float()
+    }
 )
 
 augment_schemas(EfilingsAmendmentsSchema)
@@ -919,7 +1418,7 @@ EFilingsSchema = make_schema(
         'amended_by': ma.fields.Int(),
         'fec_file_id': ma.fields.Str(),
     },
-    options={'exclude': ('report', 'amendment', 'superceded')},
+    options={'exclude': ('report', 'amendment', 'superceded', 'report_type')}
 )
 augment_schemas(EFilingsSchema)
 
@@ -935,6 +1434,7 @@ ItemizedScheduleBfilingsSchema = make_schema(
         'payee_name': ma.fields.Str(),
         'report_type': ma.fields.Str(),
         'csv_url': ma.fields.Str(),
+        'disbursement_amount': ma.fields.Float()
     },
     options={
         'relationships': [
@@ -963,7 +1463,7 @@ ItemizedScheduleEfilingsSchema = make_schema(
         'csv_url': ma.fields.Str(),
     },
     options={
-        'exclude': ['cand_fulltxt'],
+        'exclude': ('cand_fulltxt',),
         'relationships': [
             Relationship(
                 models.ScheduleEEfile.committee,
@@ -989,12 +1489,11 @@ ItemizedScheduleH4filingsSchema = make_schema(
         'payee_name': ma.fields.Str(),
         'report_type': ma.fields.Str(),
         'csv_url': ma.fields.Str(),
+        'disbursement_amount': ma.fields.Float(),
+        'fed_share': ma.fields.Float(),
+        'event_amount_year_to_date': ma.fields.Float()
     },
     options={
-        'exclude': (
-            'line_num',
-            'tran_id',
-        ),
         'relationships': [
             Relationship(
                 models.ScheduleH4Efile.committee,
@@ -1021,6 +1520,9 @@ ItemizedScheduleAfilingsSchema = make_schema(
         'contributor_name': ma.fields.Str(),
         'fec_election_type_desc': ma.fields.Str(),
         'csv_url': ma.fields.Str(),
+        'contributor_aggregate_ytd': ma.fields.Float(),
+        'contribution_receipt_amount': ma.fields.Float(),
+
     },
     options={
         'exclude': (
@@ -1051,8 +1553,8 @@ ReportingDatesSchema = make_schema(
         'report_type_full': ma.fields.Str(),
     },
     options={'exclude': ('trc_report_due_date_id', 'report')},
+    class_name='ReportingDatesSchema'
 )
-ReportingDatesPageSchema = make_page_schema(ReportingDatesSchema)
 augment_schemas(ReportingDatesSchema)
 
 ElectionDatesSchema = make_schema(
@@ -1061,11 +1563,10 @@ ElectionDatesSchema = make_schema(
         'election_type_full': ma.fields.Str(),
         'active_election': ma.fields.Boolean(),
     },
-    options={
-        'exclude': ('trc_election_id', 'election_status_id'),
-    },
+    options={'exclude': ('trc_election_id', 'election_status_id')},
+    class_name='ElectionDatesSchema'
+
 )
-ElectionDatesPageSchema = make_page_schema(ElectionDatesSchema)
 augment_schemas(ElectionDatesSchema)
 
 CalendarDateSchema = make_schema(
@@ -1077,12 +1578,8 @@ CalendarDateSchema = make_schema(
         'end_date': ma.fields.Function(format_end_date),
     },
     options={
-        'exclude': (
-            'summary_text', 'description_text'
-        )
-    },
+        'exclude': ('summary_text', 'description_text')}
 )
-CalendarDatePageSchema = make_page_schema(CalendarDateSchema)
 augment_schemas(CalendarDateSchema)
 
 
@@ -1101,9 +1598,9 @@ augment_schemas(ElectionSearchSchema)
 
 class ElectionSummarySchema(ApiSchema):
     count = ma.fields.Int()
-    receipts = ma.fields.Decimal(places=2)
-    disbursements = ma.fields.Decimal(places=2)
-    independent_expenditures = ma.fields.Decimal(places=2)
+    receipts = ma.fields.Float()
+    disbursements = ma.fields.Float()
+    independent_expenditures = ma.fields.Float()
 
 
 register_schema(ElectionSummarySchema)
@@ -1117,23 +1614,20 @@ class ElectionSchema(ma.Schema):
     committee_ids = ma.fields.List(ma.fields.Str)
     candidate_pcc_id = ma.fields.Str(doc="The candidate's primary campaign committee ID")
     candidate_pcc_name = ma.fields.Str(doc="The candidate's primary campaign committee name")
-    total_receipts = ma.fields.Decimal(places=2)
-    total_disbursements = ma.fields.Decimal(places=2)
-    cash_on_hand_end_period = ma.fields.Decimal(places=2)
+    total_receipts = ma.fields.Float()
+    total_disbursements = ma.fields.Float()
+    cash_on_hand_end_period = ma.fields.Float()
     candidate_election_year = ma.fields.Int()
     coverage_end_date = ma.fields.Date()
 
 
 augment_schemas(ElectionSchema)
 
-ElectionPageSchema = make_page_schema(ElectionSchema)
-register_schema(ElectionPageSchema)
-
 
 class ScheduleABySizeCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
     size = ma.fields.Int()
     count = ma.fields.Int()
 
@@ -1141,7 +1635,7 @@ class ScheduleABySizeCandidateSchema(ma.Schema):
 class ScheduleAByStateCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
     state = ma.fields.Str()
     state_full = ma.fields.Str()
     count = ma.fields.Int()
@@ -1150,16 +1644,16 @@ class ScheduleAByStateCandidateSchema(ma.Schema):
 class ScheduleAByContributorTypeCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
     individual = ma.fields.Bool()
 
 
 class TotalsCommitteeSchema(schemas['CommitteeHistorySchema']):
-    receipts = ma.fields.Decimal(places=2)
-    disbursements = ma.fields.Decimal(places=2)
-    cash_on_hand_end_period = ma.fields.Decimal(places=2)
-    debts_owed_by_committee = ma.fields.Decimal(places=2)
-    independent_expenditures = ma.fields.Decimal(places=2)
+    receipts = ma.fields.Float()
+    disbursements = ma.fields.Float()
+    cash_on_hand_end_period = ma.fields.Float()
+    debts_owed_by_committee = ma.fields.Float()
+    independent_expenditures = ma.fields.Float()
 
 
 augment_schemas(
@@ -1170,7 +1664,11 @@ augment_schemas(
 
 RadAnalystSchema = make_schema(
     models.RadAnalyst,
-    options={'exclude': ('idx', 'name_txt')},
+    fields={'analyst_id': ma.fields.Float(),
+            'analyst_short_id': ma.fields.Float(),
+            'telephone_ext': ma.fields.Float()
+            },
+    options={'exclude': ('idx', 'name_txt')}
 )
 RadAnalystPageSchema = make_page_schema(RadAnalystSchema)
 register_schema(RadAnalystSchema)
@@ -1187,6 +1685,7 @@ register_schema(EntityReceiptDisbursementTotalsPageSchema)
 
 ScheduleAByStateRecipientTotalsSchema = make_schema(
     models.ScheduleAByStateRecipientTotals,
+    fields={'total': ma.fields.Float()},
     options={'exclude': ('idx',)}
 )
 ScheduleAByStateRecipientTotalsPageSchema = make_page_schema(
@@ -1206,7 +1705,8 @@ AuditPrimaryCategorySchema = make_schema(
     },
     options={
         'exclude': ('tier',)
-    }
+    },
+    BaseSchema=BaseSchema
 )
 
 AuditPrimaryCategoryPageSchema = make_page_schema(AuditPrimaryCategorySchema)
@@ -1224,7 +1724,8 @@ AuditCategoryRelationSchema = make_schema(
     },
     options={
         'exclude': ('primary_category_id', 'primary_category_name')
-    }
+    },
+    BaseSchema=BaseSchema
 )
 
 AuditCategoryRelationPageSchema = make_page_schema(AuditCategoryRelationSchema)
@@ -1250,7 +1751,8 @@ AuditCategorySchema = make_schema(
         #         1
         #     ),
         # ],
-    }
+    },
+    BaseSchema=BaseSchema
 )
 
 AuditCategoryPageSchema = make_page_schema(AuditCategorySchema)
@@ -1271,7 +1773,7 @@ AuditCaseSubCategorySchema = make_schema(
         'exclude': (
             'primary_category_id',
             'audit_case_id',
-            'primary_category_name',
+            'primary_category_name'
         )
     }
 )
@@ -1316,14 +1818,12 @@ AuditCaseSchema = make_schema(
         'audit_id': ma.fields.Integer(),
         'candidate_id': ma.fields.Str(),
         'candidate_name': ma.fields.Str(),
+        'link_to_report': ma.fields.Str(),
         'primary_category_list': ma.fields.Nested(AuditCaseCategoryRelationSchema, many=True),
     },
     options={
-        'exclude': (
-            'primary_category_id',
-            'sub_category_id',
-            'idx',
-        )}
+        'exclude': ('idx',)},
+    BaseSchema=BaseSchema
 )
 AuditCasePageSchema = make_page_schema(AuditCaseSchema)
 register_schema(AuditCaseSchema)
@@ -1336,26 +1836,20 @@ ElectionsListSchema = make_schema(
             'idx',
             'sort_order',
             'incumbent_id',
-            'incumbent_name',
-        )
-    }
+            'incumbent_name')}
 )
 
 ElectionsListPageSchema = make_page_schema(ElectionsListSchema)
 register_schema(ElectionsListSchema)
 register_schema(ElectionsListPageSchema)
 
-StateElectionOfficeInfoSchema = make_schema(
-    models.StateElectionOfficeInfo,
-)
+StateElectionOfficeInfoSchema = make_schema(models.StateElectionOfficeInfo)
 
 StateElectionOfficeInfoPageSchema = make_page_schema(StateElectionOfficeInfoSchema)
 register_schema(StateElectionOfficeInfoSchema)
 register_schema(StateElectionOfficeInfoPageSchema)
 
-OperationsLogSchema = make_schema(
-    models.OperationsLog,
-)
+OperationsLogSchema = make_schema(models.OperationsLog)
 
 OperationsLogPageSchema = make_page_schema(OperationsLogSchema)
 register_schema(OperationsLogSchema)
@@ -1365,11 +1859,11 @@ register_schema(OperationsLogPageSchema)
 class TotalByOfficeSchema(ma.Schema):
     office = ma.fields.Str()
     election_year = ma.fields.Int()
-    total_receipts = ma.fields.Decimal(places=2)
-    total_disbursements = ma.fields.Decimal(places=2)
-    total_individual_itemized_contributions = ma.fields.Decimal(places=2)
-    total_transfers_from_other_authorized_committee = ma.fields.Decimal(places=2)
-    total_other_political_committee_contributions = ma.fields.Decimal(places=2)
+    total_receipts = ma.fields.Float()
+    total_disbursements = ma.fields.Float()
+    total_individual_itemized_contributions = ma.fields.Float()
+    total_transfers_from_other_authorized_committee = ma.fields.Float()
+    total_other_political_committee_contributions = ma.fields.Float()
 
 
 augment_schemas(TotalByOfficeSchema)
@@ -1379,8 +1873,8 @@ class TotalByOfficeByPartySchema(ma.Schema):
     office = ma.fields.Str()
     party = ma.fields.Str()
     election_year = ma.fields.Int()
-    total_receipts = ma.fields.Decimal(places=2)
-    total_disbursements = ma.fields.Decimal(places=2)
+    total_receipts = ma.fields.Float()
+    total_disbursements = ma.fields.Float()
 
 
 augment_schemas(TotalByOfficeByPartySchema)
@@ -1390,13 +1884,13 @@ class CandidateTotalAggregateSchema(ma.Schema):
     election_year = ma.fields.Int()
     office = ma.fields.Str()
     party = ma.fields.Str()
-    total_receipts = ma.fields.Decimal(places=2)
-    total_disbursements = ma.fields.Decimal(places=2)
-    total_individual_itemized_contributions = ma.fields.Decimal(places=2)
-    total_transfers_from_other_authorized_committee = ma.fields.Decimal(places=2)
-    total_other_political_committee_contributions = ma.fields.Decimal(places=2)
-    total_cash_on_hand_end_period = ma.fields.Decimal(places=2)
-    total_debts_owed_by_committee = ma.fields.Decimal(places=2)
+    total_receipts = ma.fields.Float()
+    total_disbursements = ma.fields.Float()
+    total_individual_itemized_contributions = ma.fields.Float()
+    total_transfers_from_other_authorized_committee = ma.fields.Float()
+    total_other_political_committee_contributions = ma.fields.Float()
+    total_cash_on_hand_end_period = ma.fields.Float()
+    total_debts_owed_by_committee = ma.fields.Float()
     state = ma.fields.Str()
     district = ma.fields.Str()
     district_number = ma.fields.Int()
@@ -1409,7 +1903,7 @@ augment_schemas(CandidateTotalAggregateSchema)
 class ECTotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
 
 
 augment_schemas(ECTotalsByCandidateSchema)
@@ -1419,7 +1913,7 @@ class IETotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
     support_oppose_indicator = ma.fields.Str()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
 
 
 augment_schemas(IETotalsByCandidateSchema)
@@ -1429,19 +1923,21 @@ class CCTotalsByCandidateSchema(ma.Schema):
     candidate_id = ma.fields.Str()
     cycle = ma.fields.Int()
     support_oppose_indicator = ma.fields.Str()
-    total = ma.fields.Decimal(places=2)
+    total = ma.fields.Float()
 
 
 augment_schemas(CCTotalsByCandidateSchema)
 
 # Presidential endpoints
-# There may be a more efficient way to do this, but we're going for speed
+# There may be a more efficient way to do this,but we're going for speed
 
 # By candidate
 
 PresidentialByCandidateSchema = make_schema(
     models.PresidentialByCandidate,
-    options={'exclude': ('idx',)},
+    fields={'net_receipts': ma.fields.Float(),
+            'rounded_net_receipts': ma.fields.Float()},
+    options={'exclude': ('idx',)}
 )
 PresidentialByCandidatePageSchema = make_page_schema(PresidentialByCandidateSchema)
 register_schema(PresidentialByCandidateSchema)
@@ -1451,7 +1947,30 @@ register_schema(PresidentialByCandidatePageSchema)
 
 PresidentialSummarySchema = make_schema(
     models.PresidentialSummary,
-    options={'exclude': ('idx',)},
+    fields={
+                'net_receipts': ma.fields.Float(),
+                'rounded_net_receipts': ma.fields.Float(),
+                'individual_contributions_less_refunds': ma.fields.Float(),
+                'pac_contributions_less_refunds': ma.fields.Float(),
+                'party_contributions_less_refunds': ma.fields.Float(),
+                'candidate_contributions_less_repayments': ma.fields.Float(),
+                'disbursements_less_offsets': ma.fields.Float(),
+                'operating_expenditures': ma.fields.Float(),
+                'transfers_to_other_authorized_committees': ma.fields.Float(),
+                'transfers_from_affiliated_committees': ma.fields.Float(),
+                'fundraising_disbursements': ma.fields.Float(),
+                'exempt_legal_accounting_disbursement': ma.fields.Float(),
+                'total_loan_repayments_made': ma.fields.Float(),
+                'repayments_loans_made_by_candidate': ma.fields.Float(),
+                'repayments_other_loans': ma.fields.Float(),
+                'other_disbursements': ma.fields.Float(),
+                'offsets_to_operating_expenditures': ma.fields.Float(),
+                'total_contribution_refunds': ma.fields.Float(),
+                'debts_owed_by_committee': ma.fields.Float(),
+                'federal_funds': ma.fields.Float(),
+                'cash_on_hand_end': ma.fields.Float()
+             },
+    options={'exclude': ('idx',)}
 )
 PresidentialSummaryPageSchema = make_page_schema(PresidentialSummarySchema)
 register_schema(PresidentialSummarySchema)
@@ -1461,7 +1980,8 @@ register_schema(PresidentialSummaryPageSchema)
 
 PresidentialBySizeSchema = make_schema(
     models.PresidentialBySize,
-    options={'exclude': ('idx',)},
+    fields={'contribution_receipt_amount': ma.fields.Float()},
+    options={'exclude': ('idx',)}
 )
 PresidentialBySizePageSchema = make_page_schema(PresidentialBySizeSchema)
 register_schema(PresidentialBySizeSchema)
@@ -1471,6 +1991,7 @@ register_schema(PresidentialBySizePageSchema)
 
 PresidentialByStateSchema = make_schema(
     models.PresidentialByState,
+    fields={'contribution_receipt_amount': ma.fields.Float()},
     options={'exclude': ('idx',)},
 )
 PresidentialByStatePageSchema = make_page_schema(PresidentialByStateSchema)
@@ -1481,13 +2002,19 @@ register_schema(PresidentialByStatePageSchema)
 
 PresidentialCoverageSchema = make_schema(
     models.PresidentialCoverage,
-    options={'exclude': ('idx',)},
+    options={'exclude': ('idx',)}
 )
 PresidentialCoveragePageSchema = make_page_schema(PresidentialCoverageSchema)
 register_schema(PresidentialCoverageSchema)
 register_schema(PresidentialCoveragePageSchema)
 
-InauguralDonationsSchema = make_schema(models.InauguralDonations)
+InauguralDonationsSchema = make_schema(
+    models.InauguralDonations,
+    fields={
+        'total_donation': ma.fields.Float(),
+        'cycle': ma.fields.Int()
+    }
+)
 InauguralDonationsPageSchema = make_page_schema(InauguralDonationsSchema)
 register_schema(InauguralDonationsSchema)
 register_schema(InauguralDonationsPageSchema)

--- a/webservices/spec.py
+++ b/webservices/spec.py
@@ -107,8 +107,8 @@ if bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL', '')):
 spec = APISpec(
     title='OpenFEC',
     version=__API_VERSION__,
+    openapi_version='2.0',
     info={'description': format_docstring(docs.API_DESCRIPTION)},
-    basePath='/v1',
     produces=['application/json'],
     plugins=[MarshmallowPlugin()],
     securityDefinitions={

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -53,7 +53,7 @@ def parse_kwargs(resource, qs):
     annotation = resolve_annotations(resource.get, "args", parent=resource)
     fields = utils.extend(*[option["args"] for option in annotation.options])
     with task_utils.get_app().test_request_context(b"?" + qs):
-        kwargs = flaskparser.parser.parse(fields)
+        kwargs = flaskparser.parser.parse(fields, location='query')
     return fields, kwargs
 
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -34,7 +34,7 @@ from json import JSONEncoder
 
 logger = logging.getLogger(__name__)
 
-use_kwargs = functools.partial(use_kwargs_original, locations=("query",))
+use_kwargs = functools.partial(use_kwargs_original, location="query")
 
 DOCQUERY_URL = 'https://docquery.fec.gov'
 
@@ -44,7 +44,7 @@ class Resource(six.with_metaclass(MethodResourceMeta, restful.Resource)):
 
 
 API_KEY_ARG = fields.Str(
-    required=True, missing="DEMO_KEY", description=docs.API_KEY_DESCRIPTION,
+     required=True, description=docs.API_KEY_DESCRIPTION,
 )
 if env.get_credential("PRODUCTION"):
     Resource = use_kwargs({"api_key": API_KEY_ARG})(Resource)


### PR DESCRIPTION
## We need to merge in [Marshmallow Pagination](https://github.com/fecgov/marshmallow-pagination/pull/6) PR first! 

## Summary (required)

- Resolves #5440 

This ticket upgrades Flask to version 2.2.5. It also upgrades the following dependencies: 
API spec 0.39 -> 4.0
webargs 5.5.3 -> 7.0.0
flask-apispec 0.7.0 -> 0.11.4
marshmallow 2.16.3 -> 3.0.0 
marshmallow-sqlalchemy 0.15.0 -> 0.23.1

### Required reviewers 2-3 back end devs 

## Impacted areas of the application

General components of the application that this PR will affect:

-  webservices/Schemas
- webservices/Resources
- webservices/args
- automated tests 

## Related PRs

Related PRs against other branches:

[Marshmallow Pagination](https://github.com/fecgov/marshmallow-pagination/pull/6) PR - upgrade marshmallow to v3 

## How to test

1. Checkout this branch 
2. `pip install -r requirements.txt`
3.  `snyk test --file=requirements.txt --package-manager=pip`
4. `pytest`
5. `flask run`
6. Test all endpoints 

