### PR TITLE
Add validation to sorting option

### DIFF
--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -160,9 +160,27 @@ class TotalsCandidateView(ApiResource):
     schema = schemas.CandidateHistoryTotalSchema
     page_schema = schemas.CandidateHistoryTotalPageSchema
 
+    sort_options = [
+        'election_year',
+        'name',
+        'party',
+        'state',
+        'office',
+        'district',
+        'receipts',
+        'disbursements',
+    ]
+
     @property
     def args(self):
-        return utils.extend(args.paging, args.candidate_totals, args.make_sort_args(),)
+        return utils.extend(
+            args.paging,
+            args.candidate_totals,
+            args.make_sort_args(
+                default='-election_year',
+                validator=args.OptionValidator(self.sort_options)
+            ),
+        )
 
     def filter_multi_fields(self, history, total):
         return [


### PR DESCRIPTION
## Summary (required)

- Resolves #5479 

Limit sortable fields to: ['election_year', 'cycle',  'state', 'office']. Add validation to sortable fields, and set status code to 422 when invalid sorting field is selected.

### Required reviewers

1 developer

## How to test
- Download feature branch and run `pytest`
- run `flask run` to start api on local and test these endpoints:

**sort = -test**
http://127.0.0.1:5000/v1/candidates/totals/?page=1&per_page=20&election_full=true&sort=-test&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

**sort = -election_year**
http://127.0.0.1:5000/v1/candidates/totals/?page=1&per_page=20&election_full=true&sort=-election_year&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false