### PR TITLE
Refactor CandidateTotals and Add Automated Tests for CandidateTotalsView

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -9,7 +9,6 @@ from nplusone.ext.flask_sqlalchemy import NPlusOne
 
 from jdbc_utils import to_jdbc_url
 from webservices import rest
-from webservices.common import models
 from webservices import __API_VERSION__
 
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
@@ -78,16 +77,12 @@ class ApiBaseTest(BaseTestCase):
                 stdout=null,
             )
 
-        tables_to_skip = [
-            models.CandidateCommitteeTotalsPresidential,
-            models.CandidateCommitteeTotalsHouseSenate,
-        ]
         rest.db.metadata.create_all(
             rest.db.engine,
             tables=[
                 each.__table__
                 for each in rest.db.Model._decl_class_registry.values()
-                if hasattr(each, '__table__') and each not in tables_to_skip
+                if hasattr(each, '__table__')
             ],
         )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -42,16 +42,9 @@ class CandidateDetailFactory(BaseCandidateFactory):
         model = models.CandidateDetail
 
 
-class CandidateCommitteeTotalsPresidentialFactory(BaseCandidateFactory):
+class CandidateTotalsFactory(BaseCandidateFactory):
     class Meta:
-        model = models.CandidateCommitteeTotalsPresidential
-
-    cycle = 2016
-
-
-class CandidateCommitteeTotalsHouseSenateFactory(BaseCandidateFactory):
-    class Meta:
-        model = models.CandidateCommitteeTotalsHouseSenate
+        model = models.CandidateTotals
 
     cycle = 2016
 

--- a/webservices/common/models/totals.py
+++ b/webservices/common/models/totals.py
@@ -4,6 +4,61 @@ from .base import db, BaseModel
 from sqlalchemy.ext.declarative import declared_attr
 
 
+# resource class that uses this model: CandidateTotalsView
+# used for endpoint: /v1/candidate/{candidate_id}/totals/
+class CandidateTotals(db.Model):
+    __tablename__ = 'ofec_candidate_totals_detail_mv'
+
+    candidate_contribution = db.Column(db.Numeric(30, 2))
+    candidate_election_year = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
+    candidate_id = db.Column(db.String, primary_key=True, doc=docs.CANDIDATE_ID)
+    contribution_refunds = db.Column(db.Numeric(30, 2))
+    contributions = db.Column(db.Numeric(30, 2), doc=docs.CONTRIBUTIONS)
+    coverage_end_date = db.Column(db.DateTime(), index=True)
+    coverage_start_date = db.Column(db.DateTime(), index=True)
+    cycle = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
+    disbursements = db.Column(db.Numeric(30, 2), doc=docs.DISBURSEMENTS)
+    election_full = db.Column(db.Boolean, primary_key=True)
+    exempt_legal_accounting_disbursement = db.Column(db.Numeric(30, 2))
+    federal_funds = db.Column(db.Numeric(30, 2))
+    fundraising_disbursements = db.Column(db.Numeric(30, 2))
+    individual_contributions = db.Column(db.Numeric(30, 2))
+    individual_itemized_contributions = db.Column(db.Numeric(30, 2), doc=docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS)
+    individual_unitemized_contributions = db.Column(db.Numeric(30, 2), doc=docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS)
+    last_beginning_image_number = db.Column(db.BigInteger)
+    last_cash_on_hand_end_period = db.Column(db.Numeric(30, 2))
+    last_debts_owed_by_committee = db.Column(db.Numeric(30, 2))
+    last_debts_owed_to_committee = db.Column(db.Numeric(30, 2))
+    last_net_contributions = db.Column(db.Numeric(30, 2))
+    last_net_operating_expenditures = db.Column(db.Numeric(30, 2))
+    last_report_type_full = db.Column(db.String)
+    last_report_year = db.Column(db.Integer)
+    loan_repayments_made = db.Column(db.Numeric(30, 2))
+    loans_received = db.Column(db.Numeric(30, 2))
+    loans_received_from_candidate = db.Column(db.Numeric(30, 2))
+    net_contributions = db.Column(db.Numeric(30, 2))
+    net_operating_expenditures = db.Column(db.Numeric(30, 2))
+    offsets_to_fundraising_expenditures = db.Column(db.Numeric(30, 2))
+    offsets_to_legal_accounting = db.Column(db.Numeric(30, 2))
+    offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2))
+    operating_expenditures = db.Column(db.Numeric(30, 2))
+    other_disbursements = db.Column(db.Numeric(30, 2))
+    other_loans_received = db.Column(db.Numeric(30, 2))
+    other_political_committee_contributions = db.Column(db.Numeric(30, 2))
+    other_receipts = db.Column(db.Numeric(30, 2))
+    political_party_committee_contributions = db.Column(db.Numeric(30, 2))
+    receipts = db.Column(db.Numeric(30, 2))
+    refunded_individual_contributions = db.Column(db.Numeric(30, 2))
+    refunded_other_political_committee_contributions = db.Column(db.Numeric(30, 2))
+    refunded_political_party_committee_contributions = db.Column(db.Numeric(30, 2))
+    repayments_loans_made_by_candidate = db.Column(db.Numeric(30, 2))
+    repayments_other_loans = db.Column(db.Numeric(30, 2))
+    total_offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2))
+    transaction_coverage_date = db.Column(db.DateTime())
+    transfers_from_affiliated_committee = db.Column(db.Numeric(30, 2))
+    transfers_to_other_authorized_committee = db.Column(db.Numeric(30, 2))
+
+
 class CommitteeTotals(BaseModel):
     __abstract__ = True
 
