### PR TITLE
Fix filter by multi candidate_id for reports/entity_type

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,10 +5,13 @@ from webservices import filters
 from webservices.common import models
 from webservices.resources.dates import CalendarDatesView
 from webservices.resources.committees import CommitteeList
-from webservices.resources.reports import get_match_filters
 
 
 class TestFilterMatch(ApiBaseTest):
+    filter_match_fields = [
+        ('filer_type', models.CommitteeReports.means_filed),
+    ]
+
     def setUp(self):
         super(TestFilterMatch, self).setUp()
         self.dates = [
@@ -53,7 +56,7 @@ class TestFilterMatch(ApiBaseTest):
         query_reports = filters.filter_match(
             models.CommitteeReportsHouseSenate.query,
             {'filer_type': 'e-file'},
-            get_match_filters(),
+            self.filter_match_fields,
         )
         self.assertEqual(
             set(query_reports.all()),
@@ -80,7 +83,7 @@ class TestFilterMatch(ApiBaseTest):
         query_reports = filters.filter_match(
             models.CommitteeReportsHouseSenate.query,
             {'filer_type': '-paper'},
-            get_match_filters(),
+            self.filter_match_fields,
         )
         self.assertEqual(
             set(query_reports.all()),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -485,8 +485,8 @@ reports = {
     'min_total_contributions': Currency(description=docs.MIN_FILTER),
     'max_total_contributions': Currency(description=docs.MAX_FILTER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
-    # candidate_id validation is in reports.py/ReportsView. (front-end:AUTHORIZING CANDIDATE)
-    'candidate_id': fields.Str(description=docs.CANDIDATE_ID),
+    # AUTHORIZING CANDIDATE
+    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),


### PR DESCRIPTION
## Summary (required)
This PR will fix bug for endpoint '/reports/<string:entity_type>/', will support multi candidate_id search.

- Resolves #5646 


### Required reviewers
1-2 dev

## Impacted areas of the application
'/reports/<string:entity_type>/'
'/committee/<string:committee_id>/reports/'

## How to test
- Check out branch
- pytest
- test api urls compare local and prod
- setup cms locally that point local api, test front-end reports page.

Test api urls:
1)(pass one candidate_id= S6MI00103, return 222 rows)
https://api.open.fec.gov/v1/reports/house-senate/?candidate_id=S6MI00103&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/reports/house-senate/?candidate_id=S6MI00103

2)(pass one candidate_id=S2TX00106, return 228 rows)
https://api.open.fec.gov/v1/reports/house-senate/?candidate_id=S2TX00106&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/reports/house-senate/?candidate_id=S2TX00106

3)(pass two candidate_id= S6MI00103 and S2TX00106, still return 222 rows on prod that is wrong)
https://api.open.fec.gov/v1/reports/house-senate/?candidate_id=S6MI00103&candidate_id=S2TX00106&api_key=DEMO_KEY

(return 228+222=450 rows on local that is correct)
http://127.0.0.1:5000/v1/reports/house-senate/?candidate_id=S6MI00103&candidate_id=S2TX00106

Test front-end cms:
(return 222 rows)
http://127.0.0.1:8000/data/reports/house-senate/?data_type=processed&candidate_id=S6MI00103

(return 228 rows)
http://127.0.0.1:8000/data/reports/house-senate/?data_type=processed&candidate_id=S2TX00106

(return 228+222=450 rows)
http://127.0.0.1:8000/data/reports/house-senate/?data_type=processed&candidate_id=S6MI00103&candidate_id=S2TX00106

Also, check '/committee/<string:committee_id>/reports/' doesn't break.
http://127.0.0.1:5000/v1/committee/C00180141/reports/