### PR TITLE
5577-remove deprecated filter from schedule_d endpoint

### DIFF
--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -21,7 +21,6 @@ class TestScheduleDView(ApiBaseTest):
         filters = [
             ('image_number', ScheduleD.image_number, ['123', '456']),
             ('committee_id', ScheduleD.committee_id, ['C01', 'C02']),
-            ('candidate_id', ScheduleD.candidate_id, ['S01', 'S02']),
             ('report_year', ScheduleD.report_year, [2023, 2019]),
             ('report_type', ScheduleD.report_type, ['60D', 'Q3']),
             ('filing_form', ScheduleD.filing_form, ['F3P', 'F3X']),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -768,7 +768,6 @@ schedule_d = {
     'max_amount_outstanding_beginning': fields.Float(),
     'min_amount_outstanding_close': fields.Float(),
     'max_amount_outstanding_close': fields.Float(),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID_DEP),  # to be deprecated
     'creditor_debtor_name': fields.List(Keyword),
     'nature_of_debt': fields.Str(),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -511,7 +511,6 @@ class ScheduleD(PdfMixin, BaseItemized):
     outstanding_balance_close_of_period = db.Column('outstg_bal_cop', db.Float)
     amount_incurred_period = db.Column('amt_incurred_per', db.Float)
     payment_period = db.Column('pymt_per', db.Float)
-    candidate_id = db.Column('cand_id', db.String, doc=docs.CANDIDATE_ID)
     action_code = db.Column('action_cd', db.String)
     action_code_full = db.Column('action_cd_desc', db.String)
     schedule_type = db.Column(db.String)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -79,18 +79,6 @@ candidate/member's district changes during re-districting. Presidential IDs don'
 The rest is sequence.
 '''
 
-CANDIDATE_ID_DEP = '''
-`DEPRECATED`
-A unique identifier assigned to each candidate registered with the FEC.
-If a person runs for several offices, that person will have separate candidate IDs for each office.
-First character indicates office - [P]residential, [H]ouse, [S]enate].
-Second character is the last digit of the two-year period the ID was created.
-Third and fourth is the candidate state. Presidential IDs don't have state.
-Fifth and sixth is the district when the candidate first ran. This does not change if the
-candidate/member's district changes during re-districting. Presidential IDs don't have districts.
-The rest is sequence.
-'''
-
 CANDIDATE_INACTIVE = '''
 True indicates that a candidate is inactive.
 '''

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -26,7 +26,6 @@ class ScheduleDView(ApiResource):
     filter_multi_fields = [
         ('image_number', models.ScheduleD.image_number),
         ('committee_id', models.ScheduleD.committee_id),
-        ('candidate_id', models.ScheduleD.candidate_id),  # TODO: deprecate and remove
         ('report_year', models.ScheduleD.report_year),
         ('report_type', models.ScheduleD.report_type),
         ('filing_form', models.ScheduleD.filing_form),


### PR DESCRIPTION
## Summary (required)

- Resolves #5605 

Remove deprecated candidate_id filter from the schedule_d endpoint. This change was approved by PM's when the first dep notice was added and sent out August 22nd 2023.

### Required reviewers

1-2 devs 

## Impacted areas of the application

General components of the application that this PR will affect:

-  sched D endpoint

## How to test

- Pull this PR
- flask run
- http://127.0.0.1:5000/developers/#/debts/get_v1_schedules_schedule_d_
-  http://127.0.0.1:5000/v1/schedules/schedule_d/?committee_type=H&page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
-  http://127.0.0.1:5000/v1/schedules/schedule_d/?filing_form=F3X&page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- pytest




