### PR TITLE
Upgrade Gevent to remove ReDOS vulnerability 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask==2.2.5
 Flask-Cors==3.0.10
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
-gevent==22.10.2
+gevent==23.9.1
 gunicorn==19.10.0
 GitPython==3.1.32
 icalendar==4.0.2


### PR DESCRIPTION
## Summary (required)

- Resolves #5594 

Since we already have setuptools pinned to v68, this ticket upgrades Gevent to remove the ReDOS vulnerability. 


### Required reviewers 1 developer


## Impacted areas of the application

 General components of the application that this PR will affect:

-  requirements.txt

## Screenshots

For some reason, my local snyk test does not show what is on the online snyk [dashboard](https://app.snyk.io/org/fecgov/project/7382e6c8-8f69-4afb-b910-ff61101c54fb). 

![image](https://github.com/fecgov/openFEC/assets/121631201/c612f6e9-1a39-4c90-b9cb-e3f89bd929d6)

However, by looking at the dashboard I can see that the issue is coming from setuptools and Gevent. Setuptools is already pinned to v68 so I upgraded Gevent. 

 
![image](https://github.com/fecgov/openFEC/assets/121631201/cad49bfa-89df-400a-9426-45370949071d)

## How to test
1. run `snyk test --file=requirements-dev.txt --package-manager=pip` on an updated develop
2. checkout this branch
3. `pyenv virtualenv  (your environment)`
4. `pyenv activate (your environment)`
5. `pip install -r requirements.txt && pip install -r requirements-dev.txt`
6. `snyk test --file=requirements-dev.txt --package-manager=pip` 
7. `dropdb cfdm_test`
8. `createdb cfdm_test`
9. `invoke create_sample_db`
10. `flask run` 
