### PR TITLE
migrate deploy to run in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
 
       - run: $FEC_BASTION_PROD_TUNNEL # establsh tunnel/port mapping to 'prod' RDS from CircleCI container through Bastion host.
 
-      - deploy:
+      - run:
           name: Deploy API
           command: |
             export PATH=$HOME/bin:$PATH


### PR DESCRIPTION
## Summary (required)

A configuration file that uses the deprecated deploy step must be converted, and all instances of the deploy step must be removed, regardless of whether or not [parallelism](https://circleci.com/docs/parallelism-faster-jobs/) is used in the job.

Replace deprecated `deploy` step with `run` in circleci/config.yml 

- Resolves #https://github.com/fecgov/openFEC/issues/5678



### Required reviewers

2 developers

## Impacted areas of the application

-  API app deployment to cloud space 

## How to test

- Create a test branch off `feature/5678-circleci-migrate-to-run`  and deploy to `dev` space
- On circleci `Deploy API` step,  API app should deploy to `dev` space without failures

Link to `feature/5678-circleci-migrate-to-run`branch circleci build: https://app.circleci.com/pipelines/github/fecgov/openFEC/2499/workflows/7df09985-58f1-474f-9a1a-780479c76511/jobs/5223
