### PR TITLE
Change purpose filter from fulltext to multi

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -105,7 +105,7 @@ class TestCommitteeAggregates(ApiBaseTest):
         aggregate = factories.ScheduleBByPurposeFactory(
             committee_id=committee.committee_id,
             cycle=committee.cycle,
-            purpose='ADMINISTRATIVE EXPENSES',
+            purpose='ADMINISTRATIVE',
         )
         results = self._results(
             api.url_for(
@@ -118,7 +118,7 @@ class TestCommitteeAggregates(ApiBaseTest):
         self.assertEqual(len(results), 1)
         expected = {
             'committee_id': committee.committee_id,
-            'purpose': 'ADMINISTRATIVE EXPENSES',
+            'purpose': 'ADMINISTRATIVE',
             'cycle': 2012,
             'total': aggregate.total,
             'count': aggregate.count,

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -1022,6 +1022,16 @@ class TestScheduleB(ApiBaseTest):
             assert len(results) == 1
             assert results[0][column.key] == values[0]
 
+    def test_schedule_b_disbursement_purpose_category_filter(self):
+        factories.ScheduleBFactory(disbursement_purpose_category='POLLING')
+        factories.ScheduleBFactory(disbursement_purpose_category='EVENTS')
+        factories.ScheduleBFactory(disbursement_purpose_category='REFUNDS')
+
+        results = self._results(
+            api.url_for(ScheduleBView, disbursement_purpose_category=['polling', 'refunds'])
+        )
+        self.assertEqual(len(results), 2)
+
 
 # Test endpoints:
 # /schedules/schedule_e/ (sched_e.ScheduleEView)

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -286,6 +286,19 @@ def make_seek_args(field=fields.Int, description=None):
     }
 
 
+disbursment_purpose_list = ['ADMINISTRATIVE',
+                            'ADVERTISING',
+                            'CONTRIBUTIONS',
+                            'EVENTS',
+                            'FUNDRAISING',
+                            'LOAN-REPAYMENTS',
+                            'MATERIALS',
+                            'OTHER',
+                            'POLLING',
+                            'REFUNDS',
+                            'TRANSFERS',
+                            'TRAVEL']
+
 names = {
     'q': fields.List(Keyword, required=True, description='Name (candidate or committee) to search for'),
 }
@@ -743,7 +756,8 @@ schedule_a_by_contributor = {
 
 schedule_b_by_purpose = {
     'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'purpose': fields.List(Keyword, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+    'purpose': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
+                           description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
 }
 
@@ -762,7 +776,8 @@ schedule_b_by_recipient_id = {
 schedule_b = {
     'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
     'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
-    'disbursement_purpose_category': fields.List(IStr, description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+    'disbursement_purpose_category': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
+                                                 description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
     'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
     'last_disbursement_date': Date(missing=None, description=docs.LAST_DISBURSEMENT_DATE),
     'line_number': fields.Str(description=docs.LINE_NUMBER),

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -173,9 +173,7 @@ class ScheduleBByPurposeView(AggregateResource):
     filter_multi_fields = [
         ('cycle', models.ScheduleBByPurpose.cycle),
         ('committee_id', models.ScheduleBByPurpose.committee_id),
-    ]
-    filter_fulltext_fields = [
-        ('purpose', models.ScheduleBByPurpose.purpose),
+        ('purpose', models.ScheduleBByPurpose.purpose)
     ]
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5736 

This PR changes the purpose filter in ScheduleBByPurposeView from filter_fulltext to filter_multi. I also changed from a text search to a multi-select in both schedule b and schedule b by purpose.

### Required reviewers 1 - 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

- schedule b endpoint
- schedule b by purpose endpoint


## How to test

1. checkout this branch 
2. activate you virtualenv 
3. `flask run`

