### PR TITLE
5497- add form_type filter

### DIFF
--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -321,6 +321,41 @@ class TestEfileFiles(ApiBaseTest):
         results = self._results(api.url_for(EFilingsView, file_number=file_number))
         self.assertEqual(results[0]["file_number"], file_number)
 
+    def test_filter_form_type_efile(self):
+
+        [
+            factories.EFilingsFactory(
+                form_type="F2A",
+                beginning_image_number=5,
+            ),
+            factories.EFilingsFactory(
+                form_type="F2N",
+                beginning_image_number=6,
+            ),
+            factories.EFilingsFactory(
+                form_type="F99",
+                beginning_image_number=8,
+            ),
+            factories.EFilingsFactory(
+                form_type="F24",
+                beginning_image_number=9,
+            ),
+        ]
+        results = self._results(
+            api.url_for(
+                EFilingsView,
+                form_type='F2',
+            )
+        )
+        self.assertEqual(len(results), 2)
+        results = self._results(
+            api.url_for(
+                EFilingsView,
+                form_type='F2A',
+            )
+        )
+        self.assertEqual(len(results), 1)
+
     def test_fulltext_keyword_search(self):
         [
             factories.EFilingsFactory(

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -413,6 +413,7 @@ efilings = {
     'min_receipt_date': Date(description=docs.MIN_RECEIPT_DATE),
     'max_receipt_date': Date(description=docs.MAX_RECEIPT_DATE),
     'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+    'form_type': fields.List(IStr, description=docs.FORM_TYPE_EFILING),
 }
 
 reports = {

--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -6,6 +6,7 @@ from webservices.common.models.dates import clean_report_type
 from webservices.common.models.reports import CsvMixin, FecMixin, AmendmentChainMixin, FecFileNumberMixin
 from webservices import exceptions
 
+
 class Filings(FecFileNumberMixin, CsvMixin, db.Model):
     __tablename__ = 'ofec_filings_all_mv'
 
@@ -123,7 +124,7 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
     __tablename__ = 'reps'
 
     file_number = db.Column('repid', db.BigInteger, index=True, primary_key=True, doc=docs.FILE_NUMBER)
-    form_type = db.Column('form', db.String, doc=docs.FORM_TYPE)
+    form_type = db.Column('form', db.String, doc=docs.FORM_TYPE_EFILING)
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
     committee_name = db.Column('com_name', db.String, doc=docs.COMMITTEE_NAME)
     receipt_date = db.Column('timestamp', db.DateTime, index=True, doc=docs.RECEIPT_DATE)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1407,6 +1407,27 @@ FORM_TYPE = 'The form where the underlying data comes from, for example, Form 1 
     - F99  Miscellaneous Text\n\
     - FRQ  Request for Additional Information\n\
 '
+
+FORM_TYPE_EFILING = 'The form where the underlying data comes from, for example Form 1 would appear as F1: \n\
+    - F1   Statement of Organization\n\
+    - F1M  Notification of Multicandidate Status\n\
+    - F2   Statement of Candidacy\n\
+    - F3   Report of Receipts and Disbursements for an Authorized Committee\n\
+    - F3P  Report of Receipts and Disbursements by an Authorized Committee of a Candidate for \
+    The Office of President or Vice President\n\
+    - F3L  Report of Contributions Bundled by Lobbyists/Registrants and Lobbyist/Registrant PACs\n\
+    - F3X  Report of Receipts and Disbursements for other than an Authorized Committee\n\
+    - F4   Report of Receipts and Disbursements for a Committee or Organization Supporting a Nomination Convention\n\
+    - F5   Report of Independent Expenditures Made and Contributions Received\n\
+    - F6   48 Hour Notice of Contributions/Loans Received\n\
+    - F7   Report of Communication Costs by Corporations and Membership Organizations\n\
+    - F8   Debt Settlement Plan\n\
+    - F9   24 Hour Notice of Disbursements for Electioneering Communications\n\
+    - F13  Report of Donations Accepted for Inaugural Committee\n\
+    - F99  Miscellaneous Text\n\
+NOTE: This filter also works if you specify new, amended, or termination, \n\
+for example F3XN, F3XA, or F3XT respectively \n\
+'
 BASE_REPORT_TYPE = 'Name of report where the underlying data comes from:\n\
     - 10D Pre-Election\n\
     - 10G Pre-General\n\

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -74,6 +74,7 @@ class BaseFilings(ApiResource):
         query = super().build_query(**kwargs)
         return query
 
+
 # use for two endpoints: under tag:filings
 # `/committee/<committee_id>/filings/`
 # `/candidate/<candidate_id>/filings/`
@@ -118,11 +119,14 @@ class EFilingsView(ApiResource):
     filter_multi_fields = [
         ("file_number", models.EFilings.file_number),
         ("committee_id", models.EFilings.committee_id),
+        ("form_type", models.EFilings.form_type),
     ]
     filter_range_fields = [
         (("min_receipt_date", "max_receipt_date"), models.EFilings.filed_date),
     ]
-    filter_fulltext_fields = [("q_filer", models.CommitteeSearch.fulltxt)]
+    filter_fulltext_fields = [
+        ("q_filer", models.CommitteeSearch.fulltxt)
+    ]
 
     @property
     def args(self):
@@ -136,6 +140,14 @@ class EFilingsView(ApiResource):
         )
 
     def build_query(self, **kwargs):
+        if kwargs.get("form_type"):
+            original_form_type_values = kwargs["form_type"]
+            new_form_type_values = []
+
+            for value in original_form_type_values:
+                new_form_type_values.extend([f"{value}{suffix}" for suffix in ("", "N", "A", "T")])
+                kwargs["form_type"] = new_form_type_values
+
         query = super().build_query(**kwargs)
 
         if kwargs.get("q_filer"):
@@ -143,6 +155,7 @@ class EFilingsView(ApiResource):
                 models.CommitteeSearch,
                 self.model.committee_id == models.CommitteeSearch.id,
             ).distinct()
+
         return query
 
     @property


### PR DESCRIPTION
## Summary (required)

- Resolves #5497 

Adds a form_type to efilings. This is a new type of filter so that the functionality remains similar to the processed filings. A user can add just the form type ie F3X and it will filter by all F3X's. Because raw filings form_types have the new/amendment/termination letter appended to this field I wanted to make sure that users could also search for just F3XN or just F2A's-- so this functionality should work as well. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Efilings endpoint

## How to test

- pull the branch
- activate your virtualenv
- pytest
- flask run 
- http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F2&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:1046]
- http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F2A&form_type=F2N&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:1046]
- http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F2A&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:292]
- http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F2N&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:754]
- http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F99&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:724]
-http://127.0.0.1:5000/v1/efile/filings/?page=1&per_page=20&form_type=F3X&form_type=-F3XA&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false  [count:11310]





