### PR TITLE
Upgrade gitpython to 3.1.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 gevent==23.9.1
 gunicorn==19.10.0
-GitPython==3.1.32
+GitPython==3.1.35
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary (required)

Upgrade gitpython to v3.1.32 in requirements.txt to remediate snyk vulnerability

- Resolves #5574 

### Required reviewers

one developer


## How to test

- run `git checkout develop`
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output shows gitpython as vulnerable package)
- run `git checkout feature/5574-upgrade-gitpython`
- run `pyenv activate venv-api`
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output **no longer shows** gitpython as vulnerable package)
- run `pytest`