### PR TITLE
[DONT MERGE UNTIL AFTER 11/8] 5609 Add form_line_number hybrid property, add tests

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -320,9 +320,16 @@ class TestScheduleA(ApiBaseTest):
             factories.ScheduleAFactory(line_number='15', filing_form='F3X'),
             factories.ScheduleAFactory(line_number='15', filing_form='F3X'),
         ]
+
         results = self._results(
             api.url_for(ScheduleAView, form_line_number='f3x-11AI', **self.kwargs)
         )
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleAView, line_number='f3x-11AI', **self.kwargs)
+        )
+
         self.assertEqual(len(results), 1)
         results = self._results(
             api.url_for(ScheduleAView, form_line_number=('f3x-11AI', 'f3X-12'), **self.kwargs)
@@ -997,6 +1004,12 @@ class TestScheduleB(ApiBaseTest):
         )
         self.assertEqual(len(results), 1)
 
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleBView, form_line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
         results = self._results(
             api.url_for(ScheduleBView, form_line_number=('f3x-23', 'f3X-17'), **self.kwargs)
         )
@@ -1516,6 +1529,12 @@ class TestScheduleH4(ApiBaseTest):
         ]
         results = self._results(
             api.url_for(ScheduleH4View, form_line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleH4View, line_number='f3x-23', **self.kwargs)
         )
         self.assertEqual(len(results), 1)
 

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -313,39 +313,34 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['contributor_name'], 'George Soros')
 
-    def test_schedule_a_filter_line_number(self):
+    def test_schedule_a_filter_form_line_number(self):
         [
-            factories.ScheduleAFactory(line_number='16', filing_form='F3X'),
-            factories.ScheduleAFactory(line_number='17', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number='12', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number='11AI', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number='15', filing_form='F3X'),
+            factories.ScheduleAFactory(line_number='15', filing_form='F3X'),
         ]
         results = self._results(
-            api.url_for(ScheduleAView, line_number='f3X-16', **self.kwargs)
+            api.url_for(ScheduleAView, form_line_number='f3x-11AI', **self.kwargs)
         )
         self.assertEqual(len(results), 1)
-
-        [
-            factories.ScheduleBFactory(line_number='21', filing_form='F3X'),
-            factories.ScheduleBFactory(line_number='22', filing_form='F3X'),
-        ]
-
         results = self._results(
-            api.url_for(ScheduleBView, line_number='f3X-21', **self.kwargs)
+            api.url_for(ScheduleAView, form_line_number=('f3x-11AI', 'f3X-12'), **self.kwargs)
         )
-        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results), 2)
 
-        # invalid line_number testing for sched_b
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleAView, form_line_number='-F3x-12', **self.kwargs)
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_a
         response = self.app.get(
-            api.url_for(ScheduleBView, line_number='f3x21', **self.kwargs)
+            api.url_for(ScheduleAView, form_line_number='f3x16', **self.kwargs)
         )
         self.assertEqual(response.status_code, 400)