@@ -65,86 +120,6 @@ class CommitteeTotals(BaseModel):
             viewonly=True,
             lazy='joined',
         )
-
-
-class CandidateCommitteeTotals(db.Model):
-    __abstract__ = True
-    # making this it's own model hieararchy until can figure out
-    # how to maybe use existing classes while removing primary
-    # key stuff on cycle
-    candidate_id = db.Column(db.String, primary_key=True, doc=docs.CANDIDATE_ID)
-    cycle = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
-    candidate_election_year = db.Column(db.Integer, primary_key=True, index=True, doc=docs.CYCLE)
-    offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2))
-    political_party_committee_contributions = db.Column(db.Numeric(30, 2))
-    other_disbursements = db.Column(db.Numeric(30, 2))
-    other_political_committee_contributions = db.Column(db.Numeric(30, 2))
-    individual_itemized_contributions = db.Column(db.Numeric(30, 2), doc=docs.INDIVIDUAL_ITEMIZED_CONTRIBUTIONS)
-    individual_unitemized_contributions = db.Column(db.Numeric(30, 2), doc=docs.INDIVIDUAL_UNITEMIZED_CONTRIBUTIONS)
-    disbursements = db.Column(db.Numeric(30, 2), doc=docs.DISBURSEMENTS)
-    contributions = db.Column(db.Numeric(30, 2), doc=docs.CONTRIBUTIONS)
-    contribution_refunds = db.Column(db.Numeric(30, 2))
-    individual_contributions = db.Column(db.Numeric(30, 2))
-    refunded_individual_contributions = db.Column(db.Numeric(30, 2))
-    refunded_other_political_committee_contributions = db.Column(db.Numeric(30, 2))
-    refunded_political_party_committee_contributions = db.Column(db.Numeric(30, 2))
-    receipts = db.Column(db.Numeric(30, 2))
-    coverage_start_date = db.Column(db.DateTime(), index=True)
-    coverage_end_date = db.Column(db.DateTime(), index=True)
-    transaction_coverage_date = db.Column(db.DateTime())
-    operating_expenditures = db.Column(db.Numeric(30, 2))
-
-    last_report_year = db.Column(db.Integer)
-    last_report_type_full = db.Column(db.String)
-    last_beginning_image_number = db.Column(db.BigInteger)
-    last_cash_on_hand_end_period = db.Column(db.Numeric(30, 2))
-    last_debts_owed_by_committee = db.Column(db.Numeric(30, 2))
-    last_debts_owed_to_committee = db.Column(db.Numeric(30, 2))
-
-
-class CandidateCommitteeTotalsPresidential(CandidateCommitteeTotals):
-    __table_args__ = {'extend_existing': True}
-    __tablename__ = 'ofec_candidate_totals_detail_mv'
-
-    candidate_contribution = db.Column(db.Numeric(30, 2))
-    exempt_legal_accounting_disbursement = db.Column(db.Numeric(30, 2))
-    federal_funds = db.Column(db.Numeric(30, 2))
-    fundraising_disbursements = db.Column(db.Numeric(30, 2))
-    loan_repayments_made = db.Column(db.Numeric(30, 2))
-    loans_received = db.Column(db.Numeric(30, 2))
-    loans_received_from_candidate = db.Column(db.Numeric(30, 2))
-    offsets_to_fundraising_expenditures = db.Column(db.Numeric(30, 2))
-    offsets_to_legal_accounting = db.Column(db.Numeric(30, 2))
-    total_offsets_to_operating_expenditures = db.Column(db.Numeric(30, 2))
-    other_loans_received = db.Column(db.Numeric(30, 2))
-    other_receipts = db.Column(db.Numeric(30, 2))
-    repayments_loans_made_by_candidate = db.Column(db.Numeric(30, 2))
-    repayments_other_loans = db.Column(db.Numeric(30, 2))
-    transfers_from_affiliated_committee = db.Column(db.Numeric(30, 2))
-    transfers_to_other_authorized_committee = db.Column(db.Numeric(30, 2))
-    election_full = db.Column(db.Boolean, primary_key=True)
-    net_operating_expenditures = db.Column('last_net_operating_expenditures', db.Numeric(30, 2))
-    net_contributions = db.Column('last_net_contributions', db.Numeric(30, 2))
-    transaction_coverage_date = db.Column(db.DateTime())
-
-
-class CandidateCommitteeTotalsHouseSenate(CandidateCommitteeTotals):
-    __table_args__ = {'extend_existing': True}
-    __tablename__ = 'ofec_candidate_totals_detail_mv'
-
-    all_other_loans = db.Column('other_loans_received', db.Numeric(30, 2))
-    candidate_contribution = db.Column(db.Numeric(30, 2))
-    loan_repayments = db.Column('loan_repayments_made', db.Numeric(30, 2))
-    loan_repayments_candidate_loans = db.Column('repayments_loans_made_by_candidate', db.Numeric(30, 2))
-    loan_repayments_other_loans = db.Column('repayments_other_loans', db.Numeric(30, 2))
-    loans = db.Column('loans_received', db.Numeric(30, 2))
-    loans_made_by_candidate = db.Column('loans_received_from_candidate', db.Numeric(30, 2))
-    other_receipts = db.Column(db.Numeric(30, 2))
-    transfers_from_other_authorized_committee = db.Column('transfers_from_affiliated_committee', db.Numeric(30, 2))
-    transfers_to_other_authorized_committee = db.Column(db.Numeric(30, 2))
-    election_full = db.Column(db.Boolean, primary_key=True)
-    net_operating_expenditures = db.Column(db.Numeric(30, 2))
-    net_contributions = db.Column(db.Numeric(30, 2))
 
 
 class CommitteeTotalsPacParty(CommitteeTotals):
