### PR TITLE
Add New Creds Service

### DIFF
--- a/manifests/manifest_api_dev.yml
+++ b/manifests/manifest_api_dev.yml
@@ -11,6 +11,7 @@ applications:
     routes:
       - route: fec-dev-api.app.cloud.gov
     services:
+      - api-creds-dev
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-dev

--- a/manifests/manifest_api_feature.yml
+++ b/manifests/manifest_api_feature.yml
@@ -11,6 +11,7 @@ applications:
     routes:
       - route: fec-feature-api.app.cloud.gov
     services:
+      - api-creds-feature
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-feature

--- a/manifests/manifest_api_prod.yml
+++ b/manifests/manifest_api_prod.yml
@@ -11,6 +11,7 @@ applications:
     routes:
       - route: fec-prod-api.app.cloud.gov
     services:
+      - api-creds-prod
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-prod

--- a/manifests/manifest_api_stage.yml
+++ b/manifests/manifest_api_stage.yml
@@ -11,6 +11,7 @@ applications:
     routes:
       - route: fec-stage-api.app.cloud.gov
     services:
+      - api-creds-stage
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-stage

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-dev
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-dev

--- a/manifests/manifest_celery_beat_feature.yml
+++ b/manifests/manifest_celery_beat_feature.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-feature
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-feature

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-prod
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-prod

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-stage
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-stage

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-dev
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-dev

--- a/manifests/manifest_celery_worker_feature.yml
+++ b/manifests/manifest_celery_worker_feature.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-feature
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-feature

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-prod
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-prod

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -12,6 +12,7 @@ applications:
     buildpacks:
       - python_buildpack
     services:
+      - api-creds-stage
       - fec-api-elasticsearch
       - fec-elasticache-redis
       - fec-creds-stage

--- a/manifests/manifest_task_dev.yml.template
+++ b/manifests/manifest_task_dev.yml.template
@@ -11,6 +11,7 @@ applications:
     - python_buildpack
   health-check-type: process
   services:
+    - api-creds-dev
     - fec-api-elasticsearch
     - fec-elasticache-redis
     - fec-creds-dev

--- a/manifests/manifest_task_feature.yml.template
+++ b/manifests/manifest_task_feature.yml.template
@@ -11,6 +11,7 @@ applications:
     - python_buildpack
   health-check-type: process
   services:
+    - api-creds-feature
     - fec-api-elasticsearch
     - fec-elasticache-redis
     - fec-creds-feature

--- a/manifests/manifest_task_prod.yml.template
+++ b/manifests/manifest_task_prod.yml.template
@@ -11,6 +11,7 @@ applications:
     - python_buildpack
   health-check-type: process
   services:
+    - api-creds-prod
     - fec-api-elasticsearch
     - fec-elasticache-redis
     - fec-creds-prod

--- a/manifests/manifest_task_stage.yml.template
+++ b/manifests/manifest_task_stage.yml.template
@@ -11,6 +11,7 @@ applications:
     - python_buildpack
   health-check-type: process
   services:
+    - api-creds-stage
     - fec-api-elasticsearch
     - fec-elasticache-redis
     - fec-creds-stage


### PR DESCRIPTION
## Summary (required)

- Resolves #5761 

This ticket adds the new creds service to the manifest files. I moved all of the API only variables into a separate service including: `API_UMBRELLA_SIGNUP_KEY , ES_SNAPSHOT_ROLE_ARN , FEC_FEATURE_PRESIDENTIAL , SQLA_FOLLOWERS,  SLACK_HOOK, SQLA_CONN,  FEC_EREGS_API`

### Required reviewers 2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- manifest files

## How to test

- Remove the API only variables from fec-creds-dev: `API_UMBRELLA_SIGNUP_KEY , ES_SNAPSHOT_ROLE_ARN , FEC_FEATURE_PRESIDENTIAL , SQLA_FOLLOWERS,  SLACK_HOOK, SQLA_CONN,  FEC_EREGS_API` using [this](https://github.com/fecgov/openFEC/wiki/Switch-out-cf-environment-variables) wiki article as reference.
- Deploy a test branch based off of this PR. You can use [this](https://github.com/fecgov/openFEC/tree/test-new-creds-service) one. 
- restage cms and eregs 
- Test that everything is working properly on dev 

With cf cli (this only works if a test branch is deployed to dev space) : 
1. login to dev: `cf target -s dev`
2. Check that api-creds-dev is only bound to api, celery-worker and celery beat: `cf services`
3. Check the environment variables on dev: `cf env api` make sure that api-creds-dev contains the following variables, `API_UMBRELLA_SIGNUP_KEY , ES_SNAPSHOT_ROLE_ARN , FEC_FEATURE_PRESIDENTIAL , SQLA_FOLLOWERS,  SLACK_HOOK, SQLA_CONN,  FEC_EREGS_API` and they are not in fec-creds-dev. 