### PR TITLE
add schedule_f test coverage

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -274,6 +274,18 @@ class ScheduleEFactory(BaseFactory):
         obj.payee_name_text = sa.func.to_tsvector(obj.payee_name)
 
 
+class ScheduleFFactory(BaseFactory):
+    class Meta:
+        model = models.ScheduleF
+
+
+class ScheduleFEfileFactory(BaseFactory):
+    class Meta:
+        model = models.ScheduleF
+
+    sub_id = factory.Sequence(lambda n: n)
+
+
 class ScheduleBEfileFactory(BaseFactory):
     class Meta:
         model = models.ScheduleBEfile

--- a/tests/test_sched_f.py
+++ b/tests/test_sched_f.py
@@ -1,0 +1,220 @@
+import datetime
+from tests import factories
+from tests.common import ApiBaseTest
+from webservices.rest import api
+from webservices.schemas import ScheduleFSchema
+from webservices.resources.sched_f import ScheduleFView, ScheduleFViewBySubId
+
+
+class TestScheduleFView(ApiBaseTest):
+    def test_fields(self):
+        factories.ScheduleFFactory()
+
+        results = self._results(api.url_for(ScheduleFView))
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].keys(), ScheduleFSchema().fields.keys())
+
+    def test_filter_image_number(self):
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2012,
+            image_number='1'
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2016,
+            image_number='2'
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2020,
+            image_number='3'
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2024,
+            image_number='4'
+            )
+
+        results = self._results(api.url_for(ScheduleFView, image_number=2))
+        self.assertEqual(results[0]['image_number'], '2')
+        self.assertEqual(len(results), 1)
+
+        results = self._results(api.url_for(ScheduleFView, min_image_number=2,
+                                            max_image_number=4))
+        self.assertEqual(len(results), 3)
+
+    def test_filter_committee_id(self):
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2012,
+            image_number=1
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000002',
+            candidate_id='S00000001',
+            election_cycle=2016,
+            image_number=2
+            )
+
+        results = self._results(api.url_for(ScheduleFView,
+                                            committee_id='C00000002'))
+        self.assertEqual(results[0]['committee_id'], 'C00000002')
+        self.assertEqual(len(results), 1)
+
+    def test_filter_candidate_id(self):
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2012,
+            image_number=1
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000002',
+            candidate_id='H00000001',
+            election_cycle=2016,
+            image_number=2
+            )
+
+        results = self._results(api.url_for(ScheduleFView,
+                                            candidate_id='S00000001'))
+        self.assertEqual(results[0]['candidate_id'], 'S00000001')
+        self.assertEqual(len(results), 1)
+
+    def test_filter_cycle(self):
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2012,
+            image_number=1
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2016,
+            image_number=2
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2020,
+            image_number=3
+            )
+        factories.ScheduleFFactory(
+            committee_id='C00000001',
+            candidate_id='S00000001',
+            election_cycle=2024,
+            image_number=4
+            )
+
+        results = self._results(api.url_for(ScheduleFView,
+                                            cycle=2024))
+        self.assertEqual(results[0]['election_cycle'], 2024)
+        self.assertEqual(len(results), 1)
+
+    def test_filter_form_line_number(self):
+        factories.ScheduleFFactory(line_number='9', filing_form='F3X')
+        factories.ScheduleFFactory(line_number='10', filing_form='F3X')
+        factories.ScheduleFFactory(line_number='9', filing_form='F3')
+        factories.ScheduleFFactory(line_number='9', filing_form='F3')
+
+        results = self._results(
+            api.url_for(ScheduleFView, form_line_number='f3X-9')
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self._results(
+            api.url_for(ScheduleFView, form_line_number=('f3x-9', 'f3X-10'))
+        )
+        self.assertEqual(len(results), 2)
+
+        # test NOT a form_line_number
+        results = self._results(
+            api.url_for(ScheduleFView, form_line_number='-F3x-10')
+        )
+        self.assertEqual(len(results), 3)
+
+        response = self.app.get(
+            api.url_for(ScheduleFView, form_line_number='f3x10')
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'Invalid form_line_number', response.data)
+
+    def test_filter_expenditure_date(self):
+        factories.ScheduleFFactory(expenditure_date=datetime.date(2024, 1, 1))
+        factories.ScheduleFFactory(expenditure_date=datetime.date(2023, 1, 1))
+        factories.ScheduleFFactory(expenditure_date=datetime.date(2022, 1, 1))
+        factories.ScheduleFFactory(expenditure_date=datetime.date(2021, 1, 1))
+
+        min_date = datetime.date(2022, 1, 1)
+        max_date = datetime.date(2024, 1, 1)
+
+        results = self._results(api.url_for(ScheduleFView,
+                                            min_date=min_date,
+                                            max_date=max_date))
+        self.assertEqual(len(results), 3)
+
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if each['expenditure_date'] <= max_date.isoformat()
+                and each['expenditure_date'] >= min_date.isoformat()
+            )
+        )
+
+    def test_filter_expenditure_amount(self):
+        factories.ScheduleFFactory(expenditure_amount=500)
+        factories.ScheduleFFactory(expenditure_amount=1000)
+        factories.ScheduleFFactory(expenditure_amount=200)
+        factories.ScheduleFFactory(expenditure_amount=2000)
+
+        results = self._results(api.url_for(ScheduleFView,
+                                            min_amount=100,
+                                            max_amount=1500))
+        self.assertEqual(len(results), 3)
+
+        self.assertTrue(
+            all(
+                each
+                for each in results
+                if each['expenditure_amount'] <= 1500
+                and each['expenditure_amount'] >= 100
+            )
+        )
+
+    def test_default_sort(self):
+        factories.ScheduleFFactory(committee_id='C00000001',
+                                   expenditure_date=datetime.date(2024, 1, 1))
+        factories.ScheduleFFactory(committee_id='C00000002',
+                                   expenditure_date=datetime.date(2023, 1, 1))
+        factories.ScheduleFFactory(committee_id='C00000003',
+                                   expenditure_date=datetime.date(2022, 1, 1))
+        factories.ScheduleFFactory(committee_id='C00000004',
+                                   expenditure_date=datetime.date(2021, 1, 1))
+
+        results = self._results(api.url_for(ScheduleFView))
+
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0]['committee_id'], 'C00000004')
+        self.assertEqual(results[1]['committee_id'], 'C00000003')
+        self.assertEqual(results[2]['committee_id'], 'C00000002')
+        self.assertEqual(results[3]['committee_id'], 'C00000001')
+
+
+class TestScheduleFViewBySubId(ApiBaseTest):
+    def test_fields(self):
+
+        factories.ScheduleFEfileFactory(sub_id='4321')
+
+        results = self._results(api.url_for(ScheduleFViewBySubId,
+                                            sub_id='4321'))
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].keys(), ScheduleFSchema().fields.keys())

