### PR TITLE
upgrade gitpython and certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apispec==4.0.0
-certifi==2022.12.7
+certifi==2023.7.22
 cfenv==0.5.2
 defusedxml==0.6.0
 elasticsearch==7.6.0
@@ -10,7 +10,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 gevent==22.10.2
 gunicorn==19.10.0
-GitPython==3.1.30
+GitPython==3.1.32
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary 

Upgrade python packages in requirements.txt: 
-  gitpython to v3.1.32
- certifi to v2023.7.22 


- Resolves #5525 #5550 
(Include a summary of proposed changes and connect issue below)

### Required reviewers

1 developer

### Screenshots:

**Before:**
<img width="1042" alt="Screen Shot 2023-08-22 at 11 51 04 AM" src="https://github.com/fecgov/openFEC/assets/11650355/aa573fc5-2d65-4e7b-91ac-0dd980115bc0">

## How to test

- run `git checkout develop`
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output show gitpython and certifi as vulnerable packages)
- run `git checkout feature/upgrade-gitpython-and-certifi-pkgs`
- run `pyenv activate venv-api`
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output **no longer shows** gitpython and certifi as vulnerable packages)
- run `pytest`