### PR TITLE
fix line_number bug

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -149,13 +149,13 @@ class IntegrationTestCase(common.BaseTestCase):
         individuals = [
             factories.ScheduleAFactory(receipt_type='15J', filing_form='F3X'),
             factories.ScheduleAFactory(
-                line_number='12', contribution_receipt_amount=150, filing_form='F3X'
+                line_number_short='12', contribution_receipt_amount=150, filing_form='F3X'
             ),
         ]
         earmarks = [
             factories.ScheduleAFactory(filing_form='F3X'),
             factories.ScheduleAFactory(
-                line_number='12',
+                line_number_short='12',
                 contribution_receipt_amount=150,
                 memo_text='earmark',
                 memo_code='X',
@@ -166,7 +166,7 @@ class IntegrationTestCase(common.BaseTestCase):
         is_individual = sa.func.is_individual(
             ScheduleA.contribution_receipt_amount,
             ScheduleA.receipt_type,
-            ScheduleA.line_number,
+            ScheduleA.line_number_short,
             ScheduleA.memo_code,
             ScheduleA.memo_text,
             ScheduleA.contributor_id,

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -315,8 +315,8 @@ class TestScheduleA(ApiBaseTest):
 
     def test_schedule_a_filter_line_number(self):
         [
-            factories.ScheduleAFactory(line_number='16', filing_form='F3X'),
-            factories.ScheduleAFactory(line_number='17', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number_short='16', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number_short='17', filing_form='F3X'),
         ]
         results = self._results(
             api.url_for(ScheduleAView, line_number='f3X-16', **self.kwargs)
@@ -324,8 +324,8 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(len(results), 1)
 
         [
-            factories.ScheduleBFactory(line_number='21', filing_form='F3X'),
-            factories.ScheduleBFactory(line_number='22', filing_form='F3X'),
+            factories.ScheduleBFactory(line_number_short='21', filing_form='F3X'),
+            factories.ScheduleBFactory(line_number_short='22', filing_form='F3X'),
         ]
 
         results = self._results(

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -201,6 +201,21 @@ class TestScheduleCView(ApiBaseTest):
         )
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
+    def test_schedule_c_filter_line_number(self):
+        [
+            factories.ScheduleCFactory(line_number_short='10', filing_form='F3X'),
+            factories.ScheduleCFactory(line_number_short='9', filing_form='F3X'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleCView, line_number='f3x-10')
+        )
+        self.assertEqual(len(results), 1)
+        response = self.app.get(
+            api.url_for(ScheduleCView, line_number='f3x21')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid line_number', response.data)
+
 
 class TestScheduleCViewBySubId(ApiBaseTest):
     def test_fields(self):

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -188,6 +188,21 @@ class TestScheduleDView(ApiBaseTest):
         results = self._results(api.url_for(ScheduleDView, sort=['-sub_id']))
         self.assertEqual(results[0]['sub_id'], '2')
         self.assertEqual(results[1]['sub_id'], '1')
+    
+    def test_schedule_d_filter_line_number(self):
+        [
+            factories.ScheduleDViewFactory(line_number_short='10', filing_form='F3X'),
+            factories.ScheduleDViewFactory(line_number_short='9', filing_form='F3X'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleDView, line_number='f3x-10')
+        )
+        self.assertEqual(len(results), 1)
+        response = self.app.get(
+            api.url_for(ScheduleDView, line_number='f3x21')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid line_number', response.data)
 
 
 class TestScheduleDViewBySubId(ApiBaseTest):

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -4,6 +4,7 @@ from tests.common import ApiBaseTest
 from webservices.rest import api
 from webservices.schemas import ScheduleEByCandidateSchema
 from webservices.resources.aggregates import ScheduleEByCandidateView
+from webservices.resources.sched_e import ScheduleEView
 
 
 # test /schedules/schedule_e/by_candidate/ under tag: independent expenditures
@@ -288,3 +289,18 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['committee_name'], 'Warner for America')
         self.assertEqual(response[1]['committee_name'], 'Ritche for America')
+
+    def test_schedule_e_filter_line_number(self):
+        [
+            factories.ScheduleEFactory(line_number_short='10', filing_form='F3X'),
+            factories.ScheduleEFactory(line_number_short='9', filing_form='F3X'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleEView, line_number='f3x-10')
+        )
+        self.assertEqual(len(results), 1)
+        response = self.app.get(
+            api.url_for(ScheduleEView, line_number='f3x21')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid line_number', response.data)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -564,9 +564,7 @@ itemized = {
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': Date(description='Minimum date'),
     'max_date': Date(description='Maximum date'),
-    'line_number': fields.Str(description='Filter for form and line number using the following format: '
-                                          '`FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter'
-                                          ' down to all entries from form `F3X` line number `16`.')
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER),
 }
 
 schedule_a = {
@@ -746,7 +744,7 @@ schedule_c = {
     'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_amount': Currency(description=docs.MIN_FILTER),
     'max_amount': Currency(description=docs.MAX_FILTER),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_name': fields.List(Keyword, description=docs.CANDIDATE_NAME),
     'loan_source_name': fields.List(Keyword, description=docs.LOAN_SOURCE),
@@ -777,9 +775,10 @@ schedule_d = {
     'max_coverage_start_date': Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'filing_form': fields.List(fields.Str, description=docs.FORM_TYPE),
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER),
+
 }
 
 schedule_e_by_candidate = {
@@ -802,6 +801,7 @@ schedule_f = {
     'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER),
 }
 
 communication_cost = {
@@ -965,6 +965,7 @@ schedule_e = {
     'max_filing_date': Date(description=docs.MAX_FILED_DATE),
     'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
     'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
+    'line_number': fields.List(IStr, description=docs.LINE_NUMBER),
 }
 
 schedule_e_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -17,19 +17,23 @@ class BaseItemized(db.Model):
     image_number = db.Column('image_num', db.String, doc=docs.IMAGE_NUMBER)
     filing_form = db.Column(db.String)
     link_id = db.Column(db.Integer)
-    line_number = db.Column('line_num', db.String)
+    line_number_short = db.Column('line_num', db.String)
     transaction_id = db.Column('tran_id', db.String)
     file_number = db.Column('file_num', db.Integer)
 
     @hybrid_property
     def memoed_subtotal(self):
         return self.memo_code == 'X'
+    
+    @hybrid_property
+    def line_number(self):
+        if self.filing_form and self.line_number_short:
+            return self.filing_form + "-" + self.line_number_short
 
 
 class BaseRawItemized(db.Model):
     __abstract__ = True
 
-    # line_number = db.Column("line_num", db.String) removed as H4 Raw data does not have line_num
     transaction_id = db.Column('tran_id', db.String)
     image_number = db.Column('imageno', db.String, doc=docs.IMAGE_NUMBER)
     entity_type = db.Column('entity', db.String)
@@ -181,7 +185,7 @@ class ScheduleAEfile(BaseRawItemized):
     __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'sa7'
 
-    line_number = db.Column("line_num", db.String)
+    line_number_short = db.Column("line_num", db.String)
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
     committee_id = db.Column("comid", db.String, index=True, doc=docs.COMMITTEE_ID)
@@ -372,7 +376,7 @@ class ScheduleB(BaseItemized):
 class ScheduleBEfile(BaseRawItemized):
     __tablename__ = 'real_efile_sb4'
 
-    line_number = db.Column("line_num", db.String)
+    line_number_short = db.Column("line_num", db.String)
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
     related_line_number = db.Column("rel_lineno", db.Integer, primary_key=True)
     committee_id = db.Column("comid", db.String, doc=docs.COMMITTEE_ID)
@@ -537,6 +541,11 @@ class ScheduleD(PdfMixin, BaseItemized):
         if self.has_pdf:
             return utils.make_schedule_pdf_url(self.image_number)
         return None
+    
+    @hybrid_property
+    def line_number(self):
+        if self.filing_form and self.line_number_short:
+            return self.filing_form + "-" + self.line_number_short
 
 
 class ScheduleE(PdfMixin, BaseItemized):
@@ -620,11 +629,16 @@ class ScheduleE(PdfMixin, BaseItemized):
     pdf_url = db.Column(db.String)
     spender_name_text = db.Column(TSVECTOR)
 
+    @hybrid_property
+    def line_number(self):
+        if self.filing_form and self.line_number_short:
+            return self.filing_form + "-" + self.line_number_short
+
 
 class ScheduleEEfile(BaseRawItemized):
     __tablename__ = 'real_efile_se_f57_vw'
 
-    line_number = db.Column("line_num", db.String)
+    line_number_short = db.Column("line_num", db.String)
     filing_form = db.Column('filing_form', db.String)
     is_notice = db.Column(db.Boolean, index=True)
     file_number = db.Column("repid", db.Integer, index=True, primary_key=True)
@@ -789,6 +803,11 @@ class ScheduleF(PdfMixin, BaseItemized):
         if self.has_pdf:
             return utils.make_schedule_pdf_url(self.image_number)
         return None
+    
+    @hybrid_property
+    def line_number(self):
+        if self.filing_form and self.line_number_short:
+            return self.filing_form + "-" + self.line_number_short
 
 
 class ScheduleH4(BaseItemized):

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -491,7 +491,7 @@ class BaseFilingSummary(db.Model):
     __table_args__ = {'schema': 'real_efile'}
     __tablename__ = 'summary'
     file_number = db.Column('repid', db.Integer, index=True, primary_key=True)
-    line_number = db.Column('lineno', db.Integer, primary_key=True)
+    line_number_short = db.Column('lineno', db.Integer, primary_key=True)
     column_a = db.Column('cola', db.Float)
     column_b = db.Column('colb', db.Float)
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -52,6 +52,7 @@ class ScheduleAView(ItemizedResource):
             models.ScheduleA.recipient_committee_designation,
         ),
         ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
+        ('line_number', models.ScheduleA.line_number),
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
@@ -130,17 +131,14 @@ class ScheduleAView(ItemizedResource):
             )
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line_number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR, status_code=400,
-                )
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
+        
 
 
 @doc(

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -46,6 +46,7 @@ class ScheduleBView(ItemizedResource):
         ('spender_committee_designation', models.ScheduleB.spender_committee_designation),
         ('two_year_transaction_period',
          models.ScheduleB.two_year_transaction_period),
+         ('line_number', models.ScheduleB.line_number),
     ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
@@ -85,17 +86,13 @@ class ScheduleBView(ItemizedResource):
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                each.upper()
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
 

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -2,6 +2,7 @@
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -41,6 +42,16 @@ class ScheduleCView(ApiResource):
         (('min_payment_to_date', 'max_payment_to_date'), models.ScheduleC.payment_to_date),
     ]
 
+    def build_query(self, **kwargs):
+        query = super().build_query(**kwargs)
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
+        return query
+
     @property
     def args(self):
         return utils.extend(
@@ -75,12 +86,6 @@ class ScheduleCViewBySubId(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if 'line_number' in kwargs:
-            for each in kwargs['line_number']:
-                if len(each.split('-')) != 2:
-                    raise exceptions.ApiError(
-                        exceptions.LINE_NUMBER_ERROR, status_code=400
-                    )
         return query
 
     @property

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -25,6 +25,8 @@ class ScheduleCView(ApiResource):
     filter_multi_fields = [
         ('image_number', models.ScheduleC.image_number),
         ('committee_id', models.ScheduleC.committee_id),
+        ('line_number', models.ScheduleC.line_number),
+
     ]
 
     filter_fulltext_fields = [
@@ -73,6 +75,12 @@ class ScheduleCViewBySubId(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
     @property

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -29,7 +29,8 @@ class ScheduleDView(ApiResource):
         ('report_year', models.ScheduleD.report_year),
         ('report_type', models.ScheduleD.report_type),
         ('filing_form', models.ScheduleD.filing_form),
-        ('committee_type', models.ScheduleD.committee_type)
+        ('committee_type', models.ScheduleD.committee_type),
+        ('line_number', models.ScheduleD.line_number),
     ]
 
     filter_range_fields = [
@@ -69,17 +70,12 @@ class ScheduleDView(ApiResource):
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -46,6 +46,7 @@ class ScheduleEView(ItemizedResource):
         ('candidate_office_state', models.ScheduleE.candidate_office_state),
         ('candidate_office_district', models.ScheduleE.candidate_office_district),
         ('candidate_party', models.ScheduleE.candidate_party),
+        ('line_number', models.ScheduleE.line_number),
     ]
     filter_fulltext_fields = [
         ('payee_name', models.ScheduleE.payee_name_text),
@@ -110,6 +111,12 @@ class ScheduleEView(ItemizedResource):
         if 'most_recent' in kwargs:
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -2,6 +2,7 @@ from flask_apispec import doc
 
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -55,6 +56,12 @@ class ScheduleFView(ApiResource):
         query = super().build_query(**kwargs)
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -27,6 +27,7 @@ class ScheduleFView(ApiResource):
         ('committee_id', models.ScheduleF.committee_id),
         ('candidate_id', models.ScheduleF.candidate_id),
         ('cycle', models.ScheduleF.election_cycle),
+        ('line_number', models.ScheduleF.line_number),
     ]
 
     filter_range_fields = [

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -50,6 +50,7 @@ class ScheduleH4View(ItemizedResource):
         ('administrative_activity_indicator', models.ScheduleH4.administrative_activity_indicator),
         ('general_voter_drive_activity_indicator', models.ScheduleH4.general_voter_drive_activity_indicator),
         ('public_comm_indicator', models.ScheduleH4.public_comm_indicator),
+        ('line_number', models.ScheduleH4.line_number),
     ]
 
     filter_range_fields = [
@@ -87,17 +88,13 @@ class ScheduleH4View(ItemizedResource):
         query = query.options(sa.orm.joinedload(models.ScheduleH4.committee))
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'line_number' in kwargs:
+            for each in kwargs['line_number']:
+                each.upper()
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.LINE_NUMBER_ERROR, status_code=400
+                    )
         return query
 
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -112,10 +112,10 @@ def extract_columns(obj, column_a, column_b, descriptions):
     ytd = re.compile('(.+?(?=ytd))')
     if obj.summary_lines:
         for row in obj.summary_lines:
-            replace_a = re.sub(per, descriptions[int(row.line_number - 1)] + '_',
-                               str(keys[int(row.line_number - 1)][0])).replace(' ', '_')
-            replace_b = re.sub(ytd, descriptions[int(row.line_number - 1)] + '_',
-                               str(keys[int(row.line_number - 1)][1])).replace(' ', '_')
+            replace_a = re.sub(per, descriptions[int(row.line_number_short - 1)] + '_',
+                               str(keys[int(row.line_number_short - 1)][0])).replace(' ', '_')
+            replace_b = re.sub(ytd, descriptions[int(row.line_number_short - 1)] + '_',
+                               str(keys[int(row.line_number_short - 1)][1])).replace(' ', '_')
             replace_a = make_period_string(replace_a)
             line_list[replace_a] = row.column_a
             line_list[replace_b] = row.column_b
@@ -148,14 +148,14 @@ class BaseF3PFilingSchema(BaseEfileSchema):
         if obj.summary_lines:
 
             for row in obj.summary_lines:
-                if row.line_number >= 33 and row.line_number < 87:
-                    state_map[keys[int(row.line_number - 1)][0]] = row.column_a
-                    state_map[keys[int(row.line_number - 1)][1]] = row.column_b
+                if row.line_number_short >= 33 and row.line_number_short < 87:
+                    state_map[keys[int(row.line_number_short - 1)][0]] = row.column_a
+                    state_map[keys[int(row.line_number_short - 1)][1]] = row.column_b
                 else:
-                    replace_a = re.sub(per, descriptions[int(row.line_number - 1)] + '_',
-                                       keys[int(row.line_number - 1)][0]).replace(' ', '_')
-                    replace_b = re.sub(ytd, descriptions[int(row.line_number - 1)] + '_',
-                                       str(keys[int(row.line_number - 1)][1])).replace(' ', '_')
+                    replace_a = re.sub(per, descriptions[int(row.line_number_short - 1)] + '_',
+                                       keys[int(row.line_number_short - 1)][0]).replace(' ', '_')
+                    replace_b = re.sub(ytd, descriptions[int(row.line_number_short - 1)] + '_',
+                                       str(keys[int(row.line_number_short - 1)][1])).replace(' ', '_')
                     replace_a = make_period_string(replace_a)
                     line_list[replace_a] = row.column_a
                     line_list[replace_b] = row.column_b
@@ -1003,7 +1003,8 @@ ScheduleASchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'report_year': ma.fields.Int()
+        'report_year': ma.fields.Int(),
+        'line_number':  ma.fields.Str()
     },
     options={
          'exclude': (
@@ -1032,6 +1033,7 @@ ScheduleCSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'line_number':  ma.fields.Str()
     },
     options={'exclude': ('loan_source_name_text', 'candidate_name_text',)}
     )
@@ -1098,6 +1100,7 @@ ScheduleDSchema = make_schema(
     models.ScheduleD,
     fields={
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'line_number':  ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
     },
@@ -1114,6 +1117,7 @@ ScheduleFSchema = make_schema(
         'subordinate_committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'line_number':  ma.fields.Str()
     },
     options={'exclude': ('payee_name_text',)}
     )
@@ -1136,7 +1140,8 @@ ScheduleBSchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'disbursement_amount': ma.fields.Float()
+        'disbursement_amount': ma.fields.Float(),
+        'line_number':  ma.fields.Str(),
     },
     options={
         'exclude': (
@@ -1171,6 +1176,7 @@ ScheduleH4Schema = make_schema(
         'federal_share': ma.fields.Float(),
         'nonfederal_share': ma.fields.Float(),
         'event_amount_year_to_date': ma.fields.Float(),
+        'line_number':  ma.fields.Str(),
 
     },
     options={
@@ -1202,6 +1208,7 @@ ScheduleESchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'line_number':  ma.fields.Str(),
     },
     options={
         'exclude': (


### PR DESCRIPTION
## Summary

- Resolves #5609 

This PR will allow line_number to support multiple user inputs. This will fix the current bug on the receipts, disbursements, debts, and H4 tables where multiple line number filters can't be selected. To fix this issue I needed to add line_number as a hybrid_property as it is a composite field of filing_form and line_number_short (which used to be just line_number as well, which was confusing.) 

During the research for this ticket, I discovered that line_number is not currently working for E and F endpoints and all efiling endpoints. This PR fixes E & F, but the broken efiling endpoints (and more test coverage) will be done in follow-up. 

### Required reviewers

2-3 devs 

## Impacted areas of the application

General components of the application that this PR will affect:

-  A, B, C, D, E, F, and H4 endpoints 

## How to test

- flask run
- http://127.0.0.1:5000/v1/schedules/schedule_a/?&line_number=F3x-15&line_number=F9-F92&two_year_transaction_period=2016&per_page=20&sort=-contribution_receipt_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_b/?line_number=F3X-23&line_number=F3P-23&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_c/?line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_d/?line_number=F3P-12&line_number=F3-10&page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- http://127.0.0.1:5000/v1/schedules/schedule_h4/?line_number=F3X-21A&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_e/?line_number=F3x-24&per_page=20&sort=-expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
- http://127.0.0.1:5000/v1/schedules/schedule_f/?line_number=F3X-25&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
-INVALID LINE NUMBER  http://127.0.0.1:5000/v1/schedules/schedule_h4/?line_number=string&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false

Deploy to dev/stage and test the front-end, add different line_numbers on the receipts and disbursements datatables. 
https://dev.fec.gov/data/receipts/?data_type=processed&two_year_transaction_period=2024&min_date=01%2F01%2F2023&max_date=12%2F31%2F2024&line_number=F3P-17A&line_number=F3P-20A
https://dev.fec.gov/data/disbursements/?data_type=processed&two_year_transaction_period=2024&min_date=01%2F01%2F2023&max_date=12%2F31%2F2024&line_number=F3-17&line_number=F3-20A&line_number=F3-21



![Screen Shot 2023-10-17 at 10 02 03 AM](https://github.com/fecgov/openFEC/assets/66386084/1a073fd7-ab9c-437f-a8f1-e35987fb94f1)



