### PR TITLE
Add candidate_id validation

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,7 +27,7 @@ class CommitteeSearchFactory(BaseFactory):
 
 
 class BaseCandidateFactory(BaseFactory):
-    candidate_id = factory.Sequence(lambda n: "ID{0}".format(n))
+    candidate_id = factory.Sequence(lambda n: "S{0}".format(n + 10000000))
 
 
 class CandidateFactory(BaseCandidateFactory):

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -62,7 +62,7 @@ class TotalTestCase(common.BaseTestCase):
     STOCK_CAND_CMTE_LINKAGE = [
         {
             'linkage_id': 1,
-            'cand_id': 'P01',
+            'cand_id': 'P00000001',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
             'cmte_id': 'C00000001',
@@ -74,7 +74,7 @@ class TotalTestCase(common.BaseTestCase):
         },
         {
             'linkage_id': 3,
-            'cand_id': 'P01',
+            'cand_id': 'P00000001',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
             'cmte_id': 'C00000002',
@@ -86,7 +86,7 @@ class TotalTestCase(common.BaseTestCase):
         },
         {
             'linkage_id': 5,
-            'cand_id': 'P03',
+            'cand_id': 'P00000003',
             'fec_election_yr': 2020,
             'cand_election_yr': 2020,
             'cmte_id': 'C00000003',
@@ -152,7 +152,7 @@ class TotalTestCase(common.BaseTestCase):
         assert committee_totals_api[0]['disbursements'] == 80
 
         params_cand = {
-            'candidate_id': 'P01',
+            'candidate_id': 'P00000001',
             'election_full': True,
         }
         candidate_totals_api = self._results(
@@ -168,7 +168,7 @@ class TotalTestCase(common.BaseTestCase):
         should return 0 row. Ex: S2MO00262, H2PA04192
         """
         params_cand = {
-            'candidate_id': 'P03',
+            'candidate_id': 'P00000003',
             'election_full': True,
         }
         candidate_totals_api = self._results(

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -42,7 +42,7 @@ class CandidatesTestCase(common.BaseTestCase):
         cand_valid_fec_yr_data = [
             {
                 'cand_valid_yr_id': 1,
-                'cand_id': 'H1',
+                'cand_id': 'H00000001',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cand_status': 'A',
@@ -53,7 +53,7 @@ class CandidatesTestCase(common.BaseTestCase):
             },
             {
                 'cand_valid_yr_id': 2,
-                'cand_id': 'H2',
+                'cand_id': 'H00000002',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cand_status': 'A',
@@ -64,7 +64,7 @@ class CandidatesTestCase(common.BaseTestCase):
             },
             {
                 'cand_valid_yr_id': 3,
-                'cand_id': 'H3',
+                'cand_id': 'H00000003',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cand_status': 'A',
@@ -80,7 +80,7 @@ class CandidatesTestCase(common.BaseTestCase):
         cand_cmte_linkage_data = [
             {
                 'linkage_id': 2,
-                'cand_id': 'H1',
+                'cand_id': 'H00000001',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cmte_id': '2',
@@ -92,7 +92,7 @@ class CandidatesTestCase(common.BaseTestCase):
             },
             {
                 'linkage_id': 4,
-                'cand_id': 'H2',
+                'cand_id': 'H00000002',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cmte_id': '3',
@@ -104,7 +104,7 @@ class CandidatesTestCase(common.BaseTestCase):
             },
             {
                 'linkage_id': 6,
-                'cand_id': 'H3',
+                'cand_id': 'H00000003',
                 'fec_election_yr': 2020,
                 'cand_election_yr': 2020,
                 'cmte_id': '3',

--- a/tests/integration/test_filings.py
+++ b/tests/integration/test_filings.py
@@ -28,7 +28,7 @@ class TestFilings(BaseTestCase):
     }
 
     SECOND_FILING = {
-        'cand_cmte_id': 'P001',
+        'cand_cmte_id': 'P00000001',
         'report_year': 1994,
         'form_type': 'F2',
         'begin_image_num': '95030061615',

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -218,20 +218,20 @@ class TestAggregates(ApiBaseTest):
             name='Ritchie for America', cycle=2012,
         )
         self.candidate = factories.CandidateDetailFactory(
-            candidate_id='P123',
+            candidate_id='P12300000',
             name='Robert Ritchie',
             election_years=[2012],
             office='P',
         )
         self.candidate_history = factories.CandidateHistoryFactory(
-            candidate_id='P123',
+            candidate_id='P12300000',
             name='Robert Ritchie',
             election_years=[2012],
             two_year_period=2012,
             office='P',
         )
         factories.CandidateElectionFactory(
-            candidate_id='P123', cand_election_year=2012,
+            candidate_id='P12300000', cand_election_year=2012,
         )
 
     def make_aggregates(self, factory):
@@ -332,7 +332,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
     def setUp(self):
         super().setUp()
         self.candidate = factories.CandidateHistoryFutureFactory(
-            candidate_id='S123', two_year_period=2012, candidate_election_year=2012,
+            candidate_id='S12300000', two_year_period=2012, candidate_election_year=2012,
         )
         self.committees = [
             factories.CommitteeHistoryFactory(cycle=2012, designation='P'),
@@ -394,7 +394,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         )
         # Create a candidate_zero without a committee and $0 in CandidateTotal
         self.candidate_zero = factories.CandidateHistoryFutureFactory(
-            candidate_id='H321',
+            candidate_id='H32100000',
             two_year_period=2018,
             candidate_election_year=2018,
             candidate_inactive=True,
@@ -417,7 +417,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         # Create data for a candidate who ran in 2017 and 2018
 
         self.candidate_17_18 = factories.CandidateHistoryFutureFactory(
-            candidate_id='S456',
+            candidate_id='S45600000',
             two_year_period=2018,
             candidate_election_year=2018,
             candidate_inactive=False,
@@ -472,7 +472,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         )
         # Create data for a candidate who ran just in 2017
         self.candidate_17_only = factories.CandidateHistoryFutureFactory(
-            candidate_id='H456', two_year_period=2018, candidate_election_year=2017,
+            candidate_id='H45600000', two_year_period=2018, candidate_election_year=2017,
         )
         self.committees_17_only = [
             factories.CommitteeHistoryFactory(cycle=2018, designation='P'),
@@ -522,12 +522,12 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         # Test full next_cycle and current_cycle 2-year totals
 
         self.candidate_20 = factories.CandidateHistoryFutureFactory(
-            candidate_id='P456',
+            candidate_id='P45600000',
             two_year_period=self.current_cycle,
             candidate_election_year=self.next_cycle,
         )
         self.candidate_20 = factories.CandidateHistoryFutureFactory(
-            candidate_id='P456',
+            candidate_id='P45600000',
             two_year_period=self.next_cycle,
             candidate_election_year=self.next_cycle,
         )
@@ -698,6 +698,15 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
             'count': 20,
         }
         assert results[0] == expected
+
+    def test_candidate_id_validation(self):
+        results = self.app.get(
+            api.url_for(
+                ScheduleABySizeCandidateView,
+                candidate_id='S000',
+            )
+        )
+        self.assertEqual(results.status_code, 422)
 # end --- test '/schedules/schedule_a/by_size/by_candidate/' (candidate_aggregates.ScheduleABySizeCandidateView)
 
 # start --- test '/schedules/schedule_a/by_state/by_candidate' (candidate_aggregates.ScheduleAByStateCandidateView)
@@ -1094,7 +1103,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         assert_dicts_subset(
             results[0],
             {
-                "candidate_id": "P456",
+                "candidate_id": "P45600000",
                 "receipts": 25000,
             },
         )
@@ -1128,7 +1137,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
         )
 
         factories.CandidateTotalFactory(
-            candidate_id="HCA01",
+            candidate_id="HCA000001",
             is_election=True,
             receipts=1000,
             disbursements=1000,
@@ -1147,7 +1156,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='California'
         )
         factories.CandidateTotalFactory(
-            candidate_id="HCA01",
+            candidate_id="HCA000001",
             is_election=False,
             receipts=1000,
             disbursements=1000,
@@ -1166,7 +1175,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='California'
         )
         factories.CandidateTotalFactory(
-            candidate_id="HCA02",
+            candidate_id="HCA000002",
             is_election=True,
             receipts=2000,
             disbursements=2000,
@@ -1185,7 +1194,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='California'
         )
         factories.CandidateTotalFactory(
-            candidate_id="HNY01",
+            candidate_id="HNY000001",
             is_election=True,
             receipts=3300,
             disbursements=3300,
@@ -1203,7 +1212,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='New York'
         )
         factories.CandidateTotalFactory(
-            candidate_id="HNY13",
+            candidate_id="HNY000013",
             is_election=True,
             receipts=4000,
             disbursements=4000,
@@ -1222,7 +1231,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
         )
 
         factories.CandidateTotalFactory(
-            candidate_id="SCA01",
+            candidate_id="SCA000001",
             is_election=True,  # candidate election year
             receipts=100,
             disbursements=100,
@@ -1240,7 +1249,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='California'
         )
         factories.CandidateTotalFactory(
-            candidate_id="SCA01",
+            candidate_id="SCA000001",
             is_election=False,  # data for two-year period (not candidate election year)
             cycle=2012,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=200,
@@ -1259,7 +1268,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='California'
         )
         factories.CandidateTotalFactory(
-            candidate_id="SNY01",
+            candidate_id="SNY000001",
             is_election=False,  # data for two-year period (not candidate election year)
             cycle=2014,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=400,
@@ -1278,7 +1287,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='New York'
         )
         factories.CandidateTotalFactory(
-            candidate_id="SNY01",
+            candidate_id="SNY000001",
             is_election=False,  # data for two-year period (not candidate election year)
             cycle=2016,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=600,
@@ -1297,7 +1306,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='New York'
         )
         factories.CandidateTotalFactory(
-            candidate_id="SNY01",
+            candidate_id="SNY000001",
             is_election=True,  # data for two-year period (not candidate election year)
             cycle=2016,  # UNIQUE INDEX=elction_year,candidate_id,cycle,is_election
             receipts=1000,
@@ -1316,7 +1325,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
             state_full='New York'
         )
         factories.CandidateTotalFactory(
-            candidate_id="SVA02",  # not exist in election list
+            candidate_id="SVA000002",  # not exist in election list
             is_election=True,  # candidate election year
             cycle=2010,
             receipts=700,
@@ -1336,7 +1345,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
         )
 
         factories.CandidateTotalFactory(
-            candidate_id="SCA03",
+            candidate_id="SCA000003",
             is_election=True,  # candidate election year
             cycle=2016,
             receipts=800,
@@ -1356,7 +1365,7 @@ class TestCandidateTotalAggregateView(ApiBaseTest):
         )
 
         factories.CandidateTotalFactory(
-            candidate_id="SCA04",
+            candidate_id="SCA000004",
             is_election=True,  # candidate election year
             cycle=2022,
             receipts=90,

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -146,8 +146,8 @@ class CandidateFormatTest(ApiBaseTest):
             factories.CandidateFactory(name='Obama'),
             factories.CandidateFactory(party='DEM'),
             factories.CandidateFactory(cycles=[2006]),
-            factories.CandidateFactory(candidate_id='BARLET'),
-            factories.CandidateFactory(candidate_id='RITCHIE'),
+            factories.CandidateFactory(candidate_id='H00000011'),
+            factories.CandidateFactory(candidate_id='H00000022'),
             factories.CandidateFactory(candidate_inactive=True),
             factories.CandidateFactory(inactive_election_years=[2012]),
         ]
@@ -158,7 +158,7 @@ class CandidateFormatTest(ApiBaseTest):
             ('state', 'CA'),
             ('party', 'DEM'),
             ('cycle', '2006'),
-            ('candidate_id', ['BARTLET', 'ritchie']),
+            ('candidate_id', ['H00000011', 'H00000022']),
             ('is_active_candidate', False),
         )
 
@@ -228,8 +228,8 @@ class TestCandidateHistory(ApiBaseTest):
         super().setUp()
         self.committee = factories.CommitteeDetailFactory()
         self.candidates = [
-            factories.CandidateDetailFactory(candidate_id='P001'),
-            factories.CandidateDetailFactory(candidate_id='P002'),
+            factories.CandidateDetailFactory(candidate_id='P00000001'),
+            factories.CandidateDetailFactory(candidate_id='P00000002'),
         ]
         self.histories = [
             factories.CandidateHistoryFactory(
@@ -277,7 +277,7 @@ class TestCandidateHistory(ApiBaseTest):
 
     def test_election_full(self):
         # When election_full=true, return all two_year_periods with that candidate_election_year
-        candidate = factories.CandidateDetailFactory(candidate_id='H001')
+        candidate = factories.CandidateDetailFactory(candidate_id='H00000001')
         first_two_year_period = factories.CandidateHistoryFactory(
             candidate_id=candidate.candidate_id,
             two_year_period=2018,

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -64,7 +64,7 @@ class CommitteeFormatTest(ApiBaseTest):
             )
 
     def test_filter_by_candidate_id(self):
-        candidate_id = "ID0"
+        candidate_id = "H00000001"
         candidate_committees = [
             factories.CommitteeFactory(candidate_ids=[candidate_id]) for _ in range(2)
         ]
@@ -73,7 +73,7 @@ class CommitteeFormatTest(ApiBaseTest):
         self.assertEqual(len(response["results"]), len(candidate_committees))
 
     def test_filter_by_candidate_ids(self):
-        candidate_ids = ["ID0", "ID1"]
+        candidate_ids = ["H00000001", "H00000002"]
         candidate1_committees = [
             factories.CommitteeFactory(candidate_ids=[candidate_ids[0]])
             for _ in range(2)
@@ -402,20 +402,20 @@ class CommitteeFormatTest(ApiBaseTest):
         )
 
     def test_filter_by_sponsor_candidate_ids(self):
-        sponsor_candidate_ids1 = ["H001"]
-        sponsor_candidate_ids2 = ["S001"]
+        sponsor_candidate_ids1 = ["H00000001"]
+        sponsor_candidate_ids2 = ["S00000001"]
         factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids1)
         factories.CommitteeFactory(sponsor_candidate_ids=sponsor_candidate_ids2)
 
         results = self._results(
-            api.url_for(CommitteeList, sponsor_candidate_id="H001")
+            api.url_for(CommitteeList, sponsor_candidate_id="H00000001")
         )
 
         assert len(results) == 1
         assert results[0]["sponsor_candidate_ids"] == sponsor_candidate_ids1
 
         results = self._results(
-            api.url_for(CommitteeList, sponsor_candidate_id="-H001")
+            api.url_for(CommitteeList, sponsor_candidate_id="S00000001")
         )
         assert len(results) == 1
         assert results[0]["sponsor_candidate_ids"] == sponsor_candidate_ids2
@@ -424,16 +424,16 @@ class CommitteeFormatTest(ApiBaseTest):
         committee = factories.CommitteeFactory(
             party="REP",
             name="For America",
-            sponsor_candidate_ids=["H002"]
+            sponsor_candidate_ids=["H00000002"]
         )
         factories.PacSponsorCandidateFactory(
             committee_id=committee.committee_id,
-            sponsor_candidate_id="H002",
+            sponsor_candidate_id="H00000002",
             sponsor_candidate_name="Sponsor A",
         )
         factories.PacSponsorCandidateFactory(
-            committee_id='C007',
-            sponsor_candidate_id="S003",
+            committee_id='C00000007',
+            sponsor_candidate_id="S00000003",
             sponsor_candidate_name="Sponsor B",
         )
         results = self._results(
@@ -446,7 +446,7 @@ class CommitteeFormatTest(ApiBaseTest):
             results[0]["sponsor_candidate_list"][0]["sponsor_candidate_name"], "Sponsor A"
         )
         self.assertEqual(
-            results[0]["sponsor_candidate_list"][0]["sponsor_candidate_id"], "H002"
+            results[0]["sponsor_candidate_list"][0]["sponsor_candidate_id"], "H00000002"
         )
 
 
@@ -526,7 +526,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
                 cycle=2020,
                 designation="D",
                 is_active=True,
-                sponsor_candidate_ids=["H003", "H004"]
+                sponsor_candidate_ids=["H00000003", "H00000004"]
             ),
             factories.CommitteeHistoryProfileFactory(
                 committee_id=self.committees[7].committee_id,
@@ -700,7 +700,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
         assert results[0].get("former_candidate_id") == self.candidate.candidate_id
 
     def test_case_insensitivity(self):
-        lower_candidate = factories.CandidateDetailFactory(candidate_id="H01")
+        lower_candidate = factories.CandidateDetailFactory(candidate_id="H00000001")
         lower_committee_1 = factories.CommitteeDetailFactory(committee_id="C00000001")
         [
             factories.CommitteeHistoryProfileFactory(
@@ -746,7 +746,7 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
         results = self._results(
             api.url_for(
                 CommitteeHistoryProfileView,
-                candidate_id="h01",
+                candidate_id="h00000001",
                 cycle=2014,
                 election_full=False
             )
@@ -761,26 +761,26 @@ class TestCommitteeHistoryProfile(ApiBaseTest):
             )
         )
         assert len(result) == 1
-        self.assertEqual(result[0]["sponsor_candidate_ids"], ["H003", "H004"])
+        self.assertEqual(result[0]["sponsor_candidate_ids"], ["H00000003", "H00000004"])
 
     def test_jfc_committee(self):
         factories.JFCCommitteeFactory(
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_001",
             most_recent_filing_flag='Y',
-            joint_committee_id="C009",
+            joint_committee_id="C00000009",
         )
         factories.JFCCommitteeFactory(
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_old",
             most_recent_filing_flag='N',
-            joint_committee_id="C009",
+            joint_committee_id="C00000009",
         )
         factories.JFCCommitteeFactory(
             committee_id=self.committees[7].committee_id,
             joint_committee_name="JFC_002",
             most_recent_filing_flag='Y',
-            joint_committee_id="C009",
+            joint_committee_id="C00000009",
         )
         results = self._results(
             api.url_for(CommitteeHistoryProfileView, committee_id=self.committees[7].committee_id)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -18,7 +18,7 @@ class TestCommunicationCost(ApiBaseTest):
         filters = [
             ('image_number', CommunicationCost.image_number, ['123', '456']),
             ('committee_id', CommunicationCost.committee_id, ['C00000001', 'C00000002']),
-            ('candidate_id', CommunicationCost.candidate_id, ['S01', 'S02']),
+            ('candidate_id', CommunicationCost.candidate_id, ['S00000001', 'S00000002']),
         ]
         for label, column, values in filters:
             [
@@ -58,7 +58,7 @@ class TestElectioneering(ApiBaseTest):
         filters = [
             ('report_year', Electioneering.report_year, [2012, 2014]),
             ('committee_id', Electioneering.committee_id, ['C00000001', 'C00000002']),
-            ('candidate_id', Electioneering.candidate_id, ['S01', 'S02']),
+            ('candidate_id', Electioneering.candidate_id, ['S00000001', 'S00000002']),
         ]
         for label, column, values in filters:
             [factories.ElectioneeringFactory(**{column.key: value}) for value in values]

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -21,7 +21,7 @@ class TestFilings(ApiBaseTest):
         self.assertEqual(results[0]['committee_id'], committee_id)
 
     def test_candidate_filings(self):
-        candidate_id = 'P12345'
+        candidate_id = 'P12345000'
         factories.FilingsFactory(candidate_id=candidate_id)
         results = self._results(api.url_for(FilingsView, candidate_id=candidate_id))
         self.assertEqual(len(results), 1)
@@ -29,15 +29,15 @@ class TestFilings(ApiBaseTest):
 
     def test_filings(self):
         """ Check filings returns in general endpoint"""
-        factories.FilingsFactory(committee_id='C001')
-        factories.FilingsFactory(committee_id='C002')
+        factories.FilingsFactory(committee_id='C00000001')
+        factories.FilingsFactory(committee_id='C00000002')
 
         results = self._results(api.url_for(FilingsList))
         self.assertEqual(len(results), 2)
 
     def test_filings_with_bank(self):
         """ Check filings returns bank information"""
-        factories.FilingsFactory(committee_id='C001', bank_depository_name='Bank A')
+        factories.FilingsFactory(committee_id='C00000001', bank_depository_name='Bank A')
 
         results = self._results(api.url_for(FilingsList))
         self.assertEqual(len(results), 1)
@@ -79,9 +79,9 @@ class TestFilings(ApiBaseTest):
 
     def test_filings_filters(self):
         [
-            factories.FilingsFactory(committee_id='C0004'),
-            factories.FilingsFactory(committee_id='C0005'),
-            factories.FilingsFactory(candidate_id='H0001'),
+            factories.FilingsFactory(committee_id='C00000004'),
+            factories.FilingsFactory(committee_id='C00000005'),
+            factories.FilingsFactory(candidate_id='H00000001'),
             factories.FilingsFactory(amendment_indicator='A'),
             factories.FilingsFactory(beginning_image_number=123456789021234567),
             factories.FilingsFactory(committee_type='P'),
@@ -118,7 +118,7 @@ class TestFilings(ApiBaseTest):
             ('report_year', 1999),
             ('request_type', '5'),
             ('state', 'MD'),
-            ('candidate_id', 'H0001'),
+            ('candidate_id', 'H00000001'),
             ('q_filer', 'action'),
         )
 
@@ -278,12 +278,12 @@ class TestEfileFiles(ApiBaseTest):
 
         [
             factories.EFilingsFactory(
-                committee_id="C013",
+                committee_id="C00000013",
                 beginning_image_number=5,
                 filed_date=datetime.date(2015, 1, 1),
             ),
             factories.EFilingsFactory(
-                committee_id="C014",
+                committee_id="C00000014",
                 beginning_image_number=6,
                 filed_date=datetime.date(2015, 1, 2),
             ),
@@ -299,8 +299,8 @@ class TestEfileFiles(ApiBaseTest):
 
     def test_efilings(self):
         """ Check filings returns in general endpoint"""
-        factories.EFilingsFactory(committee_id="C001")
-        factories.EFilingsFactory(committee_id="C002")
+        factories.EFilingsFactory(committee_id="C00000001")
+        factories.EFilingsFactory(committee_id="C00000002")
 
         results = self._results(api.url_for(EFilingsView))
         self.assertEqual(len(results), 2)
@@ -359,30 +359,30 @@ class TestEfileFiles(ApiBaseTest):
     def test_fulltext_keyword_search(self):
         [
             factories.EFilingsFactory(
-                committee_id="C01",
+                committee_id="C00000001",
                 committee_name="Danielle",
             ),
             factories.EFilingsFactory(
-                committee_id="C02",
+                committee_id="C00000002",
                 committee_name="Dana",
             ),
         ]
 
         factories.CommitteeSearchFactory(
-            id="C01", fulltxt=sa.func.to_tsvector("Danielle")
+            id="C00000001", fulltxt=sa.func.to_tsvector("Danielle")
         )
         factories.CommitteeSearchFactory(
-            id="C02", fulltxt=sa.func.to_tsvector("Dana")
+            id="C00000002", fulltxt=sa.func.to_tsvector("Dana")
         )
         rest.db.session.flush()
         results = self._results(api.url_for(EFilingsView, q_filer="Danielle"))
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]["committee_id"], "C01")
+        self.assertEqual(results[0]["committee_id"], "C00000001")
 
         results = self._results(api.url_for(EFilingsView, q_filer="dan"))
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0]["committee_id"], "C01")
-        self.assertEqual(results[1]["committee_id"], "C02")
+        self.assertEqual(results[0]["committee_id"], "C00000001")
+        self.assertEqual(results[1]["committee_id"], "C00000002")
 
     def test_invalid_keyword(self):
         response = self.app.get(

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1237,7 +1237,7 @@ class TestScheduleE(ApiBaseTest):
 
     def test_schedule_e_efile_candidate_id_filter(self):
         filters = [
-            ('candidate_id', ScheduleEEfile.candidate_id, ['S01', 'S02']),
+            ('candidate_id', ScheduleEEfile.candidate_id, ['S00000001', 'S00000002']),
         ]
         factories.EFilingsFactory(file_number=123)
         for label, column, values in filters:

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -18,16 +18,16 @@ class PresidentialByCandidate(ApiBaseTest):
     def test_without_filter(self):
         """ Check results without filter"""
         factories.PresidentialByCandidateFactory(
-            candidate_id='C001', election_year=2016, contributor_state='US'
+            candidate_id='P00000001', election_year=2016, contributor_state='US'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2016, contributor_state='NY'
+            candidate_id='P00000002', election_year=2016, contributor_state='NY'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C001', election_year=2020, contributor_state='US'
+            candidate_id='P00000001', election_year=2020, contributor_state='US'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2020, contributor_state='NY'
+            candidate_id='P00000002', election_year=2020, contributor_state='NY'
         )
 
         results = self._results(api.url_for(PresidentialByCandidateView))
@@ -35,22 +35,22 @@ class PresidentialByCandidate(ApiBaseTest):
 
     def test_filters(self):
         factories.PresidentialByCandidateFactory(
-            candidate_id='C001', election_year=2016, contributor_state='US'
+            candidate_id='P00000001', election_year=2016, contributor_state='US'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2016, contributor_state='NY'
+            candidate_id='P00000002', election_year=2016, contributor_state='NY'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C001', election_year=2020, contributor_state='US'
+            candidate_id='P00000001', election_year=2020, contributor_state='US'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2020, contributor_state='NY'
+            candidate_id='P00000002', election_year=2020, contributor_state='NY'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2020, contributor_state='VA'
+            candidate_id='P00000002', election_year=2020, contributor_state='VA'
         )
         factories.PresidentialByCandidateFactory(
-            candidate_id='C002', election_year=2020, contributor_state='CA'
+            candidate_id='P00000002', election_year=2020, contributor_state='CA'
         )
 
         filter_fields = (
@@ -73,14 +73,14 @@ class PresidentialByCandidate(ApiBaseTest):
 
     def test_sort(self):
 
-        factories.PresidentialByCandidateFactory(candidate_id='C003', net_receipts=333)
-        factories.PresidentialByCandidateFactory(candidate_id='C001', net_receipts=222)
-        factories.PresidentialByCandidateFactory(candidate_id='C004', net_receipts=111)
-        factories.PresidentialByCandidateFactory(candidate_id='C002', net_receipts=444)
+        factories.PresidentialByCandidateFactory(candidate_id='P00000003', net_receipts=333)
+        factories.PresidentialByCandidateFactory(candidate_id='P00000001', net_receipts=222)
+        factories.PresidentialByCandidateFactory(candidate_id='P00000004', net_receipts=111)
+        factories.PresidentialByCandidateFactory(candidate_id='P00000002', net_receipts=444)
 
         results = self._results(api.url_for(PresidentialByCandidateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['P00000002', 'P00000003', 'P00000001', 'P00000004']
         )
 
 
@@ -89,32 +89,32 @@ class PresidentialByState(ApiBaseTest):
 
     def test_without_filter(self):
         """ Check results without filter"""
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2016)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2016)
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000001', election_year=2016)
+        factories.PresidentialByStateFactory(candidate_id='P00000002', election_year=2016)
+        factories.PresidentialByStateFactory(candidate_id='P00000001', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000002', election_year=2020)
 
         results = self._results(api.url_for(PresidentialByStateView))
         self.assertEqual(len(results), 4)
 
     def test_filters_election_year(self):
         factories.PresidentialByStateFactory(
-            candidate_id='C001', election_year=2016, contribution_receipt_amount=100
+            candidate_id='P00000001', election_year=2016, contribution_receipt_amount=100
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C002', election_year=2016, contribution_receipt_amount=200
+            candidate_id='P00000002', election_year=2016, contribution_receipt_amount=200
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C001', election_year=2020, contribution_receipt_amount=300
+            candidate_id='P00000001', election_year=2020, contribution_receipt_amount=300
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=400
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=400
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=500
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=500
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=600
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=600
         )
 
         filter_fields = (('election_year', [2020]),)
@@ -134,14 +134,14 @@ class PresidentialByState(ApiBaseTest):
 
     def test_filters_candidate_id(self):
         """ always return 51 rows(51 states) for each candidate_id/"""
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2016)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2016)
-        factories.PresidentialByStateFactory(candidate_id='C001', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C003', election_year=2020)
-        factories.PresidentialByStateFactory(candidate_id='C004', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000001', election_year=2016)
+        factories.PresidentialByStateFactory(candidate_id='P00000002', election_year=2016)
+        factories.PresidentialByStateFactory(candidate_id='P00000001', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000002', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000003', election_year=2020)
+        factories.PresidentialByStateFactory(candidate_id='P00000004', election_year=2020)
 
-        filter_fields = (('candidate_id', ['C001', 'C002']),)
+        filter_fields = (('candidate_id', ['P00000001', 'P00000002']),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialByStateView))
@@ -158,21 +158,21 @@ class PresidentialByState(ApiBaseTest):
 
     def test_sort(self):
         factories.PresidentialByStateFactory(
-            candidate_id='C003', contribution_receipt_amount=333
+            candidate_id='P00000003', contribution_receipt_amount=333
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C001', contribution_receipt_amount=222
+            candidate_id='P00000001', contribution_receipt_amount=222
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C004', contribution_receipt_amount=111
+            candidate_id='P00000004', contribution_receipt_amount=111
         )
         factories.PresidentialByStateFactory(
-            candidate_id='C002', contribution_receipt_amount=444
+            candidate_id='P00000002', contribution_receipt_amount=444
         )
 
         results = self._results(api.url_for(PresidentialByStateView))
         self.assertEqual(
-            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['P00000002', 'P00000003', 'P00000001', 'P00000004']
         )
 
 
@@ -181,25 +181,25 @@ class PresidentialSummary(ApiBaseTest):
 
     def test_without_filter(self):
         """ Check results without filter"""
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016)
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020)
+        factories.PresidentialSummaryFactory(candidate_id='P00000001', election_year=2016)
+        factories.PresidentialSummaryFactory(candidate_id='P00000002', election_year=2016)
+        factories.PresidentialSummaryFactory(candidate_id='P00000001', election_year=2020)
+        factories.PresidentialSummaryFactory(candidate_id='P00000002', election_year=2020)
 
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(len(results), 4)
 
     def test_filters(self):
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2016, net_receipts=100)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2016, net_receipts=200)
-        factories.PresidentialSummaryFactory(candidate_id='C001', election_year=2020, net_receipts=300)
-        factories.PresidentialSummaryFactory(candidate_id='C002', election_year=2020, net_receipts=400)
-        factories.PresidentialSummaryFactory(candidate_id='C003', election_year=2020, net_receipts=500)
-        factories.PresidentialSummaryFactory(candidate_id='C004', election_year=2020, net_receipts=600)
+        factories.PresidentialSummaryFactory(candidate_id='P00000001', election_year=2016, net_receipts=100)
+        factories.PresidentialSummaryFactory(candidate_id='P00000002', election_year=2016, net_receipts=200)
+        factories.PresidentialSummaryFactory(candidate_id='P00000001', election_year=2020, net_receipts=300)
+        factories.PresidentialSummaryFactory(candidate_id='P00000002', election_year=2020, net_receipts=400)
+        factories.PresidentialSummaryFactory(candidate_id='P00000003', election_year=2020, net_receipts=500)
+        factories.PresidentialSummaryFactory(candidate_id='P00000004', election_year=2020, net_receipts=600)
 
         filter_fields = (
             ('election_year', [2020]),
-            ('candidate_id', ['C001', 'C002']),
+            ('candidate_id', ['P00000001', 'P00000002']),
         )
 
         # checking one example from each field
@@ -221,32 +221,32 @@ class PresidentialBySize(ApiBaseTest):
 
     def test_without_filter(self):
         """ Check results without filter"""
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2016)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016)
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000001', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='P00000002', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='P00000001', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000002', election_year=2020)
 
         results = self._results(api.url_for(PresidentialBySizeView))
         self.assertEqual(len(results), 4)
 
     def test_filters_election_year(self):
         factories.PresidentialBySizeFactory(
-            candidate_id='C001', election_year=2016, contribution_receipt_amount=100
+            candidate_id='P00000001', election_year=2016, contribution_receipt_amount=100
         )
         factories.PresidentialBySizeFactory(
-            candidate_id='C002', election_year=2016, contribution_receipt_amount=200
+            candidate_id='P00000002', election_year=2016, contribution_receipt_amount=200
         )
         factories.PresidentialBySizeFactory(
-            candidate_id='C001', election_year=2020, contribution_receipt_amount=300
+            candidate_id='P00000001', election_year=2020, contribution_receipt_amount=300
         )
         factories.PresidentialBySizeFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=400
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=400
         )
         factories.PresidentialBySizeFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=500
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=500
         )
         factories.PresidentialBySizeFactory(
-            candidate_id='C002', election_year=2020, contribution_receipt_amount=600
+            candidate_id='P00000002', election_year=2020, contribution_receipt_amount=600
         )
 
         filter_fields = (('election_year', [2020]),)
@@ -266,14 +266,14 @@ class PresidentialBySize(ApiBaseTest):
 
     def test_filters_candidate_id(self):
         """ always return 51 rows(51 states) for each candidate_id/"""
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2016)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2016)
-        factories.PresidentialBySizeFactory(candidate_id='C001', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C002', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C003', election_year=2020)
-        factories.PresidentialBySizeFactory(candidate_id='C004', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000001', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='P00000002', election_year=2016)
+        factories.PresidentialBySizeFactory(candidate_id='P00000001', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000002', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000003', election_year=2020)
+        factories.PresidentialBySizeFactory(candidate_id='P00000004', election_year=2020)
 
-        filter_fields = (('candidate_id', ['C001', 'C002']),)
+        filter_fields = (('candidate_id', ['P00000001', 'P00000002']),)
 
         # checking one example from each field
         orig_response = self._response(api.url_for(PresidentialBySizeView))
@@ -289,14 +289,14 @@ class PresidentialBySize(ApiBaseTest):
             self.assertGreater(original_count, response['pagination']['count'])
 
     def test_sort(self):
-        factories.PresidentialSummaryFactory(candidate_id='C003', net_receipts=333)
-        factories.PresidentialSummaryFactory(candidate_id='C001', net_receipts=222)
-        factories.PresidentialSummaryFactory(candidate_id='C004', net_receipts=111)
-        factories.PresidentialSummaryFactory(candidate_id='C002', net_receipts=444)
+        factories.PresidentialSummaryFactory(candidate_id='P00000003', net_receipts=333)
+        factories.PresidentialSummaryFactory(candidate_id='P00000001', net_receipts=222)
+        factories.PresidentialSummaryFactory(candidate_id='P00000004', net_receipts=111)
+        factories.PresidentialSummaryFactory(candidate_id='P00000002', net_receipts=444)
 
         results = self._results(api.url_for(PresidentialSummaryView))
         self.assertEqual(
-            [each['candidate_id'] for each in results], ['C002', 'C003', 'C001', 'C004']
+            [each['candidate_id'] for each in results], ['P00000002', 'P00000003', 'P00000001', 'P00000004']
         )
 
 
@@ -306,22 +306,22 @@ class PresidentialCoverage(ApiBaseTest):
     def test_without_filter(self):
         """ Check results without filter"""
         factories.PresidentialCoverageFactory(
-            candidate_id='C001',
+            candidate_id='P00000001',
             election_year=2016,
             coverage_end_date=datetime.date(2016, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C002',
+            candidate_id='P00000002',
             election_year=2016,
             coverage_end_date=datetime.date(2016, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C001',
+            candidate_id='P00000001',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C002',
+            candidate_id='P00000002',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
@@ -331,39 +331,39 @@ class PresidentialCoverage(ApiBaseTest):
 
     def test_filters(self):
         factories.PresidentialCoverageFactory(
-            candidate_id='C001',
+            candidate_id='P00000001',
             election_year=2016,
             coverage_end_date=datetime.date(2016, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C002',
+            candidate_id='P00000002',
             election_year=2016,
             coverage_end_date=datetime.date(2016, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C001',
+            candidate_id='P00000001',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C002',
+            candidate_id='P00000002',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C003',
+            candidate_id='P00000003',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
         factories.PresidentialCoverageFactory(
-            candidate_id='C004',
+            candidate_id='P00000004',
             election_year=2020,
             coverage_end_date=datetime.date(2018, 12, 31),
         )
 
         filter_fields = (
             ('election_year', [2020]),
-            ('candidate_id', ['C001', 'C002']),
+            ('candidate_id', ['P00000001', 'P00000002']),
         )
 
         # checking one example from each field

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -9,7 +9,7 @@ from webservices.resources.aggregates import ScheduleEByCandidateView
 # test /schedules/schedule_e/by_candidate/ under tag: independent expenditures
 class TestScheduleEByCandidateView(ApiBaseTest):
     def test_fields(self):
-        candidate_id = 'S001'
+        candidate_id = 'S00000001'
         support_oppose_indicator = 'S'
         factories.ScheduleEByCandidateFactory(
             candidate_id=candidate_id,
@@ -18,30 +18,30 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         factories.CandidateElectionFactory(candidate_id=candidate_id,
                                            cand_election_year=2018)
         results = self._results(api.url_for(ScheduleEByCandidateView,
-                                            candidate_id='S001'))
+                                            candidate_id='S00000001'))
         assert len(results) == 1
         assert results[0].keys() == ScheduleEByCandidateSchema().fields.keys()
 
     def test_sched_e_filter_match(self):
-        factories.CandidateElectionFactory(candidate_id='S002',
+        factories.CandidateElectionFactory(candidate_id='S00000002',
                                            cand_election_year=2014)
         factories.ScheduleEByCandidateFactory(
             total=50000,
             count=10,
             cycle=2008,
-            candidate_id='S001',
+            candidate_id='S00000001',
             support_oppose_indicator='O',
         ),
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
-            candidate_id='S002',
+            candidate_id='S00000002',
             support_oppose_indicator='S',
         ),
 
         results = self._results(
-            api.url_for(ScheduleEByCandidateView, candidate_id='S002',
+            api.url_for(ScheduleEByCandidateView, candidate_id='S00000002',
                         cycle=2014, support_oppose='S')
         )
         self.assertEqual(len(results), 1)
@@ -55,21 +55,21 @@ class TestScheduleEByCandidateView(ApiBaseTest):
     def test_sort_by_candidate_id(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             name='Robert Ritchie',
             two_year_period=2012,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             name='FARLEY Ritchie',
             two_year_period=2012,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S003',
+            candidate_id='S00000003',
             name='Robert Ritchie',
             election_years=[2012],
             two_year_period=2012,
@@ -78,32 +78,32 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             cand_election_year=2012)
         factories.CandidateElectionFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             cand_election_year=2012)
         factories.CandidateElectionFactory(
-            candidate_id='S003',
+            candidate_id='S00000003',
             cand_election_year=2012)
 
         factories.ScheduleEByCandidateFactory(
             cycle=2012,
-            candidate_id='S001',
+            candidate_id='S00000001',
             support_oppose_indicator='O',
             total=700,
             count=5,
         ),
         factories.ScheduleEByCandidateFactory(
             cycle=2012,
-            candidate_id='S002',
+            candidate_id='S00000002',
             support_oppose_indicator='O',
             total=500,
             count=3,
         ),
         factories.ScheduleEByCandidateFactory(
             cycle=2012,
-            candidate_id='S003',
+            candidate_id='S00000003',
             support_oppose_indicator='S',
             total=100,
             count=1,
@@ -112,24 +112,24 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             api.url_for(ScheduleEByCandidateView, sort='-candidate_id',
                         office='senate', state='NY', cycle=2012))
         self.assertEqual(len(response), 3)
-        self.assertEqual(response[0]['candidate_id'], 'S003')
+        self.assertEqual(response[0]['candidate_id'], 'S00000003')
         self.assertEqual(response[0]['support_oppose_indicator'], 'S')
-        self.assertEqual(response[1]['candidate_id'], 'S002')
+        self.assertEqual(response[1]['candidate_id'], 'S00000002')
         self.assertEqual(response[1]['support_oppose_indicator'], 'O')
-        self.assertEqual(response[2]['candidate_id'], 'S001')
+        self.assertEqual(response[2]['candidate_id'], 'S00000001')
         self.assertEqual(response[2]['support_oppose_indicator'], 'O')
 
     def test_sort_by_candidate_name_descending(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             name='WARNER, MARK',
             two_year_period=2010,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             name='BALDWIN, ALISSA',
             two_year_period=2010,
             office='S',
@@ -137,24 +137,24 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             cand_election_year=2010)
         factories.CandidateElectionFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             cand_election_year=2010)
 
         factories.ScheduleEByCandidateFactory(
             total=50000,
             count=10,
             cycle=2010,
-            candidate_id='S005',
+            candidate_id='S00000005',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
-            candidate_id='S006',
+            candidate_id='S00000006',
             support_oppose_indicator='S',
         ),
 
@@ -171,15 +171,15 @@ class TestScheduleEByCandidateView(ApiBaseTest):
 
         factories.CommitteeHistoryFactory(
             name='Warner for America', cycle=2010,
-            committee_id='C005'
+            committee_id='C00000005'
         )
         factories.CommitteeHistoryFactory(
             name='Ritche for America', cycle=2010,
-            committee_id='C006'
+            committee_id='C00000006'
         )
 
         factories.CandidateHistoryFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             name='WARNER, MARK',
             election_years=[2010],
             two_year_period=2010,
@@ -187,7 +187,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             name='BALDWIN, ALISSA',
             election_years=[2010],
             two_year_period=2010,
@@ -196,27 +196,27 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             cand_election_year=2010)
         factories.CandidateElectionFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             cand_election_year=2010)
 
         factories.ScheduleEByCandidateFactory(
             total=50000,
             count=10,
             cycle=2010,
-            candidate_id='S005',
+            candidate_id='S00000005',
             support_oppose_indicator='S',
-            committee_id='C005',
+            committee_id='C00000005',
         ),
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
-            candidate_id='S005',
+            candidate_id='S00000005',
             support_oppose_indicator='S',
-            committee_id='C006',
+            committee_id='C00000006',
         ),
 
         response = self._results(api.url_for(ScheduleEByCandidateView,
@@ -225,22 +225,22 @@ class TestScheduleEByCandidateView(ApiBaseTest):
                                              cycle=2010,
                                              state='NY'))
         self.assertEqual(len(response), 2)
-        self.assertEqual(response[0]['committee_id'], 'C006')
-        self.assertEqual(response[1]['committee_id'], 'C005')
+        self.assertEqual(response[0]['committee_id'], 'C00000006')
+        self.assertEqual(response[1]['committee_id'], 'C00000005')
 
     def test_sort_by_committee_name(self):
 
         factories.CommitteeHistoryFactory(
             name='Warner for America', cycle=2010,
-            committee_id='C005'
+            committee_id='C00000005'
         )
         factories.CommitteeHistoryFactory(
             name='Ritche for America', cycle=2010,
-            committee_id='C006'
+            committee_id='C00000006'
         )
 
         factories.CandidateHistoryFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             name='WARNER, MARK',
             election_years=[2010],
             two_year_period=2010,
@@ -248,7 +248,7 @@ class TestScheduleEByCandidateView(ApiBaseTest):
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             name='BALDWIN, ALISSA',
             election_years=[2010],
             two_year_period=2010,
@@ -257,27 +257,27 @@ class TestScheduleEByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S005',
+            candidate_id='S00000005',
             cand_election_year=2010)
         factories.CandidateElectionFactory(
-            candidate_id='S006',
+            candidate_id='S00000006',
             cand_election_year=2010)
 
         factories.ScheduleEByCandidateFactory(
             total=50000,
             count=10,
             cycle=2010,
-            candidate_id='S005',
+            candidate_id='S00000005',
             support_oppose_indicator='S',
-            committee_id='C005',
+            committee_id='C00000005',
         ),
         factories.ScheduleEByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
-            candidate_id='S005',
+            candidate_id='S00000005',
             support_oppose_indicator='S',
-            committee_id='C006',
+            committee_id='C00000006',
         ),
 
         response = self._results(api.url_for(ScheduleEByCandidateView,

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -165,28 +165,28 @@ class TestECTotalsByCandidateView(ApiBaseTest):
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S01', two_year_period=2018, candidate_election_year=2024
+            candidate_id='S00000001', two_year_period=2018, candidate_election_year=2024
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='S01', two_year_period=2020, candidate_election_year=2024
+            candidate_id='S00000001', two_year_period=2020, candidate_election_year=2024
         ),
 
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=300, cycle=2018, committee_id='C00000001'
+            candidate_id='S00000001', total=300, cycle=2018, committee_id='C00000001'
         ),
         factories.ElectioneeringByCandidateFactory(
-            candidate_id='S01', total=200, cycle=2020, committee_id='C00000002'
+            candidate_id='S00000001', total=200, cycle=2020, committee_id='C00000002'
         ),
 
         results = self._results(
             api.url_for(
-                ECTotalsByCandidateView, candidate_id='S01', election_full=False
+                ECTotalsByCandidateView, candidate_id='S00000001', election_full=False
             )
         )
         assert len(results) == 2
 
         results = self._results(
-            api.url_for(ECTotalsByCandidateView, candidate_id='S01', election_full=True)
+            api.url_for(ECTotalsByCandidateView, candidate_id='S00000001', election_full=True)
         )
         assert len(results) == 1
         assert results[0]['total'] == 500
@@ -194,26 +194,26 @@ class TestECTotalsByCandidateView(ApiBaseTest):
     def test_sort_validation(self):
         # sort_option = ['cycle','candidate_id','total'], sort value must be one of sort_option.
         factories.CandidateHistoryFactory(
-            candidate_id='S01', two_year_period=2018, candidate_election_year=2024
+            candidate_id='S00000001', two_year_period=2018, candidate_election_year=2024
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='S01', two_year_period=2020, candidate_election_year=2024
+            candidate_id='S00000001', two_year_period=2020, candidate_election_year=2024
         ),
 
         factories.ElectioneeringByCandidateFactory(
-            committee_id='C00000001', candidate_id='P001', cycle=2000
+            committee_id='C00000001', candidate_id='P00000001', cycle=2000
         )
         factories.ElectioneeringByCandidateFactory(
-            committee_id='C00000001', candidate_id='P002', cycle=2000
+            committee_id='C00000001', candidate_id='P00000002', cycle=2000
         )
         factories.ElectioneeringByCandidateFactory(
-            committee_id='C00000002', candidate_id='P001', cycle=2004
+            committee_id='C00000002', candidate_id='P00000001', cycle=2004
         )
         db.session.flush()
         results = self._results(api.url_for(ECAggregatesView, committee_id='C00000001'))
         self.assertEqual(len(results), 2)
 
-        results = self._results(api.url_for(ECAggregatesView, candidate_id='P001'))
+        results = self._results(api.url_for(ECAggregatesView, candidate_id='P00000001'))
         self.assertEqual(len(results), 2)
 
         results = self._results(api.url_for(ECAggregatesView, cycle=2000))
@@ -226,57 +226,57 @@ class TestIETotalsByCandidateView(ApiBaseTest):
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=100,
             cycle=2012,
-            committee_id='C01',
+            committee_id='C00000001',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=200,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=300,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='O',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=400,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=500,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='O',
         ),
 
         results = self._results(
             api.url_for(
-                IETotalsByCandidateView, candidate_id='P01', election_full=False
+                IETotalsByCandidateView, candidate_id='P00000001', election_full=False
             )
         )
         assert len(results) == 4
 
         results = self._results(
-            api.url_for(IETotalsByCandidateView, candidate_id='P01', election_full=True)
+            api.url_for(IETotalsByCandidateView, candidate_id='P00000001', election_full=True)
         )
         assert len(results) == 2
         assert results[0]['total'] == 800
@@ -286,45 +286,45 @@ class TestIETotalsByCandidateView(ApiBaseTest):
         # sort_option = ['cycle','candidate_id','total','support_oppose_indicator'],
         # sort value must be one of sort_option.
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=100,
             cycle=2012,
-            committee_id='C01',
+            committee_id='C00000001',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=200,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=300,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='O',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=400,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='S',
         ),
         factories.ScheduleEByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=500,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='O',
         ),
 
@@ -339,13 +339,13 @@ class TestIETotalsByCandidateView(ApiBaseTest):
         results = self._results(
             api.url_for(
                 IETotalsByCandidateView,
-                candidate_id='P01',
+                candidate_id='P00000001',
                 sort='cycle',
             )
         )
         assert len(results) == 2
         expected = {
-            'candidate_id': 'P01',
+            'candidate_id': 'P00000001',
             'cycle': 2016,
             'total': 800,
             'support_oppose_indicator': 'O'
@@ -359,45 +359,45 @@ class TestCCTotalsByCandidateView(ApiBaseTest):
     def test_fields(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=100,
             cycle=2012,
-            committee_id='C01',
+            committee_id='C00000001',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=200,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=300,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='O',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=400,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=500,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='O',
         ),
 
@@ -405,7 +405,7 @@ class TestCCTotalsByCandidateView(ApiBaseTest):
             api.url_for(
                 CCTotalsByCandidateView,
                 cycle='2016',
-                candidate_id='P01',
+                candidate_id='P00000001',
                 election_full=False,
             )
         )
@@ -415,7 +415,7 @@ class TestCCTotalsByCandidateView(ApiBaseTest):
             api.url_for(
                 CCTotalsByCandidateView,
                 cycle='2016',
-                candidate_id='P01',
+                candidate_id='P00000001',
                 election_full=True,
             )
         )
@@ -426,45 +426,45 @@ class TestCCTotalsByCandidateView(ApiBaseTest):
     def test_sort_validation(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2014, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2014, candidate_election_year=2016
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P01', two_year_period=2016, candidate_election_year=2016
+            candidate_id='P00000001', two_year_period=2016, candidate_election_year=2016
         ),
 
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=100,
             cycle=2012,
-            committee_id='C01',
+            committee_id='C00000001',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=200,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=300,
             cycle=2014,
-            committee_id='C02',
+            committee_id='C00000002',
             support_oppose_indicator='O',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=400,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
-            candidate_id='P01',
+            candidate_id='P00000001',
             total=500,
             cycle=2016,
-            committee_id='C03',
+            committee_id='C00000003',
             support_oppose_indicator='O',
         ),
 
@@ -480,13 +480,13 @@ class TestCCTotalsByCandidateView(ApiBaseTest):
             api.url_for(
                 CCTotalsByCandidateView,
                 cycle='2016',
-                candidate_id='P01',
+                candidate_id='P00000001',
                 election_full=True,
             )
         )
         assert len(results) == 2
         expected = {
-            'candidate_id': 'P01',
+            'candidate_id': 'P00000001',
             'cycle': 2016,
             'total': 800,
             'support_oppose_indicator': 'O'
@@ -501,14 +501,14 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
     def test_sort_by_candidate_name_descending(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             name='WARNER, MARK',
             two_year_period=2010,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             name='BALDWIN, ALISSA',
             two_year_period=2010,
             office='S',
@@ -516,24 +516,24 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             cand_election_year=2010)
         factories.CandidateElectionFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             cand_election_year=2010)
 
         factories.CommunicationCostByCandidateFactory(
             total=50000,
             count=10,
             cycle=2010,
-            candidate_id='S001',
+            candidate_id='S00000001',
             support_oppose_indicator='S',
         ),
         factories.CommunicationCostByCandidateFactory(
             total=10000,
             count=5,
             cycle=2010,
-            candidate_id='S002',
+            candidate_id='S00000002',
             support_oppose_indicator='S',
         ),
 
@@ -550,21 +550,21 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
     def test_sort_by_candidate_id(self):
 
         factories.CandidateHistoryFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             name='Robert Ritchie',
             two_year_period=2012,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             name='FARLEY Ritchie',
             two_year_period=2012,
             office='S',
             state='NY',
         )
         factories.CandidateHistoryFactory(
-            candidate_id='S003',
+            candidate_id='S00000003',
             name='Robert Ritchie',
             election_years=[2012],
             two_year_period=2012,
@@ -573,32 +573,32 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
         )
 
         factories.CandidateElectionFactory(
-            candidate_id='S001',
+            candidate_id='S00000001',
             cand_election_year=2012)
         factories.CandidateElectionFactory(
-            candidate_id='S002',
+            candidate_id='S00000002',
             cand_election_year=2012)
         factories.CandidateElectionFactory(
-            candidate_id='S003',
+            candidate_id='S00000003',
             cand_election_year=2012)
 
         factories.CommunicationCostByCandidateFactory(
             cycle=2012,
-            candidate_id='S001',
+            candidate_id='S00000001',
             support_oppose_indicator='O',
             total=700,
             count=5,
         ),
         factories.CommunicationCostByCandidateFactory(
             cycle=2012,
-            candidate_id='S002',
+            candidate_id='S00000002',
             support_oppose_indicator='O',
             total=500,
             count=3,
         ),
         factories.CommunicationCostByCandidateFactory(
             cycle=2012,
-            candidate_id='S003',
+            candidate_id='S00000003',
             support_oppose_indicator='S',
             total=100,
             count=1,
@@ -611,11 +611,11 @@ class TestCommunicationCostByCandidateView(ApiBaseTest):
                 state='NY',
                 cycle=2012))
         self.assertEqual(len(response), 3)
-        self.assertEqual(response[0]['candidate_id'], 'S003')
+        self.assertEqual(response[0]['candidate_id'], 'S00000003')
         self.assertEqual(response[0]['support_oppose_indicator'], 'S')
-        self.assertEqual(response[1]['candidate_id'], 'S002')
+        self.assertEqual(response[1]['candidate_id'], 'S00000002')
         self.assertEqual(response[1]['support_oppose_indicator'], 'O')
-        self.assertEqual(response[2]['candidate_id'], 'S001')
+        self.assertEqual(response[2]['candidate_id'], 'S00000001')
         self.assertEqual(response[2]['support_oppose_indicator'], 'O')
 
 
@@ -628,13 +628,13 @@ class TestCCAggregatesView(ApiBaseTest):
 
     def test_filters_committee_candidate_id_cycle(self):
         factories.CandidateHistoryFactory(
-            candidate_id='P001', two_year_period=2000, candidate_election_year=2000, name='Apple Smith'
+            candidate_id='P00000001', two_year_period=2000, candidate_election_year=2000, name='Apple Smith'
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P002', two_year_period=2000, candidate_election_year=2000, name='Snapple Smith'
+            candidate_id='P00000002', two_year_period=2000, candidate_election_year=2000, name='Snapple Smith'
         ),
         factories.CandidateHistoryFactory(
-            candidate_id='P002', two_year_period=2004, candidate_election_year=2004, name='Zapple Smith'
+            candidate_id='P00000002', two_year_period=2004, candidate_election_year=2004, name='Zapple Smith'
         ),
 
         factories.CommitteeHistoryFactory(
@@ -648,13 +648,13 @@ class TestCCAggregatesView(ApiBaseTest):
         ),
 
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C00000001', candidate_id='P001', cycle=2000
+            committee_id='C00000001', candidate_id='P00000001', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C00000001', candidate_id='P002', cycle=2000
+            committee_id='C00000001', candidate_id='P00000002', cycle=2000
         )
         factories.CommunicationCostByCandidateFactory(
-            committee_id='C00000002', candidate_id='P001', cycle=2004
+            committee_id='C00000002', candidate_id='P00000001', cycle=2004
         )
         db.session.flush()
 
@@ -671,13 +671,13 @@ class TestCCAggregatesView(ApiBaseTest):
         self.assertEqual(results[1]['candidate_name'], 'Snapple Smith')
 
         # assert results filtered by candidate_id sorted by committee name in descending order
-        results = self._results(api.url_for(CCAggregatesView, candidate_id='P001', sort='-committee_name'))
+        results = self._results(api.url_for(CCAggregatesView, candidate_id='P00000001', sort='-committee_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['committee_name'], 'Winner PAC')
         self.assertEqual(results[1]['committee_name'], 'Acme Co')
 
         # assert results filtered by candidate_id sorted by committee name in ascending order
-        results = self._results(api.url_for(CCAggregatesView, candidate_id='P001', sort='committee_name'))
+        results = self._results(api.url_for(CCAggregatesView, candidate_id='P00000001', sort='committee_name'))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['committee_name'], 'Acme Co')
         self.assertEqual(results[1]['committee_name'], 'Winner PAC')

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -79,7 +79,7 @@ class TestTotalsByEntityType(ApiBaseTest):
         'first_file_date': datetime.date.fromisoformat("1982-12-31"),
         'receipts': 50,
         'disbursements': 200,
-        'sponsor_candidate_ids': ['H01'],
+        'sponsor_candidate_ids': ['H00000001'],
         'organization_type': 'C',
         'organization_type_full': 'Corporation',
         'first_f1_date': datetime.date.fromisoformat("1983-02-01"),
@@ -98,7 +98,7 @@ class TestTotalsByEntityType(ApiBaseTest):
         'first_file_date': datetime.date.fromisoformat("1984-12-31"),
         'receipts': 200,
         'disbursements': 50,
-        'sponsor_candidate_ids': ['H02'],
+        'sponsor_candidate_ids': ['H00000002'],
         'organization_type': 'T',
         'organization_type_full': 'Trade',
         'first_f1_date': datetime.date.fromisoformat("1984-12-31"),
@@ -134,7 +134,7 @@ class TestTotalsByEntityType(ApiBaseTest):
 
     def test_cycle_filter(self):
         presidential_fields = {
-            'committee_id': 'C00001',
+            'committee_id': 'C00000001',
             'cycle': 2016,
             'candidate_contribution': 1,
             'exempt_legal_accounting_disbursement': 2,
@@ -150,7 +150,7 @@ class TestTotalsByEntityType(ApiBaseTest):
 
     def test_designation_filter(self):
         party_fields = {
-            'committee_id': 'C00001',
+            'committee_id': 'C00000001',
             'cycle': 2014,
             'committee_name': 'REPUBLICAN COMMITTEE',
             'committee_designation': 'U',
@@ -209,7 +209,7 @@ class TestTotalsByEntityType(ApiBaseTest):
                 "first_file_date": datetime.date.fromisoformat("1984-12-31"),
                 "receipts": 200,
                 "disbursements": 50,
-                "sponsor_candidate_ids": ["H02"],
+                "sponsor_candidate_ids": ["H00000002"],
                 "organization_type": "T",
                 "organization_type_full": "Trade",
             }
@@ -324,7 +324,7 @@ class TestTotalsByEntityType(ApiBaseTest):
             api.url_for(
                 TotalsByEntityTypeView,
                 entity_type='pac-party',
-                sponsor_candidate_id='H02'
+                sponsor_candidate_id='H00000002'
             )
         )
         assert len(results) == 1
@@ -337,19 +337,19 @@ class TestTotalsByEntityType(ApiBaseTest):
         factories.PacSponsorCandidatePerCycleFactory(
             committee_id=committee.committee_id,
             cycle=committee.cycle,
-            sponsor_candidate_id="H01",
+            sponsor_candidate_id="H00000001",
             sponsor_candidate_name="Sponsor A",
         )
         factories.PacSponsorCandidatePerCycleFactory(
             committee_id='C00000007',
             cycle=committee.cycle + 2,
-            sponsor_candidate_id="S03",
+            sponsor_candidate_id="S00000003",
             sponsor_candidate_name="Sponsor B",
         )
         factories.PacSponsorCandidatePerCycleFactory(
             committee_id='C00000007',
             cycle=committee.cycle,
-            sponsor_candidate_id="S03",
+            sponsor_candidate_id="S00000003",
             sponsor_candidate_name="Sponsor B",
         )
         results = self._results(
@@ -365,7 +365,7 @@ class TestTotalsByEntityType(ApiBaseTest):
             results[0]["sponsor_candidate_list"][0]["sponsor_candidate_name"], "Sponsor A"
         )
         self.assertEqual(
-            results[0]["sponsor_candidate_list"][0]["sponsor_candidate_id"], "H01"
+            results[0]["sponsor_candidate_list"][0]["sponsor_candidate_id"], "H00000001"
         )
 
     def test_first_f1_date_filter(self):
@@ -1299,12 +1299,12 @@ class TestCandidateTotalsDetail(ApiBaseTest):
         }
         first_candidate = utils.extend(self.excluded_schema_fields,
                                        self.candidate_totals_fields,
-                                       {'candidate_id': 'H0001',
+                                       {'candidate_id': 'H00000001',
                                         'cycle': 2020})
 
         second_candidate = utils.extend(self.excluded_schema_fields,
                                         self.candidate_totals_fields,
-                                        {'candidate_id': 'H0002',
+                                        {'candidate_id': 'H00000002',
                                          'cycle': 2022})
         factories.CandidateTotalsDetailFactory(**first_candidate)
 
@@ -1312,11 +1312,11 @@ class TestCandidateTotalsDetail(ApiBaseTest):
             **second_candidate)
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='H0001')
+             api.url_for(CandidateTotalsDetailView, candidate_id='H00000001')
          )
         fields = utils.extend(self.candidate_totals_fields,
                               changed_schema_fields,
-                              {'candidate_id': 'H0001',
+                              {'candidate_id': 'H00000001',
                                'cycle': 2020})
 
         self.assertEqual(len(results), 1)
@@ -1337,12 +1337,12 @@ class TestCandidateTotalsDetail(ApiBaseTest):
         }
         first_candidate = utils.extend(self.candidate_totals_fields,
                                        self.excluded_schema_fields,
-                                       {'candidate_id': 'P0001',
+                                       {'candidate_id': 'P00000001',
                                         'cycle': 2020})
 
         second_candidate = utils.extend(self.candidate_totals_fields,
                                         self.excluded_schema_fields,
-                                        {'candidate_id': 'P0002',
+                                        {'candidate_id': 'P00000002',
                                          'cycle': 2022})
         factories.CandidateTotalsDetailFactory(
             **first_candidate)
@@ -1351,11 +1351,11 @@ class TestCandidateTotalsDetail(ApiBaseTest):
             **second_candidate)
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='P0002')
+             api.url_for(CandidateTotalsDetailView, candidate_id='P00000002')
          )
         fields = utils.extend(self.candidate_totals_fields,
                               changed_schema_fields,
-                              {'candidate_id': 'P0002',
+                              {'candidate_id': 'P00000002',
                                'cycle': 2022})
 
         self.assertEqual(len(results), 1)
@@ -1363,138 +1363,138 @@ class TestCandidateTotalsDetail(ApiBaseTest):
 
     def test_election_full_filter(self):
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0001',
+            candidate_id='H00000001',
             candidate_election_year=2020,
             cycle=2020,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0001',
+            candidate_id='H00000001',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0001',
+            candidate_id='H00000001',
             candidate_election_year=2016,
             cycle=2016,
             election_full=False
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='H0001',
+             api.url_for(CandidateTotalsDetailView, candidate_id='H00000001',
                          election_full=True))
 
         self.assertEqual(len(results), 1)
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2020,
             cycle=2020,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2016,
             cycle=2016,
             election_full=False
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='P0001',
+             api.url_for(CandidateTotalsDetailView, candidate_id='P00000001',
                          election_full=False))
 
         self.assertEqual(len(results), 2)
 
     def test_cycle_filter(self):
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0001',
+            candidate_id='H00000001',
             candidate_election_year=2020,
             cycle=2020,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0001',
+            candidate_id='H00000001',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0002',
+            candidate_id='H00000002',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='H0002',
+             api.url_for(CandidateTotalsDetailView, candidate_id='H00000002',
                          cycle=2018))
 
         self.assertEqual(len(results), 1)
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2020,
             cycle=2020,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2022,
             cycle=2020,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2024,
             cycle=2020,
             election_full=False
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='P0001',
+             api.url_for(CandidateTotalsDetailView, candidate_id='P00000001',
                          cycle=2020))
 
         self.assertEqual(len(results), 3)
 
     def test_sort(self):
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0003',
+            candidate_id='H00000003',
             candidate_election_year=2020,
             cycle=2020,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0003',
+            candidate_id='H00000003',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='H0003',
+            candidate_id='H00000003',
             candidate_election_year=2018,
             cycle=2016,
             election_full=False
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='H0003',
+             api.url_for(CandidateTotalsDetailView, candidate_id='H00000003',
                          sort='cycle'))
 
         self.assertEqual(len(results), 3)
@@ -1503,28 +1503,28 @@ class TestCandidateTotalsDetail(ApiBaseTest):
         self.assertEqual(results[0]['candidate_election_year'], 2018)
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2016,
             cycle=2016,
             election_full=True
         )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2018,
             cycle=2018,
             election_full=False
             )
 
         factories.CandidateTotalsDetailFactory(
-            candidate_id='P0001',
+            candidate_id='P00000001',
             candidate_election_year=2022,
             cycle=2022,
             election_full=True
             )
 
         results = self._results(
-             api.url_for(CandidateTotalsDetailView, candidate_id='P0001',
+             api.url_for(CandidateTotalsDetailView, candidate_id='P00000001',
                          sort='-cycle'))
 
         self.assertEqual(len(results), 3)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -6,7 +6,7 @@ from webargs import fields, validate
 from webservices import docs
 from webservices import exceptions
 from webservices.common.models import db
-from webservices.utils import check_committee_id
+from webservices.utils import check_committee_id, check_candidate_id
 import datetime
 
 
@@ -27,7 +27,7 @@ per_page = Natural(
 
 
 class Committee_ID(fields.Str):
-
+    # A valid committee_id begins with a 'C' followed by 8 digits
     def _deserialize(self, value, attr, data, **kwargs):
         return super()._deserialize(value, attr, data, **kwargs).upper()
 
@@ -35,6 +35,16 @@ class Committee_ID(fields.Str):
         super()._validate(value)
 
         check_committee_id(value)
+
+
+class Candidate_ID(fields.Str):
+    # A valid candidate_id begins with a 'P' or 'H' or 'S' followed by 8 letters or numbers
+    def _deserialize(self, value, attr, data, **kwargs):
+        return super()._deserialize(value, attr, data, **kwargs).upper()
+
+    def _validate(self, value):
+        super()._validate(value)
+        check_candidate_id(value)
 
 
 class Currency(fields.Decimal):
@@ -347,7 +357,7 @@ candidate_detail = {
 
 candidate_list = {
     'q': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'min_first_file_date': Date(description=docs.CANDIDATE_MIN_FIRST_FILE_DATE),
     'max_first_file_date': Date(description=docs.CANDIDATE_MAX_FIRST_FILE_DATE),
     'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
@@ -383,7 +393,7 @@ committee = {
 committee_list = {
     'q': fields.List(Keyword, description=docs.COMMITTEE_NAME),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'state': fields.List(IStr, description=docs.STATE_GENERIC),
     'party': fields.List(IStr, description=docs.PARTY),
     'min_first_file_date': Date(description=docs.MIN_FIRST_FILE_DATE),
@@ -393,7 +403,7 @@ committee_list = {
     'min_last_f1_date': Date(description=docs.MIN_LAST_F1_DATE),
     'max_last_f1_date': Date(description=docs.MAX_LAST_F1_DATE),
     'treasurer_name': fields.List(Keyword, description=docs.TREASURER_NAME),
-    'sponsor_candidate_id': fields.List(IStr, description=docs.SPONSOR_CANDIDATE_ID),
+    'sponsor_candidate_id': fields.List(Candidate_ID, description=docs.SPONSOR_CANDIDATE_ID),
 }
 
 
@@ -405,6 +415,8 @@ committee_history = {
     ),
 }
 
+# used for endpoint:`/filings/`
+# under tag: filing
 filings = {
     'committee_type': fields.Str(description=docs.COMMITTEE_TYPE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
@@ -472,6 +484,7 @@ reports = {
     'min_total_contributions': Currency(description=docs.MIN_FILTER),
     'max_total_contributions': Currency(description=docs.MAX_FILTER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
+    # candidate_id validation is in reports.py/ReportsView. (front-end:AUTHORIZING CANDIDATE)
     'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'amendment_indicator': fields.List(
@@ -501,8 +514,7 @@ committee_reports = {
     'max_party_coordinated_expenditures': Currency(description=docs.MAX_FILTER),
     'min_total_contributions': Currency(description=docs.MIN_FILTER),
     'max_total_contributions': Currency(description=docs.MAX_FILTER),
-    'type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
-    'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
+    'type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE)
 }
 
 committee_totals = {
@@ -528,7 +540,9 @@ totals_by_entity_type = {
     'max_last_cash_on_hand_end_period': Currency(description=docs.MAX_FILTER),
     'min_last_debts_owed_by_committee': Currency(description=docs.MIN_FILTER),
     'max_last_debts_owed_by_committee': Currency(description=docs.MAX_FILTER),
-    'sponsor_candidate_id': fields.List(IStr, description=docs.SPONSOR_CANDIDATE_ID),
+
+    # sponsor_candidate_id Only for 'pac' and 'pac-party'
+    'sponsor_candidate_id': fields.List(Candidate_ID, description=docs.SPONSOR_CANDIDATE_ID),
     'organization_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
         description=docs.ORGANIZATION_TYPE,
@@ -650,8 +664,7 @@ schedule_a_e_file = {
     'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
     'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
     'contributor_employer': fields.List(Keyword, description=docs.CONTRIBUTOR_EMPLOYER),
-    'contributor_occupation': fields.List(Keyword, description=docs.CONTRIBUTOR_OCCUPATION),
-
+    'contributor_occupation': fields.List(Keyword, description=docs.CONTRIBUTOR_OCCUPATION)
 }
 
 schedule_a_by_size = {
@@ -810,7 +823,7 @@ schedule_d = {
 
 schedule_e_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
@@ -824,7 +837,7 @@ schedule_e_by_candidate = {
 }
 
 schedule_f = {
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
@@ -832,7 +845,7 @@ schedule_f = {
 
 communication_cost = {
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
         description=docs.SUPPORT_OPPOSE,
@@ -841,7 +854,7 @@ communication_cost = {
 
 CC_aggregates = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'support_oppose_indicator': IStr(
         missing=None,
@@ -852,7 +865,7 @@ CC_aggregates = {
 
 electioneering = {
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'min_amount': Currency(description=docs.ELECTIONEERING_MIN_AMOUNT),
     'max_amount': Currency(description=docs.ELECTIONEERING_MAX_AMOUNT),
@@ -863,16 +876,18 @@ electioneering = {
 
 electioneering_by_candidate = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
         description=docs.OFFICE,
     ),
 }
 
+# used for endpoint:`/electioneering/aggregates/`
+# under tag: electioneering
 EC_aggregates = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
@@ -902,15 +917,23 @@ state_election_office_info = {
     'state': IStr(required=True, description=docs.STATE_ELECTION_OFFICES_ADDRESS),
 }
 
+# used for endpoints
+# 'schedules/schedule_a/by_size/by_candidate/'
+# 'schedules/schedule_a/by_state/by_candidate/'
+# 'schedules/schedule_a/by_state/by_candidate/totals/'
+# under tag: receipts
+
 schedule_a_candidate_aggregate = {
-    'candidate_id': fields.List(IStr, required=True, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, required=True, description=docs.CANDIDATE_ID),
     'cycle': fields.List(fields.Int, required=True, description=docs.RECORD_CYCLE),
     'election_full': election_full,
 }
 
+# used for '/candidates/totals/'
+# under tag: candidate
 candidate_totals = {
     'q': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
@@ -939,7 +962,7 @@ totals_committee_aggregate = {
 }
 
 communication_cost_by_candidate = {
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
@@ -954,9 +977,11 @@ communication_cost_by_candidate = {
 
 entities = {
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
 }
 
+# Used for endpoint `/schedules/schedule_e/`
+# under tag: independent expenditure
 schedule_e = {
     'candidate_office': fields.List(fields.Str(
         validate=validate.OneOf(['', 'H', 'S', 'P'])),
@@ -966,7 +991,7 @@ schedule_e = {
     'candidate_office_district': fields.List(District, description=docs.DISTRICT),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
     'last_expenditure_date': Date(
         missing=None,
@@ -993,10 +1018,12 @@ schedule_e = {
     'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
 }
 
+# Used for endpoint `/schedules/schedule_e/efile/`
+# under tag: independent expenditures
 schedule_e_efile = {
     'candidate_search': fields.List(Keyword, description=docs.CANDIDATE_FULL_SEARCH),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
     'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
     'support_oppose_indicator': fields.List(
@@ -1068,7 +1095,7 @@ auditCase = {
     'committee_type': fields.List(fields.Str(), description=docs.COMMITTEE_TYPE),
     'committee_designation': fields.Str(description=docs.COMMITTEE_DESCRIPTION),
     'audit_id': fields.List(fields.Int(), description=docs.AUDIT_ID),
-    'candidate_id': fields.List(fields.Str(), description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'min_election_cycle': fields.Int(description=docs.CYCLE),
     'max_election_cycle': fields.Int(description=docs.CYCLE),
 }
@@ -1109,21 +1136,27 @@ candidate_total_aggregate = {
 totals_by_candidate_other_costs_EC = {
 
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'election_full': election_full,
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'election_full': election_full
 }
 
+# used for '/schedules/schedule_e/totals/by_candidate/'
+# under tag: independent expenditures
+# IETotalsByCandidateView in spending_by_others.py
 schedule_e_totals_by_candidate_other_costs_IE = {
 
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'election_full': election_full,
 }
 
+# used for '/communication_costs/totals/by_candidate/'
+# under tag: communication cost
+# CCTotalsByCandidateView in spending_by_others.py
 totals_by_candidate_other_costs_CC = {
 
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'election_full': election_full,
 }
 
@@ -1187,19 +1220,28 @@ schedule_h4_efile = {
     'max_amount': Currency(description=docs.MAX_FILTER),
 }
 
+# used for endpoints:
+#  '/presidential/financial_summary/'
+#  '/presidential/contributions/by_state/'
+#  '/presidential/coverage_end_date/'
+# under tag: presidential
 presidential = {
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID_PRESIDENTIAL),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID_PRESIDENTIAL),
 }
 
+# used for endpoint: '/presidential/contributions/by_candidate/'
+# under tag: presidential
 presidential_by_candidate = {
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
     'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
 }
 
+# used for endpoint: '/presidential/contributions/by_size/'
+# under tag: presidential
 presidential_by_size = {
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID_PRESIDENTIAL),
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID_PRESIDENTIAL),
     'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
 }
 

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -16,8 +16,12 @@ NEXT_IN_CHAIN_DATA_ERROR = """next_in_chain data error, please contact apiinfo@f
 DATE_ERROR = """Invalid date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD.\
 """
 
-COMMITTEE_ID_ERROR = """Invalid committee_id. A committee_id begins with a 'C'\
+COMMITTEE_ID_ERROR = """Invalid committee_id. A valid committee_id begins with a 'C'\
  followed by 8 digits. For example: C00100005.\
+"""
+
+CANDIDATE_ID_ERROR = """Invalid candidate_id. A valid candidate_id begins with a 'P' or 'H' or 'S'\
+ followed by 8 letters or numbers. For example: P00000034, S6MI00103, H0LA01087.\
 """
 
 

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -30,7 +30,7 @@ def filter_range_fields(model):
 
 # used for endpoint:`/candidates/`
 # under tag: candidate
-# Ex: http://127.0.0.1:5000/v1/candidates/
+# Ex: http://127.0.0.1:5000/v1/candidates/?candidate_id=S0LA00071&sort=name
 @doc(
     tags=['candidate'], description=docs.CANDIDATE_LIST,
 )
@@ -192,7 +192,9 @@ class CandidateView(ApiResource):
         query = super().build_query(**kwargs)
 
         if candidate_id is not None:
-            query = query.filter_by(candidate_id=candidate_id.upper())
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)
+            query = query.filter_by(candidate_id=candidate_id)
 
         if committee_id is not None:
             committee_id = committee_id.upper()
@@ -271,7 +273,9 @@ class CandidateHistoryView(ApiResource):
             # use for
             # '/candidate/<string:candidate_id>/history/',
             # '/candidate/<string:candidate_id>/history/<int:cycle>/',
-            query = query.filter(models.CandidateHistory.candidate_id == candidate_id.upper())
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)
+            query = query.filter(models.CandidateHistory.candidate_id == candidate_id)
 
         if committee_id:
             committee_id = committee_id.upper()

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -30,6 +30,7 @@ def filter_year(model, query, years):
 # used for endpoint:'/committees/'
 # under tag: committee
 # Ex: http://127.0.0.1:5000/v1/committees/
+# http://127.0.0.1:5000/v1/committees/?candidate_id=S0LA00071
 @doc(
     tags=["committee"],
     description=docs.COMMITTEE_LIST,
@@ -157,10 +158,12 @@ class CommitteeView(ApiResource):
             query = query.filter_by(committee_id=committee_id)
 
         if candidate_id is not None:
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)            
             query = query.join(
                 models.CandidateCommitteeLink
             ).filter(
-                models.CandidateCommitteeLink.candidate_id == candidate_id.upper()
+                models.CandidateCommitteeLink.candidate_id == candidate_id
             ).distinct()
 
         if kwargs.get("year"):
@@ -236,6 +239,8 @@ class CommitteeHistoryProfileView(ApiResource):
             # '/candidate/<candidate_id>/committees/history/<int:cycle>/',
 
             # 1) query for regular committees
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)
             query_regular = query.join(
                 models.CandidateCommitteeLink,
                 sa.and_(
@@ -243,13 +248,13 @@ class CommitteeHistoryProfileView(ApiResource):
                     models.CandidateCommitteeLink.fec_election_year == models.CommitteeHistoryProfile.cycle,
                 ),
             ).filter(
-                models.CandidateCommitteeLink.candidate_id == candidate_id.upper(),
+                models.CandidateCommitteeLink.candidate_id == candidate_id,
             )
 
             # 2) query for PCC to PAC conversion
             query_pcc_converted = query.filter(
                 models.CommitteeHistoryProfile.former_candidate_id ==
-                candidate_id.upper())
+                candidate_id)
 
             # 3) query for Leadership PAC committees
             query_leadership_pac = query.join(
@@ -259,7 +264,7 @@ class CommitteeHistoryProfileView(ApiResource):
                     models.CandidateCommitteeAlternateLink.fec_election_year == models.CommitteeHistoryProfile.cycle,
                 ),
             ).filter(
-                models.CandidateCommitteeAlternateLink.candidate_id == candidate_id.upper(),
+                models.CandidateCommitteeAlternateLink.candidate_id == candidate_id,
             )
 
             # query for election_full=false

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -90,13 +90,16 @@ class FilingsView(BaseFilings):
             utils.check_committee_id(committee_id)
             query = query.filter(models.Filings.committee_id == committee_id)
         if candidate_id:
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)
             query = query.filter(models.Filings.candidate_id == candidate_id)
         return query
 
 
 # used for endpoint:`/filings/`
 # under tag: filing
-# Ex: http://127.0.0.1:5000/v1/filings/?filer_name_text=san
+# Ex1: http://127.0.0.1:5000/v1/filings/?q_filer=san
+# Ex2: http://127.0.0.1:5000/v1/filings/?candidate_id=H8TX10094
 class FilingsList(BaseFilings):
 
     filter_multi_fields = BaseFilings.filter_multi_fields + [

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -184,10 +184,10 @@ class ReportsView(views.ApiResource):
             )
 
         if kwargs.get('candidate_id'):
+            candidate_id_upper = kwargs.get('candidate_id').upper()
+            utils.check_candidate_id(candidate_id_upper)
             query = query.filter(
-                models.CommitteeHistory.candidate_ids.overlap(
-                    [kwargs.get('candidate_id')]
-                )
+                models.CommitteeHistory.candidate_ids.overlap([candidate_id_upper])
             )
 
         if kwargs.get('committee_type'):

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -13,7 +13,8 @@ from webservices.common.views import ItemizedResource
 
 # Used for endpoint `/schedules/schedule_e/`
 # under tag: independent expenditure
-# Ex: http://127.0.0.1:5000/v1/schedules/schedule_e/
+# Ex1: http://127.0.0.1:5000/v1/schedules/schedule_e/
+# Ex2: http://127.0.0.1:5000/v1/schedules/schedule_e/?candidate_id=S0OH00133
 @doc(
     tags=['independent expenditures'],
     description=docs.SCHEDULE_E,

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -311,6 +311,8 @@ class CandidateTotalsDetailView(utils.Resource):
 
     def _resolve_committee_type(self, candidate_id=None, **kwargs):
         if candidate_id is not None:
+            candidate_id = candidate_id.upper()
+            utils.check_candidate_id(candidate_id)
             return candidate_id[0]
 
 

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -327,18 +327,26 @@ def check_election_arguments(kwargs):
 
 
 def check_committee_id(committee_id):
-
+    # A valid committee_id begins with a 'C' followed by 8 digits
     if len(committee_id) != 9 or not committee_id.startswith('C'):
         raise exceptions.ApiError(
-                    exceptions.COMMITTEE_ID_ERROR,
-                    status_code=422)
+            exceptions.COMMITTEE_ID_ERROR,
+            status_code=422)
 
     try:
         committee_id = int(committee_id[1:])
     except (TypeError, ValueError):
         raise exceptions.ApiError(
-                exceptions.COMMITTEE_ID_ERROR,
-                status_code=422)
+            exceptions.COMMITTEE_ID_ERROR,
+            status_code=422)
+
+
+def check_candidate_id(candidate_id):
+    # A valid candidate_id begins with a 'P' or 'H' or 'S' followed by 8 letters or numbers
+    if len(candidate_id) != 9 or candidate_id[0] not in ('P', 'S', 'H'):
+        raise exceptions.ApiError(
+            exceptions.CANDIDATE_ID_ERROR,
+            status_code=422)
 
 
 def get_model(name):


### PR DESCRIPTION
## Summary (required)
This ticket adds validation to the candidate_id as filter by adding a custom field in args.py and adding validation to candidate_id in paths (for instance: v1/[candidate/S6LA00029/]. It checks that the length is exactly 9, that it begins with a capital 'P' or 'S' or 'H' and following are char and number.

- Resolves #5602 

### Required reviewers

2 dev

## Impacted areas of the application

General components of the application that this PR will affect:
- all endpoints with filter by candidate_id or include {candidate_id} in the path
- all automated tests that use candidate_id 
- args.py

## How to test
- checkout this branch 
- flask run 
- pytest
- test all endpoints that use candidate_id. 
go through  the 'test api urls' column in google sheet. modify candidate_id to invalid value.
[test urls](https://docs.google.com/spreadsheets/d/1AkQjXA2XMQfxlRyinSY0uynhf2ZRMh7l_BTWdJgHzXY/edit#gid=2069155363)
