### PR TITLE
add legal date formats

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -46,6 +46,7 @@ ALL_DOCUMENT_TYPES = [
     "admin_fines",
 ]
 
+ACCEPTED_DATE_FORMATS = "strict_date_optional_time_nanos||MM/dd/yyyy||M/d/yyyy||MM/d/yyyy||M/dd/yyyy"
 
 # endpoint path: /legal/docs/<doc_type>/<no>
 # test urls:
@@ -55,6 +56,7 @@ ALL_DOCUMENT_TYPES = [
 # http://127.0.0.1:5000/v1/legal/docs/murs/8070/
 # http://127.0.0.1:5000/v1/legal/docs/adrs/1091/
 # http://127.0.0.1:5000/v1/legal/docs/admin_fines/4399/
+
 
 # TODO: add this endpoint to swagger
 @doc(
@@ -270,6 +272,7 @@ def apply_af_specific_query_params(query, **kwargs):
     if kwargs.get("af_max_rtb_date"):
         date_range["lte"] = kwargs.get("af_max_rtb_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", reason_to_believe_action_date=date_range))
 
     date_range = {}
@@ -278,6 +281,7 @@ def apply_af_specific_query_params(query, **kwargs):
     if kwargs.get("af_max_fd_date"):
         date_range["lte"] = kwargs.get("af_max_fd_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", final_determination_date=date_range))
 
     if kwargs.get("af_rtb_fine_amount"):
@@ -319,6 +323,7 @@ def apply_mur_specific_query_params(query, **kwargs):
     if kwargs.get("case_max_open_date"):
         date_range["lte"] = kwargs.get("case_max_open_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", open_date=date_range))
 
     date_range = {}
@@ -327,6 +332,7 @@ def apply_mur_specific_query_params(query, **kwargs):
     if kwargs.get("case_max_close_date"):
         date_range["lte"] = kwargs.get("case_max_close_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", close_date=date_range))
 
     query = query.query("bool", must=must_clauses)
@@ -453,6 +459,7 @@ def apply_adr_specific_query_params(query, **kwargs):
     if kwargs.get("case_max_open_date"):
         date_range["lte"] = kwargs.get("case_max_open_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", open_date=date_range))
 
     date_range = {}
@@ -461,6 +468,7 @@ def apply_adr_specific_query_params(query, **kwargs):
     if kwargs.get("case_max_close_date"):
         date_range["lte"] = kwargs.get("case_max_close_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", close_date=date_range))
 
     query = query.query("bool", must=must_clauses)
@@ -645,6 +653,7 @@ def apply_ao_specific_query_params(query, **kwargs):
     if kwargs.get("ao_max_issue_date"):
         date_range["lte"] = kwargs.get("ao_max_issue_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", issue_date=date_range))
 
     date_range = {}
@@ -653,6 +662,7 @@ def apply_ao_specific_query_params(query, **kwargs):
     if kwargs.get("ao_max_request_date"):
         date_range["lte"] = kwargs.get("ao_max_request_date")
     if date_range:
+        date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", request_date=date_range))
 
     if kwargs.get("ao_entity_name"):


### PR DESCRIPTION
## Summary (required)

- Resolves #5531 

This PR fixes the issue we are having with legal dates. These changes somehow got lost when rolling back the initial Flask deployment and deploying the flask hotfix. Here is the previous PR https://github.com/fecgov/openFEC/pull/5489

### Required reviewers 1-2 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

-  legal.py


## How to test
This can be tested locally or on dev 

local: 
1. Follow the [wiki](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally) to setup and test elastic search locally
2. `flask run`
3. Test date fields under the legal search endpoint including:
- af_max_fd_date
- af_min_fd_date
- af_max_rtb_date
- af_min_rtb_date
- case_max_close_date
- case_min_close_date
- case_max_open_date 
- case_min_open_date
- ao_max_request_date
- ao_min_request_date
- ao_max_issue_date
- ao_min_issue_date

on stage: 
Test date filters on legal search pages

example urls:
https://stage.fec.gov/data/legal/search/murs/?search_type=murs&sort=-case_no&search=&case_no=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=06%2F06%2F2023&case_max_close_date=07%2F06%2F2023