### PR TITLE
5755-add check and clear queries commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -203,6 +203,18 @@ def slack_message_cli(message):
     manage.slack_message(message)
 
 
+@app.cli.command('check_long_queries')
+@click.argument('minutes', default=5, required=False)
+def check_long_queries_cli(minutes):
+    manage.check_long_queries(minutes)
+
+
+@app.cli.command('clear_long_queries')
+@click.argument('minutes', default=5, required=False)
+def clear_long_queries_cli(minutes):
+    manage.clear_long_queries(minutes)
+
+
 @app.shell_context_processor
 def make_shell_context():
     return {'app': app, 'db': db, 'models': models}

--- a/manage.py
+++ b/manage.py
@@ -176,7 +176,7 @@ def check_long_queries(minutes: int):
             logger.info(row)
         total_rows = results.rowcount
         space = env.app.get("space_name")
-        slack_message = "Currently {} queries running longer than {} minutes [{}]".format(total_rows, minutes, space)
+        slack_message = "Currently {} queries running longer than {} minutes in {}".format(total_rows, minutes, space)
         logger.info(slack_message)
         post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:
@@ -211,7 +211,7 @@ def clear_long_queries(minutes: int):
         results = db.engine.execute(sa.text(SQL), minutes=f"{minutes} minutes")
         total_rows = results.rowcount
         space = env.app.get("space_name")
-        slack_message = "Terminated {} queries running longer than {} minutes [{}]".format(total_rows, minutes, space)
+        slack_message = "Terminated {} queries running longer than {} minutes in {}".format(total_rows, minutes, space)
         logger.info(slack_message)
         post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:

--- a/manage.py
+++ b/manage.py
@@ -175,7 +175,8 @@ def check_long_queries(minutes: int):
         for row in rows:
             logger.info(row)
         total_rows = results.rowcount
-        slack_message = "Currently {} queries running longer than {} minutes".format(total_rows, minutes)
+        space = env.app.get("space_name")
+        slack_message = "Currently {} queries running longer than {} minutes [{}]".format(total_rows, minutes, space)
         logger.info(slack_message)
         post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:
@@ -209,7 +210,8 @@ def clear_long_queries(minutes: int):
     try:
         results = db.engine.execute(sa.text(SQL), minutes=f"{minutes} minutes")
         total_rows = results.rowcount
-        slack_message = "Terminated {} queries running longer than {} minutes".format(total_rows, minutes)
+        space = env.app.get("space_name")
+        slack_message = "Terminated {} queries running longer than {} minutes [{}]".format(total_rows, minutes, space)
         logger.info(slack_message)
         post_to_slack(slack_message, SLACK_BOTS)
     except Exception as error:


### PR DESCRIPTION
## Summary (required)

- Resolves #5755 

This PR adds commands to manually check for and clear long running queries. Due to ongoing discussion with db team, I did not make it a celery task yet. I also have concerns with being able to support this kind of celery task. 

Here's the [dashboard](https://logs.fr.cloud.gov/app/dashboards#/view/0fd6ea60-f5b6-11ee-927c-73315d2dd7b2?_g=) for check_queries 

### Required reviewers

3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- cf tasks, db

## How to test

Locally: 
-**unset SQLA_CONN**
- Remove the datname and usename portions of the SQL for both commands
they should read
SELECT pg_terminate_backend(pid)
        FROM pg_stat_activity
        WHERE lower(query) like 'select %'
        and lower(query) not like '%refresh%'
        and lower(query) not like '%rollback%'
        and (now() - pg_stat_activity.query_start) >= interval :minutes
        order by pg_stat_activity.query_start desc;
-in dbeaver create a long-running test query like "select pg_sleep(5 * 60);"
-wait 2 min
-"python cli.py check_long_queries 2"
-"python cli.py clear_long_queries 2" 

Deploy to a space:
-remove the datname and **change the usename to your personal information** 
-deploy to dev
-run a long query in dev like "select pg_sleep(5 * 60);" and wait 2 minutes
-cf run-task api --command "python cli.py check_long_queries 2" --name check_queries
-search for check_queries (or whatever you named the task) in logs
-You should see the number of queries show up in the bots channel
-cf run-task api --command "python cli.py clear_long_queries 2" --name clear_queries
-search for clear_queries (or whatever you named the task) in logs
-You should see the number of queries show up in the bots channel