@@ -287,18 +262,6 @@ class CommitteeTotalsIEOnly(BaseModel):
     )
 
 
-class ScheduleAByStateRecipientTotals(BaseModel):
-    __tablename__ = 'ofec_sched_a_aggregate_state_recipient_totals_mv'
-
-    total = db.Column(db.Numeric(30, 2), index=True, doc='The calculated total.')
-    count = db.Column(db.Integer, index=True, doc='Number of records making up the total.')
-    cycle = db.Column(db.Integer, index=True, doc=docs.CYCLE)
-    state = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
-    state_full = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
-    committee_type = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
-    committee_type_full = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
-
-
 class CommitteeTotalsCombined(CommitteeTotals):
     __tablename__ = 'ofec_totals_combined_vw'
 
@@ -346,6 +309,19 @@ class CommitteeTotalsPerCycle(CommitteeTotals):
     cash_on_hand_beginning_period = db.Column(db.Numeric(30, 2))
     net_operating_expenditures = db.Column('last_net_operating_expenditures', db.Numeric(30, 2))
     net_contributions = db.Column('last_net_contributions', db.Numeric(30, 2))
+
+
+class ScheduleAByStateRecipientTotals(BaseModel):
+    __tablename__ = 'ofec_sched_a_aggregate_state_recipient_totals_mv'
+
+    total = db.Column(db.Numeric(30, 2), index=True, doc='The calculated total.')
+    count = db.Column(db.Integer, index=True, doc='Number of records making up the total.')
+    cycle = db.Column(db.Integer, index=True, doc=docs.CYCLE)
+    state = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
+    state_full = db.Column(db.String, index=True, doc=docs.STATE_GENERIC)
+    committee_type = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
+    committee_type_full = db.Column(db.String, index=True, doc=docs.COMMITTEE_TYPE)
+
 
 # used for endpoint:'/totals/inaugural_committees/by_contributor/'
 class InauguralDonations(db.Model):

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -40,12 +40,6 @@ pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
 
 party_cmte_list = {'X', 'Y'}
 
