### PR TITLE
5754-add robots.txt

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -19,6 +19,7 @@ from flask import jsonify
 from flask import url_for
 from flask import redirect
 from flask import render_template
+from flask import send_from_directory
 from flask import Flask
 from flask import Blueprint
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -584,6 +585,11 @@ def api_ui():
         PRODUCTION=env.get_credential('PRODUCTION'),
         api_key_signup_key=env.get_credential('API_UMBRELLA_SIGNUP_KEY'),
     )
+
+
+@app.route('/robots.txt/')
+def robots():
+    return send_from_directory(app.static_folder, 'robots.txt')
 
 
 @app.route('/report-csp-violation/', methods=['POST'])

--- a/webservices/static/robots.txt
+++ b/webservices/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /v1/*


### PR DESCRIPTION
## Summary (required)

- Resolves #5754 

This PR adds the robots.txt to our API so that search engines know we don't want them crawling our endpoints. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-API 


## How to test

- pyenv activate api (or your env)
- flask run
- http://127.0.0.1:5000/robots.txt

deploy to a space
-you can use my branch here to deploy to dev https://app.circleci.com/pipelines/github/fecgov/openFEC/2633/workflows/7211175f-67ba-4fd1-9fad-d65a2c8f8536/jobs/5387
-test the robots.txt using the tool here:
https://technicalseo.com/tools/robots-txt/
(select any user-agent like google-bot and try any url for an endpoint (v1) and it should disallow.)
