### PR TITLE
5570- remove re-install of npm (LTS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
             nvm install 18.17.1
             nvm use 18.17.1
             nvm alias default 18.17.1
-            npm install -g npm
             npm install
             npm run build
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5570

We have been installing the latest version of npm (`npm install -g npm`) after installing node with nvm in circleci.  Nvm already installs npm with node, so we are re-installing the latest npm version which can break the builds. This happened when npm 10 was released. We use the nvm recommended version (and specify it) in production, so this PR will remove the upgrade command and make the circleci config match production.

There is an argument to keeping the configuration the same and letting the circle builds fail to force us to upgrade, but I think we should just regularly upgrade without it. CMS runs the nvm recommended version in circleci, so that is why API deploy failed when CMS did not last week.

If we make this change, I will put in a ticket to remove the line from CMS-- it doesn't seem to be working and we should be able to remove the sudo version, but more research is necessary (we may need to add sudo to the nvm install) 

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci config

## How to test

-  nvm install 18.17.1 
-  npm -v
(should show 9.6.7)
- npm install -g npm
- npm -v 
(should show latest version 10) 