### PR TITLE
5510 add line_num filter

### DIFF
--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -23,7 +23,8 @@ class TestScheduleDView(ApiBaseTest):
             ('committee_id', ScheduleD.committee_id, ['C01', 'C02']),
             ('candidate_id', ScheduleD.candidate_id, ['S01', 'S02']),
             ('report_year', ScheduleD.report_year, [2023, 2019]),
-            ('report_type', ScheduleD.report_type, ['60D', 'Q3'])
+            ('report_type', ScheduleD.report_type, ['60D', 'Q3']),
+            ('line_number', ScheduleD.line_number, ['9', '10']),
         ]
         for label, column, values in filters:
             [factories.ScheduleDViewFactory(**{column.key: value}) for value in values]

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -776,7 +776,8 @@ schedule_d = {
     'min_coverage_start_date': Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
     'max_coverage_start_date': Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE)
+    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER_ONLY),
 }
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -536,6 +536,7 @@ class ScheduleD(PdfMixin, BaseItemized):
     coverage_end_date = db.Column(db.Date, index=True, doc=docs.COVERAGE_END_DATE)
     report_year = db.Column('rpt_yr', db.Integer, index=True, doc=docs.REPORT_YEAR)
     report_type = db.Column('rpt_tp', db.String, index=True, doc=docs.REPORT_TYPE)
+    line_number = db.Column('line_num', db.String, index=True, doc=docs.LINE_NUMBER_ONLY)
 
     committee = db.relationship(
         'CommitteeHistory',

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1798,6 +1798,10 @@ Filter for form and line number using the following format:
 down to all entries from form `F3X` line number `16`.
 '''
 
+LINE_NUMBER_ONLY = '''
+Filter for line number using the following format: "9" or "10".
+'''
+
 IMAGE_NUMBER = '''
 An unique identifier for each page where the electronic or paper filing is reported.
 '''

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -27,7 +27,8 @@ class ScheduleDView(ApiResource):
         ('committee_id', models.ScheduleD.committee_id),
         ('candidate_id', models.ScheduleD.candidate_id),
         ('report_year', models.ScheduleD.report_year),
-        ('report_type', models.ScheduleD.report_type)
+        ('report_type', models.ScheduleD.report_type),
+        ('line_number', models.ScheduleD.line_number),
     ]
 
     filter_range_fields = [


### PR DESCRIPTION
## Summary (required)

- Resolves #5510 

This PR adds the line_number filter to the debts endpoint. 

### Required reviewers
2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Debts endpoint



## How to test

- flask run
- test debts line_num filter with (9, 10, 11, 12,) (valid lines)

