### PR TITLE
Create celery task to delete snapshots 

### DIFF
--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -830,7 +830,8 @@ def create_es_snapshot(index_name):
             body=body,
             wait_for_completion=True,
         )
-        if result.get("accepted"):
+        result = result.get("snapshot")
+        if result.get("state") == 'SUCCESS':
             logger.info(" The snapshot: {0} is created successfully.".format(snapshot_name))
         else:
             logger.error(" Unable to create snapshot: {0}".format(snapshot_name))

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -828,6 +828,7 @@ def create_es_snapshot(index_name):
             repository=repo_name,
             snapshot=snapshot_name,
             body=body,
+            wait_for_completion=True,
         )
         if result.get("accepted"):
             logger.info(" The snapshot: {0} is created successfully.".format(snapshot_name))
@@ -1033,6 +1034,8 @@ def display_snapshot_detail(repo_name=None, snapshot_name=None):
         snapshot=snapshot_name
     )
     logger.info(" Snapshot details =" + json.dumps(result, indent=3, cls=DateTimeEncoder))
+
+    return result
 
 # =========== end snapshot management =============
 

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -59,6 +59,13 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.refresh_db.refresh_materialized_views",
             "schedule": crontab(minute=0, hour=9),
         },
+        # Task 7: This task is launched at 1am(EST) on the first day of the
+        # month
+        # Deletes snapshots older than 30 days
+        "delete_elasticsearch_backups_monthly": {
+            "task": "webservices.tasks.legal_docs.delete_es_backup_monthly",
+            "schedule": crontab(minute=0, hour=5, day_of_month=1),
+        },
     }
 
 

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -238,7 +238,7 @@ def delete_es_backup_monthly():
                     logger.info("deleting snapshot: '{0}'".format(id))
                     time.sleep(30)
             logger.info(" Monthly (%s) elasticsearch snapshot deletion completed", datetime.date.today().strftime("%A"))
-            slack_message = "Monthly elasticsearch deletion completed in {0} space in repoistory: ({1})".format(
+            slack_message = "Monthly elasticsearch deletion completed in {0} space in repository: ({1})".format(
                 get_app_name(), repo_name)
             utils.post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:


### PR DESCRIPTION
## Summary (required)

- Resolves #5610 

This ticket fixes two issues we are having with our snapshots. 

The first issue is that we have to manually delete old snapshots. This ticket creates a celery task to automatically delete any snapshots older than 30 days.

The second issue we're having is that two snapshots cannot be created at the same time. To fix this I set `wait_for_completion` to true when creating a snapshot. This makes the request wait until the operation has completed before returning. [Here](https://elasticsearch-py.readthedocs.io/en/7.6.0/api.html#snapshot) is the documentation on that.

### Required reviewers 2-3 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  celery tasks 

## How to test - deploy test branch to dev

1. checkout this branch or you can refer to my [test branch ](https://github.com/fecgov/openFEC/commit/5e189f15f9d263af5b097fdea198f6b7a7927c8d)
2. Make the following changes: 
    - in webservices/tasks/legal_docs.py line 237 comment out the `delete_snapshot(repo_name, id)` call. 
    - in webservices/tasks/legal_docs.py line 243 and 247 change `SLACK_BOTS` to `'#test-bot'`
    - in webservices/tasks/__init__.py change the schedule (line 67)  for `delete_elasticsearch_backups_monthly` to every 30 or 15 mins  `"schedule": crontab(minute='*/30')`,
    - in tasks.py line 146 change dev branch to your test branch. 
3. Login to cf in terminal `cf login -a api.fr.cloud.gov  --sso`
4. Create a backup to ensure snapshot creation still works `cf run-task api --command "python cli.py create_es_snapshot case_index" -m 2G --name create_snapshot_case`
    - You can delete this snapshot after by following our ElasticSearch management [guide](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-management-instruction)
5. Get list of all current snapshots by running the following commands:
`cf run-task api --command "python cli.py display_snapshots case_repo" -m 2G --name display_snapshots_case`
`cf run-task api --command "python cli.py display_snapshots ao_repo" -m 2G --name display_snapshot_ao`
6. Wait for celery task to start. If it's every 30 mins it will start at the beginning or middle of the hour i.e 3:00 and 3:30. 
7. Once task has started, watch the log for `deleting snapshot: <snapshot_name>`. It's easy to find them in kibana by searching for 'deleting snapshot' in the last 15 mins. [Kibana link](https://logs.fr.cloud.gov/app/dashboards#/view/App-Overview?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(description:'',filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:query,negate:!f,type:query_string,value:'*'),query:(query_string:(analyze_wildcard:!t,query:'*')))),fullScreenMode:!f,options:(darkTheme:!f),query:(language:kuery,query:'%22deleting%20snapshot%22'),timeRestore:!f,title:'App%20-%20Overview',viewMode:view)). 
8. Check for a success message in the `#test-bot ` channel on slack. 
9. Check the date of the deleted snapshots to ensure that it is correctly identifying snapshots to delete. 
10. Check the list of snapshots from step 5 to ensure no snapshots were missed 

Example Kibana output: 
![image](https://github.com/fecgov/openFEC/assets/121631201/138edaa2-af2d-492d-9ca6-6abaf5d3ec07)