-        self.assertIn(b'Invalid line_number', response.data)
-
-        # invalid line_number testing for sched_a
-        response = self.app.get(
-            api.url_for(ScheduleAView, line_number='f3x16', **self.kwargs)
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(b'Invalid line_number', response.data)
+        self.assertIn(b'Invalid form_line_number', response.data)
 
     def test_schedule_a_filter_fulltext_employer(self):
         employers = ['Acme Corporation', 'Vandelay Industries']
@@ -990,6 +985,36 @@ class TestScheduleB(ApiBaseTest):
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
+    def test_schedule_b_filter_form_line_number(self):
+        [
+            factories.ScheduleBFactory(line_number='23', filing_form='F3X'),
+            factories.ScheduleBFactory(line_number='17', filing_form='F3X'),
+            factories.ScheduleBFactory(line_number='22', filing_form='F3'),
+            factories.ScheduleBFactory(line_number='22', filing_form='F3P'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleBView, form_line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleBView, form_line_number=('f3x-23', 'f3X-17'), **self.kwargs)
+        )
+        self.assertEqual(len(results), 2)
+
+        # test searching for NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleBView, form_line_number='-f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_b
+        response = self.app.get(
+            api.url_for(ScheduleBView, form_line_number='f3x21', **self.kwargs)
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 # Test endpoints:
 # /schedules/schedule_e/ (sched_e.ScheduleEView)
@@ -1481,3 +1506,33 @@ class TestScheduleH4(ApiBaseTest):
             )
             assert len(results) == 1
             assert results[0][column.key] == values[0]
+
+    def test_schedule_h4_filter_form_line_number(self):
+        [
+            factories.ScheduleH4Factory(line_number='23', filing_form='F3X'),
+            factories.ScheduleH4Factory(line_number='17', filing_form='F3X'),
+            factories.ScheduleH4Factory(line_number='22', filing_form='F3'),
+            factories.ScheduleH4Factory(line_number='22', filing_form='F3P'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number=('f3x-23', 'f3X-17'), **self.kwargs)
+        )
+        self.assertEqual(len(results), 2)
+
+        # test searching for NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number='-f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_h4
+        response = self.app.get(
+            api.url_for(ScheduleH4View, form_line_number='f3x21', **self.kwargs)
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -201,6 +201,35 @@ class TestScheduleCView(ApiBaseTest):
         )
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
+    def test_schedule_c_filter_form_line_number(self):
+        [
+            factories.ScheduleCFactory(line_number='9', filing_form='F3X'),
+            factories.ScheduleCFactory(line_number='10', filing_form='F3X'),
+            factories.ScheduleCFactory(line_number='9', filing_form='F3'),
+            factories.ScheduleCFactory(line_number='9', filing_form='F3'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number=('f3x-9', 'f3X-10'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number='-F3x-10')
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_c
+        response = self.app.get(
+            api.url_for(ScheduleCView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 class TestScheduleCViewBySubId(ApiBaseTest):
     def test_fields(self):

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -212,6 +212,13 @@ class TestScheduleCView(ApiBaseTest):
             api.url_for(ScheduleCView, form_line_number='f3X-9')
         )
         self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleCView, line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
         results = self._results(
             api.url_for(ScheduleCView, form_line_number=('f3x-9', 'f3X-10'))
         )

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -189,6 +189,35 @@ class TestScheduleDView(ApiBaseTest):
         self.assertEqual(results[0]['sub_id'], '2')
         self.assertEqual(results[1]['sub_id'], '1')
 
+    def test_schedule_d_filter_form_line_number(self):
+        [
+            factories.ScheduleDViewFactory(line_number='9', filing_form='F3X'),
+            factories.ScheduleDViewFactory(line_number='10', filing_form='F3X'),
+            factories.ScheduleDViewFactory(line_number='12', filing_form='F3'),
+            factories.ScheduleDViewFactory(line_number='9', filing_form='F3'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number=('f3x-9', 'f3X-10'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number='-F3x-10')
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_d
+        response = self.app.get(
+            api.url_for(ScheduleDView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 class TestScheduleDViewBySubId(ApiBaseTest):
     def test_sub_id_field(self):

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -200,6 +200,13 @@ class TestScheduleDView(ApiBaseTest):
             api.url_for(ScheduleDView, form_line_number='f3X-9')
         )
         self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleDView, line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
         results = self._results(
             api.url_for(ScheduleDView, form_line_number=('f3x-9', 'f3X-10'))
         )

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -297,10 +297,18 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             factories.ScheduleEFactory(line_number='24', filing_form='F3'),
             factories.ScheduleEFactory(line_number='25', filing_form='F3'),
         ]
+
         results = self._results(
             api.url_for(ScheduleEView, form_line_number='f3X-24')
         )
         self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleEView, line_number='f3X-24')
+        )
+        self.assertEqual(len(results), 1)
+
         results = self._results(
             api.url_for(ScheduleEView, form_line_number=('f3x-24', 'f3X-25'))
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -564,7 +564,8 @@ itemized = {
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': Date(description='Minimum date'),
     'max_date': Date(description='Maximum date'),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number TBR
 }
 
 schedule_a = {
@@ -744,7 +745,7 @@ schedule_c = {
     'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_amount': Currency(description=docs.MIN_FILTER),
     'max_amount': Currency(description=docs.MAX_FILTER),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
     'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
     'candidate_name': fields.List(Keyword, description=docs.CANDIDATE_NAME),
     'loan_source_name': fields.List(Keyword, description=docs.LOAN_SOURCE),
@@ -752,6 +753,7 @@ schedule_c = {
     'max_payment_to_date': fields.Int(description=docs.MAX_PAYMENT_DATE),
     'min_incurred_date': Date(missing=None, description=docs.MIN_INCURRED_DATE),
     'max_incurred_date': Date(missing=None, description=docs.MAX_INCURRED_DATE),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number TBR
 }
 
 schedule_d = {
@@ -775,9 +777,10 @@ schedule_d = {
     'max_coverage_start_date': Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'filing_form': fields.List(fields.Str, description=docs.FORM_TYPE),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number TBR
 }
 
 schedule_e_by_candidate = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -25,6 +25,11 @@ class BaseItemized(db.Model):
     def memoed_subtotal(self):
         return self.memo_code == 'X'
 
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
+
 
 class BaseRawItemized(db.Model):
     __abstract__ = True

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1813,11 +1813,15 @@ also incorporate any changes made by committees, if any report covering the peri
 '''
 EFILE_REPORTS += WIP_TAG
 
-LINE_NUMBER = '''
-`DEPRECATED This filter will be renamed to form_line_number`
+FORM_LINE_NUMBER = '''
 Filter for form and line number using the following format:
 `FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter
 down to all entries from form `F3X` line number `16`.
+'''
+
+# Added to ease transition to FORM_LINE_NUMBER, to be removed
+LINE_NUMBER = ''' `OBSOLETE`
+Please use form_line_number
 '''
 
 IMAGE_NUMBER = '''

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,7 +1,10 @@
 
-LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is using the following format:
-'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries
+FORM_LINE_NUMBER_ERROR = """Invalid form_line_number detected. A valid form_line_number is using the following format: \
+'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries \
 from form F3X line number 16.\
+"""
+
+LINE_NUMBER_ERROR = """LINE_NUMBER is obsolete. Please use form_line_number\
 """
 
 IMAGE_NUMBER_ERROR = """Invalid image_number detected. A valid image_number is numeric only.\

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -139,11 +139,17 @@ class ScheduleAView(ItemizedResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -52,6 +52,7 @@ class ScheduleAView(ItemizedResource):
             models.ScheduleA.recipient_committee_designation,
         ),
         ('two_year_transaction_period', models.ScheduleA.two_year_transaction_period),
+        ('form_line_number', models.ScheduleA.form_line_number),
     ]
     filter_match_fields = [
         ('is_individual', models.ScheduleA.is_individual),
@@ -130,16 +131,19 @@ class ScheduleAView(ItemizedResource):
             )
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line_number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR, status_code=400,
-                )
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -46,6 +46,7 @@ class ScheduleBView(ItemizedResource):
         ('spender_committee_designation', models.ScheduleB.spender_committee_designation),
         ('two_year_transaction_period',
          models.ScheduleB.two_year_transaction_period),
+        ('form_line_number', models.ScheduleB.form_line_number),
     ]
     filter_fulltext_fields = [
         ('recipient_name', models.ScheduleB.recipient_name_text),
@@ -85,17 +86,19 @@ class ScheduleBView(ItemizedResource):
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -94,11 +94,17 @@ class ScheduleBView(ItemizedResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -51,11 +51,17 @@ class ScheduleCView(ApiResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
     @property

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -2,6 +2,7 @@
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -25,6 +26,7 @@ class ScheduleCView(ApiResource):
     filter_multi_fields = [
         ('image_number', models.ScheduleC.image_number),
         ('committee_id', models.ScheduleC.committee_id),
+        ('form_line_number', models.ScheduleC.form_line_number),
     ]
 
     filter_fulltext_fields = [
@@ -38,6 +40,23 @@ class ScheduleCView(ApiResource):
         (('min_image_number', 'max_image_number'), models.ScheduleC.image_number),
         (('min_payment_to_date', 'max_payment_to_date'), models.ScheduleC.payment_to_date),
     ]
+
+    def build_query(self, **kwargs):
+        query = super().build_query(**kwargs)
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
+        return query
 
     @property
     def args(self):

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -29,7 +29,8 @@ class ScheduleDView(ApiResource):
         ('report_year', models.ScheduleD.report_year),
         ('report_type', models.ScheduleD.report_type),
         ('filing_form', models.ScheduleD.filing_form),
-        ('committee_type', models.ScheduleD.committee_type)
+        ('committee_type', models.ScheduleD.committee_type),
+        ('form_line_number', models.ScheduleD.form_line_number),
     ]
 
     filter_range_fields = [
@@ -69,17 +70,19 @@ class ScheduleDView(ApiResource):
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -78,11 +78,17 @@ class ScheduleDView(ApiResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -120,11 +120,17 @@ class ScheduleEView(ItemizedResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager
@@ -46,6 +47,7 @@ class ScheduleEView(ItemizedResource):
         ('candidate_office_state', models.ScheduleE.candidate_office_state),
         ('candidate_office_district', models.ScheduleE.candidate_office_district),
         ('candidate_party', models.ScheduleE.candidate_party),
+        ('form_line_number', models.ScheduleE.form_line_number),
     ]
     filter_fulltext_fields = [
         ('payee_name', models.ScheduleE.payee_name_text),
@@ -110,6 +112,19 @@ class ScheduleEView(ItemizedResource):
         if 'most_recent' in kwargs:
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -2,6 +2,7 @@ from flask_apispec import doc
 
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -27,6 +28,7 @@ class ScheduleFView(ApiResource):
         ('committee_id', models.ScheduleF.committee_id),
         ('candidate_id', models.ScheduleF.candidate_id),
         ('cycle', models.ScheduleF.election_cycle),
+        ('form_line_number', models.ScheduleF.form_line_number),
     ]
 
     filter_range_fields = [
@@ -54,6 +56,19 @@ class ScheduleFView(ApiResource):
         query = super().build_query(**kwargs)
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -64,11 +64,17 @@ class ScheduleFView(ApiResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -50,6 +50,7 @@ class ScheduleH4View(ItemizedResource):
         ('administrative_activity_indicator', models.ScheduleH4.administrative_activity_indicator),
         ('general_voter_drive_activity_indicator', models.ScheduleH4.general_voter_drive_activity_indicator),
         ('public_comm_indicator', models.ScheduleH4.public_comm_indicator),
+        ('form_line_number', models.ScheduleH4.form_line_number),
     ]
 
     filter_range_fields = [
@@ -87,17 +88,19 @@ class ScheduleH4View(ItemizedResource):
         query = query.options(sa.orm.joinedload(models.ScheduleH4.committee))
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
+        if 'form_line_number' in kwargs:
+            for each in kwargs['form_line_number']:
+                if each.startswith('-'):
+                    each = each[1:]
+                if len(each.split('-')) != 2:
+                    raise exceptions.ApiError(
+                        exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                    )
+        # added to help with transition to the new form_line_number, to be removed
+        if 'line_number' in kwargs:
+            raise exceptions.ApiError(
+                exceptions.LINE_NUMBER_ERROR, status_code=400
+            )
         return query
 
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -96,11 +96,17 @@ class ScheduleH4View(ItemizedResource):
                     raise exceptions.ApiError(
                         exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                     )
-        # added to help with transition to the new form_line_number, to be removed
+        # added for transition to form_line_number, to be replaced w/obsolete error
         if 'line_number' in kwargs:
-            raise exceptions.ApiError(
-                exceptions.LINE_NUMBER_ERROR, status_code=400
-            )
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1003,7 +1003,8 @@ ScheduleASchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'report_year': ma.fields.Int()
+        'report_year': ma.fields.Int(),
+        'form_line_number': ma.fields.Str(),
     },
     options={
          'exclude': (
@@ -1032,6 +1033,7 @@ ScheduleCSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('loan_source_name_text', 'candidate_name_text',)}
     )
@@ -1100,6 +1102,7 @@ ScheduleDSchema = make_schema(
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('creditor_debtor_name_text',)}
 )
@@ -1114,6 +1117,7 @@ ScheduleFSchema = make_schema(
         'subordinate_committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('payee_name_text',)}
     )
@@ -1136,7 +1140,8 @@ ScheduleBSchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'disbursement_amount': ma.fields.Float()
+        'disbursement_amount': ma.fields.Float(),
+        'form_line_number': ma.fields.Str(),
     },
     options={
         'exclude': (
@@ -1171,6 +1176,7 @@ ScheduleH4Schema = make_schema(
         'federal_share': ma.fields.Float(),
         'nonfederal_share': ma.fields.Float(),
         'event_amount_year_to_date': ma.fields.Float(),
+        'form_line_number': ma.fields.Str(),
 
     },
     options={
@@ -1202,6 +1208,7 @@ ScheduleESchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={
         'exclude': (


### PR DESCRIPTION
## Summary 

- Resolves #5609 

This PR will allow line_number to support multiple user inputs. This will fix the current bug on the receipts, disbursements,  and debts tables where multiple line number filters can't be selected. To fix this issue I needed to add form_line_number as a hybrid_property as it is a composite field of filing_form and line_number_short (which used to be just line_number as well, which was confusing.) This required a deprecation notice (sent Oct 18th) as the filter will change from line_number to form_line_number. I kept the line_number logic to allow a grace period for our users. I will be removing the line_number logic in a follow-up ticket.

During the research for this ticket, I discovered that line_number is not currently working for E and F endpoints and all efiling endpoints. This PR fixes E & F, but the broken efiling endpoints will be done in follow-up.  The CMS PR here should be released with this PR. 

CHANGES
- [ ] adds filter form_line_number, which allows multiple inputs
- [ ] fixes NOT functionality for form_line_number 
- [ ] fixes newlines (\n)  showing up in the invalid form_line_number error message
- [ ] adds tests for each endpoint (except F) that checks multiple inputs, lowercase letters, invalid strings, and tests the old filter
- [ ] fixes functionality of filter for E & F endpoints
- [ ] keeps the old line_number functionality (will be removed)
- [ ] removes deprecation notice, adds obsolete to line_number


### Required reviewers
2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Schedule A, B, C, D, E, F, and H4 endpoint form_line_number filter


## Related PRs

https://github.com/fecgov/fec-cms/pull/5971

## How to test

- flask run
- http://127.0.0.1:5000/v1/schedules/schedule_a/?&form_line_number=F3x-15&form_line_number=F9-F92&two_year_transaction_period=2016&per_page=20&sort=-contribution_receipt_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_b/?form_line_number=F3X-23&form_line_number=F3P-23&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3-10&form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_d/?form_line_number=F3P-12&form_line_number=F3-10&page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- http://127.0.0.1:5000/v1/schedules/schedule_h4/?form_line_number=F3X-21A&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_e/?form_line_number=F3x-24&per_page=20&sort=-expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
- http://127.0.0.1:5000/v1/schedules/schedule_f/?form_line_number=F3X-25&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
-INVALID LINE NUMBER  http://127.0.0.1:5000/v1/schedules/schedule_h4/?form_line_number=string&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false

Deploy to dev/stage and test the front-end PR, add different line_numbers on the receipts and disbursements data tables. 
https://dev.fec.gov/data/receipts/?data_type=processed&two_year_transaction_period=2024&min_date=01%2F01%2F2023&max_date=12%2F31%2F2024&line_number=F3P-17A&line_number=F3P-20A
https://dev.fec.gov/data/disbursements/?data_type=processed&two_year_transaction_period=2024&min_date=01%2F01%2F2023&max_date=12%2F31%2F2024&line_number=F3-17&line_number=F3-20A&line_number=F3-21



![Screen Shot 2023-10-17 at 10 02 03 AM](https://github.com/fecgov/openFEC/assets/66386084/1a073fd7-ab9c-437f-a8f1-e35987fb94f1)