--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -725,6 +725,15 @@ class ScheduleF(PdfMixin, BaseItemized):
     __table_args__ = {'schema': 'disclosure'}
     __tablename__ = 'fec_fitem_sched_f'
 
+    committee = db.relationship(
+        'CommitteeHistory',
+        primaryjoin='''and_(
+            foreign(ScheduleF.committee_id) == CommitteeHistory.committee_id,
+            ScheduleF.election_cycle == CommitteeHistory.cycle,
+        )''',
+        lazy='joined',
+    )
+
     sub_id = db.Column(db.Integer, primary_key=True)
     original_sub_id = db.Column('orig_sub_id', db.Integer)
     committee_designated_coordinated_expenditure_indicator = db.Column('cmte_desg_coord_exp_ind', db.String)
@@ -738,7 +747,8 @@ class ScheduleF(PdfMixin, BaseItemized):
         primaryjoin='''and_(
             foreign(ScheduleF.subordinate_committee_id) == CommitteeHistory.committee_id,
             ScheduleF.report_year + ScheduleF.report_year % 2 == CommitteeHistory.cycle,
-        )'''
+        )''',
+        lazy='joined',
     )
     subordinate_committee_id = db.Column('subord_cmte_id', db.String)
     """


### PR DESCRIPTION
## Summary (required)

- Resolves #5619 

This ticket adds test coverage to the schedule F endpoint. To add test coverage I had to fix the n + 1 query performance bug that we were getting by switching to[ joined loading](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html). 

### Required reviewers 2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  schedule f endpoints 


## How to test

1. checkout this branch 
2. `pytest`
3. `flask run` (compare changes to prod to make sure `committee` and `subordinate_committee` fields are the same. 

Sample URLs: 

example 1:
https://api.open.fec.gov/v1/schedules/schedule_f/?page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_f/?page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

example 2:
https://api.open.fec.gov/v1/schedules/schedule_f/?cycle=2024&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_f/?cycle=2024&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

example 3:
https://api.open.fec.gov/v1/schedules/schedule_f/?cycle=2016&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

http://127.0.0.1:5000/v1/schedules/schedule_f/?cycle=2016&page=1&per_page=20&sort=expenditure_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
