### PR TITLE
5621- Remove line_number functionality CDEFH4

### DIFF
--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1398,12 +1398,6 @@ class TestScheduleE(ApiBaseTest):
         )
         self.assertEqual(len(results), 1)
 
-        # to be removed
-        results = self._results(
-            api.url_for(ScheduleEView, line_number='f3X-24')
-        )
-        self.assertEqual(len(results), 1)
-
         results = self._results(
             api.url_for(ScheduleEView, form_line_number=('f3x-24', 'f3X-25'))
         )
@@ -1546,12 +1540,6 @@ class TestScheduleH4(ApiBaseTest):
         ]
         results = self._results(
             api.url_for(ScheduleH4View, form_line_number='f3x-23', **self.kwargs)
-        )
-        self.assertEqual(len(results), 1)
-
-        # to be removed
-        results = self._results(
-            api.url_for(ScheduleH4View, line_number='f3x-23', **self.kwargs)
         )
         self.assertEqual(len(results), 1)
 

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -213,12 +213,6 @@ class TestScheduleCView(ApiBaseTest):
         )
         self.assertEqual(len(results), 1)
 
-        # to be removed
-        results = self._results(
-            api.url_for(ScheduleCView, line_number='f3X-9')
-        )
-        self.assertEqual(len(results), 1)
-
         results = self._results(
             api.url_for(ScheduleCView, form_line_number=('f3x-9', 'f3X-10'))
         )

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -201,12 +201,6 @@ class TestScheduleDView(ApiBaseTest):
         )
         self.assertEqual(len(results), 1)
 
