### PR TITLE
Change conduit_committee_zip to string

### DIFF
--- a/webservices/common/models/itemized.py
+++ b/webservices/common/models/itemized.py
@@ -151,7 +151,7 @@ class ScheduleA(BaseItemized):
     conduit_committee_street2 = db.Column('conduit_cmte_st2', db.String)
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
-    conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
+    conduit_committee_zip = db.Column('conduit_cmte_zip', db.String)
 
     donor_committee_name = db.Column('donor_cmte_nm', db.String)
     national_committee_nonfederal_account = db.Column('national_cmte_nonfed_acct', db.String)
@@ -211,7 +211,7 @@ class ScheduleAEfile(BaseRawItemized):
     conduit_committee_street2 = db.Column('other_str2', db.String)
     conduit_committee_city = db.Column('other_city', db.String)
     conduit_committee_state = db.Column('other_state', db.String)
-    conduit_committee_zip = db.Column('other_zip', db.Integer)
+    conduit_committee_zip = db.Column('other_zip', db.String)
     pgo = db.Column(db.String)
 
     committee = db.relationship(
@@ -358,7 +358,7 @@ class ScheduleB(BaseItemized):
     conduit_committee_street2 = db.Column('conduit_cmte_st2', db.String)
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
-    conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
+    conduit_committee_zip = db.Column('conduit_cmte_zip', db.String)
 
     ref_disp_excess_flg = db.Column('ref_disp_excess_flg', db.String)
     comm_dt = db.Column('comm_dt', db.Date)
@@ -439,7 +439,7 @@ class ScheduleC(PdfMixin, BaseItemized):
     loan_source_street_2 = db.Column('loan_src_st2', db.String)
     loan_source_city = db.Column('loan_src_city', db.String)
     loan_source_state = db.Column('loan_src_st', db.String)
-    loan_source_zip = db.Column('loan_src_zip', db.Integer)
+    loan_source_zip = db.Column('loan_src_zip', db.String)
     loan_source_name = db.Column('loan_src_nm', db.String, doc=docs.LOAN_SOURCE)
     loan_source_name_text = db.Column(TSVECTOR)
     entity_type = db.Column('entity_tp', db.String)
@@ -603,7 +603,7 @@ class ScheduleE(PdfMixin, BaseItemized):
     conduit_committee_street2 = db.Column('conduit_cmte_st2', db.String)
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
-    conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
+    conduit_committee_zip = db.Column('conduit_cmte_zip', db.String)
     # Transaction meta info
     independent_sign_name = db.Column('indt_sign_nm', db.String)
     independent_sign_date = db.Column('indt_sign_dt', db.Date)
@@ -791,7 +791,7 @@ class ScheduleF(PdfMixin, BaseItemized):
     conduit_committee_street2 = db.Column('conduit_cmte_st2', db.String)
     conduit_committee_city = db.Column('conduit_cmte_city', db.String)
     conduit_committee_state = db.Column('conduit_cmte_st', db.String)
-    conduit_committee_zip = db.Column('conduit_cmte_zip', db.Integer)
+    conduit_committee_zip = db.Column('conduit_cmte_zip', db.String)
     action_code = db.Column('action_cd', db.String)
     action_code_full = db.Column('action_cd_desc', db.String)
     back_reference_transaction_id = db.Column('back_ref_tran_id', db.String)


### PR DESCRIPTION
## Summary (required)

- Resolves #5722 

This ticket fixes a bug with `conduit_committee_zip` where the data type in the model was an Integer but the zip code in the database contained alphanumeric characters because it is a Canadian zip code. 

Here are some links in docquery for reference: 
https://docquery.fec.gov/cgi-bin/fecimg/?202307129582515808
https://docquery.fec.gov/cgi-bin/fecimg/?202212069547174185
https://docquery.fec.gov/cgi-bin/fecimg/?202204089495979742
https://docquery.fec.gov/cgi-bin/fecimg/?202201259475160806

I changed all `conduit_committee_zip` fields to a string and cross referenced this with the database tables. I changed Schedule C `loan_source_zip` as well because it is a varchar data type in the database. 

### Required reviewers 1-2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

-  Schedule A, B, C, E,F, A efile 



## How to test
1. checkout this branch 
2. activate you virtualenv 
3. `flask run`
4. Run queries that the user reported 
5. Run queries for Schedules B, C, E, F, and A efile 

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=contribution_receipt_date&min_amount=1000&two_year_transaction_period=2024&min_date=2023-01-19&max_date=2023-01-19&last_contribution_receipt_date=2023-01-19&last_index=4042720231744864529&per_page=100

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=contribution_receipt_date&min_amount=1000&two_year_transaction_period=2022&min_date=2022-10-20&max_date=2022-10-20&last_contribution_receipt_date=2022-10-20&last_index=4121320221635175467&per_page=100

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=contribution_receipt_date&min_amount=1000&two_year_transaction_period=2022&min_date=2022-02-03&max_date=2022-02-03&last_contribution_receipt_date=2022-02-03&last_index=4040520221465315780&per_page=100

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=-contribution_receipt_date&min_amount=1000&two_year_transaction_period=2022&min_date=2021-10-27&max_date=2021-10-27&last_contribution_receipt_date=2021-10-27&last_index=4020720221405294106&per_page=100

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=contribution_receipt_date&min_amount=1000&two_year_transaction_period=2022&min_date=2021-10-20&max_date=2021-10-20&last_contribution_receipt_date=2021-10-20&last_index=4012520221389410863&per_page=100

http://127.0.0.1:5000/v1/schedules/schedule_a/?sort=contribution_receipt_date&min_amount=1000&two_year_transaction_period=2024&min_date=2023-01-19&max_date=2023-01-19&last_contribution_receipt_date=2023-01-19&last_index=4042720231744846112&per_page=100