### PR TITLE
Remove per_page cap on ScheduleABySizeCandidateView, ScheduleAByStateCandidateView, and ScheduleAByStateCandidateTotalsView

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -587,7 +587,7 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
             fec_election_year=self.next_cycle,
         )
 
-# start --- test '/schedules/schedule_a/by_size/by_candidate/' (candidate_aggregates.ScheduleABySizeCandidateView)
+    # start --- test '/schedules/schedule_a/by_size/by_candidate/' (candidate_aggregates.ScheduleABySizeCandidateView)
     def test_schedule_a_by_size_candidate(self):
         [
             factories.ScheduleABySizeFactory(
@@ -646,6 +646,18 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
             'count': 40,
         }
         assert results[0] == expected
+
+    def test_schedule_a_by_size_candidate_no_cap_per_page(self):
+        # when per_page >100 (=101), api call no error that means no cap for per_page value
+        response = self.app.get(
+            api.url_for(
+                ScheduleABySizeCandidateView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                per_page=101
+            )
+        )
+        self.assertEqual(response.status_code, 200)
 
     def test_sort_validation_schedule_a_by_size_candidate(self):
         [
@@ -774,6 +786,18 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         }
         assert results[0] == expected
 
+    def test_schedule_a_by_state_candidate_no_cap_per_page(self):
+        # when per_page =101 (>100), api call no error that means no cap for per_page value
+        response = self.app.get(
+            api.url_for(
+                ScheduleAByStateCandidateView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                per_page=101
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_sort_validation_schedule_a_by_state_candidate(self):
         [
             factories.ScheduleAByStateFactory(
@@ -883,6 +907,18 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
             'count': 100,
         }
         assert results[0] == expected
+
+    def test_schedule_a_by_state_candidate_totals_no_cap_per_page(self):
+        # when per_page =101 (>100), api call no error that means no cap for per_page value
+        response = self.app.get(
+            api.url_for(
+                ScheduleAByStateCandidateTotalsView,
+                candidate_id=self.candidate.candidate_id,
+                cycle=2012,
+                per_page=101
+            )
+        )
+        self.assertEqual(response.status_code, 200)
 
     def test_sort_validation_schedule_a_by_state_candidate_totals(self):
         [

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -132,3 +132,35 @@ class ItemizedResource(ApiResource):
                 ),
                 status_code=422,
             )
+
+
+# return all results, per_page without cap (cap=0). It is used for:
+# ScheduleABySizeCandidateView
+# ScheduleAByStateCandidateView
+# ScheduleAByStateCandidateTotalsView
+class NoCapResource(utils.Resource):
+
+    args = {}
+    model = None
+    schema = None
+    page_schema = None
+    index_column = None
+    unique_column = None
+    filter_match_fields = []
+    filter_multi_fields = []
+    filter_range_fields = []
+    filter_fulltext_fields = []
+    filter_overlap_fields = []
+    query_options = []
+    join_columns = {}
+    aliases = {}
+    cap = ''
+
+    @use_kwargs(Ref('args'))
+    @marshal_with(Ref('page_schema'))
+    def get(self, *args, **kwargs):
+        query = self.build_query(*args, **kwargs)
+        multi = False
+        if isinstance(kwargs['sort'], (list, tuple)):
+            multi = True
+        return utils.fetch_page(query, kwargs, multi=multi, cap=0, is_count_exact=True)

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -7,7 +7,7 @@ from webservices import utils
 from webservices import docs
 from webservices import filters
 from webservices import schemas
-from webservices.common.views import ApiResource
+from webservices.common.views import ApiResource, NoCapResource
 from webservices.common import models
 from webservices.common.models import (
     CandidateCommitteeLink,
@@ -82,7 +82,7 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
 @doc(
     tags=['receipts'], description=docs.SCHEDULE_A_SIZE_CANDIDATE_TAG,
 )
-class ScheduleABySizeCandidateView(ApiResource):
+class ScheduleABySizeCandidateView(NoCapResource):
     schema = schemas.ScheduleABySizeCandidateSchema
     page_schema = schemas.ScheduleABySizeCandidatePageSchema()
     sort_option = [
@@ -117,12 +117,14 @@ class ScheduleABySizeCandidateView(ApiResource):
 
 # used for 'schedules/schedule_a/by_state/by_candidate/'
 # under tag: receipts
-# Ex: http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=H8CA05035
+# Ex1: http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=H8CA05035
 # &cycle=2022&election_full=true
+# Ex2: http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=P00014530&
+# candidate_id=P80000722&candidate_id=P80001571&cycle=2020&election_full=true&per_page=200
 @doc(
     tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TAG,
 )
-class ScheduleAByStateCandidateView(ApiResource):
+class ScheduleAByStateCandidateView(NoCapResource):
     schema = schemas.ScheduleAByStateCandidateSchema
     page_schema = schemas.ScheduleAByStateCandidatePageSchema()
     sort_option = [
@@ -164,7 +166,7 @@ class ScheduleAByStateCandidateView(ApiResource):
 @doc(
     tags=['receipts'], description=docs.SCHEDULE_A_STATE_CANDIDATE_TOTAL_TAG,
 )
-class ScheduleAByStateCandidateTotalsView(ApiResource):
+class ScheduleAByStateCandidateTotalsView(NoCapResource):
     schema = schemas.ScheduleAByStateCandidateSchema
     page_schema = schemas.ScheduleAByStateCandidatePageSchema()
     sort_option = [


### PR DESCRIPTION
## Summary (required)
This PR will remove the per_page cap for these three endpoints:
ScheduleABySizeCandidateView
ScheduleAByStateCandidateView
ScheduleAByStateCandidateTotalsView

- Resolves #5734 

### Required reviewers

1-2 devs

## Impacted areas of the application
schedules/schedule_a/by_state/by_candidate/
schedules/schedule_a/by_state/by_candidate/totals
schedules/schedule_a/by_size/by_candidate/

## Screenshots

## How to test
- Check out branch
- pytest
- Test 3 endpoints will allow return more than 100 rows (per_page >100)
compare with on prod, will get 422 error: "Parameter 'per_page' must be between 1 and 100"

1)ScheduleAByStateCandidateView
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=P00014530&candidate_id=P80000722&candidate_id=P80001571&cycle=2020&election_full=true&per_page=200

https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=P00014530&candidate_id=P80000722&candidate_id=P80001571&cycle=2020&election_full=true&per_page=200&api_key=DEMO_KEY

2)ScheduleAByStateCandidateTotalsView
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=total&candidate_id=H4OH07064&candidate_id=H8CA05035&cycle=2024&election_full=true&per_page=101

https://api.open.fec.gov/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=total&candidate_id=H4OH07064&candidate_id=H8CA05035&cycle=2024&election_full=true&per_page=101&api_key=DEMO_KEY

3)ScheduleABySizeCandidateView
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?sort=-count&candidate_id=H4OH07064&candidate_id=H8CA05035&cycle=2024&election_full=true&per_page=101

https://api.open.fec.gov/v1/schedules/schedule_a/by_size/by_candidate/?sort=-count&candidate_id=H4OH07064&candidate_id=H8CA05035&cycle=2024&election_full=true&per_page=101&api_key=DEMO_KEY

- Setup local cms that points to local api, test elections page, go to section: Individual contributions to candidates, click group by Contributor state, make sure "Contributor state" datatable display.

http://127.0.0.1:8000/data/elections/president/2024/
<img width="600" alt="Screenshot 2024-03-10 at 4 40 22 PM" src="https://github.com/fecgov/openFEC/assets/24395751/0967a4b9-003e-425c-abb8-00811be4ef68">




