### PR TITLE
Fix sort validation to skip 500 error

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -176,6 +176,22 @@ class IndicesValidator(IndexValidator):
                 )
 
 
+class SortMultiOptionValidator(object):
+
+    def __init__(self, values):
+        self.values = values
+
+    def __call__(self, sort_arg_value_list):
+        for sort_arg_value in sort_arg_value_list:
+            if sort_arg_value.lstrip('-') not in self.values:
+                raise exceptions.ApiError(
+                    'Cannot sort on value "{0}". Instead choose one of: "{1}"'.format(
+                        sort_arg_value, '", "'.join(self.values)
+                    ),
+                    status_code=422,
+                )
+
+
 def make_sort_args(
     default=None, validator=None, default_hide_null=False,
         default_nulls_only=False, default_sort_nulls_last=False, show_nulls_last_arg=True,
@@ -207,14 +223,14 @@ def make_sort_args(
     return args
 
 
-def make_multi_sort_args(
-    default=None, validator=None, default_hide_null=False,
-        default_nulls_only=False, default_sort_nulls_last=False):
+def make_multi_sort_args(default=None, validator=None, default_hide_null=False, default_nulls_only=False,
+                         default_sort_nulls_last=False, show_nulls_last_arg=True, additional_description=''):
 
-    args = make_sort_args(default, validator, default_hide_null, default_nulls_only, default_sort_nulls_last)
-    args['sort'] = fields.List(
-        fields.Str, missing=default, validate=validator, required=False, allow_none=True,
-        description=docs.SORT)
+    args = make_sort_args(default, validator, default_hide_null, default_nulls_only,
+                          default_sort_nulls_last, show_nulls_last_arg, additional_description)
+
+    args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True, description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
+                                    additional_description))
     return args
 
 

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -224,6 +224,7 @@ class TotalsCandidateView(ApiResource):
         'receipts',
         'disbursements',
         'individual_itemized_contributions',
+        'candidate_id',
     ]
 
     @property

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -76,15 +76,32 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
     return rows, aggregates
 
 
+# used for 'schedules/schedule_a/by_size/by_candidate/'
+# Ex: http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?sort=-count&candidate_id=H8CA05035&cycle=2022
+# &election_full=true
 @doc(
     tags=['receipts'], description=docs.SCHEDULE_A_SIZE_CANDIDATE_TAG,
 )
