### PR TITLE
[DON'T MERGE YET] - Remove address from site footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -36,12 +36,6 @@ const Footer = () => (
             </div>
           </li>
         </ul>
-
-        <p>
-          1050 First Street, NE
-          <br /> Washington, DC 20463
-        </p>
-
         <a href="mailto:apiinfo@fec.gov">
           <button className="button--standard button--envelope" type="button">
             Email FEC API Info


### PR DESCRIPTION
## Summary

- Resolves #5526 

Removing the address from the Swagger interface footer

Original context here: https://github.com/fecgov/fec-cms/issues/5838


### Required reviewers

- 1 Back-end (edit list as needed)
- UX?

## Impacted areas of the application

Site footer in every instance

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

Related PRs against other branches:

branch | PR
------ | ------
fix/other_pr | [link]()
feature/other_pr | [link]()

## How to test

- I've never been able to get it launched locally
