### PR TITLE
5648 - Update CSP for cloud.gov API

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -238,7 +238,7 @@ def add_secure_headers(response):
         "default-src": "'self' *.fec.gov *.app.cloud.gov",
         "img-src": "'self' data:",
         "script-src": "'self' https://api.data.gov https://dap.digitalgov.gov https://www.google-analytics.com \
-            https://www.googletagmanager.com 'unsafe-inline'",
+            https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-inline'",
         "style-src": "'self' https://fonts.googleapis.com https://api.data.gov 'unsafe-inline'",
         "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
         "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov https://www.google-analytics.com",

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -236,6 +236,7 @@ def add_secure_headers(response):
     }
     content_security_policy = {
         "default-src": "'self' *.fec.gov *.app.cloud.gov",
+        "frame-src": "'self' *.fec.gov *.app.cloud.gov https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/",
         "img-src": "'self' data:",
         "script-src": "'self' https://api.data.gov https://dap.digitalgov.gov https://www.google-analytics.com \
             https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-inline'",

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -236,14 +236,14 @@ def add_secure_headers(response):
     }
     content_security_policy = {
         "default-src": "'self' *.fec.gov *.app.cloud.gov",
+        "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov https://www.google-analytics.com",
+        "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
         "frame-src": "'self' *.fec.gov *.app.cloud.gov https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/",
         "img-src": "'self' data:",
+        "object-src": "'none'",
         "script-src": "'self' https://api.data.gov https://dap.digitalgov.gov https://www.google-analytics.com \
             https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-inline'",
         "style-src": "'self' https://fonts.googleapis.com https://api.data.gov 'unsafe-inline'",
-        "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
-        "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov https://www.google-analytics.com",
-        "object-src": "'none'",
         "report-uri": "/report-csp-violation/",
     }
     if env.app.get('space_name', 'local').lower() == 'local':


### PR DESCRIPTION
## Summary

- Resolves #5648 

Cloud.gov needs us to add the reCAPTCHA URLs to our CSP (content-security-policy).

Adding the reCAPTCHA paths to the `script-src` rule is pretty straightforward (tells the browser that we're cool with script requests made to those paths).

**Maybe tricky**: They requested that we add the reCAPTCHA to our `frame-src` rule but we didn't have one. Without a rule for `frame-src`, browsers would have used `default-src` as a fallback. Because of that, I copied our standard values for `default-src` into a new `frame-src` rule and added the new values for reCAPTCHA. We may not need the non-Google values in `frame-src`.


### Required reviewers

Best to review it on not-localhost
2 devs?

## Impacted areas of the application

Theoretically every page, but only comes into play when requesting
- script files from
   - `https://www.google.com/recaptcha/` †
   - `https://www.gstatic.com/recaptcha/` †
   - `'self'` ‡
   - `https://api.data.gov https://dap.digitalgov.gov` ‡
   - `https://www.google-analytics.com` ‡
   - `https://www.googletagmanager.com` ‡
- frame content from
   - `https://www.google.com/recaptcha/` †
   - `https://recaptcha.google.com/recaptcha/` †
   - `'self'` (inherited from default-src, just in case) ‡
   - `*.fec.gov` (inherited from default-src, just in case) ‡
   - `*.app.cloud.gov` (inherited from default-src, just in case) ‡


† new addition, which should work now
‡ existing entry that shouldn't break


## Screenshots

No visible changes

## Related PRs

None

## How to test

1. on not-localhost, test that reCAPTCHA is working
2. if we were using frames anywhere, check that they're still working
