### PR TITLE
add validation to two_year_transaction_period

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -892,6 +892,15 @@ class TestScheduleA(ApiBaseTest):
             )
         )
 
+    def test_schedule_a_invalid_two_year_transaction_period(self):
+
+        response = self.app.get(
+            api.url_for(ScheduleAView, two_year_transaction_period=2013)
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertIn(b'Invalid two_year_transaction period', response.data)
+
 
 class TestScheduleB(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
@@ -971,6 +980,15 @@ class TestScheduleB(ApiBaseTest):
             )
         )
         self.assertEqual([each['sub_id'] for each in results], sub_ids)
+
+    def test_schedule_b_invalid_two_year_transaction_period(self):
+
+        response = self.app.get(
+            api.url_for(ScheduleBView, two_year_transaction_period=2013)
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertIn(b'Invalid two_year_transaction period', response.data)
 
     def test_schedule_b_efile_filters(self):
         filters = [

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -901,6 +901,13 @@ class TestScheduleA(ApiBaseTest):
         self.assertEqual(response.status_code, 422)
         self.assertIn(b'Invalid two_year_transaction period', response.data)
 
+        response = self.app.get(
+            api.url_for(ScheduleAView, two_year_transaction_period=1920)
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b'two_year_transaction_period not found', response.data)
+
 
 class TestScheduleB(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2016}
@@ -989,6 +996,13 @@ class TestScheduleB(ApiBaseTest):
 
         self.assertEqual(response.status_code, 422)
         self.assertIn(b'Invalid two_year_transaction period', response.data)
+
+        response = self.app.get(
+            api.url_for(ScheduleAView, two_year_transaction_period=1920)
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b'two_year_transaction_period not found', response.data)
 
     def test_schedule_b_efile_filters(self):
         filters = [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -132,15 +132,17 @@ class TwoYearTransactionPeriod(fields.Int):
     def _validate(self, value):
         super()._validate(value)
         current_cycle = get_current_cycle()
-        if value < 1976 or value > current_cycle:
-            raise exceptions.ApiError(
-                exceptions.TWO_YEAR_TRANSACTION_PERIOD_ERROR,
-                status_code=422,
-            )
         if value % 2 != 0:
             raise exceptions.ApiError(
-                exceptions.TWO_YEAR_TRANSACTION_PERIOD_ERROR,
+                exceptions.TWO_YEAR_TRANSACTION_PERIOD_ERROR
+                + str(current_cycle) + ".",
                 status_code=422,
+            )
+        if value < 1976 or value > current_cycle:
+            raise exceptions.ApiError(
+                exceptions.TWO_YEAR_TRANSACTION_PERIOD_404
+                + str(current_cycle) + ".",
+                status_code=404,
             )
 
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -6,7 +6,7 @@ from webargs import fields, validate
 from webservices import docs
 from webservices import exceptions
 from webservices.common.models import db
-from webservices.utils import check_committee_id, check_candidate_id
+from webservices.utils import check_committee_id, check_candidate_id, get_current_cycle
 import datetime
 
 
@@ -123,6 +123,23 @@ class Keyword(fields.Str):
         if len(value) < VALID_KEYWORD_LENGTH:  # noqa
             raise exceptions.ApiError(
                 exceptions.KEYWORD_LENGTH_ERROR,
+                status_code=422,
+            )
+
+
+class TwoYearTransactionPeriod(fields.Int):
+
+    def _validate(self, value):
+        super()._validate(value)
+        current_cycle = get_current_cycle()
+        if value < 1976 or value > current_cycle:
+            raise exceptions.ApiError(
+                exceptions.TWO_YEAR_TRANSACTION_PERIOD_ERROR,
+                status_code=422,
+            )
+        if value % 2 != 0:
+            raise exceptions.ApiError(
+                exceptions.TWO_YEAR_TRANSACTION_PERIOD_ERROR,
                 status_code=422,
             )
 
@@ -637,7 +654,7 @@ schedule_a = {
         description='Filters individual or committee contributions based on line number'
     ),
     'two_year_transaction_period': fields.List(
-        fields.Int,
+        TwoYearTransactionPeriod,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
     ),
     'recipient_committee_type': fields.List(
@@ -748,7 +765,7 @@ schedule_b = {
         description=docs.COMMITTEE_TYPE,
     ),
     'two_year_transaction_period': fields.List(
-        fields.Int,
+        TwoYearTransactionPeriod,
         description=docs.TWO_YEAR_TRANSACTION_PERIOD,
     ),
 }

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -29,6 +29,10 @@ CANDIDATE_ID_ERROR = """Invalid candidate_id. A valid candidate_id begins with a
  followed by 8 letters or numbers. For example: P00000034, S6MI00103, H0LA01087.\
 """
 
+TWO_YEAR_TRANSACTION_PERIOD_ERROR = """ Invalid two_year_transaction period. A valid two_year_transaction_period\
+ should be an even year between 1976 and the current cycle.\
+"""
+
 
 class ApiError(Exception):
     status_code = 400

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -29,8 +29,12 @@ CANDIDATE_ID_ERROR = """Invalid candidate_id. A valid candidate_id begins with a
  followed by 8 letters or numbers. For example: P00000034, S6MI00103, H0LA01087.\
 """
 
-TWO_YEAR_TRANSACTION_PERIOD_ERROR = """ Invalid two_year_transaction period. A valid two_year_transaction_period\
- should be an even year between 1976 and the current cycle.\
+TWO_YEAR_TRANSACTION_PERIOD_ERROR = """Invalid two_year_transaction period. A\
+ valid two_year_transaction_period should be an even year between 1976 and \
+"""
+
+TWO_YEAR_TRANSACTION_PERIOD_404 = """two_year_transaction_period not found.\
+ Data exists for two_year_transaction_periods between 1976 and \
 """
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #4628 

This ticket adds validation to two_year_transaction_period fields and auto-tests. 

### Required reviewers 2 developers 


## Impacted areas of the application

- schedule_a endpoint 
- schedule_b endpoint 

## How to test

- `pyenv activate (your virtual environment)`
- `pytest`
- `flask run`
- test /schedules/schedule_a/ and /schedules/schedule_b endpoints 

Sample URLs: 

schedule_a: 
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2026
 
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=1976
 
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=1974
 
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2003

 
schedule_b: 
http://127.0.0.1:5000/v1/schedules/schedule_b/?two_year_transaction_period=2026
 
http://127.0.0.1:5000/v1/schedules/schedule_b/?two_year_transaction_period=1976
 
http://127.0.0.1:5000/v1/schedules/schedule_b/?two_year_transaction_period=1974
 
http://127.0.0.1:5000/v1/schedules/schedule_b/?two_year_transaction_period=2003
 


