### PR TITLE
Upgrade python v3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
         environment:
           TZ: America/New_York
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
 
 1. Ensure you have the following requirements installed:
 
-   - Python (the latest 3.9 release, which includes `pip` and a built-in version of `virtualenv` called `venv`).
+   - Python (the latest 3.10 release, which includes `pip` and a built-in version of `virtualenv` called `venv`).
    - The latest long term support (LTS) or stable release of Node.js (which includes npm)
    - PostgreSQL (the latest 13 release).
      - Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ coverage==7.0.3
 factory_boy==2.8.1
 importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: SelectableGroups dict interface
 nplusone==0.8.0
-pytest==5.2.0
-pytest-cov==2.5.1
+pytest==8.0.2
+pytest-cov==4.1.0
 setuptools==68.0.0 #pin to remediate snyk ReDoS#5477
 webtest==2.0.34

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x


### PR DESCRIPTION
## Summary (required)

- Resolves #5682 

This ticket upgrades python to version 3.10.13. 

Note: CircleCI will not pass until the marshmallow-pagination PR is merged in 

### Required reviewers 1 - 2 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

- pytest
- circleci 
- marshmallow_pagination 



## Related PRs

Related PRs against other branches:

| branch           | PR       |
| ---------------- | -------- |
| marshmallow_pagination PR   | [link](https://github.com/fecgov/marshmallow-pagination/pull/17) |

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)


1. `pyenv virtualenv 3.10.13 <new env name>`
2. `pyenv activate <new env name>`
3. Open requirements.txt and change marshmallow_pagination from this `git+https://github.com/fecgov/marshmallow-pagination@master` to this `git+https://github.com/fecgov/marshmallow-pagination@upgrade-python-v3.10`
4. `pip install -r requirements.txt`
5.  `pip install -r requirements-dev.txt`
6.  `npm install`
7.  `npm run build`
8. `pytest`
9. `flask run` - test pagination 