### PR TITLE
Upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 gevent==23.9.1
 gunicorn==19.10.0
-GitPython==3.1.35
+GitPython==3.1.41
 icalendar==4.0.2
 invoke==0.15.0
 kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary (required)

- Resolves #5694 

This ticket upgrades gitpython to remove a security vulnerability.


## Impacted areas of the application

General components of the application that this PR will affect:

-  automated release process/interaction with git libraries


## How to test

- run `git checkout develop`
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output shows gitpython as vulnerable package)
- run `git checkout feature/5694-upgrade-gitpython`
- run `pyenv activate venv-api`
- run `pip install -r requirements.txt` 
- run `snyk test --file=requirements.txt --package-manager=pip` (Terminal output **no longer shows** gitpython as vulnerable package)
- run `pytest`
