### PR TITLE
upgrade flyway to v9.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.19.4/flyway-commandline-9.19.4-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-9.19.4:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/9.20.0/flyway-commandline-9.20.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-9.20.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-   - Flyway 9.19.4 ([download](https://documentation.red-gate.com/fd/command-line-184127404.html?_ga=2.234928961.193109968.1681304355-253257385.1681304355))
+   - Flyway 9.20.0 ([download](https://documentation.red-gate.com/fd/command-line-184127404.html?_ga=2.234928961.193109968.1681304355-253257385.1681304355))
 
-     - After downloading, open `flyway-9.19.4/conf/.conf` and set
+     - After downloading, open `flyway-9.20.0/conf/.conf` and set
        the flyway environment variables `flyway.url` and
        `flyway.locations` as
 
@@ -785,9 +785,9 @@ You can optionally choose to restrict traffic that goes to the mirrors/replicas 
 
 `flyway` is a Java application and requires a Java runtime environment (JRE) for execution.
 
-It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.19.4.tar.gz` from [Flyway downloads](https://documentation.red-gate.com/fd/command-line-184127404.html?_ga=2.234928961.193109968.1681304355-253257385.1681304355). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.19.4-macosx-x64.tar.gz`, `flyway-commandline-9.19.4-linux-x64.tar.gz`, etc.
+It is recommended that you install the JRE separately using your package manager of choice, e.g., `Homebrew`, `apt`, etc, and download the version without the JRE e.g. `flyway-commandline-9.20.0.tar.gz` from [Flyway downloads](https://documentation.red-gate.com/fd/command-line-184127404.html?_ga=2.234928961.193109968.1681304355-253257385.1681304355). This way, you have complete control over your Java version and can use the JRE for other applications like `Elasticsearch`. If you have trouble with a separate JRE or if not comfortable with managing a separate JRE, you can download the `flyway` archive that bundles the JRE based on the platform, e.g., `flyway-commandline-9.20.0-macosx-x64.tar.gz`, `flyway-commandline-9.20.0-linux-x64.tar.gz`, etc.
 
-Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.19.4` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
+Expand the downloaded archive. Add `<target_directory>/flyway/flyway-9.20.0` to your `PATH` where `target_directory` is the directory in which the archive has been expanded.
 
 #### How `flyway` works
 

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.19.4"
-    implementation(group: "org.flywaydb", name: "flyway-commandline", version: "9.19.4") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.20.0"
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "9.20.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-9.19.4.jar:app/gradle/lib/flyway-core-9.19.4.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-9.20.0.jar:app/gradle/lib/flyway-core-9.20.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

Upgrade flyway to v9.20.0

- Resolves #5482 


### Required reviewers

One developer 


## Impacted areas of the application

-  Database migrations


## How to test

-  checkout develop
- run `snyk test --file=data/flyway/build.gradle` (snyk flags io.netty:netty-handler)
- checkout feature/upgrade-flyway
- run `brew install flyway` (v9.20.0 will be downloaded)
- run `flyway -v` (verify the downloaded flyway v9.20.0)
- run `dropdb cfdm_test`
- run `createdb cfdm_test`
- run `flyway migrate` **OR** - run `invoke create_sample_db`
- run `snyk test --file=data/flyway/build.gradle` (snyk no longer flags snyk flags io.netty:netty-handler vulnerability)
- run `pytest` (all tests PASS)