### PR TITLE
Fix N/A fulltext search for schedule a and b

### DIFF
--- a/webservices/resources/sched_a.py
+++ b/webservices/resources/sched_a.py
@@ -68,10 +68,16 @@ class ScheduleAView(ItemizedResource):
         (('min_image_number', 'max_image_number'), models.ScheduleA.image_number),
         (('min_load_date', 'max_load_date'), models.ScheduleA.load_date),
     ]
-    filter_fulltext_fields = [
-        ('contributor_name', models.ScheduleA.contributor_name_text),
-        ('contributor_employer', models.ScheduleA.contributor_employer_text),
-        ('contributor_occupation', models.ScheduleA.contributor_occupation_text),
+    filter_fulltext_fields_NA = [
+        ('contributor_name',
+         models.ScheduleA.contributor_name_text,
+         models.ScheduleA.contributor_name),
+        ('contributor_employer',
+         models.ScheduleA.contributor_employer_text,
+         models.ScheduleA.contributor_employer),
+        ('contributor_occupation',
+         models.ScheduleA.contributor_occupation_text,
+         models.ScheduleA.contributor_occupation),
     ]
     filter_multi_start_with_fields = [
         ('contributor_zip', models.ScheduleA.contributor_zip),

--- a/webservices/resources/sched_b.py
+++ b/webservices/resources/sched_b.py
@@ -52,10 +52,11 @@ class ScheduleBView(ItemizedResource):
         ('two_year_transaction_period',
          models.ScheduleB.two_year_transaction_period),
     ]
-    filter_fulltext_fields = [
-        ('recipient_name', models.ScheduleB.recipient_name_text),
+    filter_fulltext_fields_NA = [
+        ('recipient_name', models.ScheduleB.recipient_name_text, models.ScheduleB.recipient_name),
         ('disbursement_description',
-         models.ScheduleB.disbursement_description_text),
+         models.ScheduleB.disbursement_description_text,
+         models.ScheduleB.disbursement_description),
     ]
     filter_range_fields = [
         (('min_date', 'max_date'), models.ScheduleB.disbursement_date),


### PR DESCRIPTION
## Summary (required)
This PR fix N/A fulltext search issue for `/schedules/schedule_a/` and `/schedules/schedule_b/`
also add auto test for filter by fulltext_NA function.


- Resolves #5812 
- will partially fix cms ticket: [https://github.com/fecgov/fec-cms/issues/5220](https://github.com/fecgov/fec-cms/issues/5220)

### Required reviewers
1-2 devs

## Impacted areas of the application
/schedules/schedule_a/
/schedules/schedule_b/


## How to test
- Checkout branch and 'pytest'
- test two endpoints

1)test endpoint: schedules/schedule_a
Test 1_1: contributor_employer=N/A(take 2mins), return correct rows: 610 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00003418&contributor_employer=N/A&two_year_transaction_period=2020

Compare on Prod: contributor_employer=N/A, return 9717 wrong data 
https://api.open.fec.gov/v1/schedules/schedule_a/?committee_id=C00003418&contributor_employer=N/A&two_year_transaction_period=2020&api_key=DEMO_KEY


Test 1_2: contributor_employer=-N/A, return:6040550
is_count_exact": false
http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00003418&contributor_employer=-N/A&two_year_transaction_period=2020

Compare Prod: return 6210270, is_count_exact": false
https://api.open.fec.gov/v1/schedules/schedule_a/?committee_id=C00003418&contributor_employer=-N/A&two_year_transaction_period=2020&api_key=DEMO_KEY


Test 1_3: make sure contributor_name filter works correctly.
Return: 42077 rows, database return:43238
http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00003418&contributor_name=smith&two_year_transaction_period=2020

Compare on Prod, Return: 42077
https://api.open.fec.gov/v1/schedules/schedule_a/?committee_id=C00003418&contributor_name=smith&two_year_transaction_period=2020&api_key=DEMO_KEY




Test 1_4: contributor_name=N/A, return 0 (correct)
http://127.0.0.1:5000/v1/schedules/schedule_a/?contributor_name=N/A&two_year_transaction_period=2000

Compare Prod: contributor_name=N/A, return wrong data: 6693
https://api.open.fec.gov/v1/schedules/schedule_a/?contributor_name=N/A&two_year_transaction_period=2000&api_key=DEMO_KEY


Test 1_5: contributor_occupation=N/A, return 334 rows
http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00003418&contributor_occupation=N/A&two_year_transaction_period=2020

Compare Prod: contributor_occupation=N/A, take 3 mins return wrong data: 3709 rows
https://api.open.fec.gov/v1/schedules/schedule_a/?committee_id=C00003418&contributor_occupation=N/A&two_year_transaction_period=2020&api_key=DEMO_KEY


2) test endpoint: schedules/schedule_b

Test 2_1: recipient_name=N/A(take 2mins), return 0 (correct)
http://127.0.0.1:5000/v1/schedules/schedule_b/?api_key=DEMO_KEY&data_type=processed&recipient_name=N/A&two_year_transaction_period=2008

Compare on Prod, recipient_name=N/A, return wrong data: 26738 rows
https://api.open.fec.gov/v1/schedules/schedule_b/?api_key=DEMO_KEY&data_type=processed&recipient_name=N/A&two_year_transaction_period=2008


Test 2_2: disbursement_description=N/A, return: 1 row (4mins)
http://127.0.0.1:5000/v1/schedules/schedule_b/?data_type=processed&disbursement_description=N/A&two_year_transaction_period=2020&committee_id=C00001636


Compare on Prod: disbursement_description=N/A, return wrong data: 20 rows
https://api.open.fec.gov/v1/schedules/schedule_b/?api_key=DEMO_KEY&data_type=processed&disbursement_description=N/A&two_year_transaction_period=2020&committee_id=C00001636
