### PR TITLE
re-label debt settlement plan

### DIFF
--- a/webservices/decoders.py
+++ b/webservices/decoders.py
@@ -25,6 +25,7 @@ form_types = {
     "F12": "24-Hour notice of suspension of increased limits",
     "F99": "Miscellaneous document",
     "F6": "48-Hour notice of contribution/loans received",
+    "F8": "Debt Settlement Plan",
 }
 
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -379,7 +379,6 @@ related_efile_summary = functools.partial(
 def document_description(
     report_year, report_type=None, document_type=None, form_type=None
 ):
-    DEBT_DOCUMENT_NAME = "Debt Settlement Plan"
 
     if report_type:
         clean = re.sub(r"\{[^)]*\}", "", report_type)
@@ -388,7 +387,7 @@ def document_description(
     elif form_type and form_type in decoders.form_types:
         clean = decoders.form_types[form_type]
     else:
-        clean = DEBT_DOCUMENT_NAME
+        clean = "Document"
 
     if form_type and (form_type == "RFAI" or form_type == "FRQ"):
         clean = "RFAI: " + clean


### PR DESCRIPTION
## Summary (required)

- Resolves #5540 

This PR fixes a bug where the label "Debt Settlement Plan" is being applied to other documents incorrectly.

### Required reviewers 
Frontend - 1
Backend - 1

## Impacted areas of the application

General components of the application that this PR will affect:

-  committee profile page 
- filings datatable 

## Screenshots

## Related PRs

Related PRs against other branches:

https://github.com/fecgov/openFEC/pull/5541

## Screenshots

dev.fec.gov (incorrect) 
![image](https://github.com/fecgov/openFEC/assets/121631201/9c3fc2ff-4489-491c-8475-1d78b36879a0)

fec.gov (correct)
![image](https://github.com/fecgov/openFEC/assets/121631201/ab8f2cdc-a2dc-467d-81c4-4fa819b919c0)

## How to test 
1. Test local cms-->local api

**Terminal#1:** (fec-cms repo)
- git checkout develop
- pyenv activate venv-cms
- cd fec
- export FEC_API_URL=http://localhost:5000
- ./manage.py runserver

**Terminal#2:** (openFEC repo)
- git checkout this branch
- git pull
- pyenv activate venv-api
- flask run

Here are few sample URLs to test. Clink the links to make sure that the correct document names are being used.

Test that document name shows as `Debt Settlement Plan <report year>`
      - http://localhost:8000/data/committee/C00637611/?tab=filings  
      - http://localhost:8000/data/committee/C00393009/?tab=filings
      - http://localhost:8000/data/committee/C00592311/?tab=filings
      - http://localhost:8000/data/committee/C00425009/?tab=filings

Test that verification letters show as `Document YYYY`
      - CONTENT WARNING - http://localhost:8000/data/filings/?data_type=processed&q_filer=trump

**OR** 

2. Deploy this API to Dev space and test above urls 