### PR TITLE
Rename Document YYYY as "Debt Settlement Plan YYYY"

### DIFF
--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -379,6 +379,8 @@ related_efile_summary = functools.partial(
 def document_description(
     report_year, report_type=None, document_type=None, form_type=None
 ):
+    DEBT_DOCUMENT_NAME = "Debt Settlement Plan"
+
     if report_type:
         clean = re.sub(r"\{[^)]*\}", "", report_type)
     elif document_type:
@@ -386,7 +388,7 @@ def document_description(
     elif form_type and form_type in decoders.form_types:
         clean = decoders.form_types[form_type]
     else:
-        clean = "Document"
+        clean = DEBT_DOCUMENT_NAME
 
     if form_type and (form_type == "RFAI" or form_type == "FRQ"):
         clean = "RFAI: " + clean


### PR DESCRIPTION
## Summary (required)

- Resolves #5540 

Rename Document YYYY as "Debt Settlement Plan YYYY"

When report_type, document_type and form_types data is not available then the document_description text is defaulted/hard coded to "Document" + report_year. In this PR, document_description text for debt settlement is changed as  "Debt Settlement Plan YYYY"

### Required reviewers

UX - 1  
Frontend  - 1
Backend - 1

## Impacted areas of the application

-  Committee profile page-->Filings --> Other documents section

## Screenshots
**Before (In Prod):**
<img width="1396" alt="Screen Shot 2023-08-10 at 12 40 59 PM" src="https://github.com/fecgov/openFEC/assets/11650355/25020544-f51c-4b50-9321-733b65bda7a3">

**After (In this PR):**
<img width="1410" alt="Screen Shot 2023-08-10 at 12 41 41 PM" src="https://github.com/fecgov/openFEC/assets/11650355/e1e92683-7512-4ab5-8edd-191cca294ef3">


## How to test
1. Test local cms-->local api

**Terminal#1:** (fec-cms repo)
- git checkout develop
- pyenv activate venv-cms
- cd fec
- export FEC_API_URL=http://localhost:5000
- ./manage.py runserver

**Terminal#2:** (openFEC repo)
- git checkout feature/rename-document-label
- git pull
- pyenv activate venv-api
- flask run

Here are few sample URLs to test. Copy the following URL's in a browser.  In  Committee profile page-->Filings --> Other documents section--> document name shows as `Debt Settlement Plan <report year>`

      - http://localhost:8000/data/committee/C00637611/?tab=filings
      - http://localhost:8000/data/committee/C00004960/?tab=filings
      - http://localhost:8000/data/committee/C00252593/?tab=filings
      - http://localhost:8000/data/committee/C00393009/?tab=filings
      - http://localhost:8000/data/committee/C00592311/?tab=filings
      - http://localhost:8000/data/committee/C00425009/?tab=filings

**OR** 

2. Deploy this API pr#5541 to Dev space and test above urls 