-default_candidate_schemas = (
-    models.CandidateTotals,
-    schemas.CandidateTotalsHouseSenatePageSchema,
-)
-
-
 @doc(
     tags=['financial'],
     description=docs.TOTALS,

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -36,20 +36,6 @@ default_schemas = (
     schemas.CommitteeTotalsPacPartyPageSchema,
 )
 
-candidate_totals_schema_map = {
-    'P': (
-        models.CandidateTotals,
-        schemas.CandidateTotalsPresidentialPageSchema,
-    ),
-    'H': (
-        models.CandidateTotals,
-        schemas.CandidateTotalsHouseSenatePageSchema,
-    ),
-    'S': (
-        models.CandidateTotals,
-        schemas.CandidateTotalsHouseSenatePageSchema,
-    ),
-}
 pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
 
 party_cmte_list = {'X', 'Y'}
@@ -289,10 +275,9 @@ class CandidateTotalsView(utils.Resource):
         return totals_schema().dump(page)
 
     def build_query(self, candidate_id=None, **kwargs):
-        totals_class, totals_schema = candidate_totals_schema_map.get(
-            self._resolve_committee_type(candidate_id=candidate_id.upper(), **kwargs),
-            default_schemas,
-        )
+        committee_type = self._resolve_committee_type(candidate_id=candidate_id.upper(), **kwargs)
+        totals_class = models.CandidateTotals
+        totals_schema = schemas.CandidateTotalsPresidentialPageSchema if committee_type == 'P' else schemas.CandidateTotalsHouseSenatePageSchema
         query = totals_class.query
         query = query.filter(totals_class.candidate_id == candidate_id.upper())
 

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -38,16 +38,16 @@ default_schemas = (
 
 candidate_totals_schema_map = {
     'P': (
-        models.CandidateCommitteeTotalsPresidential,
-        schemas.CandidateCommitteeTotalsPresidentialPageSchema,
+        models.CandidateTotals,
+        schemas.CandidateTotalsPresidentialPageSchema,
     ),
     'H': (
-        models.CandidateCommitteeTotalsHouseSenate,
-        schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+        models.CandidateTotals,
+        schemas.CandidateTotalsHouseSenatePageSchema,
     ),
     'S': (
-        models.CandidateCommitteeTotalsHouseSenate,
-        schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+        models.CandidateTotals,
+        schemas.CandidateTotalsHouseSenatePageSchema,
     ),
 }
 pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
@@ -55,8 +55,8 @@ pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
 party_cmte_list = {'X', 'Y'}
 
 default_candidate_schemas = (
-    models.CandidateCommitteeTotalsHouseSenate,
-    schemas.CandidateCommitteeTotalsHouseSenatePageSchema,
+    models.CandidateTotals,
+    schemas.CandidateTotalsHouseSenatePageSchema,
 )
 
 
@@ -272,6 +272,7 @@ class TotalsCommitteeView(ApiResource):
     description=docs.TOTALS,
     params={'candidate_id': {'description': docs.CANDIDATE_ID}, },
 )
+# used for endpoint: /v1/candidate/{candidate_id}/totals/
 class CandidateTotalsView(utils.Resource):
     @use_kwargs(args.paging)
     @use_kwargs(args.candidate_totals_detail)

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -758,6 +758,9 @@ reports_schemas = (
 CommitteeReportsSchema = type('CommitteeReportsSchema', reports_schemas, {})
 CommitteeReportsPageSchema = make_page_schema(CommitteeReportsSchema)
 
+register_schema(CommitteeReportsSchema)
+register_schema(CommitteeReportsPageSchema)
+
 entity_fields = {
     'pdf_url': ma.fields.Str(),
     'report_form': ma.fields.Str(),
@@ -975,77 +978,6 @@ augment_models(
     make_pac_party_totals_schema,
     models.CommitteeTotalsPacParty,
 )
-
-candidate_committee_fields = {
-        'last_cash_on_hand_end_period': ma.fields.Float(),
-        'last_beginning_image_number': ma.fields.Str(),
-        'receipts': ma.fields.Float(),
-        'candidate_contribution': ma.fields.Float(),
-        'offsets_to_operating_expenditures': ma.fields.Float(),
-        'political_party_committee_contributions': ma.fields.Float(),
-        'other_disbursements': ma.fields.Float(),
-        'other_political_committee_contributions': ma.fields.Float(),
-        'individual_itemized_contributions': ma.fields.Float(),
-        'individual_unitemized_contributions': ma.fields.Float(),
-        'disbursements': ma.fields.Float(),
-        'contributions': ma.fields.Float(),
-        'individual_contributions': ma.fields.Float(),
-        'contribution_refunds': ma.fields.Float(),
-        'operating_expenditures': ma.fields.Float(),
-        'refunded_individual_contributions': ma.fields.Float(),
-        'refunded_other_political_committee_contributions': ma.fields.Float(),
-        'refunded_political_party_committee_contributions': ma.fields.Float(),
-        'last_debts_owed_by_committee': ma.fields.Float(),
-        'last_debts_owed_to_committee': ma.fields.Float()
-
-}
-
-make_candidate_totals_schema = make_schema(
-    models.CandidateCommitteeTotalsPresidential,
-    fields=utils.extend({
-        'exempt_legal_accounting_disbursement': ma.fields.Float(),
-        'federal_funds': ma.fields.Float(),
-        'fundraising_disbursements': ma.fields.Float(),
-        'loan_repayments_made': ma.fields.Float(),
-        'loans_received': ma.fields.Float(),
-        'loans_received_from_candidate': ma.fields.Float(),
-        'offsets_to_fundraising_expenditures': ma.fields.Float(),
-        'offsets_to_legal_accounting': ma.fields.Float(),
-        'total_offsets_to_operating_expenditures': ma.fields.Float(),
-        'other_loans_received': ma.fields.Float(),
-        'other_receipts': ma.fields.Float(),
-        'repayments_loans_made_by_candidate': ma.fields.Float(),
-        'repayments_other_loans': ma.fields.Float(),
-        'transfers_from_affiliated_committee': ma.fields.Float(),
-        'transfers_to_other_authorized_committee': ma.fields.Float(),
-        'net_operating_expenditures': ma.fields.Float(),
-        'net_contributions': ma.fields.Float(),
-        'disbursements': ma.fields.Float()
-    }, candidate_committee_fields)
-)
-augment_schemas(make_candidate_totals_schema)
-
-candidate_committee_totals_hs = make_schema(
-    models.CandidateCommitteeTotalsHouseSenate,
-    fields=utils.extend({
-        'all_other_loans': ma.fields.Float(),
-        'candidate_contribution': ma.fields.Float(),
-        'loan_repayments': ma.fields.Float(),
-        'loan_repayments_candidate_loans': ma.fields.Float(),
-        'loan_repayments_other_loans': ma.fields.Float(),
-        'loans': ma.fields.Float(),
-        'loans_made_by_candidate': ma.fields.Float(),
-        'other_receipts': ma.fields.Float(),
-        'transfers_from_other_authorized_committee': ma.fields.Float(),
-        'transfers_to_other_authorized_committee': ma.fields.Float(),
-        'net_operating_expenditures': ma.fields.Float(),
-        'net_contributions': ma.fields.Float()
-    }, candidate_committee_fields)
-)
-augment_schemas(candidate_committee_totals_hs)
-
-register_schema(CommitteeReportsSchema)
-register_schema(CommitteeReportsPageSchema)
 
 totals_schemas = (
     schemas['CommitteeTotalsHouseSenateSchema'],
@@ -2018,6 +1950,90 @@ InauguralDonationsSchema = make_schema(
 InauguralDonationsPageSchema = make_page_schema(InauguralDonationsSchema)
 register_schema(InauguralDonationsSchema)
 register_schema(InauguralDonationsPageSchema)
+
+
+class CandidateTotalsBaseSchema(BaseAutoSchema):
+    class Meta:
+        model = models.CandidateTotals
+        sqla_session = models.db.session
+        load_instance = True
+        include_relationships = True
+        include_fk = True
+
+    last_cash_on_hand_end_period = ma.fields.Float()
+    last_beginning_image_number = ma.fields.Str()
+    receipts = ma.fields.Float()
+    candidate_contribution = ma.fields.Float()
+    offsets_to_operating_expenditures = ma.fields.Float()
+    political_party_committee_contributions = ma.fields.Float()
+    other_disbursements = ma.fields.Float()
+    other_political_committee_contributions = ma.fields.Float()
+    individual_itemized_contributions = ma.fields.Float()
+    individual_unitemized_contributions = ma.fields.Float()
+    disbursements = ma.fields.Float()
+    contributions = ma.fields.Float()
+    individual_contributions = ma.fields.Float()
+    contribution_refunds = ma.fields.Float()
+    operating_expenditures = ma.fields.Float()
+    refunded_individual_contributions = ma.fields.Float()
+    refunded_other_political_committee_contributions = ma.fields.Float()
+    refunded_political_party_committee_contributions = ma.fields.Float()
+    last_debts_owed_by_committee = ma.fields.Float()
+    last_debts_owed_to_committee = ma.fields.Float()
+    fundraising_disbursements = ma.fields.Float()
+    exempt_legal_accounting_disbursement = ma.fields.Float()
+    federal_funds = ma.fields.Float()
+    offsets_to_fundraising_expenditures = ma.fields.Float()
+    total_offsets_to_operating_expenditures = ma.fields.Float()
+    offsets_to_legal_accounting = ma.fields.Float()
+    net_operating_expenditures = ma.fields.Float()
+    net_contributions = ma.fields.Float()
+    last_net_contributions = ma.fields.Float()
+    last_net_operating_expenditures = ma.fields.Float()
+    other_receipts = ma.fields.Float()
+    transfers_to_other_authorized_committee = ma.fields.Float()
+    other_loans_received = ma.fields.Float()
+    loan_repayments_made = ma.fields.Float()
+    repayments_loans_made_by_candidate = ma.fields.Float()
+    repayments_other_loans = ma.fields.Float()
+    loans_received = ma.fields.Float()
+    loans_received_from_candidate = ma.fields.Float()
+    transfers_from_affiliated_committee = ma.fields.Float()
+
+
+class CandidateTotalsPresidentialSchema(CandidateTotalsBaseSchema):
+    class Meta(CandidateTotalsBaseSchema.Meta):
+        exclude = ('last_net_operating_expenditures', 'last_net_contributions')
+    net_operating_expenditures = ma.fields.Float(attribute='last_net_operating_expenditures')
+    net_contributions = ma.fields.Float(attribute='last_net_contributions')
+
+
+class CandidateTotalsHouseSenateSchema(CandidateTotalsBaseSchema):
+    class Meta(CandidateTotalsBaseSchema.Meta):
+        exclude = ('loans_received',
+                   'repayments_other_loans',
+                   'transfers_from_affiliated_committee',
+                   'loans_received_from_candidate',
+                   'loan_repayments_made',
+                   'repayments_loans_made_by_candidate',
+                   'other_loans_received')
+    all_other_loans = ma.fields.Float(attribute='other_loans_received')
+    loan_repayments = ma.fields.Float(attribute='loan_repayments_made')
+    loan_repayments_candidate_loans = ma.fields.Float(attribute='repayments_loans_made_by_candidate')
+    loan_repayments_other_loans = ma.fields.Float(attribute='repayments_other_loans')
+    loans = ma.fields.Float(attribute='loans_received')
+    loans_made_by_candidate = ma.fields.Float(attribute='loans_received_from_candidate')
+    transfers_from_other_authorized_committee = ma.fields.Float(attribute='transfers_from_affiliated_committee')
+
+
+CandidateTotalsPresidentialPageSchema = make_page_schema(CandidateTotalsPresidentialSchema)
+CandidateTotalsHouseSenatePageSchema = make_page_schema(CandidateTotalsHouseSenateSchema)
+
+register_schema(CandidateTotalsPresidentialSchema)
+register_schema(CandidateTotalsHouseSenateSchema)
+
+register_schema(CandidateTotalsPresidentialPageSchema)
+register_schema(CandidateTotalsHouseSenatePageSchema)
 
 # Copy schemas generated by helper methods to module namespace
 globals().update(schemas)


### PR DESCRIPTION
## Summary (required)

- Resolves #3930 

This PR adds automated tests for CandidateTotalsView and refactors CandidateTotals. 

We couldn't test this view before because CandidateCommitteeTotalsHouseSenate and CandidateCommitteeTotalsPresidential  had `{'extend_existing': True}` and repeated fields which caused a duplicate error when creating all of the database tables. [Here](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.extend_existing) is the documentation explaining how extend_existing works. So I merged the three models into one and created two separate schemas instead. 

Also when writing the tests I noticed a few data types were incorrect. This was caused by the marshmallow_sqlalchemy upgrade. Any field declared as Numeric in the model is automatically converted to a string in the schema by marshmallow_sqlalchemy. I had to manually convert them to float. 

### Required reviewers 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

-  /candidate/<string:candidate_id>/totals/ endpoint


## How to test
1. Checkout this branch 
2. `pytest`
3. `flask run`
4. Test endpoint by making sure there are no extra or missing fields and compare output to dev 

Sample URLs: 

http://127.0.0.1:5000/v1/candidate/S0AZ00350/totals/?page=1&per_page=20&sort=-cycle&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

http://127.0.0.1:5000/v1/candidate/P00014241/totals/?page=1&per_page=20&sort=-cycle&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

http://127.0.0.1:5000/v1/candidate/H2UT03280/totals/?page=1&per_page=20&sort=-cycle&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false