### PR TITLE
Add Count Type Indicator 

### DIFF
--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -46,6 +46,7 @@ class CandidateFormatTest(ApiBaseTest):
             'page': 1,
             'pages': 1,
             'per_page': 20,
+            'is_count_exact': True,
         }
         # we are showing the full history rather than one result
         assert len(response['results']) == 1

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -37,7 +37,11 @@ class TestCommunicationCost(ApiBaseTest):
         self.assertEqual(
             response['pagination'],
             {
-                'count': 1, 'page': 1, 'per_page': 20, 'pages': 1
+                'count': 1,
+                'page': 1,
+                'per_page': 20,
+                'pages': 1,
+                'is_count_exact': True,
             }
         )
         response = self._response(

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -26,7 +26,9 @@ def is_estimated_count(resource, query):
     if resource.use_estimated_counts:
         estimated_count = get_estimated_count(query)
         if estimated_count > resource.estimated_count_threshold:
+            resource.is_count_exact = False
             return True
+    resource.is_count_exact = True
     return False
 
 

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -30,6 +30,7 @@ class ApiResource(utils.Resource):
     use_estimated_counts = True
     estimated_count_threshold = 500000
     use_pk_for_count = False
+    is_count_exact = ''
 
     @use_kwargs(Ref('args'))
     @marshal_with(Ref('page_schema'))
@@ -44,7 +45,7 @@ class ApiResource(utils.Resource):
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
         return utils.fetch_page(
-            query, kwargs,
+            query, kwargs, is_count_exact=self.is_count_exact,
             count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
             index_column=self.index_column, cap=self.cap, multi=multi,
         )
@@ -73,14 +74,14 @@ class ItemizedResource(ApiResource):
         """Get itemized resources.
         """
         self.validate_kwargs(kwargs)
-        
+
         query = self.build_query(**kwargs)
         is_estimate = counts.is_estimated_count(self, query)
         if not is_estimate:
             count = None
         else:
             count, _ = counts.get_count(self, query)
-        return utils.fetch_seek_page(query, kwargs, self.index_column, count=count, cap=self.cap)
+        return utils.fetch_seek_page(query, kwargs, self.index_column, is_count_exact=self.is_count_exact, count=count, cap=self.cap)
 
     def validate_kwargs(self, kwargs):
         """Custom keyword argument validation

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -845,6 +845,7 @@ case #1:
 pagination: {\n\
     pages: 2152643,\n\
     per_page: 20,\n\
+    is_count_exact: False,\n\
     count: 43052850,\n\
     last_indexes: {\n\
         last_index: "230880619",\n\
@@ -860,6 +861,7 @@ pagination: {\n\
     pages: 2152644,\n\
     per_page: 20,\n\
     count: 43052850,\n\
+    is_count_exact: False,\n\
     last_indexes: {\n\
         last_index: "230880639",\n\
         sort_null_only: True\n\
@@ -913,6 +915,7 @@ pagination: {\n\
     pages: 965191,\n\
     per_page: 20,\n\
     count: 19303814,\n\
+    is_count_exact: False,\n\
     last_indexes: {\n\
         last_index: "230906248",\n\
         last_disbursement_date: "2014-07-04"\n\
@@ -999,6 +1002,7 @@ results with the following pagination information:
 ```
  "pagination": {\n\
     "count": 152623,\n\
+    "is_count_exact": True,\n\
     "last_indexes": {\n\
       "last_index": "3023037",\n\
       "last_expenditure_amount": -17348.5\n\

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -69,7 +69,7 @@ class ElectionsListView(utils.Resource):
     @marshal_with(schemas.ElectionsListPageSchema())
     def get(self, **kwargs):
         query = self._get_elections(kwargs)
-        return utils.fetch_page(query, kwargs, model=ElectionsList, multi=True)
+        return utils.fetch_page(query, kwargs, is_count_exact=True, model=ElectionsList, multi=True)
 
     def _get_elections(self, kwargs):
         """Get elections from ElectionsList model."""
@@ -149,6 +149,7 @@ class ElectionView(ApiResource):
         return utils.fetch_page(
             query,
             kwargs,
+            is_count_exact=self.is_count_exact,
             count=count,
             model=self.model,
             join_columns=self.join_columns,

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -119,6 +119,7 @@ filter_match_fields = [
     ('most_recent', models.CommitteeReports.most_recent),
 ]
 
+
 # Used for endpoint '/reports/<string:entity_type>/'
 # under tag:'financial'
 # Sample urls:
@@ -149,7 +150,7 @@ class ReportsView(views.ApiResource):
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
-        page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
+        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=reports_class, multi=True)
         return reports_schema().dump(page)
 
     def build_query(self, entity_type=None, **kwargs):
@@ -214,7 +215,7 @@ class CommitteeReportsView(views.ApiResource):
         if kwargs['sort']:
             validator = args.IndicesValidator(reports_class)
             validator(kwargs['sort'])
-        page = utils.fetch_page(query, kwargs, model=reports_class, multi=True)
+        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=reports_class, multi=True)
         return reports_schema().dump(page)
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -77,7 +77,7 @@ class TotalsByEntityTypeView(ApiResource):
         query, totals_class, totals_schema = self.build_query(
             committee_id=committee_id, entity_type=entity_type, **kwargs
         )
-        page = utils.fetch_page(query, kwargs, model=totals_class)
+        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
         return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, entity_type=None, **kwargs):
@@ -231,7 +231,7 @@ class TotalsCommitteeView(ApiResource):
         query, totals_class, totals_schema = self.build_query(
             committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
         )
-        page = utils.fetch_page(query, kwargs, model=totals_class)
+        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
         return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
@@ -280,7 +280,8 @@ class CandidateTotalsDetailView(utils.Resource):
         if kwargs['sort']:
             validator = args.IndexValidator(totals_class)
             validator(kwargs['sort'])
-        page = utils.fetch_page(query, kwargs, model=totals_class)
+
+        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
         return totals_schema().dump(page)
 
     def build_query(self, candidate_id=None, **kwargs):


### PR DESCRIPTION
## Summary (required)

- Resolves #4003

This ticket adds a count_type indicator field to every endpoint with pagination. Counts are estimated if the estimated count (counts.py get_estimated_count) is greater than 500000. Counts are exact when the estimated count is less than 500000 or `is_estimated_count = false`. Counts for ElectionsListView, ReportsView, CommitteeReportsView, TotalsByEntityTypeView, TotalsCommitteeView, and CandidateTotalsDetailView are always exact. 

Note: The Marshmallow Pagination PR must be merged first. This branch will not pass CircleCI until marshmallow pagination is merged. 

### Required reviewers 2 - 3 developers

## Impacted areas of the application

General components of the application that this PR will affect:

- counts.py
- all endpoints with pagination

## Related PRs

Related PRs against other branches:

[Marshmallow Pagination PR
](https://github.com/fecgov/marshmallow-pagination/pull/15)
## How to test
To test you can either edit requirements.txt and change marshmallow pagination (line 33) to: 
`git+https://github.com/fecgov/marshmallow-pagination@add-count-type` or deploy [this](https://github.com/fecgov/openFEC/tree/test-count-type-indicator) test branch to dev
1. `pip install -r requirements.txt`
2. `flask run`
3. Test all endpoints with pagination


Sample URLs: 

Use_estimated_count = False:
 
http://127.0.0.1:5000/v1/schedules/schedule_e/efile/?page=1&per_page=20&sort=-expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

over  500000:
 
http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2020&per_page=20&sort=-contribution_receipt_date&sort_hide_null=false&sort_null_only=false
 
 
http://127.0.0.1:5000/v1/schedules/schedule_b/?per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false

under  500000:
 
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?page=1&per_page=20&employer=Amazon&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
 
http://127.0.0.1:5000/v1/communication_costs/?page=1&per_page=20&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

Other endpoints:
 
http://127.0.0.1:5000/v1/elections/search/?page=1&per_page=20&sort=sort_order&sort=district&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
 
 
http://127.0.0.1:5000/v1/elections/?cycle=2020&office=president
 
 
http://127.0.0.1:5000/v1/reports/pac-party/?page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
 
http://127.0.0.1:5000/v1/reports/ie-only/?q_spender=bid
 
 
http://127.0.0.1:5000/v1/totals/presidential/
http://127.0.0.1:5000/v1/totals/house-senate/
http://127.0.0.1:5000/v1/totals/pac/
http://127.0.0.1:5000/v1/totals/party/
http://127.0.0.1:5000/v1/totals/pac-party/
http://127.0.0.1:5000/v1/totals/ie-only/
 
 
http://127.0.0.1:5000/v1/committee/C00358796/totals/
 
http://127.0.0.1:5000/v1/candidate/H2CO07170/totals/

