### PR TITLE
Add candidate_id limitation on schedule a aggregate

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -659,6 +659,17 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_schedule_a_by_size_candidate_max_filter_count(self):
+        max_count = 10
+        filters_with_max_count = [
+            ('candidate_id', [str(number) for number in range(max_count + 1)]),
+        ]
+        for label, values in filters_with_max_count:
+            response = self.app.get(
+                api.url_for(ScheduleABySizeCandidateView, **{label: values})
+            )
+            self.assertEqual(response.status_code, 422)
+
     def test_sort_validation_schedule_a_by_size_candidate(self):
         [
             factories.ScheduleABySizeFactory(
@@ -798,6 +809,17 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_schedule_a_by_state_candidate_max_filter_count(self):
+        max_count = 10
+        filters_with_max_count = [
+            ('candidate_id', [str(number) for number in range(max_count + 1)]),
+        ]
+        for label, values in filters_with_max_count:
+            response = self.app.get(
+                api.url_for(ScheduleAByStateCandidateView, **{label: values})
+            )
+            self.assertEqual(response.status_code, 422)
+
     def test_sort_validation_schedule_a_by_state_candidate(self):
         [
             factories.ScheduleAByStateFactory(
@@ -919,6 +941,17 @@ class TestScheduleACandidateAggregates(ApiBaseTest):
             )
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_schedule_a_by_state_candidate__total_max_filter_count(self):
+        max_count = 10
+        filters_with_max_count = [
+            ('candidate_id', [str(number) for number in range(max_count + 1)]),
+        ]
+        for label, values in filters_with_max_count:
+            response = self.app.get(
+                api.url_for(ScheduleAByStateCandidateTotalsView, **{label: values})
+            )
+            self.assertEqual(response.status_code, 422)
 
     def test_sort_validation_schedule_a_by_state_candidate_totals(self):
         [

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -90,6 +90,9 @@ class ScheduleABySizeCandidateView(NoCapResource):
             'size',
             'count'
     ]
+    filters_with_max_count = [
+        'candidate_id',
+    ]
 
     @property
     def args(self):
@@ -133,6 +136,9 @@ class ScheduleAByStateCandidateView(NoCapResource):
             'state',
             'state_full',
     ]
+    filters_with_max_count = [
+        'candidate_id',
+    ]
 
     @property
     def args(self):
@@ -172,6 +178,9 @@ class ScheduleAByStateCandidateTotalsView(NoCapResource):
     sort_option = [
             'total',
             'count',
+    ]
+    filters_with_max_count = [
+        'candidate_id',
     ]
 
     @property


### PR DESCRIPTION
## Summary (required)
This PR will add filter by "candidate_id" limitation (max =10) on three endpoints:
ScheduleABySizeCandidateView
ScheduleAByStateCandidateView
ScheduleAByStateCandidateTotalsView

Blocking https://github.com/fecgov/fec-cms/issues/6226

- Resolves #5753 


### Required reviewers

1-2 devs

## Impacted areas of the application
ScheduleABySizeCandidateView
ScheduleAByStateCandidateView
ScheduleAByStateCandidateTotalsView

## How to test
- checkout branch
- pytest
- test urls


1)/schedules/schedule_a/by_size/by_candidate/:
pass 10 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?sort=size&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&cycle=2020&election_full=true&per_page=200

pass 11 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_size/by_candidate/?sort=size&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&candidate_id=P80003353&cycle=2020&election_full=true&per_page=200


2)/schedules/schedule_a/by_state/by_candidate/
pass 10 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&cycle=2020&election_full=true&per_page=200

pass 11 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/?sort=state&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&candidate_id=P80003353&cycle=2020&election_full=true&per_page=200


3)/schedules/schedule_a/by_state/by_candidate/totals
pass 10 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=total&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&cycle=2020&election_full=true&per_page=200

pass 11 candidate_ids:
http://127.0.0.1:5000/v1/schedules/schedule_a/by_state/by_candidate/totals/?sort=total&candidate_id=P80001571&candidate_id=S2TX00106&candidate_id=H6IL09061&candidate_id=H8IA01094&candidate_id=H8MO03164&candidate_id=P80003338&candidate_id=H6MT01095&candidate_id=H4CA12055&candidate_id=S6CT00042&candidate_id=S2ND00099&candidate_id=P80003353&cycle=2020&election_full=true&per_page=200


