### PR TITLE
5364 add pdf_url to h4 endpoint results

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -851,6 +851,7 @@ class ScheduleH4(BaseItemized):
     cycle = db.Column('election_cycle', db.Numeric(4, 0))
     disbursement_purpose_text = db.Column(TSVECTOR)
     payee_name_text = db.Column(TSVECTOR)
+    pdf_url = db.Column('pdf_url', db.String)
 
 
 class ScheduleH4Efile(BaseRawItemized):


### PR DESCRIPTION
## Summary (required)

- Resolves #5364

Adding the python portion of 5364, adding pdf_url to the model so the show image button will automatically show up on the datatable. This was a change in response to UAT testing of the H4 data table. 

### Required reviewers
1 dev

## Impacted areas of the application

-  H4 endpoint
![Screen Shot 2023-06-09 at 5 01 39 PM](https://github.com/fecgov/openFEC/assets/66386084/04581e02-09f7-4b32-ad8d-d604ded10abf)


## How to test
The migration file should be merged to dev, so either re-run the latest migrations on your local cfdm_test or point to dev
- flask run
You should see pdf_url and it should link to docquery