### PR TITLE
Fix sched-a by-employer,by-occupation and schedule_b/by_recipient fulltext and n/a search issue

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -140,9 +140,7 @@ class TestCommitteeAggregates(ApiBaseTest):
                 ScheduleBByRecipientView,
                 committee_id=committee.committee_id,
                 cycle=2012,
-                recipient_name='Starboard Strategies',
-            )
-        )
+                recipient_name='Starboard Strategies',))
         self.assertEqual(len(results), 1)
         expected = {
             'committee_id': committee.committee_id,

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1,3 +1,4 @@
+import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest, assert_dicts_subset
 
@@ -133,7 +134,8 @@ class TestCommitteeAggregates(ApiBaseTest):
         aggregate = factories.ScheduleBByRecipientFactory(
             committee_id=committee.committee_id,
             cycle=committee.cycle,
-            recipient_name='STARBOARD STRATEGIES, INC.',
+            recipient_name_text=sa.func.to_tsvector('STARBOARD STRATEGIES, INC.'),
+            recipient_name='STARBOARD STRATEGIES, INC.'
         )
         results = self._results(
             api.url_for(

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -1,3 +1,4 @@
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from webservices import docs, utils
 
 from .base import db, BaseModel
@@ -33,15 +34,19 @@ class ScheduleAByZip(BaseAggregate):
 
 
 class ScheduleAByEmployer(BaseAggregate):
-    __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_a_aggregate_employer'
+    # __table_args__ = {'schema': 'disclosure'}
+    # __tablename__ = 'dsc_sched_a_aggregate_employer'
+    __tablename__ = 'ofec_sched_a_aggregate_employer_mv_tmp_jl'
     employer = db.Column(db.String, primary_key=True, doc=docs.EMPLOYER)
+    employer_text = db.Column(TSVECTOR)
 
 
 class ScheduleAByOccupation(BaseAggregate):
-    __table_args__ = {'schema': 'disclosure'}
-    __tablename__ = 'dsc_sched_a_aggregate_occupation'
+    # __table_args__ = {'schema': 'disclosure'}
+    # __tablename__ = 'dsc_sched_a_aggregate_occupation'
+    __tablename__ = 'ofec_sched_a_aggregate_occupation_mv_tmp_jl'
     occupation = db.Column(db.String, primary_key=True, doc=docs.OCCUPATION)
+    occupation_text = db.Column(TSVECTOR)
 
 
 class BaseDisbursementAggregate(BaseAggregate):

--- a/webservices/common/models/aggregates.py
+++ b/webservices/common/models/aggregates.py
@@ -34,17 +34,13 @@ class ScheduleAByZip(BaseAggregate):
 
 
 class ScheduleAByEmployer(BaseAggregate):
-    # __table_args__ = {'schema': 'disclosure'}
-    # __tablename__ = 'dsc_sched_a_aggregate_employer'
-    __tablename__ = 'ofec_sched_a_aggregate_employer_mv_tmp_jl'
+    __tablename__ = 'ofec_sched_a_aggregate_employer_mv'
     employer = db.Column(db.String, primary_key=True, doc=docs.EMPLOYER)
     employer_text = db.Column(TSVECTOR)
 
 
 class ScheduleAByOccupation(BaseAggregate):
-    # __table_args__ = {'schema': 'disclosure'}
-    # __tablename__ = 'dsc_sched_a_aggregate_occupation'
-    __tablename__ = 'ofec_sched_a_aggregate_occupation_mv_tmp_jl'
+    __tablename__ = 'ofec_sched_a_aggregate_occupation_mv'
     occupation = db.Column(db.String, primary_key=True, doc=docs.OCCUPATION)
     occupation_text = db.Column(TSVECTOR)
 
@@ -63,6 +59,7 @@ class ScheduleBByRecipient(BaseDisbursementAggregate):
 
     recipient_name = db.Column('recipient_nm', db.String, primary_key=True, doc=docs.RECIPIENT_NAME)
     committee_total_disbursements = db.Column('disbursements', db.Numeric(30, 2), index=True, doc=docs.DISBURSEMENTS)
+    recipient_name_text = db.Column('recipient_nm_text', TSVECTOR)
 
     @property
     def recipient_disbursement_percent(self):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -19,6 +19,7 @@ class ApiResource(utils.Resource):
     filter_multi_fields = []
     filter_range_fields = []
     filter_fulltext_fields = []
+    filter_fulltext_fields_NA = []
     filter_overlap_fields = []
     query_options = []
     join_columns = {}
@@ -53,6 +54,7 @@ class ApiResource(utils.Resource):
         query = filters.filter_multi(query, kwargs, self.filter_multi_fields)
         query = filters.filter_range(query, kwargs, self.filter_range_fields)
         query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
+        query = filters.filter_fulltext_NA(query, kwargs, self.filter_fulltext_fields_NA)
         query = filters.filter_overlap(query, kwargs, self.filter_overlap_fields)
         if _apply_options:
             query = query.options(*self.query_options)

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -100,9 +100,9 @@ def filter_fulltext(query, kwargs, fields):
     return query
 
 
-# support N/A search
+# Support N/A search, 'column' is tsvector datatype, 'original_column' is varchar datatype.
 def filter_fulltext_NA(query, kwargs, fields):
-    for key, column, column_org in fields:
+    for key, column, original_column in fields:
         if kwargs.get(key):
             exclude_list = build_exclude_list(kwargs.get(key))
             include_list = build_include_list(kwargs.get(key))
@@ -110,7 +110,7 @@ def filter_fulltext_NA(query, kwargs, fields):
                 filters = []
                 for value in exclude_list:
                     if value.strip().upper() == "N/A":
-                        query = query.filter(column_org != 'N/A')
+                        query = query.filter(original_column != 'N/A')
                     else:
                         filters.append(sa.not_(column.match(utils.parse_fulltext(value))))
                 query = query.filter(sa.and_(*filters))
@@ -118,7 +118,7 @@ def filter_fulltext_NA(query, kwargs, fields):
                 filters = []
                 for value in include_list:
                     if value.strip().upper() == "N/A":
-                        query = query.filter(column_org == 'N/A')
+                        query = query.filter(original_column == 'N/A')
                     else:
                         filters.append(column.match(utils.parse_fulltext(value)))
                         if value.upper() == 'NULL':

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -54,8 +54,11 @@ class ScheduleAByEmployerView(AggregateResource):
         ('cycle', models.ScheduleAByEmployer.cycle),
         ('committee_id', models.ScheduleAByEmployer.committee_id),
     ]
-    filter_fulltext_fields = [
-        ('employer', models.ScheduleAByEmployer.employer),
+    # filter_fulltext_fields = [
+    #     ('employer', models.ScheduleAByEmployer.employer),
+    # ]
+    filter_fulltext_fields_NA = [
+        ('employer', models.ScheduleAByEmployer.employer_text, models.ScheduleAByEmployer.employer),
     ]
 
 
@@ -76,8 +79,8 @@ class ScheduleAByOccupationView(AggregateResource):
         ('cycle', models.ScheduleAByOccupation.cycle),
         ('committee_id', models.ScheduleAByOccupation.committee_id),
     ]
-    filter_fulltext_fields = [
-        ('occupation', models.ScheduleAByOccupation.occupation),
+    filter_fulltext_fields_NA = [
+        ('occupation', models.ScheduleAByOccupation.occupation_text, models.ScheduleAByOccupation.occupation),
     ]
 
 

--- a/webservices/resources/aggregates.py
+++ b/webservices/resources/aggregates.py
@@ -54,9 +54,7 @@ class ScheduleAByEmployerView(AggregateResource):
         ('cycle', models.ScheduleAByEmployer.cycle),
         ('committee_id', models.ScheduleAByEmployer.committee_id),
     ]
-    # filter_fulltext_fields = [
-    #     ('employer', models.ScheduleAByEmployer.employer),
-    # ]
+
     filter_fulltext_fields_NA = [
         ('employer', models.ScheduleAByEmployer.employer_text, models.ScheduleAByEmployer.employer),
     ]
@@ -182,7 +180,8 @@ class ScheduleBByPurposeView(AggregateResource):
 
 # used for endpoint:`/schedules/schedule_b/by_recipient/`
 # under tag: disbursements
-# Ex: http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/
+# Ex: http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2022
+# &committee_id=C00160937&recipient_name=zoom.com
 @doc(
     tags=['disbursements'],
     description=docs.SCHEDULE_B_BY_RECIPIENT,
@@ -197,8 +196,8 @@ class ScheduleBByRecipientView(AggregateResource):
         ('cycle', models.ScheduleBByRecipient.cycle),
         ('committee_id', models.ScheduleBByRecipient.committee_id),
     ]
-    filter_fulltext_fields = [
-        ('recipient_name', models.ScheduleBByRecipient.recipient_name),
+    filter_fulltext_fields_NA = [
+        ('recipient_name', models.ScheduleBByRecipient.recipient_name_text, models.ScheduleBByRecipient.recipient_name),
     ]
 
 

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1075,9 +1075,33 @@ augment_itemized_aggregate_models(
     models.ScheduleAByZip,
     models.ScheduleABySize,
     models.ScheduleAByState,
-    models.ScheduleAByEmployer,
-    models.ScheduleAByOccupation,
+    # models.ScheduleAByEmployer,
+    # models.ScheduleAByOccupation,
     models.ScheduleBByPurpose,
+)
+
+ScheduleAByEmployerSchema = make_schema(
+    models.ScheduleAByEmployer,
+    fields={
+        'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'employer': ma.fields.Str(),
+    },
+    options={'exclude': ('idx', 'committee', 'employer_text',)}
+)
+ScheduleAByEmployerPageSchema = make_page_schema(
+    ScheduleAByEmployerSchema
+)
+
+ScheduleAByOccupationSchema = make_schema(
+    models.ScheduleAByOccupation,
+    fields={
+        'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
+        'employer': ma.fields.Str(),
+    },
+    options={'exclude': ('idx', 'committee', 'occupation_text',)}
+)
+ScheduleAByOccupationPageSchema = make_page_schema(
+    ScheduleAByOccupationSchema
 )
 
 make_aggregate_schema = functools.partial(

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -1060,9 +1060,10 @@ ScheduleBByRecipientSchema = make_schema(
         'recipient_disbursement_percent': ma.fields.Float(),
         'committee_total_disbursements': ma.fields.Float(),
         'total': ma.fields.Float(),
-        'memo_total': ma.fields.Float()
+        'memo_total': ma.fields.Float(),
+        'recipient_name': ma.fields.Str(),
     },
-    options={'exclude': ('idx', 'committee')}
+    options={'exclude': ('idx', 'committee', 'recipient_name_text')}
 )
 
 ScheduleBByRecipientPageSchema = make_page_schema(ScheduleBByRecipientSchema, page_type=paging_schemas.SeekPageSchema)
@@ -1075,8 +1076,6 @@ augment_itemized_aggregate_models(
     models.ScheduleAByZip,
     models.ScheduleABySize,
     models.ScheduleAByState,
-    # models.ScheduleAByEmployer,
-    # models.ScheduleAByOccupation,
     models.ScheduleBByPurpose,
 )
 
@@ -1096,7 +1095,7 @@ ScheduleAByOccupationSchema = make_schema(
     models.ScheduleAByOccupation,
     fields={
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
-        'employer': ma.fields.Str(),
+        'occupation': ma.fields.Str(),
     },
     options={'exclude': ('idx', 'committee', 'occupation_text',)}
 )


### PR DESCRIPTION
## Summary 
This PR will fix fulltext search and N/A search issue in these three endpoints
ScheduleAByEmployerView
ScheduleAByOccupationView
ScheduleBByRecipientView

- Resolves #3885 
- Related https://github.com/fecgov/openFEC/pull/5790

- [ ] Create follow up openFEC ticket to fix N/A issue on schedule-a and schedule-b endpoints
cms ticket: [https://github.com/fecgov/fec-cms/issues/5220](https://github.com/fecgov/fec-cms/issues/5220)

### Required reviewers
1-2 devs

## Impacted three endpoints
"/schedules/schedule_a/by_employer/"
"/schedules/schedule_a/by_occupation/"
"/schedules/schedule_b/by_recipient/"

## How to test
- Check out branch
- pytest
- test urls for three endpoints
 
—[1]ScheduleAByEmployerView
Test 1-1) when employer=amazon.com, return two rows:
employer=[amazon.com](http://amazon.com/)
employer=amazon com
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&employer=amazon.com&committee_id=C00003418

When employer=-[amazon.com](http://amazon.com/) (exclude [amazon.com](http://amazon.com/)), return 127487 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&employer=-amazon.com&committee_id=C00003418

Without employer parameter pass, return 2+ 127487= 127489 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&committee_id=C00003418

Compare with Prod: return 1 (only employer=amazon com, no return for employer=amazon.com)
https://api.open.fec.gov/v1/schedules/schedule_a/by_employer/?cycle=2020&committee_id=C00003418&api_key=DEMO_KEY&employer=amazon.com

Test 1-2) 
when employer=N/A, return 1 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&employer=N/A&committee_id=C00003418

when employer=-N/A, return 127488 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&employer=-N/A&committee_id=C00003418

Without employer parameter pass, return 1+ 127488= 127489 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_employer/?cycle=2020&committee_id=C00003418

Compare with Prod: return 962 rows (contain: n, a…)
https://api.open.fec.gov/v1/schedules/schedule_a/by_employer/?cycle=2020&committee_id=C00003418&api_key=DEMO_KEY&employer=N/A


—[2]ScheduleAByOccupationView
Test 2-1)
when occupation=C.E.O, return 46 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2022&committee_id=C00003418&occupation=C.E.O

when occupation=-C.E.O, return 19665 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2022&committee_id=C00003418&occupation=-C.E.O

Without occupation parameter pass, return 46+ 19665 =19711 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2022&committee_id=C00003418

Compare with Prod: return  29 (occupation=c…e…o)
https://api.open.fec.gov/v1/schedules/schedule_a/by_occupation/?cycle=2022&committee_id=C00003418&occupation=C.E.O&api_key=DEMO_KEY

Test 2-2)
when occupation=N/A, return 1 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2020&committee_id=C00003418&occupation=N/A

when occupation=-N/A, return 39455 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2020&committee_id=C00003418&occupation=-N/A

Without occupation parameter pass, return 1+ 39455 = 39456 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/by_occupation/?cycle=2020&committee_id=C00003418

Compare with Prod: return 193 rows (contain: n, a…)
https://api.open.fec.gov/v1/schedules/schedule_a/by_occupation/?cycle=2020&committee_id=C00003418&occupation=N/A&api_key=DEMO_KEY

—[3]ScheduleBByRecipientView
Test 3-1)
When recipient_name=zoom.com, return 1 row
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2022&committee_id=C00160937&recipient_name=zoom.com

When recipient_name=-zoom.com, return 126 rows
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2022&committee_id=C00160937&recipient_name=-zoom.com

Without recipient_name parameter pass, return 1+126=127 rows
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2022&committee_id=C00160937

Compare prod, return 0 (cannot find recipient_name=[zoom.com](http://zoom.com/))
https://api.open.fec.gov/v1/schedules/schedule_b/by_recipient/?cycle=2022&committee_id=C00160937&recipient_name=zoom.com&api_key=DEMO_KEY

Test 3-2)
when recipient_name=N/A, return 1 rows
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2018&committee_id=C00586768&recipient_name=N/A

when recipient_name=-N/A, return 17 rows
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2018&committee_id=C00586768&recipient_name=-N/A

Without recipient_name parameter pass, return 1+17=18 rows
http://127.0.0.1:5000/v1/schedules/schedule_b/by_recipient/?cycle=2018&committee_id=C00586768

Compare prod, return 0 (cannot find recipient_name=N/A)
https://api.open.fec.gov/v1/schedules/schedule_b/by_recipient/?cycle=2018&committee_id=C00586768&recipient_name=N/A&api_key=DEMO_KEY


Replace PR: [https://github.com/fecgov/openFEC/pull/5773](https://github.com/fecgov/openFEC/pull/5773)