### PR TITLE
update marshmallow pagination to point to master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ werkzeug==2.2.3
 
 # Marshalling
 flask-apispec==0.11.4
-git+https://github.com/fecgov/marshmallow-pagination@develop
+git+https://github.com/fecgov/marshmallow-pagination@master
 marshmallow==3.0.0
 marshmallow-sqlalchemy==0.23.1
 


### PR DESCRIPTION
This PR points marshmallow pagination requirement back to master instead of develop.

Required reviewers 1 developer
