### PR TITLE
Add committee_id validation

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -86,7 +86,7 @@ class CandidateFlagsFactory(BaseFactory):
 
 
 class BaseCommitteeFactory(BaseFactory):
-    committee_id = factory.Sequence(lambda n: "ID{0}".format(n))
+    committee_id = factory.Sequence(lambda n: "C{0}".format(n + 10000000))
 
 
 class CommitteeFactory(BaseCommitteeFactory):

--- a/tests/integration/test_amendment_chain.py
+++ b/tests/integration/test_amendment_chain.py
@@ -14,7 +14,7 @@ from webservices.resources.filings import FilingsView, FilingsList
 class TestAmendmentChain(BaseTestCase):
 
     STOCK_FIRST_F1 = {
-        'committee_id': 'C006',
+        'committee_id': 'C00000006',
         'report_year': 2018,
         'amendment_indicator': 'N',
         'receipt_date': datetime.date(2018, 1, 31),
@@ -28,7 +28,7 @@ class TestAmendmentChain(BaseTestCase):
         'begin_image_num': '20180131001',
     }
     STOCK_SECOND_F1 = {
-        'committee_id': 'C006',
+        'committee_id': 'C00000006',
         'report_year': 2018,
         'amendment_indicator': 'A',
         'receipt_date': datetime.date(2018, 2, 28),
@@ -138,7 +138,7 @@ class TestAmendmentChain(BaseTestCase):
 
     def test_multiple_form_3s(self):
         form_3_q2_new = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'N',
             'receipt_date': datetime.date(2018, 7, 15),
@@ -152,7 +152,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20180715001',
         }
         form_3_q2_amend_1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'A',
             'receipt_date': datetime.date(2018, 8, 15),
@@ -166,7 +166,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20180815001',
         }
         form_3_q3_new = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'N',
             'receipt_date': datetime.date(2018, 10, 15),
@@ -180,7 +180,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20181015001',
         }
         form_3_q3_amend_1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'A',
             'receipt_date': datetime.date(2018, 11, 15),
@@ -194,7 +194,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20181115001',
         }
         form_3_q2_amend_2 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'A',
             'receipt_date': datetime.date(2018, 12, 15),
@@ -247,7 +247,7 @@ class TestAmendmentChain(BaseTestCase):
 
     def test_multiple_form_1s(self):
         first_f1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'N',
             'receipt_date': datetime.date(2018, 1, 31),
@@ -261,7 +261,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20180131004',
         }
         second_f1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'A',
             'receipt_date': datetime.date(2018, 2, 28),
@@ -275,7 +275,7 @@ class TestAmendmentChain(BaseTestCase):
             'begin_image_num': '20180228001',
         }
         third_f1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'A',
             'receipt_date': datetime.date(2018, 3, 28),
