### PR TITLE
Add sortable field: party_full in /candidates/totals/

### DIFF
--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -164,6 +164,7 @@ class TotalsCandidateView(ApiResource):
         'election_year',
         'name',
         'party',
+        'party_full',
         'state',
         'office',
         'district',

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -170,6 +170,7 @@ class TotalsCandidateView(ApiResource):
         'district',
         'receipts',
         'disbursements',
+        'individual_itemized_contributions',
     ]
 
     @property


### PR DESCRIPTION
## Summary (required)

- Resolves #5528 
Add party_full to sortable list of endpoint /candidates/totals/ 

This PR will merge into current release branch to avoid broken page on prod website

### Required reviewers

1 dev

## Related PRs

[5519](https://github.com/fecgov/openFEC/pull/5509)

## How to test
- Download feature branch and run `pytest`
- Start api on local by running `flask run`

http://127.0.0.1:5000/v1/candidates/totals/?page=1&per_page=20&election_full=true&sort=party_full&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false