### PR TITLE
Pin setuptool to remediate ReDoS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,5 @@ importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: Select
 nplusone==0.8.0
 pytest==5.2.0
 pytest-cov==2.5.1
+setuptools==68.0.0 #pin to remediate snyk ReDoS#5477
 webtest==2.0.34


### PR DESCRIPTION
## Summary (required)

- Resolves #5477

Upgrading locust and gevent resulted in package errors. Had to pin setuptool==68.0.0 in requirements.txt to remediate ReDoS snyk vulnerability

### Required reviewers

1 developer

## Screenshots

Before:
<img width="920" alt="Screen Shot 2023-07-18 at 3 37 30 PM" src="https://github.com/fecgov/openFEC/assets/11650355/10dbac89-673f-4e6d-a7c0-e97a06faa21e">

## How to test

- run `git checkout feature/5477-snyk-redos`
- run `pyenv virtualenv venv-api-5477`
- run `pyenv activate venv-api-5477`
- run `pip install -r requirements.txt`
- run `pip install -r requirements-dev.txt`
- run `snyk test --file=requirements.txt --package-manager=pip` (ReDos vulnerability no longer flagged)
- run `snyk test --file=requirements-dev.txt --package-manager=pip` (ReDos vulnerability no longer flagged)
- run `pytest`