-        # to be removed
-        results = self._results(
-            api.url_for(ScheduleDView, line_number='f3X-9')
-        )
-        self.assertEqual(len(results), 1)
-
         results = self._results(
             api.url_for(ScheduleDView, form_line_number=('f3x-9', 'f3X-10'))
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -626,7 +626,6 @@ itemized = {
     'max_amount': Currency(description='Filter for all amounts less than a value.'),
     'min_date': Date(description='Minimum date'),
     'max_date': Date(description='Maximum date'),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number TBR
 }
 
 schedule_a = {
@@ -650,6 +649,7 @@ schedule_a = {
         `contribution_receipt_amount` of the last result. However, you will need to pass the index \
         of that last result to `last_index` to get the next page.'
     ),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),
     'is_individual': fields.Bool(missing=None, description=docs.IS_INDIVIDUAL),
     'contributor_type': fields.List(
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
@@ -748,6 +748,7 @@ schedule_b = {
     'disbursement_purpose_category': fields.List(IStr, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
     'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
     'last_disbursement_date': Date(missing=None, description=docs.LAST_DISBURSEMENT_DATE),
+    'line_number': fields.Str(description=docs.LINE_NUMBER),
     'recipient_city': fields.List(IStr, description=docs.RECIPIENT_CITY),
     'recipient_committee_id': fields.List(Committee_ID, description=docs.RECIPIENT_COMMITTEE_ID),
     'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
@@ -805,7 +806,6 @@ schedule_c = {
     'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
     'min_amount': Currency(description=docs.MIN_FILTER),
     'max_amount': Currency(description=docs.MAX_FILTER),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'candidate_name': fields.List(Keyword, description=docs.CANDIDATE_NAME),
     'loan_source_name': fields.List(Keyword, description=docs.LOAN_SOURCE),
@@ -840,7 +840,6 @@ schedule_d = {
     'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
     'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
     'filing_form': fields.List(fields.Str, description=docs.FORM_TYPE),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),     # added to ease transition to form_line_number
 }
 
 schedule_e_by_candidate = {

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -29,7 +29,6 @@ class BaseItemized(db.Model):
 class BaseRawItemized(db.Model):
     __abstract__ = True
 
-    # line_number = db.Column("line_num", db.String) removed as H4 Raw data does not have line_num
     transaction_id = db.Column('tran_id', db.String)
     image_number = db.Column('imageno', db.String, doc=docs.IMAGE_NUMBER)
     entity_type = db.Column('entity', db.String)

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1819,8 +1819,7 @@ Filter for form and line number using the following format:
 down to all entries from form `F3X` line number `16`.
 '''
 
-# Added to ease transition to FORM_LINE_NUMBER, to be removed
-LINE_NUMBER = ''' `DEPRECATED This filter will be renamed to form_line_number`
+LINE_NUMBER = '''
 Filter for form and line number using the following format:
 `FORM-LINENUMBER`.  For example an argument such as `F3X-16` would filter
 down to all entries from form `F3X` line number `16`.

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -9,6 +9,9 @@ LINE_NUMBER_ERROR = """Invalid line_number detected. A valid line_number is usin
 from form F3X line number 16.\
 """
 
+LINE_NUMBER_OBSOLETE_ERROR = """Obsolete, please use form_line_number.\
+"""
+
 IMAGE_NUMBER_ERROR = """Invalid image_number detected. A valid image_number is numeric only.\
 """
 

--- a/webservices/resources/sched_c.py
+++ b/webservices/resources/sched_c.py
@@ -2,7 +2,6 @@
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
-from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -47,17 +46,6 @@ class ScheduleCView(ApiResource):
     def build_query(self, **kwargs):
         query = super().build_query(**kwargs)
         utils.check_form_line_number(kwargs)
-        # added for transition to form_line_number, to be replaced w/obsolete error
-        if 'line_number' in kwargs:
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
         return query
 
     @property

--- a/webservices/resources/sched_d.py
+++ b/webservices/resources/sched_d.py
@@ -2,7 +2,6 @@ from flask_apispec import doc
 
 from webservices import args
 from webservices import docs
-from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -74,17 +73,6 @@ class ScheduleDView(ApiResource):
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         utils.check_form_line_number(kwargs)
-        # added for transition to form_line_number, to be replaced w/obsolete error
-        if 'line_number' in kwargs:
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
         return query
 
 

--- a/webservices/resources/sched_e.py
+++ b/webservices/resources/sched_e.py
@@ -3,7 +3,6 @@ import sqlalchemy as sa
 from flask_apispec import doc
 from webservices import args
 from webservices import docs
-from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from sqlalchemy.orm import aliased, contains_eager
@@ -116,17 +115,6 @@ class ScheduleEView(ItemizedResource):
             query = query.filter(sa.or_(self.model.most_recent == kwargs.get('most_recent'),
                                         self.model.most_recent == None))  # noqa
         utils.check_form_line_number(kwargs)
-        # added for transition to form_line_number, to be replaced w/obsolete error
-        if 'line_number' in kwargs:
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
         return query
 
 

--- a/webservices/resources/sched_f.py
+++ b/webservices/resources/sched_f.py
@@ -2,7 +2,6 @@ from flask_apispec import doc
 
 from webservices import args
 from webservices import docs
-from webservices import exceptions
 from webservices import utils
 from webservices import schemas
 from webservices.common import models
@@ -60,17 +59,6 @@ class ScheduleFView(ApiResource):
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         utils.check_form_line_number(kwargs)
-        # added for transition to form_line_number, to be replaced w/obsolete error
-        if 'line_number' in kwargs:
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
         return query
 
 

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -8,7 +8,6 @@ from webservices import schemas
 from webservices.common import models
 from webservices.common import views
 from webservices.common.views import ItemizedResource
-from webservices import exceptions
 
 
 # Used for endpoint `/schedules/schedule_h4/`
@@ -92,17 +91,6 @@ class ScheduleH4View(ItemizedResource):
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         utils.check_form_line_number(kwargs)
-        # added for transition to form_line_number, to be replaced w/obsolete error
-        if 'line_number' in kwargs:
-            if len(kwargs.get('line_number').split('-')) == 2:
-                form, line_no = kwargs.get('line_number').split('-')
-                query = query.filter_by(filing_form=form.upper())
-                query = query.filter_by(line_number=line_no)
-            else:
-                raise exceptions.ApiError(
-                    exceptions.LINE_NUMBER_ERROR,
-                    status_code=400,
-                )
         return query
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5621 

Removes line_number from CDEFH4 endpoints (has been replaced with form_line_number)  and removes the dep notices. 


I confirmed there's no users right now hitting this filter on these endpoints in the last 120 days (besides me)

### Required reviewers

1-2 devs


## How to test

- activate your virtual environment
- pull this branch
- flask run (check the line_number is present for A and B, and form_line_number is present for CDEFH4)
- http://127.0.0.1:5000/v1/schedules/schedule_b/?line_number=F3X-21B&two_year_transaction_period=2012&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_a/?line_number=F3X-15&two_year_transaction_period=2016&per_page=20&sort=-contribution_receipt_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_c/?form_line_number=F3-10&form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_c/?line_number=F3-10&form_line_number=F3X-10&page=1&per_page=20&sort=-incurred_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=true
- http://127.0.0.1:5000/v1/schedules/schedule_h4/?line_number=F3X-21A&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false
- http://127.0.0.1:5000/v1/schedules/schedule_e/?form_line_number=F3x-24&per_page=20&sort=-expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
- http://127.0.0.1:5000/v1/schedules/schedule_f/?line_number=F3X-25&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
-INVALID  FORM LINE NUMBER  http://127.0.0.1:5000/v1/schedules/schedule_h4/?form_line_number=string&per_page=20&sort=-event_purpose_date&sort_hide_null=false&sort_null_only=false

