### PR TITLE
5755-add long query commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -203,6 +203,18 @@ def slack_message_cli(message):
     manage.slack_message(message)
 
 
+@app.cli.command('check_long_queries')
+@click.argument('minutes', default=5, required=False)
+def check_long_queries_cli(minutes):
+    manage.check_long_queries(minutes)
+
+
+@app.cli.command('clear_long_queries')
+@click.argument('minutes', default=5, required=False)
+def clear_long_queries_cli(minutes):
+    manage.clear_long_queries(minutes)
+
+
 @app.shell_context_processor
 def make_shell_context():
     return {'app': app, 'db': db, 'models': models}

--- a/manage.py
+++ b/manage.py
@@ -152,6 +152,82 @@ def cf_startup():
         subprocess.Popen(["python", "cli.py", "refresh_materialized"])
 
 
+def check_long_queries(minutes: int):
+    """
+    Check for queries running longer than interval, default is 5
+    """
+    SLACK_BOTS = "#bots"
+    SQL = """
+        SELECT *
+        FROM pg_stat_activity
+        WHERE datname <>'rdsadmin'
+        and usename ='fec_api'
+        and state = 'active'
+        and lower(query) like 'select %'
+        and lower(query) not like '%refresh%'
+        and lower(query) not like '%rollback%'
+        and (now() - pg_stat_activity.query_start) >= interval '{} minutes'
+        order by pg_stat_activity.query_start desc;
+        """
+    SQL_formatted = SQL.format(minutes)
+    try:
+        if minutes < 2:
+            raise ValueError("Interval must be greater than 2 minutes")
+        space = env.app.get("space_name")
+        if space == 'prod' and (db.session.get_bind().url.__to_string__()) != env.get_credential('SQLA_FOLLOWERS'):
+            raise ValueError("Must be run in RO replica")
+        results = db.session.execute(SQL_formatted)
+        rows = (results.fetchall())
+        for row in rows:
+            logger.info(row)
+        total_rows = results.rowcount
+        slack_message = "Currently {} queries running longer than {} minutes in {}".format(total_rows, minutes, space)
+        logger.info(slack_message)
+        post_to_slack(slack_message, SLACK_BOTS)
+    except Exception as error:
+        logger.exception(error)
+        slack_message = "*ERROR* long running query check failed."
+        slack_message = slack_message + "\n Error message: " + str(error)
+        post_to_slack(slack_message, SLACK_BOTS)
+
+
+def clear_long_queries(minutes: int):
+    """
+    Terminate queries running longer than interval minutes, default is 5
+    """
+    SLACK_BOTS = "#bots"
+    SQL = """
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE datname <>'rdsadmin'
+        and usename ='fec_api'
+        and state = 'active'
+        and lower(query) like 'select %'
+        and lower(query) not like '%refresh%'
+        and lower(query) not like '%rollback%'
+        and (now() - pg_stat_activity.query_start) >= interval '{} minutes'
+        order by pg_stat_activity.query_start desc;
+        """
+    SQL_formatted = SQL.format(minutes)
+    try:
+        if minutes < 2:
+            raise ValueError("Interval must be greater than 2 minutes")
+        space = env.app.get("space_name")
+        if space == 'prod' and (db.session.get_bind().url.__to_string__()) != env.get_credential('SQLA_FOLLOWERS'):
+            raise ValueError("Must be run in RO replica")
+        results = db.session.execute(SQL_formatted)
+        total_rows = results.rowcount
+        space = env.app.get("space_name")
+        slack_message = "Terminated {} queries running longer than {} minutes in {}".format(total_rows, minutes, space)
+        logger.info(slack_message)
+        post_to_slack(slack_message, SLACK_BOTS)
+    except Exception as error:
+        logger.exception(error)
+        slack_message = "*ERROR* long running query termination failed."
+        slack_message = slack_message + "\n Error message: " + str(error)
+        post_to_slack(slack_message, SLACK_BOTS)
+
+
 def slack_message(message):
     """ Sends a message to the bots channel. you can add this command to ping you when a task is done, etc.
     run ./manage.py slack_message 'The message you want to post'


### PR DESCRIPTION
## Summary (required)

- Resolves #5755 

This PR re-adds commands to manually check for and clear long running queries. I added logic to make sure that we are only killing queries in the read replica in prod. 

Here's the [dashboard](https://logs.fr.cloud.gov/app/dashboards#/view/0fd6ea60-f5b6-11ee-927c-73315d2dd7b2?_g=) for check_queries 

If we use db.engine our logic routes to the default engine created by flask-sqlalchemy and points to SQLA_CONN. If we use db.session our logic goes through the follower logic, and IF the session is non-flushing the command will go to the read replica. We can test this on our locals by setting SQLA_FOLLOWERS. If you don't have SQLA_FOLLOWERS set, it will run against SQLA_CONN and if you don't have either set, it will run against cfdm_test. 

### Required reviewers

3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- RO replica long running queries

## How to test

Locally: 
- You can test the db routing logic by exporting SQLA_FOLLOWERS to your local cfdm_test, if you don't do this and just unset SQLA_CONN it will run against your local test db
'export SQLA_FOLLOWERS=postgresql://:@/cfdm_test'
WARNING: Unsetting SQLA_CONN will be priority over exporting SQLA_FOLLOWERS. 
- If you haven't already, export the slack hook (you can grab from cf env api)
'export SLACK_HOOK="slack hook here"'
- In each function change SLACK_BOTS="#test-bot"
- Remove the datname and usename portions of the SQL for both commands
check_long_queries (lines 160-171): 
SQL = """
        SELECT *
        FROM pg_stat_activity
        WHERE state = 'active'
        and lower(query) like 'select %'
        and lower(query) not like '%refresh%'
        and lower(query) not like '%rollback%'
        and (now() - pg_stat_activity.query_start) >= interval '{} minutes'
        order by pg_stat_activity.query_start desc;
        """
clear_long_queries (lines 199-210): 
SQL = """
        SELECT pg_terminate_backend(pid)
        FROM pg_stat_activity
        WHERE state = 'active'
        and lower(query) like 'select %'
        and lower(query) not like '%refresh%'
        and lower(query) not like '%rollback%'
        and (now() - pg_stat_activity.query_start) >= interval '{} minutes'
        order by pg_stat_activity.query_start desc;
        """
- in dbeaver create a long-running test query like "select pg_sleep(5 * 60);"
- wait 2 min
- 'python cli.py check_long_queries 2'
You should see the output in test-bot and in your terminal
- 'python cli.py clear_long_queries 2' 
You should see the output in test-bot
You can test running intervals lower than 2 (will create an error) or without an interval (will default to 5)
You can also run multiple long queries. 

Deploy to a space:
- remove the datname and  usename for both commands like above
- switch bots to test-bot for both commands
- deploy to dev
- run a long query in dev like 'select pg_sleep(5 * 60);' and wait 2 minutes
- 'cf run-task api --command "python cli.py check_long_queries 2" --name check_queries'
- search for check_queries (or whatever you named the task) in logs
- You should see the number of queries show up in the test-bot channel, and the query information in the logs
- 'cf run-task api --command "python cli.py clear_long_queries 2" --name clear_queries'
- search for clear_queries (or whatever you named the task) in logs
- You should see the number of queries show up in the test-bot channel