-class ScheduleABySizeCandidateView(utils.Resource):
-    @use_kwargs(args.paging)
-    @use_kwargs(args.make_sort_args())
-    @use_kwargs(args.schedule_a_candidate_aggregate)
-    @marshal_with(schemas.ScheduleABySizeCandidatePageSchema())
-    def get(self, **kwargs):
+class ScheduleABySizeCandidateView(ApiResource):
+    schema = schemas.ScheduleABySizeCandidateSchema
+    page_schema = schemas.ScheduleABySizeCandidatePageSchema()
+    sort_option = [
+            'total',
+            'size',
+            'count'
+    ]
+
+    @property
+    def args(self):
+        return utils.extend(
+            args.paging,
+            args.schedule_a_candidate_aggregate,
+            args.make_multi_sort_args(default=["size", ], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
+        )
+
+    def build_query(self, **kwargs):
         label_columns = [
             ScheduleABySize.size,
             sa.func.sum(ScheduleABySize.total).label('total'),
@@ -95,18 +112,75 @@ class ScheduleABySizeCandidateView(utils.Resource):
         _, query = candidate_aggregate(
             ScheduleABySize, label_columns, group_columns, kwargs
         )
-        return utils.fetch_page(query, kwargs, cap=None)
+        return query
 
 
+# used for 'schedules/schedule_a/by_state/by_candidate/'
+# Ex: http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=H8CA05035
+# &cycle=2022&election_full=true
+@doc(
+    tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
+)
+class ScheduleAByStateCandidateView(ApiResource):
+    schema = schemas.ScheduleAByStateCandidateSchema
+    page_schema = schemas.ScheduleAByStateCandidatePageSchema()
+    sort_option = [
+            'total',
+            'count',
+            'state',
+            'state_full',
+    ]
+
+    @property
+    def args(self):
+        return utils.extend(
+            args.paging,
+            args.schedule_a_candidate_aggregate,
+            args.make_multi_sort_args(default=["state", ], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
+        )
+
+    def build_query(self, **kwargs):
+        _, query = candidate_aggregate(
+            ScheduleAByState,
+            [
+                ScheduleAByState.state,
+                sa.func.sum(ScheduleAByState.total).label('total'),
+                sa.func.max(ScheduleAByState.state_full).label('state_full'),
+                sa.func.sum(ScheduleAByState.count).label('count'),
+            ],
+            [ScheduleAByState.state],
+            kwargs,
+        )
+        return query
+
+
+# used for 'schedules/schedule_a/by_state/by_candidate/totals/'. always return one row.
+# Ex: http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=total&candidate_id=H8CA05035
+# &cycle=2022&election_full=true
 @doc(
     tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TOTAL_TAG,
 )
-class ScheduleAByStateCandidateTotalsView(utils.Resource):
-    @use_kwargs(args.paging)
-    @use_kwargs(args.make_sort_args())
-    @use_kwargs(args.schedule_a_candidate_aggregate)
-    @marshal_with(schemas.ScheduleAByStateCandidatePageSchema())
-    def get(self, **kwargs):
+class ScheduleAByStateCandidateTotalsView(ApiResource):
+    schema = schemas.ScheduleAByStateCandidateSchema
+    page_schema = schemas.ScheduleAByStateCandidatePageSchema()
+    sort_option = [
+            'total',
+            'count',
+    ]
+
+    @property
+    def args(self):
+        return utils.extend(
+            args.paging,
+            args.schedule_a_candidate_aggregate,
+            args.make_multi_sort_args(default=["total", ], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
+        )
+
+    def build_query(self, **kwargs):
         _, query = candidate_aggregate(
             ScheduleAByState,
             [
@@ -126,32 +200,11 @@ class ScheduleAByStateCandidateTotalsView(utils.Resource):
             q.c.cycle,
         ).group_by(q.c.candidate_id, q.c.cycle)
 
-        return utils.fetch_page(query, kwargs, cap=0)
+        return query
 
 
-@doc(
-    tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
-)
-class ScheduleAByStateCandidateView(utils.Resource):
-    @use_kwargs(args.paging)
-    @use_kwargs(args.make_sort_args())
-    @use_kwargs(args.schedule_a_candidate_aggregate)
-    @marshal_with(schemas.ScheduleAByStateCandidatePageSchema())
-    def get(self, **kwargs):
-        _, query = candidate_aggregate(
-            ScheduleAByState,
-            [
-                ScheduleAByState.state,
-                sa.func.sum(ScheduleAByState.total).label('total'),
-                sa.func.max(ScheduleAByState.state_full).label('state_full'),
-                sa.func.sum(ScheduleAByState.count).label('count'),
-            ],
-            [ScheduleAByState.state],
-            kwargs,
-        )
-        return utils.fetch_page(query, kwargs, cap=0)
-
-
+# used for '/candidates/totals/'
+# Ex: http://127.0.0.1:5000/v1/candidates/totals/?sort=-election_year&election_full=true
 @doc(
     tags=['candidate'], description=docs.TOTAL_CANDIDATE_TAG,
 )
@@ -265,6 +318,15 @@ class TotalsCandidateView(ApiResource):
     tags=["candidate"], description=docs.CANDIDATE_TOTAL_AGGREGATE_TAG,
 )
 class CandidateTotalAggregateView(ApiResource):
+    sort_options = [
+        'election_year',
+        'office',
+        'state',
+        'state_full',
+        'party',
+        'district',
+    ]
+
     schema = schemas.CandidateTotalAggregateSchema
     page_schema = schemas.CandidateTotalAggregatePageSchema
 
@@ -273,11 +335,14 @@ class CandidateTotalAggregateView(ApiResource):
         return utils.extend(
             args.paging,
             args.candidate_total_aggregate,
-            args.make_multi_sort_args(default=["-election_year", ]),
+            args.make_multi_sort_args(default=["-election_year", ], validator=args.SortMultiOptionValidator(
+                self.sort_options),
+            ),
         )
 
     def build_query(self, **kwargs):
         total = models.CandidateTotal
+
         query = db.session.query(
             total.election_year.label("election_year"),
             sa.func.sum(total.receipts).label(

--- a/webservices/resources/spending_by_others.py
+++ b/webservices/resources/spending_by_others.py
@@ -45,6 +45,8 @@ def get_candidate_list(kwargs):
     return cycle_column, candidate
 
 
+# used for '/electioneering/totals/by_candidate/'
+# Ex:http://127.0.0.1:5000/v1/electioneering/totals/by_candidate/?sort=-cycle&election_full=true
 @doc(
     tags=['electioneering'], description=docs.ELECTIONEERING_TOTAL_BY_CANDIDATE,
 )
@@ -52,11 +54,20 @@ class ECTotalsByCandidateView(ApiResource):
 
     schema = schemas.ECTotalsByCandidateSchema
     page_schema = schemas.ECTotalsByCandidatePageSchema
+    sort_option = [
+            'cycle',
+            'candidate_id',
+            'total',
+    ]
 
     @property
     def args(self):
         return utils.extend(
-            args.paging, args.totals_by_candidate_other_costs_EC, args.make_sort_args(),
+            args.paging,
+            args.totals_by_candidate_other_costs_EC,
+            args.make_multi_sort_args(default=["-cycle", "candidate_id"], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
         )
 
     def build_query(self, **kwargs):
@@ -79,12 +90,15 @@ class ECTotalsByCandidateView(ApiResource):
             .filter(
                 (cycle_column.in_(kwargs['cycle']) if kwargs.get('cycle') else True)
             )
-            .group_by(ElectioneeringByCandidate.candidate_id, cycle_column,)
+            .group_by(ElectioneeringByCandidate.candidate_id, cycle_column,)   
         )
 
         return query
 
 
+# used for '/schedules/schedule_e/totals/by_candidate/'
+# Ex: http://127.0.0.1:5000/v1/schedules/schedule_e/totals/by_candidate/?sort=-cycle&sort=candidate_id
+# &election_full=true
 @doc(
     tags=['independent expenditures'],
     description=docs.SCHEDULE_E_INDEPENDENT_EXPENDITURES_TOTALS_BY_CANDIDATE,
@@ -94,12 +108,21 @@ class IETotalsByCandidateView(ApiResource):
     schema = schemas.IETotalsByCandidateSchema
     page_schema = schemas.IETotalsByCandidatePageSchema
 
+    sort_option = [
+            'cycle',
+            'candidate_id',
+            'total',
+            'support_oppose_indicator',
+    ]
+
     @property
     def args(self):
         return utils.extend(
             args.paging,
             args.schedule_e_totals_by_candidate_other_costs_IE,
-            args.make_sort_args(),
+            args.make_multi_sort_args(default=["-cycle", "candidate_id"], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
         )
 
     def build_query(self, **kwargs):
@@ -127,16 +150,15 @@ class IETotalsByCandidateView(ApiResource):
                 cycle_column,
                 ScheduleEByCandidate.support_oppose_indicator,
             )
-            .order_by(
-                ScheduleEByCandidate.candidate_id,
-                cycle_column,
-                ScheduleEByCandidate.support_oppose_indicator,
-            )
+
         )
 
         return query
 
 
+# used for '/communication_costs/totals/by_candidate/'
+# Ex: http://127.0.0.1:5000/v1/communication_costs/totals/by_candidate/?sort=-cycle&sort=candidate_id
+# &election_full=true
 @doc(
     tags=['communication cost'],
     description=docs.COMMUNICATIONS_COSTS_TOTALS_BY_CANDIDATE,
@@ -146,10 +168,21 @@ class CCTotalsByCandidateView(ApiResource):
     schema = schemas.CCTotalsByCandidateSchema
     page_schema = schemas.CCTotalsByCandidatePageSchema
 
+    sort_option = [
+            'cycle',
+            'candidate_id',
+            'total',
+            'support_oppose_indicator',
+    ]
+
     @property
     def args(self):
         return utils.extend(
-            args.paging, args.totals_by_candidate_other_costs_CC, args.make_sort_args(),
+            args.paging,
+            args.totals_by_candidate_other_costs_CC,
+            args.make_multi_sort_args(default=["-cycle", "candidate_id"], validator=args.SortMultiOptionValidator(
+                self.sort_option),
+            ),
         )
 
     def build_query(self, **kwargs):
@@ -178,11 +211,7 @@ class CCTotalsByCandidateView(ApiResource):
                 cycle_column,
                 CommunicationCostByCandidate.support_oppose_indicator,
             )
-            .order_by(
-                CommunicationCostByCandidate.candidate_id,
-                cycle_column,
-                CommunicationCostByCandidate.support_oppose_indicator,
-            )
+
         )
 
         return query


### PR DESCRIPTION
## Summary (required)
After this PR, when pass Invalid sort options, api will return 422, not 500 error code.
- Resolves #5588 
- #5626

### Required reviewers

1 dev

Completion criteria
- [x] Add sort option validation, when pass Invalid sort options, api will return 422, not 500 error code.
- [x] Add auto test
- [x] Update endpoint note on [google drive](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=408125426)

## Impacted areas of the application

General components of the application that this PR will affect:
/v1/candidates/totals/aggregates/
/v1/schedules/schedule_a/by_size/by_candidate/
/v1/schedules/schedule_a/by_state/by_candidate/
/v1/schedules/schedule_a/by_state/by_candidate/totals/
/v1/schedules/schedule_e/totals/by_candidate/
/v1/communication_costs/totals/by_candidate/
/v1/electioneering/totals/by_candidate/

<img width="550" alt="sort" src="https://github.com/fecgov/openFEC/assets/24395751/ff3137d7-b485-4971-a3b0-261fcc3bcf86">


## How to test
1) checkout branch
2) pytest
3) test urls, compare with prod api and make sure not return 500 error instead 422 error.

**[receipts](https://api.open.fec.gov/developers/#/receipts)**
**/v1/schedules/schedule_a/by_size/by_candidate/**
https://api.open.fec.gov/v1/schedules/schedule_a/by_size/by_candidate/?&sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?&sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true

**/v1/schedules/schedule_a/by_state/by_candidate/**
https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/?sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true

**/v1/schedules/schedule_a/by_state/by_candidate/totals/**
https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=test&candidate_id=H8CA05035&cycle=2022&election_full=true


**[independent expenditures](https://api.open.fec.gov/developers/#/independent%20expenditures)**
**/v1/schedules/schedule_e/totals/by_candidate/**
https://api.open.fec.gov/v1/schedules/schedule_e/totals/by_candidate/?election_full=true&sort=test&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_e/totals/by_candidate/?election_full=true&sort=test


**[communication cost](https://api.open.fec.gov/developers/#/communication%20cost)**
**/v1/communication_costs/totals/by_candidate/**
https://api.open.fec.gov/v1/communication_costs/totals/by_candidate/?election_full=true&sort=test&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/communication_costs/totals/by_candidate/?election_full=true&sort=test


**[electioneering](https://api.open.fec.gov/developers/#/electioneering)**
**/v1/electioneering/totals/by_candidate/**
https://api.open.fec.gov/v1/electioneering/totals/by_candidate/?election_full=true&sort=test&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/electioneering/totals/by_candidate/?election_full=true&sort=test


**[candidate](https://api.open.fec.gov/developers/#/candidate)**
**/v1/candidates/totals/aggregates/**
https://api.open.fec.gov/v1/candidates/totals/aggregates/?aggregate_by=office-state-district&sort=test&election_full=true&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/candidates/totals/aggregates/?aggregate_by=office-state-district&sort=test&election_full=true


test '/candidate/totals/' sort by candidate_id
http://127.0.0.1:5000/v1/candidates/totals/?cycle=2020&election_full=true&sort=candidate_id