@@ -316,7 +316,7 @@ class TestAmendmentChain(BaseTestCase):
     def test_negative_filing_chain(self):
         # Make sure no negative numbers appear in amendment chain
         negative_f1 = {
-            'committee_id': 'C006',
+            'committee_id': 'C00000006',
             'report_year': 2018,
             'amendment_indicator': 'N',
             'receipt_date': datetime.date(2018, 1, 31),

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -35,7 +35,7 @@ class TotalTestCase(common.BaseTestCase):
     STOCK_CMTE_VALID_FEC_YR = [
         {
             'valid_fec_yr_id': 1,
-            'cmte_id': 'C001',
+            'cmte_id': 'C00000001',
             'fec_election_yr': 2020,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -43,7 +43,7 @@ class TotalTestCase(common.BaseTestCase):
         },
         {
             'valid_fec_yr_id': 2,
-            'cmte_id': 'C002',
+            'cmte_id': 'C00000002',
             'fec_election_yr': 2020,
             'cmte_tp': 'P',
             'cmte_dsgn': 'A',
@@ -51,7 +51,7 @@ class TotalTestCase(common.BaseTestCase):
         },
         {
             'valid_fec_yr_id': 3,
-            'cmte_id': 'C003',
+            'cmte_id': 'C00000003',
             'fec_election_yr': 2020,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -65,7 +65,7 @@ class TotalTestCase(common.BaseTestCase):
             'cand_id': 'P01',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
-            'cmte_id': 'C001',
+            'cmte_id': 'C00000001',
             'cmte_count_cand_yr': 1,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -77,7 +77,7 @@ class TotalTestCase(common.BaseTestCase):
             'cand_id': 'P01',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
-            'cmte_id': 'C002',
+            'cmte_id': 'C00000002',
             'cmte_count_cand_yr': 1,
             'cmte_tp': 'P',
             'cmte_dsgn': 'A',
@@ -89,7 +89,7 @@ class TotalTestCase(common.BaseTestCase):
             'cand_id': 'P03',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
-            'cmte_id': 'C003',
+            'cmte_id': 'C00000003',
             'cmte_count_cand_yr': 1,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -99,7 +99,7 @@ class TotalTestCase(common.BaseTestCase):
     ]
 
     STOCK_FILING_F3P_Q1 = {
-        'committee_id': 'C001',
+        'committee_id': 'C00000001',
         'report_year': 2019,
         'file_number': 10001,
         'ttl_receipts': 100,
@@ -109,7 +109,7 @@ class TotalTestCase(common.BaseTestCase):
         'rpt_year': 2019,
     }
     STOCK_FILING_F3X_Q2 = {
-        'committee_id': 'C001',
+        'committee_id': 'C00000001',
         'report_year': 2019,
         'file_number': 10002,
         'ttl_receipts': 200,
@@ -119,7 +119,7 @@ class TotalTestCase(common.BaseTestCase):
         'rpt_year': 2019,
     }
     STOCK_FILING_F3_Q1 = {
-        'committee_id': 'C002',
+        'committee_id': 'C00000002',
         'report_year': 2019,
         'file_number': 10004,
         'ttl_receipts': 11,
@@ -138,11 +138,11 @@ class TotalTestCase(common.BaseTestCase):
         manage.refresh_materialized(concurrent=False)
 
         """
-        Test committee 'C001' filed wrong form: F3P and F3X(wrong form)
+        Test committee 'C00000001' filed wrong form: F3P and F3X(wrong form)
         totals should be sum of them
         """
         params_cmte = {
-            'committee_id': 'C001',
+            'committee_id': 'C00000001',
         }
         committee_totals_api = self._results(
             rest.api.url_for(TotalsCommitteeView, **params_cmte)

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -39,7 +39,7 @@ class CommitteeTestCase(BaseTestCase):
     committee_data = [
         {
             'valid_fec_yr_id': 10,
-            'cmte_id': 'C001',
+            'cmte_id': 'C00000001',
             'fec_election_yr': 2020,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -53,7 +53,7 @@ class CommitteeTestCase(BaseTestCase):
             'cand_id': 'P01',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
-            'cmte_id': 'C001',
+            'cmte_id': 'C00000001',
             'cmte_count_cand_yr': 1,
             'cmte_tp': 'P',
             'cmte_dsgn': 'P',
@@ -64,28 +64,28 @@ class CommitteeTestCase(BaseTestCase):
 
     f_rpt_or_form_sub_data = [
         {
-            'cand_cmte_id': 'C001',
+            'cand_cmte_id': 'C00000001',
             'receipt_dt': 20160610,
             'form_tp': 'F1',
             'rpt_yr': 2015,
             'sub_id': 1001,
         },
         {
-            'cand_cmte_id': 'C001',
+            'cand_cmte_id': 'C00000001',
             'receipt_dt': 20170310,
             'form_tp': 'F3',
             'rpt_yr': 2017,
             'sub_id': 1002,
         },
         {
-            'cand_cmte_id': 'C001',
+            'cand_cmte_id': 'C00000001',
             'receipt_dt': 20170510,
             'form_tp': 'F3',
             'rpt_yr': None,
             'sub_id': 1003,
         },
         {
-            'cand_cmte_id': 'C001',
+            'cand_cmte_id': 'C00000001',
             'receipt_dt': 20190310,
             'form_tp': 'F3',
             'rpt_yr': 2019,
@@ -100,7 +100,7 @@ class CommitteeTestCase(BaseTestCase):
         manage.refresh_materialized(concurrent=False)
 
         params_cmte = {
-            'committee_id': 'C001',
+            'committee_id': 'C00000001',
         }
 
         committee_api = self._results(
@@ -116,7 +116,7 @@ class CommitteeTestCase(BaseTestCase):
 
     def check_nulls_in_array_column(self, api_result, array_column):
         self.assertEqual(len(api_result), 1)
-        self.assertEqual(api_result[0]['committee_id'], 'C001')
+        self.assertEqual(api_result[0]['committee_id'], 'C00000001')
 
         for each in api_result[0][array_column]:
             has_null = 1 if each is None else 0

--- a/tests/integration/test_filings.py
+++ b/tests/integration/test_filings.py
@@ -13,14 +13,14 @@ class TestFilings(BaseTestCase):
 
     committee = {
         'valid_fec_yr_id': 1,
-        'committee_id': 'C001',
+        'committee_id': 'C00000001',
         'fec_election_yr': 1998,
         'committee_type': 'H',
         'date_entered': 'now()',
     }
 
     FIRST_FILING = {
-        'cand_cmte_id': 'C001',
+        'cand_cmte_id': 'C00000001',
         'report_year': 1997,
         'form_type': 'F1',
         'begin_image_num': '95039770818',

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -33,7 +33,7 @@ class TestCommitteeAggregates(ApiBaseTest):
     def test_stable_sort(self):
         rows = [
             factories.ScheduleAByEmployerFactory(
-                committee_id='C001', employer='omnicorp-{}'.format(idx), total=538,
+                committee_id='C00000001', employer='omnicorp-{}'.format(idx), total=538,
             )
             for idx in range(100)
         ]
@@ -50,7 +50,7 @@ class TestCommitteeAggregates(ApiBaseTest):
     def test_by_state(self):
         [
             factories.ScheduleAByStateFactory(
-                committee_id='C0001',
+                committee_id='C00000001',
                 cycle=2012,
                 total=50,
                 state='NY',
@@ -58,7 +58,7 @@ class TestCommitteeAggregates(ApiBaseTest):
                 count=5,
             ),
             factories.ScheduleAByStateFactory(
-                committee_id='C0002',
+                committee_id='C00000002',
                 cycle=2012,
                 total=150,
                 state='NY',
@@ -66,14 +66,14 @@ class TestCommitteeAggregates(ApiBaseTest):
                 count=6,
             ),
             factories.ScheduleAByStateFactory(
-                committee_id='C0003',
+                committee_id='C00000003',
                 cycle=2018,
                 total=100,
                 state='OT',
                 state_full='Other',
             ),
             factories.ScheduleAByStateFactory(
-                committee_id='C0001',
+                committee_id='C00000001',
                 cycle=2016,
                 total=200,
                 state='CT',
@@ -82,7 +82,7 @@ class TestCommitteeAggregates(ApiBaseTest):
             ),
         ]
         results = self._results(
-            api.url_for(ScheduleAByStateView, committee_id='C0001', cycle=2012)
+            api.url_for(ScheduleAByStateView, committee_id='C00000001', cycle=2012)
         )
         assert len(results) == 1
 
@@ -95,7 +95,7 @@ class TestCommitteeAggregates(ApiBaseTest):
         assert len(results) == 1
 
         results = self._results(
-            api.url_for(ScheduleAByStateView, committee_id='C0001',)
+            api.url_for(ScheduleAByStateView, committee_id='C00000001',)
         )
         assert len(results) == 2
 

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -170,12 +170,12 @@ class CommitteeFormatTest(ApiBaseTest):
             factories.CommitteeFactory(designation="P"),
             factories.CommitteeFactory(party="DEM"),
             factories.CommitteeFactory(organization_type="C"),
-            factories.CommitteeFactory(committee_id="C01"),
+            factories.CommitteeFactory(committee_id="C00000001"),
         ]
 
         # checking one example from each field
         filter_fields = (
-            ("committee_id", ["C01", "C02"]),
+            ("committee_id", ["C00000001", "C00000002"]),
             ("state", ["CA", "DC"]),
             ("committee_type", "S"),
             ("designation", "P"),
@@ -701,7 +701,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
 
     def test_case_insensitivity(self):
         lower_candidate = factories.CandidateDetailFactory(candidate_id="H01")
-        lower_committee_1 = factories.CommitteeDetailFactory(committee_id="ID01")
+        lower_committee_1 = factories.CommitteeDetailFactory(committee_id="C00000001")
         [
             factories.CommitteeHistoryProfileFactory(
                 committee_id=lower_committee_1.committee_id,
@@ -736,7 +736,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
         results = self._results(
             api.url_for(
                 CommitteeHistoryProfileView,
-                committee_id="id01",
+                committee_id="c00000001",
                 cycle=2014,
                 election_full=False
             )

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -17,7 +17,7 @@ class TestCommunicationCost(ApiBaseTest):
     def test_filters(self):
         filters = [
             ('image_number', CommunicationCost.image_number, ['123', '456']),
-            ('committee_id', CommunicationCost.committee_id, ['C01', 'C02']),
+            ('committee_id', CommunicationCost.committee_id, ['C00000001', 'C00000002']),
             ('candidate_id', CommunicationCost.candidate_id, ['S01', 'S02']),
         ]
         for label, column, values in filters:
@@ -57,7 +57,7 @@ class TestElectioneering(ApiBaseTest):
     def test_filters(self):
         filters = [
             ('report_year', Electioneering.report_year, [2012, 2014]),
-            ('committee_id', Electioneering.committee_id, ['C01', 'C02']),
+            ('committee_id', Electioneering.committee_id, ['C00000001', 'C00000002']),
             ('candidate_id', Electioneering.candidate_id, ['S01', 'S02']),
         ]
         for label, column, values in filters:

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -8,7 +8,7 @@ from webservices.resources.rad_analyst import RadAnalystView
 class TestFilerResources(ApiBaseTest):
     def test_committee_id_fetch(self):
         """ Check Analyst is returned with a specified committee id"""
-        committee_id = 'C8675309'
+        committee_id = 'C86753090'
         factories.RadAnalystFactory(committee_id=committee_id)
 
         results = self._results(api.url_for(RadAnalystView, committee_id=committee_id))
@@ -16,8 +16,8 @@ class TestFilerResources(ApiBaseTest):
 
     def test_rad(self):
         """ Check RAD returns in general endpoint"""
-        factories.RadAnalystFactory(committee_id='C001')
-        factories.RadAnalystFactory(committee_id='C002')
+        factories.RadAnalystFactory(committee_id='C00000001')
+        factories.RadAnalystFactory(committee_id='C00000002')
 
         results = self._results(api.url_for(RadAnalystView))
         self.assertEqual(len(results), 2)
@@ -25,24 +25,24 @@ class TestFilerResources(ApiBaseTest):
     def test_filters(self):
         [
             factories.RadAnalystFactory(
-                telephone_ext=123, committee_id='C0001', title='xyz 111'
+                telephone_ext=123, committee_id='C0000001', title='xyz 111'
             ),
             factories.RadAnalystFactory(
                 telephone_ext=456,
-                committee_id='C0002',
+                committee_id='C00000002',
                 title='abc',
                 email='test2@fec.gov',
             ),
             factories.RadAnalystFactory(
-                analyst_id=789, committee_id='C0003', email='test1@fec.gov'
+                analyst_id=789, committee_id='C00000003', email='test1@fec.gov'
             ),
             factories.RadAnalystFactory(
-                analyst_id=1011, analyst_short_id=11, committee_id='C0004'
+                analyst_id=1011, analyst_short_id=11, committee_id='C00000004'
             ),
         ]
 
         filter_fields = (
-            ('committee_id', 'C0002'),
+            ('committee_id', 'C00000002'),
             ('telephone_ext', 123),
             ('analyst_id', 789),
             ('analyst_short_id', 11),
@@ -65,9 +65,9 @@ class TestFilerResources(ApiBaseTest):
 
     def test_sort(self):
         [
-            factories.RadAnalystFactory(last_name='Young', committee_id='C0005'),
-            factories.RadAnalystFactory(last_name='Old', committee_id='C0006'),
-            factories.RadAnalystFactory(last_name='Someone-Else', committee_id='C0007'),
+            factories.RadAnalystFactory(last_name='Young', committee_id='C00000005'),
+            factories.RadAnalystFactory(last_name='Old', committee_id='C00000006'),
+            factories.RadAnalystFactory(last_name='Someone-Else', committee_id='C00000007'),
         ]
         results = self._results(api.url_for(RadAnalystView, sort='last_name'))
         self.assertEqual(
@@ -77,16 +77,16 @@ class TestFilerResources(ApiBaseTest):
     def test_assignment_date_filters(self):
         [
             factories.RadAnalystFactory(
-                assignment_update_date='2015-01-01', committee_id='C0007'
+                assignment_update_date='2015-01-01', committee_id='C00000007'
             ),
             factories.RadAnalystFactory(
-                assignment_update_date='2015-02-01', committee_id='C0008'
+                assignment_update_date='2015-02-01', committee_id='C00000008'
             ),
             factories.RadAnalystFactory(
-                assignment_update_date='2015-03-01', committee_id='C0009'
+                assignment_update_date='2015-03-01', committee_id='C00000009'
             ),
             factories.RadAnalystFactory(
-                assignment_update_date='2015-04-01', committee_id='C0010'
+                assignment_update_date='2015-04-01', committee_id='C00000010'
             ),
         ]
         results = self._results(

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -14,7 +14,7 @@ from webservices.resources.filings import FilingsView, FilingsList, EFilingsView
 class TestFilings(ApiBaseTest):
     def test_committee_filings(self):
         """ Check filing returns with a specified committee id"""
-        committee_id = 'C8675309'
+        committee_id = 'C86753090'
         factories.FilingsFactory(committee_id=committee_id)
 
         results = self._results(api.url_for(FilingsView, committee_id=committee_id))
@@ -209,12 +209,12 @@ class TestFilings(ApiBaseTest):
         """ Getting rid of extra text that comes in the tables."""
         factories.FilingsFactory(
             report_type_full_original='report    {more information than we want}',
-            committee_id='C007',
+            committee_id='C00000007',
             form_type='RFAI',
             report_year=2004,
         )
 
-        results = self._results(api.url_for(FilingsView, committee_id='C007'))
+        results = self._results(api.url_for(FilingsView, committee_id='C00000007'))
 
         self.assertEqual(results[0]['document_description'], 'RFAI: report 2004')
 
@@ -307,7 +307,7 @@ class TestEfileFiles(ApiBaseTest):
 
     def test_committee_efilings(self):
         """ Check filing returns with a specified committee id"""
-        committee_id = "C8675309"
+        committee_id = "C86753090"
         factories.EFilingsFactory(committee_id=committee_id)
 
         results = self._results(api.url_for(EFilingsView, committee_id=committee_id))

--- a/tests/test_inaugural_donations.py
+++ b/tests/test_inaugural_donations.py
@@ -11,38 +11,39 @@ class TestInauguralDonations(ApiBaseTest):
         super().setUp()
 
         factories.TotalsInauguralDonationsFactory(
-            committee_id='C00001',
+            committee_id='C00000001',
             contributor_name='Walmart',
             cycle=2015,
             total_donation=1000
         )
 
         factories.TotalsInauguralDonationsFactory(
-            committee_id='C00002',
+            committee_id='C00000002',
             contributor_name='Target',
             cycle=2016,
             total_donation=4000
         )
         factories.TotalsInauguralDonationsFactory(
-            committee_id='C00003',
+            committee_id='C00000003',
             contributor_name='Jason',
             cycle=2020,
             total_donation=3000
         )
 
         factories.TotalsInauguralDonationsFactory(
-            committee_id='C00004',
+            committee_id='C00000004',
             contributor_name='Bass Pro Shop',
             cycle=2023,
             total_donation=6000
         )
 
         factories.TotalsInauguralDonationsFactory(
-            committee_id='C00005',
+            committee_id='C00000005',
             contributor_name='Petsmart',
             cycle=2023,
             total_donation=6000
         )
+
     def test_base(self):
         results = self._results(api.url_for(InauguralDonationsView))
 
@@ -50,14 +51,14 @@ class TestInauguralDonations(ApiBaseTest):
 
     def test_filter_by_committee(self):
         results = self._results(api.url_for(InauguralDonationsView,
-                                            committee_id='C00003'))
+                                            committee_id='C00000003'))
 
         assert len(results) == 1
 
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00003',
+                'committee_id': 'C00000003',
                 'contributor_name': 'Jason',
                 'cycle': 2020,
                 'total_donation': 3000
@@ -73,7 +74,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00002',
+                'committee_id': 'C00000002',
                 'contributor_name': 'Target',
                 'cycle': 2016,
                 'total_donation': 4000
@@ -82,14 +83,14 @@ class TestInauguralDonations(ApiBaseTest):
 
     def test_multi_filter(self):
         results = self._results(api.url_for(InauguralDonationsView,
-                                            cycle=2023, committee_id='C00005'))
+                                            cycle=2023, committee_id='C00000005'))
 
         assert len(results) == 1
 
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00005',
+                'committee_id': 'C00000005',
                 'contributor_name': 'Petsmart',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -104,7 +105,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00005',
+                'committee_id': 'C00000005',
                 'contributor_name': 'Petsmart',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -113,7 +114,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[1],
             {
-                'committee_id': 'C00004',
+                'committee_id': 'C00000004',
                 'contributor_name': 'Bass Pro Shop',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -122,7 +123,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[2],
             {
-                'committee_id': 'C00003',
+                'committee_id': 'C00000003',
                 'contributor_name': 'Jason',
                 'cycle': 2020,
                 'total_donation': 3000
@@ -131,7 +132,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[3],
             {
-                'committee_id': 'C00002',
+                'committee_id': 'C00000002',
                 'contributor_name': 'Target',
                 'cycle': 2016,
                 'total_donation': 4000
@@ -140,7 +141,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[4],
             {
-                'committee_id': 'C00001',
+                'committee_id': 'C00000001',
                 'contributor_name': 'Walmart',
                 'cycle': 2015,
                 'total_donation': 1000
@@ -155,7 +156,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00004',
+                'committee_id': 'C00000004',
                 'contributor_name': 'Bass Pro Shop',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -164,7 +165,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[1],
             {
-                'committee_id': 'C00003',
+                'committee_id': 'C00000003',
                 'contributor_name': 'Jason',
                 'cycle': 2020,
                 'total_donation': 3000
@@ -173,7 +174,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[2],
             {
-                'committee_id': 'C00005',
+                'committee_id': 'C00000005',
                 'contributor_name': 'Petsmart',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -182,7 +183,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[3],
             {
-                'committee_id': 'C00002',
+                'committee_id': 'C00000002',
                 'contributor_name': 'Target',
                 'cycle': 2016,
                 'total_donation': 4000
@@ -191,7 +192,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[4],
             {
-                'committee_id': 'C00001',
+                'committee_id': 'C00000001',
                 'contributor_name': 'Walmart',
                 'cycle': 2015,
                 'total_donation': 1000
@@ -206,7 +207,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00001',
+                'committee_id': 'C00000001',
                 'contributor_name': 'Walmart',
                 'cycle': 2015,
                 'total_donation': 1000
@@ -215,7 +216,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[1],
             {
-                'committee_id': 'C00002',
+                'committee_id': 'C00000002',
                 'contributor_name': 'Target',
                 'cycle': 2016,
                 'total_donation': 4000
@@ -224,7 +225,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[2],
             {
-                'committee_id': 'C00003',
+                'committee_id': 'C00000003',
                 'contributor_name': 'Jason',
                 'cycle': 2020,
                 'total_donation': 3000
@@ -233,7 +234,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[3],
             {
-                'committee_id': 'C00005',
+                'committee_id': 'C00000005',
                 'contributor_name': 'Petsmart',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -242,7 +243,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[4],
             {
-                'committee_id': 'C00004',
+                'committee_id': 'C00000004',
                 'contributor_name': 'Bass Pro Shop',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -257,7 +258,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                'committee_id': 'C00005',
+                'committee_id': 'C00000005',
                 'contributor_name': 'Petsmart',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -266,7 +267,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[1],
             {
-                'committee_id': 'C00004',
+                'committee_id': 'C00000004',
                 'contributor_name': 'Bass Pro Shop',
                 'cycle': 2023,
                 'total_donation': 6000
@@ -275,7 +276,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[2],
             {
-                'committee_id': 'C00002',
+                'committee_id': 'C00000002',
                 'contributor_name': 'Target',
                 'cycle': 2016,
                 'total_donation': 4000
@@ -284,7 +285,7 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[3],
             {
-                'committee_id': 'C00003',
+                'committee_id': 'C00000003',
                 'contributor_name': 'Jason',
                 'cycle': 2020,
                 'total_donation': 3000
@@ -293,11 +294,9 @@ class TestInauguralDonations(ApiBaseTest):
         assert_dicts_subset(
             results[4],
             {
-                'committee_id': 'C00001',
+                'committee_id': 'C00000001',
                 'contributor_name': 'Walmart',
                 'cycle': 2015,
                 'total_donation': 1000
             }
         )
-
-

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -76,26 +76,26 @@ class TestScheduleA(ApiBaseTest):
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
                 two_year_transaction_period=2014,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
                 two_year_transaction_period=2016,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
                 two_year_transaction_period=2018,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
         ]
         response = self._response(
             api.url_for(
                 ScheduleAView,
                 two_year_transaction_period=[2016, 2018],
-                committee_id='C001',
+                committee_id='C00000001',
             )
         )
         self.assertEqual(len(response['results']), 2)
@@ -109,69 +109,69 @@ class TestScheduleA(ApiBaseTest):
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
                 two_year_transaction_period=2014,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
                 two_year_transaction_period=2016,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
                 two_year_transaction_period=2018,
-                committee_id='C001',
+                committee_id='C00000001',
             ),
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
                 two_year_transaction_period=2014,
-                committee_id='C002',
+                committee_id='C00000002',
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
                 two_year_transaction_period=2016,
-                committee_id='C002',
+                committee_id='C00000002',
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
                 two_year_transaction_period=2018,
-                committee_id='C002',
+                committee_id='C00000002',
             ),
             factories.ScheduleAFactory(
                 report_year=2014,
                 contribution_receipt_date=datetime.date(2014, 1, 1),
                 two_year_transaction_period=2014,
-                committee_id='C003',
+                committee_id='C00000003',
             ),
             factories.ScheduleAFactory(
                 report_year=2016,
                 contribution_receipt_date=datetime.date(2016, 1, 1),
                 two_year_transaction_period=2016,
-                committee_id='C003',
+                committee_id='C00000003',
             ),
             factories.ScheduleAFactory(
                 report_year=2018,
                 contribution_receipt_date=datetime.date(2018, 1, 1),
                 two_year_transaction_period=2018,
-                committee_id='C003',
+                committee_id='C00000003',
             ),
         ]
         response = self._response(
             api.url_for(
                 ScheduleAView,
                 two_year_transaction_period=[2016, 2018],
-                committee_id=['C001', 'C002'],
+                committee_id=['C00000001', 'C00000002'],
             )
         )
         self.assertEqual(len(response['results']), 4)
         response = self._response(
             api.url_for(
                 ScheduleAView,
-                committee_id='C001',
+                committee_id='C00000001',
             )
         )
         self.assertEqual(len(response['results']), 3)
@@ -457,13 +457,13 @@ class TestScheduleA(ApiBaseTest):
         filings = [
             factories.ScheduleAFactory(
                 contribution_receipt_date=None,
-                committee_id="1") for _ in range(5)
+                committee_id="C00000001") for _ in range(5)
         ]
         # Results [5:30] have date
         filings = filings + [
             factories.ScheduleAFactory(
                 contribution_receipt_date=datetime.date(2016, 1, 1),
-                committee_id="2")
+                committee_id="C00000002")
             for _ in range(25)
         ]
         page1 = self._results(
@@ -515,7 +515,7 @@ class TestScheduleA(ApiBaseTest):
                 sort='contribution_receipt_date',
                 sort_hide_null=True,
                 per_page=30,
-                committee_id=["1", "2"],
+                committee_id=["C00000001", "C00000002"],
                 **self.kwargs)
         )
         count = response["pagination"]["count"]
@@ -527,7 +527,7 @@ class TestScheduleA(ApiBaseTest):
                 sort='contribution_receipt_date',
                 sort_hide_null=True,
                 per_page=30,
-                committee_id=["1"],
+                committee_id=["C00000001"],
                 **self.kwargs)
         )
         count = response["pagination"]["count"]
@@ -844,7 +844,7 @@ class TestScheduleA(ApiBaseTest):
     def test_schedule_a_efile_filters(self):
         filters = [
             ('image_number', ScheduleAEfile.image_number, ['123', '456']),
-            ('committee_id', ScheduleAEfile.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleAEfile.committee_id, ['C00000001', 'C00000002']),
             # may have to rethink this, currently on efile itemized resources the city isn't all caps
             # but for processed it is, is that something we are forcing when when
             # we build the tables?
@@ -975,7 +975,7 @@ class TestScheduleB(ApiBaseTest):
     def test_schedule_b_efile_filters(self):
         filters = [
             ('image_number', ScheduleBEfile.image_number, ['123', '456']),
-            ('committee_id', ScheduleBEfile.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleBEfile.committee_id, ['C00000001', 'C00000002']),
             (
                 'recipient_state',
                 ScheduleBEfile.recipient_state,
@@ -1002,13 +1002,13 @@ class TestScheduleE(ApiBaseTest):
             factories.ScheduleEFactory(
                 expenditure_amount=100,
                 expenditure_date=datetime.date(2016, 1, 1),
-                committee_id='101',
+                committee_id='C00000001',
                 support_oppose_indicator='s',
             ),
             factories.ScheduleEFactory(
                 expenditure_amount=100,
                 expenditure_date=datetime.date(2016, 1, 1),
-                committee_id='101',
+                committee_id='C00000001',
                 support_oppose_indicator='o',
             ),
         ]
@@ -1101,7 +1101,7 @@ class TestScheduleE(ApiBaseTest):
     def test_schedule_e_filters(self):
         filters = [
             ('image_number', ScheduleE.image_number, ['123', '456']),
-            ('committee_id', ScheduleE.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleE.committee_id, ['C00000001', 'C00000002']),
             (
                 'support_oppose_indicator',
                 ScheduleE.support_oppose_indicator,
@@ -1141,10 +1141,14 @@ class TestScheduleE(ApiBaseTest):
     def test_filter_sched_e_spender_name_text(self):
         [
             factories.ScheduleEFactory(
-                committee_id='C001', spender_name_text=sa.func.to_tsvector('international abc action committee C001'),
+                committee_id='C00000001',
+                spender_name_text=sa.func.to_tsvector(
+                            'international abc action committee C00000001'),
             ),
             factories.ScheduleEFactory(
-                committee_id='C002', spender_name_text=sa.func.to_tsvector('international xyz action committee C002'),
+                committee_id='C00000002',
+                spender_name_text=sa.func.to_tsvector(
+                            'international xyz action committee C00000002'),
             ),
         ]
         results = self._results(
@@ -1156,7 +1160,7 @@ class TestScheduleE(ApiBaseTest):
         )
         self.assertEqual(len(results), 1)
         results = self._results(
-            api.url_for(ScheduleEView, q_spender='C001')
+            api.url_for(ScheduleEView, q_spender='C00000001')
         )
         self.assertEqual(len(results), 1)
 
@@ -1175,13 +1179,13 @@ class TestScheduleE(ApiBaseTest):
             factories.ScheduleEFactory(
                 expenditure_amount=100,
                 expenditure_date=datetime.date(2016, 1, 1),
-                committee_id='101',
+                committee_id='C00000001',
                 support_oppose_indicator='s',
             ),
             factories.ScheduleEFactory(
                 expenditure_amount=100,
                 expenditure_date=datetime.date(2016, 1, 1),
-                committee_id='101',
+                committee_id='C00000001',
                 support_oppose_indicator='o',
             ),
         ]
@@ -1191,7 +1195,7 @@ class TestScheduleE(ApiBaseTest):
         self.assertEqual(results[0]['support_oppose_indicator'], 's')
 
     def test_schedule_e_expenditure_description_field(self):
-        factories.ScheduleEFactory(committee_id='C001', expenditure_description='Advertising Costs')
+        factories.ScheduleEFactory(committee_id='C00000001', expenditure_description='Advertising Costs')
         results = self._results(
             api.url_for(ScheduleEView)
         )
@@ -1201,7 +1205,7 @@ class TestScheduleE(ApiBaseTest):
     def test_schedule_e_efile_filters(self):
         filters = [
             ('image_number', ScheduleEEfile.image_number, ['456', '789']),
-            ('committee_id', ScheduleEEfile.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleEEfile.committee_id, ['C00000001', 'C00000002']),
             (
                 'support_oppose_indicator',
                 ScheduleEEfile.support_oppose_indicator,
@@ -1287,13 +1291,13 @@ class TestScheduleE(ApiBaseTest):
     def test_schedule_e_efile_filter_cand_search(self):
         [
             factories.ScheduleEEfileFactory(
-                cand_fulltxt=sa.func.to_tsvector('C001, Rob, Senior')
+                cand_fulltxt=sa.func.to_tsvector('C00000001, Rob, Senior')
             ),
             factories.ScheduleEEfileFactory(
-                cand_fulltxt=sa.func.to_tsvector('C002, Ted, Berry')
+                cand_fulltxt=sa.func.to_tsvector('C00000002, Ted, Berry')
             ),
             factories.ScheduleEEfileFactory(
-                cand_fulltxt=sa.func.to_tsvector('C003, Rob, Junior')
+                cand_fulltxt=sa.func.to_tsvector('C00000003, Rob, Junior')
             ),
         ]
         factories.EFilingsFactory(file_number=123)
@@ -1304,19 +1308,19 @@ class TestScheduleE(ApiBaseTest):
     def test_filter_sched_e_most_recent(self):
         [
             factories.ScheduleEFactory(
-                committee_id='C001', filing_form='F24', most_recent=True
+                committee_id='C00000001', filing_form='F24', most_recent=True
             ),
             factories.ScheduleEFactory(
-                committee_id='C002', filing_form='F5', most_recent=False
+                committee_id='C00000002', filing_form='F5', most_recent=False
             ),
             factories.ScheduleEFactory(
-                committee_id='C003', filing_form='F24', most_recent=True
+                committee_id='C00000003', filing_form='F24', most_recent=True
             ),
             factories.ScheduleEFactory(
-                committee_id='C004', filing_form='F3X', most_recent=True
+                committee_id='C00000004', filing_form='F3X', most_recent=True
             ),
-            factories.ScheduleEFactory(committee_id='C005', filing_form='F3X'),
-            factories.ScheduleEFactory(committee_id='C006', filing_form='F3X'),
+            factories.ScheduleEFactory(committee_id='C00000005', filing_form='F3X'),
+            factories.ScheduleEFactory(committee_id='C00000006', filing_form='F3X'),
         ]
         results = self._results(
             api.url_for(ScheduleEView, most_recent=True)
@@ -1327,19 +1331,19 @@ class TestScheduleE(ApiBaseTest):
     def test_filter_sched_e_efile_most_recent(self):
         [
             factories.ScheduleEEfileFactory(
-                committee_id='C001', filing_form='F24', most_recent=True
+                committee_id='C00000001', filing_form='F24', most_recent=True
             ),
             factories.ScheduleEEfileFactory(
-                committee_id='C002', filing_form='F5', most_recent=False
+                committee_id='C00000002', filing_form='F5', most_recent=False
             ),
             factories.ScheduleEEfileFactory(
-                committee_id='C003', filing_form='F24', most_recent=True
+                committee_id='C00000003', filing_form='F24', most_recent=True
             ),
             factories.ScheduleEEfileFactory(
-                committee_id='C004', filing_form='F3X', most_recent=True
+                committee_id='C00000004', filing_form='F3X', most_recent=True
             ),
-            factories.ScheduleEEfileFactory(committee_id='C005', filing_form='F3X'),
-            factories.ScheduleEEfileFactory(committee_id='C006', filing_form='F3X'),
+            factories.ScheduleEEfileFactory(committee_id='C00000005', filing_form='F3X'),
+            factories.ScheduleEEfileFactory(committee_id='C00000006', filing_form='F3X'),
         ]
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
@@ -1376,14 +1380,14 @@ class TestScheduleH4(ApiBaseTest):
 
     def test_schedule_h4_filters(self):
         [
-            factories.ScheduleH4Factory(committee_id='C001', cycle=2016),
-            factories.ScheduleH4Factory(committee_id='C002', cycle=2016),
-            factories.ScheduleH4Factory(committee_id='C003', cycle=2016),
-            factories.ScheduleH4Factory(committee_id='C004', cycle=2018),
+            factories.ScheduleH4Factory(committee_id='C00000001', cycle=2016),
+            factories.ScheduleH4Factory(committee_id='C00000002', cycle=2016),
+            factories.ScheduleH4Factory(committee_id='C00000003', cycle=2016),
+            factories.ScheduleH4Factory(committee_id='C00000004', cycle=2018),
         ]
         results = self._results(api.url_for(ScheduleH4View, cycle=2016))
         self.assertEqual(len(results), 3)
-        results = self._results(api.url_for(ScheduleH4View, committee_id='C001'))
+        results = self._results(api.url_for(ScheduleH4View, committee_id='C00000001'))
         self.assertEqual(len(results), 1)
 
     def test_schedule_h4_filter_fulltext_purpose_and(self):
@@ -1467,7 +1471,7 @@ class TestScheduleH4(ApiBaseTest):
     def test_schedule_h4_efile_filters(self):
         filters = [
             ('image_number', ScheduleH4Efile.image_number, ['123', '456']),
-            ('committee_id', ScheduleH4Efile.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleH4Efile.committee_id, ['C00000001', 'C00000002']),
             (
                 'payee_state',
                 ScheduleH4Efile.payee_state,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -393,10 +393,10 @@ class TestCommitteeReports(ApiBaseTest):
 
     def test_reports_committee_not_found(self):
         resp = self.app.get(api.url_for(CommitteeReportsView, committee_id='fake'))
-        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.status_code, 422)
         self.assertEqual(resp.content_type, 'application/json')
         data = json.loads(resp.data.decode('utf-8'))
-        self.assertIn('not found', data['message'].lower())
+        self.assertIn('invalid committee_id', data['message'].lower())
 
 
 # Test 3 endpoints:
@@ -435,8 +435,8 @@ class TestEFileReports(ApiBaseTest):
         self._check_committee_ids(results, [committee_efile], [other_efile])
 
     def test_efile_pac_party_reports(self):
-        committee_id = 'C8675310'
-        other_id = 'C3333333'
+        committee_id = 'C86753100'
+        other_id = 'C33333330'
 
         committee_efile = factories.EfileReportsPacPartyFactory(
             committee_id=committee_id
@@ -451,8 +451,8 @@ class TestEFileReports(ApiBaseTest):
         self._check_committee_ids(results, [committee_efile], [other_efile])
 
     def test_efile_house_senate_reports(self):
-        committee_id = 'C8675311'
-        other_id = 'C1111111'
+        committee_id = 'C86753110'
+        other_id = 'C11111110'
 
         committee_efile = factories.EfileReportsHouseSenateFactory(
             committee_id=committee_id

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -20,7 +20,7 @@ class TestScheduleDView(ApiBaseTest):
     def test_filters(self):
         filters = [
             ('image_number', ScheduleD.image_number, ['123', '456']),
-            ('committee_id', ScheduleD.committee_id, ['C01', 'C02']),
+            ('committee_id', ScheduleD.committee_id, ['C00000001', 'C00000002']),
             ('report_year', ScheduleD.report_year, [2023, 2019]),
             ('report_type', ScheduleD.report_type, ['60D', 'Q3']),
             ('filing_form', ScheduleD.filing_form, ['F3P', 'F3X']),

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -56,7 +56,11 @@ class TestElectioneeringByCandidateView(ApiBaseTest):
         ),
 
         response = self._results(api.url_for(
-            ElectioneeringByCandidateView, cycle=2010, office='senate', state='NY', sort='-candidate_name'))
+            ElectioneeringByCandidateView,
+            cycle=2010,
+            office='senate',
+            state='NY',
+            sort='-candidate_name'))
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
         self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
@@ -115,7 +119,12 @@ class TestElectioneeringByCandidateView(ApiBaseTest):
             count=1,
         ),
         response = self._results(
-            api.url_for(ElectioneeringByCandidateView, sort='-candidate_id', office='senate', state='NY', cycle=2012))
+            api.url_for(
+                ElectioneeringByCandidateView,
+                sort='-candidate_id',
+                office='senate',
+                state='NY',
+                cycle=2012))
         self.assertEqual(len(response), 3)
         self.assertEqual(response[0]['candidate_id'], 'S003')
         self.assertEqual(response[1]['candidate_id'], 'S002')
@@ -131,19 +140,19 @@ class TestECAggregatesView(ApiBaseTest):
 
     def test_filters_committee_candidate_id_cycle(self):
         factories.ElectioneeringByCandidateFactory(
-            committee_id='P001', candidate_id='C001', cycle=2000
+            committee_id='C00000001', candidate_id='P00000001', cycle=2000
         )
         factories.ElectioneeringByCandidateFactory(
-            committee_id='P001', candidate_id='C002', cycle=2000
+            committee_id='C00000001', candidate_id='P00000002', cycle=2000
         )
         factories.ElectioneeringByCandidateFactory(
-            committee_id='P002', candidate_id='C001', cycle=2004
+            committee_id='C00000002', candidate_id='P00000001', cycle=2004
         )
         db.session.flush()
-        results = self._results(api.url_for(ECAggregatesView, committee_id='P001'))
+        results = self._results(api.url_for(ECAggregatesView, committee_id='C00000001'))
         self.assertEqual(len(results), 2)
 
-        results = self._results(api.url_for(ECAggregatesView, candidate_id='C001'))
+        results = self._results(api.url_for(ECAggregatesView, candidate_id='P00000001'))
         self.assertEqual(len(results), 2)
 
         results = self._results(api.url_for(ECAggregatesView, cycle=2000))
@@ -163,10 +172,10 @@ class TestECTotalsByCandidateView(ApiBaseTest):
         ),
 
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=300, cycle=2018, committee_id='C01'
+            candidate_id='S01', total=300, cycle=2018, committee_id='C00000001'
         ),
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=200, cycle=2020, committee_id='C02'
+            candidate_id='S01', total=200, cycle=2020, committee_id='C00000002'
         ),
 
         results = self._results(
@@ -192,35 +201,23 @@ class TestECTotalsByCandidateView(ApiBaseTest):
         ),
 
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=300, cycle=2018, committee_id='C01'
-        ),
+            committee_id='C00000001', candidate_id='P001', cycle=2000
+        )
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=200, cycle=2020, committee_id='C02'
-        ),
-
-        results = self.app.get(
-            api.url_for(
-                ECTotalsByCandidateView,
-                sort='bad_value',
-            )
+            committee_id='C00000001', candidate_id='P002', cycle=2000
         )
-        self.assertEqual(results.status_code, 422)
-
-        results = self._results(
-            api.url_for(
-                ECTotalsByCandidateView,
-                candidate_id='S01',
-                election_full=False,
-                sort='cycle'
-            )
+        factories.ElectioneeringByCandidateFactory(
+            committee_id='C00000002', candidate_id='P001', cycle=2004
         )
-        assert len(results) == 2
-        expected = {
-            'candidate_id': 'S01',
-            'cycle': 2018,
-            'total': 300,
-        }
-        assert results[0] == expected
+        db.session.flush()
+        results = self._results(api.url_for(ECAggregatesView, committee_id='C00000001'))
+        self.assertEqual(len(results), 2)
+
+        results = self._results(api.url_for(ECAggregatesView, candidate_id='P001'))
+        self.assertEqual(len(results), 2)
+
+        results = self._results(api.url_for(ECAggregatesView, cycle=2000))
+        self.assertEqual(len(results), 2)
 
 
 # Test endpoint: '/schedules/schedule_e/totals/by_candidate/' (spending_by_others.IETotalsByCandidateView)
@@ -540,8 +537,12 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
             support_oppose_indicator='S',
         ),
 
-        response = self._results(api.url_for(CommunicationCostByCandidateView, cycle=2010,
-            office='senate', state='NY', sort='-candidate_name'))
+        response = self._results(api.url_for(
+            CommunicationCostByCandidateView,
+            cycle=2010,
+            office='senate',
+            state='NY',
+            sort='-candidate_name'))
         self.assertEqual(len(response), 2)
         self.assertEqual(response[0]['candidate_name'], 'WARNER, MARK')
         self.assertEqual(response[1]['candidate_name'], 'BALDWIN, ALISSA')
@@ -603,8 +604,12 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
             count=1,
         ),
         response = self._results(
-            api.url_for(CommunicationCostByCandidateView, sort='-candidate_id',
-                office='senate', state='NY', cycle=2012))
+            api.url_for(
+                CommunicationCostByCandidateView,
+                sort='-candidate_id',
+                office='senate',
+                state='NY',
+                cycle=2012))
         self.assertEqual(len(response), 3)
         self.assertEqual(response[0]['candidate_id'], 'S003')
         self.assertEqual(response[0]['support_oppose_indicator'], 'S')
@@ -633,34 +638,34 @@ class TestCCAggregatesView(ApiBaseTest):
         ),
 
         factories.CommitteeHistoryFactory(
-            committee_id='C001', cycle=2000, name='Acme Co'
+            committee_id='C00000001', cycle=2000, name='Acme Co'
         ),
         factories.CommitteeHistoryFactory(
-            committee_id='C002', cycle=2000, name='Tetris Corp'
+            committee_id='C00000002', cycle=2000, name='Tetris Corp'
         ),
         factories.CommitteeHistoryFactory(
-            committee_id='C002', cycle=2004, name='Winner PAC'
+            committee_id='C00000002', cycle=2004, name='Winner PAC'
         ),
 
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C001', candidate_id='P001', cycle=2000
+            committee_id='C00000001', candidate_id='P001', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C001', candidate_id='P002', cycle=2000
+            committee_id='C00000001', candidate_id='P002', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C002', candidate_id='P001', cycle=2004
+            committee_id='C00000002', candidate_id='P001', cycle=2004
         )
         db.session.flush()
 
         # assert results filtered by committee_id sorted by candidate name in descending order
-        results = self._results(api.url_for(CCAggregatesView, committee_id='C001', sort='-candidate_name'))
+        results = self._results(api.url_for(CCAggregatesView, committee_id='C00000001', sort='-candidate_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['candidate_name'], 'Snapple Smith')
         self.assertEqual(results[1]['candidate_name'], 'Apple Smith')
 
         # assert results filtered by committee_id sorted by candidate name in ascending order
-        results = self._results(api.url_for(CCAggregatesView, committee_id='C001', sort='candidate_name'))
+        results = self._results(api.url_for(CCAggregatesView, committee_id='C00000001', sort='candidate_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['candidate_name'], 'Apple Smith')
         self.assertEqual(results[1]['candidate_name'], 'Snapple Smith')

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -66,7 +66,7 @@ class TestTotalsByEntityType(ApiBaseTest):
 
     # Factories are being weird about test data - base cases to share
     first_pac_total = {
-        'committee_id': 'C00001',
+        'committee_id': 'C00000001',
         'committee_type': 'O',
         'cycle': 2018,
         'committee_designation': 'A',
@@ -85,7 +85,7 @@ class TestTotalsByEntityType(ApiBaseTest):
         'first_f1_date': datetime.date.fromisoformat("1983-02-01"),
     }
     second_pac_total = {
-        'committee_id': 'C00002',
+        'committee_id': 'C00000002',
         'committee_type': 'N',
         'cycle': 2016,
         'committee_designation': 'B',
@@ -113,8 +113,8 @@ class TestTotalsByEntityType(ApiBaseTest):
             api.url_for(TotalsByEntityTypeView, entity_type='pac')
         )
         assert len(results) == 2
-        assert results[0]['committee_id'] == 'C00001'
-        assert results[1]['committee_id'] == 'C00002'
+        assert results[0]['committee_id'] == 'C00000001'
+        assert results[1]['committee_id'] == 'C00000002'
 
         # Test all fields for result #2
 
@@ -196,7 +196,7 @@ class TestTotalsByEntityType(ApiBaseTest):
         factories.TotalsPacFactory(**self.second_pac_total)
         factories.TotalsPacFactory(
             **{
-                "committee_id": "C00003",
+                "committee_id": "C00000003",
                 "committee_type": "Q",
                 "cycle": 2016,
                 "committee_designation": "B",
@@ -227,7 +227,7 @@ class TestTotalsByEntityType(ApiBaseTest):
         )
 
         assert len(results) == 2
-        self.assertTrue(all(each["committee_id"] != "C00003" for each in results))
+        self.assertTrue(all(each["committee_id"] != "C00000003" for each in results))
 
     def test_filter_receipts(self):
 
@@ -341,13 +341,13 @@ class TestTotalsByEntityType(ApiBaseTest):
             sponsor_candidate_name="Sponsor A",
         )
         factories.PacSponsorCandidatePerCycleFactory(
-            committee_id='C007',
+            committee_id='C00000007',
             cycle=committee.cycle + 2,
             sponsor_candidate_id="S03",
             sponsor_candidate_name="Sponsor B",
         )
         factories.PacSponsorCandidatePerCycleFactory(
-            committee_id='C007',
+            committee_id='C00000007',
             cycle=committee.cycle,
             sponsor_candidate_id="S03",
             sponsor_candidate_name="Sponsor B",
@@ -381,16 +381,16 @@ class TestTotalsByEntityType(ApiBaseTest):
         )
 
         assert len(results) == 1
-        assert results[0]['committee_id'] == 'C00001'
+        assert results[0]['committee_id'] == 'C00000001'
 
     def test_entity_type_filter(self):
         first_committee = {
-            'committee_id': 'C00003',
+            'committee_id': 'C00000003',
             'committee_type': 'H',
             'cycle': 2016,
         }
         second_committee = {
-            'committee_id': 'C00004',
+            'committee_id': 'C00000004',
             'committee_type': 'P',
             'cycle': 2016,
         }
@@ -402,13 +402,13 @@ class TestTotalsByEntityType(ApiBaseTest):
         )
 
         assert len(results) == 1
-        assert results[0]['committee_id'] == 'C00004'
+        assert results[0]['committee_id'] == 'C00000004'
 
 
 # test for endpoint: /committee/{committee_id}/totals/
 class TestTotals(ApiBaseTest):
     def test_presidential_totals(self):
-        committee_id = 'C8675309'
+        committee_id = 'C86753090'
         transaction_coverage = factories.TransactionCoverageFactory(  # noqa
             committee_id=committee_id, fec_election_year=2016
         )
@@ -416,7 +416,7 @@ class TestTotals(ApiBaseTest):
             committee_id=committee_id, committee_type='P',
         )
         presidential_fields = {
-            'committee_id': 'C8675309',
+            'committee_id': 'C86753090',
             'cycle': 2016,
             'candidate_contribution': 1,
             'exempt_legal_accounting_disbursement': 2,
@@ -454,7 +454,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(results[0], fields)
 
     def test_House_Senate_totals(self):
-        committee_id = 'C8675310'
+        committee_id = 'C86753100'
         transaction_coverage = factories.TransactionCoverageFactory(  # noqa
             committee_id=committee_id, fec_election_year=2016
         )
@@ -496,7 +496,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(results[0], fields)
 
     def test_House_Senate_Jointed_totals(self):
-        committee_id = 'C009'
+        committee_id = 'C00000009'
         history = factories.CommitteeHistoryFactory(  # noqa
             committee_id=committee_id, committee_type='S',
         )
@@ -521,7 +521,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(len(results), 1)
 
     def test_Pac_Party_totals(self):
-        committee_id = 'C8675311'
+        committee_id = 'C86753110'
         transaction_coverage = factories.TransactionCoverageFactory(  # noqa
             committee_id=committee_id, fec_election_year=2016
         )
@@ -650,7 +650,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(results[0], fields)
 
     def test_Pac_totals(self):
-        committee_id = 'C8675311'
+        committee_id = 'C86753110'
         transaction_coverage = factories.TransactionCoverageFactory(  # noqa
             committee_id=committee_id, fec_election_year=2016
         )
@@ -913,7 +913,7 @@ class TestTotals(ApiBaseTest):
         self.assertEqual(results[0], fields)
 
     def test_ie_totals(self):
-        committee_id = 'C8675312'
+        committee_id = 'C86753120'
         history = factories.CommitteeHistoryFactory(  # noqa
             committee_id=committee_id, committee_type='I',
         )
@@ -970,10 +970,10 @@ class TestTotals(ApiBaseTest):
 
     def test_totals_committee_not_found(self):
         resp = self.app.get(api.url_for(TotalsCommitteeView, committee_id='fake'))
-        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.status_code, 422)
         self.assertEqual(resp.content_type, 'application/json')
         data = json.loads(resp.data.decode('utf-8'))
-        self.assertIn('not found', data['message'].lower())
+        self.assertIn('invalid committee_id', data['message'].lower())
 
     def test_sched_a_by_state_recipient_totals(self):
         rows = [  # noqa

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -6,6 +6,7 @@ from webargs import fields, validate
 from webservices import docs
 from webservices import exceptions
 from webservices.common.models import db
+from webservices.utils import check_committee_id
 import datetime
 
 
@@ -23,6 +24,17 @@ per_page = Natural(
     missing=20,
     description='The number of results returned per page. Defaults to 20.',
 )
+
+
+class Committee_ID(fields.Str):
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        return super()._deserialize(value, attr, data, **kwargs).upper()
+
+    def _validate(self, value):
+        super()._validate(value)
+
+        check_committee_id(value)
 
 
 class Currency(fields.Decimal):
@@ -301,7 +313,7 @@ legal_universal_search = {
         required=False, validate=validate.OneOf(["archived", "current"]), description=docs.MUR_TYPE),
 
     'af_name': fields.List(IStr, required=False, description=docs.AF_NAME),
-    'af_committee_id': IStr(required=False, description=docs.AF_COMMITTEE_ID),
+    'af_committee_id': Committee_ID(required=False, description=docs.AF_COMMITTEE_ID),
     'af_report_year': IStr(required=False, description=docs.AF_REPORT_YEAR),
     'af_min_rtb_date': Date(required=False, description=docs.AF_MIN_RTB_DATE),
     'af_max_rtb_date': Date(required=False, description=docs.AF_MAX_RTB_DATE),
@@ -370,7 +382,7 @@ committee = {
 
 committee_list = {
     'q': fields.List(Keyword, description=docs.COMMITTEE_NAME),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'state': fields.List(IStr, description=docs.STATE_GENERIC),
     'party': fields.List(IStr, description=docs.PARTY),
@@ -461,7 +473,7 @@ reports = {
     'max_total_contributions': Currency(description=docs.MAX_FILTER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(fields.Str, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
         description=docs.AMENDMENT_INDICATOR),
@@ -500,7 +512,7 @@ committee_totals = {
 totals_by_entity_type = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_designation': fields.List(fields.Str, description=docs.DESIGNATION),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'committee_state': fields.List(IStr, description=docs.STATE_GENERIC),
     'filing_frequency': fields.List(
@@ -584,7 +596,7 @@ itemized = {
 }
 
 schedule_a = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
     'contributor_name': fields.List(Keyword, description=docs.CONTRIBUTOR_NAME),
     'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
@@ -632,7 +644,7 @@ schedule_a = {
 }
 
 schedule_a_e_file = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     # 'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
     'contributor_name': fields.List(Keyword, description=docs.CONTRIBUTOR_NAME),
     'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
@@ -645,13 +657,13 @@ schedule_a_e_file = {
 schedule_a_by_size = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_state = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'hide_null': fields.Bool(missing=False, description=docs.MISSING_STATE),
 }
 
@@ -659,19 +671,19 @@ schedule_a_by_zip = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'zip': fields.List(fields.Str, description=docs.CONTRIBUTOR_ZIP),
     'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_employer = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'employer': fields.List(Keyword, description=docs.EMPLOYER),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_occupation = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'occupation': fields.List(Keyword, description=docs.OCCUPATION),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_a_by_contributor = {
@@ -682,29 +694,29 @@ schedule_a_by_contributor = {
 schedule_b_by_purpose = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'purpose': fields.List(Keyword, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_b_by_recipient = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_b_by_recipient_id = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'recipient_id': fields.List(IStr, description=docs.RECIPIENT_ID),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 schedule_b = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
     'disbursement_purpose_category': fields.List(IStr, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
     'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
     'last_disbursement_date': Date(missing=None, description=docs.LAST_DISBURSEMENT_DATE),
     'recipient_city': fields.List(IStr, description=docs.RECIPIENT_CITY),
-    'recipient_committee_id': fields.List(IStr, description=docs.RECIPIENT_COMMITTEE_ID),
+    'recipient_committee_id': fields.List(Committee_ID, description=docs.RECIPIENT_COMMITTEE_ID),
     'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
     'recipient_state': fields.List(IStr, description=docs.RECIPIENT_STATE),
     'spender_committee_designation': fields.List(
@@ -728,7 +740,7 @@ schedule_b = {
 }
 
 schedule_b_efile = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     # 'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here
     # if the contributor is registered with the FEC.'),
     # 'recipient_name': fields.List(fields.Str, description='Name of recipient'),
@@ -761,7 +773,7 @@ schedule_c = {
     'min_amount': Currency(description=docs.MIN_FILTER),
     'max_amount': Currency(description=docs.MAX_FILTER),
     'line_number': fields.Str(description=docs.LINE_NUMBER),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_name': fields.List(Keyword, description=docs.CANDIDATE_NAME),
     'loan_source_name': fields.List(Keyword, description=docs.LOAN_SOURCE),
     'min_payment_to_date': fields.Int(description=docs.MIN_PAYMENT_DATE),
@@ -784,7 +796,7 @@ schedule_d = {
     'max_amount_outstanding_close': fields.Float(),
     'creditor_debtor_name': fields.List(Keyword),
     'nature_of_debt': fields.Str(),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'min_coverage_end_date': Date(missing=None, description=docs.MIN_COVERAGE_END_DATE),
     'max_coverage_end_date': Date(missing=None, description=docs.MAX_COVERAGE_END_DATE),
     'min_coverage_start_date': Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
@@ -799,7 +811,7 @@ schedule_d = {
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
@@ -814,12 +826,12 @@ schedule_e_by_candidate = {
 schedule_f = {
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
 }
 
 communication_cost = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
@@ -830,7 +842,7 @@ communication_cost = {
 CC_aggregates = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'support_oppose_indicator': IStr(
         missing=None,
         validate=validate.OneOf(['S', 'O']),
@@ -839,7 +851,7 @@ CC_aggregates = {
 }
 
 electioneering = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'min_amount': Currency(description=docs.ELECTIONEERING_MIN_AMOUNT),
@@ -861,7 +873,7 @@ electioneering_by_candidate = {
 EC_aggregates = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
 elections_list = {
@@ -941,7 +953,7 @@ communication_cost_by_candidate = {
 }
 
 entities = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
 }
 
@@ -953,7 +965,7 @@ schedule_e = {
     'candidate_office_state': fields.List(IStr, description=docs.STATE_GENERIC),
     'candidate_office_district': fields.List(District, description=docs.DISTRICT),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
     'last_expenditure_date': Date(
@@ -983,7 +995,7 @@ schedule_e = {
 
 schedule_e_efile = {
     'candidate_search': fields.List(Keyword, description=docs.CANDIDATE_FULL_SEARCH),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
     'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
@@ -1009,7 +1021,7 @@ schedule_e_efile = {
 }
 
 rad_analyst = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'analyst_id': fields.List(fields.Int(), description='ID of RAD analyst'),
     'analyst_short_id': fields.List(fields.Int(), description='Short ID of RAD analyst'),
     'telephone_ext': fields.List(fields.Int(), description='Telephone extension of RAD analyst'),
@@ -1052,7 +1064,7 @@ auditCase = {
     'sub_category_id': fields.Str(missing='all', description=docs.SUB_CATEGORY_ID),
     'audit_case_id': fields.List(fields.Str(), description=docs.AUDIT_CASE_ID),
     'cycle': fields.List(fields.Int(), description=docs.CYCLE),
-    'committee_id': fields.List(fields.Str(), description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'committee_type': fields.List(fields.Str(), description=docs.COMMITTEE_TYPE),
     'committee_designation': fields.Str(description=docs.COMMITTEE_DESCRIPTION),
     'audit_id': fields.List(fields.Int(), description=docs.AUDIT_ID),
@@ -1128,7 +1140,7 @@ schedule_h4 = {
     'payee_state': fields.List(IStr, description=docs.PAYEE_STATE),
     'q_disbursement_purpose': fields.List(Keyword, description=docs.DISBURSEMENT_PURPOSE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'last_payee_name': fields.List(IStr, missing=None, description=docs.LAST_PAYEE_NAME),
     'last_disbursement_purpose': fields.List(IStr, missing=None, description=docs.LAST_DISBURSEMENT_PURPOSE),
     'last_event_purpose_date': Date(missing=None, description=docs.LAST_EVENT_DATE),
@@ -1165,7 +1177,7 @@ schedule_h4_efile = {
     'payee_city': fields.List(fields.Str, description=docs.PAYEE_CITY),
     'payee_zip': fields.List(fields.Str, description=docs.PAYEE_ZIP),
     'payee_state': fields.List(fields.Str, description=docs.PAYEE_STATE),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'last_disbursement_purpose': fields.List(IStr, missing=None, description=docs.LAST_DISBURSEMENT_PURPOSE),
     'last_event_purpose_date': Date(missing=None, description=docs.LAST_EVENT_DATE),
     'min_date': Date(missing=None, description=docs.MIN_EVENT_DATE),
@@ -1197,7 +1209,7 @@ presidential_by_candidate = {
 }
 
 Inaugural_donations_by_contributor = {
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'contributor_name': fields.List(IStr, description=docs.CONTRIBUTOR_NAME),
     'cycle': fields.List(fields.Int(), description=docs.COMMITTEE_CYCLE)
 }

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -244,7 +244,7 @@ The committee endpoints primarily use data from FEC registration Form 1 and Form
 
 COMMITTEE_ID = '''
 A unique identifier assigned to each committee or filer registered with the FEC. In general \
-committee id's begin with the letter C which is followed by eight digits.
+a committee id begins with the letter C which is followed by eight digits.
 '''
 
 COMMITTEE_NAME = 'The name of the committee. If a committee changes its name, \

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -16,6 +16,10 @@ NEXT_IN_CHAIN_DATA_ERROR = """next_in_chain data error, please contact apiinfo@f
 DATE_ERROR = """Invalid date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD.\
 """
 
+COMMITTEE_ID_ERROR = """Invalid committee_id. A committee_id begins with a 'C'\
+ followed by 8 digits. For example: C00100005.\
+"""
+
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -184,9 +184,12 @@ class CandidateView(ApiResource):
             query = query.filter_by(candidate_id=candidate_id.upper())
 
         if committee_id is not None:
+            committee_id = committee_id.upper()
+            utils.check_committee_id(committee_id)
+
             query = (
                 query.join(models.CandidateCommitteeLink)
-                .filter(models.CandidateCommitteeLink.committee_id == committee_id.upper())
+                .filter(models.CandidateCommitteeLink.committee_id == committee_id)
                 .distinct()
             )
 
@@ -251,6 +254,9 @@ class CandidateHistoryView(ApiResource):
             query = query.filter(models.CandidateHistory.candidate_id == candidate_id.upper())
 
         if committee_id:
+            committee_id = committee_id.upper()
+            utils.check_committee_id(committee_id)
+
             # use for
             # '/committee/<string:committee_id>/candidates/history/',
             # '/committee/<string:committee_id>/candidates/history/<int:cycle>/',
@@ -260,7 +266,7 @@ class CandidateHistoryView(ApiResource):
                     models.CandidateCommitteeLink.candidate_id
                     == models.CandidateHistory.candidate_id,
                 )
-                .filter(models.CandidateCommitteeLink.committee_id == committee_id.upper())
+                .filter(models.CandidateCommitteeLink.committee_id == committee_id)
                 .distinct()
             )
         if cycle:

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -147,7 +147,9 @@ class CommitteeView(ApiResource):
         query = super().build_query(**kwargs)
 
         if committee_id is not None:
-            query = query.filter_by(committee_id=committee_id.upper())
+            committee_id = committee_id.upper()
+            utils.check_committee_id(committee_id)
+            query = query.filter_by(committee_id=committee_id)
 
         if candidate_id is not None:
             query = query.join(
@@ -210,10 +212,13 @@ class CommitteeHistoryProfileView(ApiResource):
         query = super().build_query(**kwargs)
 
         if committee_id:
+            committee_id = committee_id.upper()
+            utils.check_committee_id(committee_id)
+
             # use for
             # '/committee/<string:committee_id>/history/',
             # '/committee/<string:committee_id>/history/<int:cycle>/',
-            query = query.filter(models.CommitteeHistoryProfile.committee_id == committee_id.upper())
+            query = query.filter(models.CommitteeHistoryProfile.committee_id == committee_id)
 
         elif candidate_id:
             # use for
@@ -232,7 +237,9 @@ class CommitteeHistoryProfileView(ApiResource):
             )
 
             # 2) query for PCC to PAC conversion
-            query_pcc_converted = query.filter(models.CommitteeHistoryProfile.former_candidate_id == candidate_id.upper())
+            query_pcc_converted = query.filter(
+                models.CommitteeHistoryProfile.former_candidate_id ==
+                candidate_id.upper())
 
             # 3) query for Leadership PAC committees
             query_leadership_pac = query.join(
@@ -298,4 +305,3 @@ class CommitteeHistoryProfileView(ApiResource):
                 # for election_full=false
                 query = query.filter(models.CommitteeHistoryProfile.cycle == cycle)
         return query
-

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -83,6 +83,8 @@ class FilingsView(BaseFilings):
     def build_query(self, committee_id=None, candidate_id=None, **kwargs):
         query = super().build_query(**kwargs)
         if committee_id:
+            committee_id = committee_id.upper()
+            utils.check_committee_id(committee_id)
             query = query.filter(models.Filings.committee_id == committee_id)
         if candidate_id:
             query = query.filter(models.Filings.candidate_id == candidate_id)

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -243,7 +243,7 @@ class CommitteeReportsView(views.ApiResource):
                 sa.orm.joinedload(reports_class.committee)
             )
         if committee_id is not None:
-            query = query.filter_by(committee_id=committee_id.upper())
+            query = query.filter_by(committee_id=committee_id)
 
         query = filters.filter_range(query, kwargs, get_range_filters())
         query = filters.filter_match(query, kwargs, get_match_filters())
@@ -252,7 +252,8 @@ class CommitteeReportsView(views.ApiResource):
 
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
-            query = models.CommitteeHistory.query.filter_by(committee_id=committee_id.upper())
+            utils.check_committee_id(committee_id)
+            query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
 
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -40,6 +40,7 @@ pac_cmte_list = {'N', 'O', 'Q', 'V', 'W'}
 
 party_cmte_list = {'X', 'Y'}
 
+
 @doc(
     tags=['financial'],
     description=docs.TOTALS,
@@ -231,7 +232,7 @@ class TotalsCommitteeView(ApiResource):
         )
         query = totals_class.query
         if committee_id is not None:
-            query = query.filter(totals_class.committee_id == committee_id.upper())
+            query = query.filter(totals_class.committee_id == committee_id)
         if kwargs.get('cycle'):
             query = query.filter(totals_class.cycle.in_(kwargs['cycle']))
 
@@ -239,6 +240,7 @@ class TotalsCommitteeView(ApiResource):
 
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
+            utils.check_committee_id(committee_id)
             query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -326,6 +326,21 @@ def check_election_arguments(kwargs):
             )
 
 
+def check_committee_id(committee_id):
+
+    if len(committee_id) != 9 or not committee_id.startswith('C'):
+        raise exceptions.ApiError(
+                    exceptions.COMMITTEE_ID_ERROR,
+                    status_code=422)
+
+    try:
+        committee_id = int(committee_id[1:])
+    except (TypeError, ValueError):
+        raise exceptions.ApiError(
+                exceptions.COMMITTEE_ID_ERROR,
+                status_code=422)
+
+
 def get_model(name):
     from webservices.common.models import db
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5603 

This ticket adds validation to the committee_id field by adding a custom field in args.py and adding validation to committee_id in paths (for instance: v1/committee/C00429613/filings/).  It checks that the length is exactly 9, that it begins with a capital 'C', and that the characters after 'C' are digits. 


### Required reviewers 3 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

-  all committee_id fields 
- all automated tests that use committee_id 
- args.py


## How to test

- checkout this branch 
- flask run 
- test all endpoints that use committee_id. I will include a list of endpoints and test urls in the comments. 

