### PR TITLE
5609-add form_line_number to Schedule_CDEFH

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1353,6 +1353,43 @@ class TestScheduleE(ApiBaseTest):
         # Most recent should include null values
         self.assertEqual(len(results), 5)
 
+    def test_schedule_e_filter_form_line_number(self):
+        [
+            factories.ScheduleEFactory(line_number='24', filing_form='F3X'),
+            factories.ScheduleEFactory(line_number='25', filing_form='F3X'),
+            factories.ScheduleEFactory(line_number='24', filing_form='F3'),
+            factories.ScheduleEFactory(line_number='25', filing_form='F3'),
+        ]
+
+        results = self._results(
+            api.url_for(ScheduleEView, form_line_number='f3X-24')
+        )
+        self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleEView, line_number='f3X-24')
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleEView, form_line_number=('f3x-24', 'f3X-25'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleEView, form_line_number='-F3x-24')
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_e
+        response = self.app.get(
+            api.url_for(ScheduleEView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 class TestScheduleH4(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
@@ -1467,6 +1504,42 @@ class TestScheduleH4(ApiBaseTest):
                 <= max_date.isoformat()
             )
         )
+
+    def test_schedule_h4_filter_form_line_number(self):
+        [
+            factories.ScheduleH4Factory(line_number='23', filing_form='F3X'),
+            factories.ScheduleH4Factory(line_number='17', filing_form='F3X'),
+            factories.ScheduleH4Factory(line_number='22', filing_form='F3'),
+            factories.ScheduleH4Factory(line_number='22', filing_form='F3P'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleH4View, line_number='f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number=('f3x-23', 'f3X-17'), **self.kwargs)
+        )
+        self.assertEqual(len(results), 2)
+
+        # test searching for NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleH4View, form_line_number='-f3x-23', **self.kwargs)
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_h4
+        response = self.app.get(
+            api.url_for(ScheduleH4View, form_line_number='f3x21', **self.kwargs)
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
 
     def test_schedule_h4_efile_filters(self):
         filters = [

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -201,6 +201,42 @@ class TestScheduleCView(ApiBaseTest):
         )
         self.assertTrue(all('2' <= each['image_number'] <= '3' for each in results))
 
+    def test_schedule_c_filter_form_line_number(self):
+        [
+            factories.ScheduleCFactory(line_number='9', filing_form='F3X'),
+            factories.ScheduleCFactory(line_number='10', filing_form='F3X'),
+            factories.ScheduleCFactory(line_number='9', filing_form='F3'),
+            factories.ScheduleCFactory(line_number='9', filing_form='F3'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleCView, line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number=('f3x-9', 'f3X-10'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleCView, form_line_number='-F3x-10')
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_c
+        response = self.app.get(
+            api.url_for(ScheduleCView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 class TestScheduleCViewBySubId(ApiBaseTest):
     def test_fields(self):

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -189,6 +189,42 @@ class TestScheduleDView(ApiBaseTest):
         self.assertEqual(results[0]['sub_id'], '2')
         self.assertEqual(results[1]['sub_id'], '1')
 
+    def test_schedule_d_filter_form_line_number(self):
+        [
+            factories.ScheduleDViewFactory(line_number='9', filing_form='F3X'),
+            factories.ScheduleDViewFactory(line_number='10', filing_form='F3X'),
+            factories.ScheduleDViewFactory(line_number='12', filing_form='F3'),
+            factories.ScheduleDViewFactory(line_number='9', filing_form='F3'),
+        ]
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
+        # to be removed
+        results = self._results(
+            api.url_for(ScheduleDView, line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number=('f3x-9', 'f3X-10'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleDView, form_line_number='-F3x-10')
+        )
+        self.assertEqual(len(results), 3)
+
+        # invalid form_line_number testing for sched_d
+        response = self.app.get(
+            api.url_for(ScheduleDView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
 
 class TestScheduleDViewBySubId(ApiBaseTest):
     def test_sub_id_field(self):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -241,8 +241,9 @@ def make_multi_sort_args(default=None, validator=None, default_hide_null=False, 
     args = make_sort_args(default, validator, default_hide_null, default_nulls_only,
                           default_sort_nulls_last, show_nulls_last_arg, additional_description)
 
-    args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True, description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
-                                    additional_description))
+    args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True,
+                               description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
+                                additional_description))
     return args
 
 
@@ -592,7 +593,7 @@ itemized = {
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': Date(description='Minimum date'),
     'max_date': Date(description='Maximum date'),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number TBR
 }
 
 schedule_a = {
@@ -780,6 +781,7 @@ schedule_c = {
     'max_payment_to_date': fields.Int(description=docs.MAX_PAYMENT_DATE),
     'min_incurred_date': Date(missing=None, description=docs.MIN_INCURRED_DATE),
     'max_incurred_date': Date(missing=None, description=docs.MAX_INCURRED_DATE),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
 }
 
 schedule_d = {
@@ -803,9 +805,10 @@ schedule_d = {
     'max_coverage_start_date': Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
     'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
     'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'filing_form': fields.List(fields.Str, description=docs.FORM_TYPE),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number
 }
 
 schedule_e_by_candidate = {
@@ -828,6 +831,7 @@ schedule_f = {
     'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
 }
 
 communication_cost = {
@@ -991,6 +995,7 @@ schedule_e = {
     'max_filing_date': Date(description=docs.MAX_FILED_DATE),
     'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
     'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
 }
 
 schedule_e_efile = {
@@ -1167,7 +1172,8 @@ schedule_h4 = {
     'spender_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
         description=docs.DESIGNATION,
-    )
+    ),
+    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
 }
 
 schedule_h4_efile = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -487,6 +487,11 @@ class ScheduleC(PdfMixin, BaseItemized):
             return utils.make_schedule_pdf_url(self.image_number)
         return None
 
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
+
 
 class ScheduleD(PdfMixin, BaseItemized):
     __tablename__ = 'ofec_sched_d_mv'
@@ -537,6 +542,11 @@ class ScheduleD(PdfMixin, BaseItemized):
         if self.has_pdf:
             return utils.make_schedule_pdf_url(self.image_number)
         return None
+
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
 
 
 class ScheduleE(PdfMixin, BaseItemized):
@@ -619,6 +629,11 @@ class ScheduleE(PdfMixin, BaseItemized):
     schedule_type_full = db.Column('schedule_type_desc', db.String)
     pdf_url = db.Column(db.String)
     spender_name_text = db.Column(TSVECTOR)
+
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
 
 
 class ScheduleEEfile(BaseRawItemized):
@@ -790,6 +805,11 @@ class ScheduleF(PdfMixin, BaseItemized):
             return utils.make_schedule_pdf_url(self.image_number)
         return None
 
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
+
 
 class ScheduleH4(BaseItemized):
     __tablename__ = 'ofec_sched_h4_mv'
@@ -838,6 +858,11 @@ class ScheduleH4(BaseItemized):
     disbursement_purpose_text = db.Column(TSVECTOR)
     payee_name_text = db.Column(TSVECTOR)
     pdf_url = db.Column('pdf_url', db.String)
+
+    @hybrid_property
+    def form_line_number(self):
+        if self.filing_form and self.line_number:
+            return self.filing_form + "-" + self.line_number
 
 
 class ScheduleH4Efile(BaseRawItemized):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1813,8 +1813,14 @@ also incorporate any changes made by committees, if any report covering the peri
 '''
 EFILE_REPORTS += WIP_TAG
 
-LINE_NUMBER = '''
-`DEPRECATED This filter will be renamed to form_line_number`
+FORM_LINE_NUMBER = '''
+Filter for form and line number using the following format:
+`FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter
+down to all entries from form `F3X` line number `16`.
+'''
+
+# Added to ease transition to FORM_LINE_NUMBER, to be removed
+LINE_NUMBER = ''' `DEPRECATED This filter will be renamed to form_line_number`
 Filter for form and line number using the following format:
 `FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter
 down to all entries from form `F3X` line number `16`.

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -1,4 +1,9 @@
 
+FORM_LINE_NUMBER_ERROR = """Invalid form_line_number detected. A valid form_line_number is using the following format: \
+'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries \
+from form F3X line number 16.\
+"""
+
 LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is using the following format:
 'FORM-LINENUMBER'.  For example an argument such as 'F3X-16' would filter down to all schedule a entries
 from form F3X line number 16.\

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -32,7 +32,8 @@ class ScheduleDView(ApiResource):
         ('report_year', models.ScheduleD.report_year),
         ('report_type', models.ScheduleD.report_type),
         ('filing_form', models.ScheduleD.filing_form),
-        ('committee_type', models.ScheduleD.committee_type)
+        ('committee_type', models.ScheduleD.committee_type),
+        ('form_line_number', models.ScheduleD.form_line_number),
     ]
 
     filter_range_fields = [
@@ -72,8 +73,9 @@ class ScheduleDView(ApiResource):
         # might be worth looking to factoring these out into the filter script
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
+        utils.check_form_line_number(kwargs)
+        # added for transition to form_line_number, to be replaced w/obsolete error
+        if 'line_number' in kwargs:
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager
@@ -48,6 +49,7 @@ class ScheduleEView(ItemizedResource):
         ('candidate_office_state', models.ScheduleE.candidate_office_state),
         ('candidate_office_district', models.ScheduleE.candidate_office_district),
         ('candidate_party', models.ScheduleE.candidate_party),
+        ('form_line_number', models.ScheduleE.form_line_number),
     ]
     filter_fulltext_fields = [
         ('payee_name', models.ScheduleE.payee_name_text),
@@ -112,6 +114,18 @@ class ScheduleEView(ItemizedResource):
         if 'most_recent' in kwargs:
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
+        utils.check_form_line_number(kwargs)
+        # added for transition to form_line_number, to be replaced w/obsolete error
+        if 'line_number' in kwargs:
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -2,6 +2,7 @@ from flask_apispec import doc
 
 from webservices import args
 from webservices import docs
+from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -30,6 +31,7 @@ class ScheduleFView(ApiResource):
         ('committee_id', models.ScheduleF.committee_id),
         ('candidate_id', models.ScheduleF.candidate_id),
         ('cycle', models.ScheduleF.election_cycle),
+        ('form_line_number', models.ScheduleF.form_line_number),
     ]
 
     filter_range_fields = [
@@ -57,6 +59,18 @@ class ScheduleFView(ApiResource):
         query = super().build_query(**kwargs)
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
+        utils.check_form_line_number(kwargs)
+        # added for transition to form_line_number, to be replaced w/obsolete error
+        if 'line_number' in kwargs:
+            if len(kwargs.get('line_number').split('-')) == 2:
+                form, line_no = kwargs.get('line_number').split('-')
+                query = query.filter_by(filing_form=form.upper())
+                query = query.filter_by(line_number=line_no)
+            else:
+                raise exceptions.ApiError(
+                    exceptions.LINE_NUMBER_ERROR,
+                    status_code=400,
+                )
         return query
 
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -53,6 +53,7 @@ class ScheduleH4View(ItemizedResource):
         ('administrative_activity_indicator', models.ScheduleH4.administrative_activity_indicator),
         ('general_voter_drive_activity_indicator', models.ScheduleH4.general_voter_drive_activity_indicator),
         ('public_comm_indicator', models.ScheduleH4.public_comm_indicator),
+        ('form_line_number', models.ScheduleH4.form_line_number),
     ]
 
     filter_range_fields = [
@@ -90,8 +91,9 @@ class ScheduleH4View(ItemizedResource):
         query = query.options(sa.orm.joinedload(models.ScheduleH4.committee))
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
-        if kwargs.get('line_number'):
-            # line number is a composite value of 'filing_form-line_number'
+        utils.check_form_line_number(kwargs)
+        # added for transition to form_line_number, to be replaced w/obsolete error
+        if 'line_number' in kwargs:
             if len(kwargs.get('line_number').split('-')) == 2:
                 form, line_no = kwargs.get('line_number').split('-')
                 query = query.filter_by(filing_form=form.upper())

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1003,7 +1003,7 @@ ScheduleASchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'report_year': ma.fields.Int()
+        'report_year': ma.fields.Int(),
     },
     options={
          'exclude': (
@@ -1032,6 +1032,7 @@ ScheduleCSchema = make_schema(
         'sub_id': ma.fields.Str(),
         'pdf_url': ma.fields.Str(),
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('loan_source_name_text', 'candidate_name_text',)}
     )
@@ -1100,6 +1101,7 @@ ScheduleDSchema = make_schema(
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('creditor_debtor_name_text',)}
 )
@@ -1114,6 +1116,7 @@ ScheduleFSchema = make_schema(
         'subordinate_committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'pdf_url': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={'exclude': ('payee_name_text',)}
     )
@@ -1136,7 +1139,7 @@ ScheduleBSchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
-        'disbursement_amount': ma.fields.Float()
+        'disbursement_amount': ma.fields.Float(),
     },
     options={
         'exclude': (
@@ -1171,6 +1174,7 @@ ScheduleH4Schema = make_schema(
         'federal_share': ma.fields.Float(),
         'nonfederal_share': ma.fields.Float(),
         'event_amount_year_to_date': ma.fields.Float(),
+        'form_line_number': ma.fields.Str(),
 
     },
     options={
@@ -1202,6 +1206,7 @@ ScheduleESchema = make_schema(
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
+        'form_line_number': ma.fields.Str(),
     },
     options={
         'exclude': (

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -605,3 +605,14 @@ def report_type_full(report_type, form_type, report_type_full_original):
         return "48-HOUR NOTICE OF CONTRIBUTIONS OR LOANS RECEIVED"
     else:
         return report_type_full_original
+
+
+def check_form_line_number(kwargs):
+    if 'form_line_number' in kwargs:
+        for each in kwargs['form_line_number']:
+            if each.startswith('-'):
+                each = each[1:]
+            if len(each.split('-')) != 2:
+                raise exceptions.ApiError(
+                    exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
+                )

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -612,7 +612,7 @@ def check_form_line_number(kwargs):
         for each in kwargs['form_line_number']:
             if each.startswith('-'):
                 each = each[1:]
-            if len(each.split('-')) != 2:
+            if len(each.split('-')) != 2 or not each.startswith('F'):
                 raise exceptions.ApiError(
                     exceptions.FORM_LINE_NUMBER_ERROR, status_code=400
                 )


### PR DESCRIPTION
## Summary 

- Resolves #5609 

This PR will allow line_number to support multiple user inputs for schedules C, D, E, F, and H4. This will fix the current bug on the debts tables where multiple line number filters can't be selected. To fix this issue I needed to add form_line_number as a hybrid_property as it is a composite field of filing_form and line_number.  This required a deprecation notice (sent Oct 18th) as the filter will change from line_number to form_line_number. I kept the line_number logic to allow a grace period for our users. I will be removing the line_number logic in a follow-up ticket.

During the research for this ticket, I discovered that line_number is not currently working for E and F endpoints and all efiling endpoints. This PR fixes E & F.  The CMS PR should be released with this PR. 

CHANGES
- [ ] adds filter form_line_number, which allows multiple inputs
- [ ] fixes NOT functionality for form_line_number 
- [ ] fixes newlines (\n)  showing up in the invalid form_line_number error message
- [ ] adds tests for each endpoint (except F) that checks multiple inputs, lowercase letters, invalid strings, and tests the old filter
- [ ] fixes functionality of filter for E & F endpoints
- [ ] keeps the old line_number functionality (will be removed)


### Required reviewers
2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-  Schedule C, D, E, F, and H4 endpoint form_line_number filter


## Related PRs

https://github.com/fecgov/fec-cms/pull/5971

## How to test

- flask run
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3-10&form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_d/?form_line_number=F3P-12&form_line_number=F3-10&page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- http://127.0.0.1:5000/v1/schedules/schedule_h4/?form_line_number=F3X-21A&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_e/?form_line_number=F3x-24&per_page=20&sort=-expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
- http://127.0.0.1:5000/v1/schedules/schedule_f/?form_line_number=F3X-25&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
-INVALID LINE NUMBER  http://127.0.0.1:5000/v1/schedules/schedule_h4/?form_line_number=string&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false

Deploy to dev/stage and test the front-end PR, add different line_numbers on the debts data tables. 


