### PR TITLE
suppress specific pytest warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [tool:pytest]
 addopts=--cov webservices --cov-report term-missing
 testpaths=tests
+filterwarnings =
+    ignore:.*propagate_exceptions:DeprecationWarning:flask_restful:
+    ignore:.*_app_ctx_stack:DeprecationWarning:flask_sqlalchemy:


### PR DESCRIPTION
## Summary (required)

- Resolves #5546 

This ticket suppresses the pytest warnings related to sqlalchemy since we are holding off on the sqlalchemy upgrade. Documentation on how to suppress pytest warnings can be found [Here](https://docs.pytest.org/en/stable/how-to/capture-warnings.html#controlling-warnings). 

### Required reviewers 1-2 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

-  pytest

## How to test
1. `git checkout feature/5546-remove-pytest-warnings`
2. `pytest`

You can also look at the circleci [build](https://app.circleci.com/pipelines/github/fecgov/openFEC/2188/workflows/3f839de4-9883-4f09-8c43-e6ac85e87082/jobs/4837) for this branch
