### PR TITLE
Update committee_id and candidate_id validation

### DIFF
--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -30,7 +30,7 @@ def filter_range_fields(model):
 
 # used for endpoint:`/candidates/`
 # under tag: candidate
-# Ex: http://127.0.0.1:5000/v1/candidates/?candidate_id=S0LA00071&sort=name
+# Ex: http://127.0.0.1:5000/v1/candidates/?candidate_id=S2TX00106&sort=name
 @doc(
     tags=['candidate'], description=docs.CANDIDATE_LIST,
 )

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -30,7 +30,7 @@ def filter_year(model, query, years):
 # used for endpoint:'/committees/'
 # under tag: committee
 # Ex: http://127.0.0.1:5000/v1/committees/
-# http://127.0.0.1:5000/v1/committees/?candidate_id=S0LA00071
+# http://127.0.0.1:5000/v1/committees/?candidate_id=S2TX00106
 @doc(
     tags=["committee"],
     description=docs.COMMITTEE_LIST,

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -328,6 +328,7 @@ def check_election_arguments(kwargs):
 
 def check_committee_id(committee_id):
     # A valid committee_id begins with a 'C' followed by 8 digits
+    committee_id = committee_id.lstrip('-')
     if len(committee_id) != 9 or not committee_id.startswith('C'):
         raise exceptions.ApiError(
             exceptions.COMMITTEE_ID_ERROR,
@@ -343,7 +344,7 @@ def check_committee_id(committee_id):
 
 def check_candidate_id(candidate_id):
     # A valid candidate_id begins with a 'P' or 'H' or 'S' followed by 8 letters or numbers
-    if len(candidate_id) != 9 or candidate_id[0] not in ('P', 'S', 'H'):
+    if len(candidate_id.lstrip('-')) != 9 or candidate_id.lstrip('-')[0] not in ('P', 'S', 'H'):
         raise exceptions.ApiError(
             exceptions.CANDIDATE_ID_ERROR,
             status_code=422)


### PR DESCRIPTION
## Summary (required)
This PR will allow committee_id and candidate_id with '-' exclude search.

- Resolves #5657 

### Required reviewers
1 dev

## Impacted areas of the application
endpoints with committee_id and candidate_id validation

## How to test
1)Check out branch
2)pytest
3)Test some endpoint committee_id and candidate_id validation with exclude '-'
1)(return total 79820 rows)
http://127.0.0.1:5000/v1/committees/

(return 1 row)
http://127.0.0.1:5000/v1/committees/?committee_id=C00855759

(return 79820-1 = 79819 rows, that excluded committee_id=C00855759)
http://127.0.0.1:5000/v1/committees/?committee_id=-C00855759


2)(return total 49083 rows)
http://127.0.0.1:5000/v1/candidates/

(return1 row)
http://127.0.0.1:5000/v1/candidates/?candidate_id=S2TX00106

(return 49083-1=49082 rows)
http://127.0.0.1:5000/v1/candidates/?candidate_id=-S2TX00106

3)some endpoints don't support '-' filter now, compare local with prod. it will return 0 rows locally and return warning message on prod)
http://127.0.0.1:5000/v1/committees/?candidate_id=-S2TN00058
https://api.open.fec.gov/v1/committees/?candidate_id=-S2TN00058&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/totals/house-senate/?committee_id=-C00855759
https://api.open.fec.gov/v1/totals/house-senate/?committee_id=-C00855759&api_key=DEMO_KEY

