### PR TITLE
Add task to create new public api keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ static/swagger-ui/js
 # Pycharm
 .idea
 .vscode/launch.json
+
+# token file
+token.txt

--- a/cli.py
+++ b/cli.py
@@ -197,6 +197,32 @@ def cf_startup_cli():
     manage.cf_startup()
 
 
+@app.cli.command('update_public_api_key')
+@click.argument('space', default=None, required=True)
+@click.argument('service_instance_name', default=None, required=True)
+@click.argument('token', default=None, required=True)
+@click.argument('first_rate_limit', default=250, required=False)
+@click.argument('first_rate_limit_duration', default=60000, required=False)
+@click.argument('second_rate_limit', default=30000, required=False)
+@click.argument('second_rate_limit_duration', default=86400000, required=False)
+def create_and_update_public_api_key_cli(
+        space,
+        service_instance_name,
+        token,
+        first_rate_limit,
+        first_rate_limit_duration,
+        second_rate_limit,
+        second_rate_limit_duration):
+    manage.create_and_update_public_api_key(
+        space,
+        service_instance_name,
+        token,
+        first_rate_limit,
+        first_rate_limit_duration,
+        second_rate_limit,
+        second_rate_limit_duration)
+
+
 @app.cli.command('slack_message')
 @click.argument('message')
 def slack_message_cli(message):

--- a/manage.py
+++ b/manage.py
@@ -350,6 +350,28 @@ def update_credentials_by_guid(token, GUID, merged_creds):
         raise
 
 
+def check_token(token):
+    error_message = "Error occured when checking bearer token, check logs"
+
+    header = {
+        "Authorization": token,
+        "Content-Type": "application/json"
+    }
+
+    url = "https://api.fr.cloud.gov/v3/routes"
+
+    response = requests.get(url, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        if response.status_code == 401:
+            logger.error("Token may be expired, try generating new bearer token using `cf oauth-token > token.txt`")
+        slack_message(error_message)
+        logger.error("Error occured with updating credentials: {}".format(error))
+        raise
+
+
 def create_and_update_public_api_key(
         space,
         service_instance_name,
@@ -358,6 +380,8 @@ def create_and_update_public_api_key(
         first_rate_limit_duration,
         second_rate_limit,
         second_rate_limit_duration):
+
+    check_token(token)
 
     new_api_key = create_public_api_key(
         space,

--- a/manage.py
+++ b/manage.py
@@ -167,7 +167,8 @@ def create_public_api_key(
         "first_name": space,
         "last_name": "Public API Key",
         "email": env.get_credential("FEC_EMAIL"),
-        "use_description": "FEC_WEB_API_KEY_PUBLIC for prod environment. Rate limited key per IP. Created {}".format(
+        "use_description": "FEC_WEB_API_KEY_PUBLIC for {} environment. Rate limited key per IP. Created {}".format(
+            space,
             datetime.datetime.today()),
         "registration_source": "update_public_api_key task",
         "throttle_by_ip": True,
@@ -313,17 +314,11 @@ def get_credentials_by_guid(token, GUID):
 
     creds = response.json()
 
-    logger.info("Existing Credentials:")
-    logger.info(creds)
-
     return creds
 
 
 def update_credentials(creds, update_data):
     creds.update(update_data)
-
-    logger.info("Updated Credentials:")
-    logger.info(creds)
 
     return {"credentials": creds}
 

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,8 @@ import subprocess
 import multiprocessing
 import networkx as nx
 import sqlalchemy as sa
-
+import datetime
+import requests
 from webservices import flow
 from webservices.env import env
 from webservices.rest import db
@@ -143,6 +144,253 @@ def refresh_materialized(concurrent=True):
                 logger.error("Error refreshing node {}: not found.".format(node))
 
     logger.info("Finished refreshing materialized views.")
+
+
+def create_public_api_key(
+        space,
+        first_rate_limit,
+        first_rate_limit_duration,
+        second_rate_limit,
+        second_rate_limit_duration):
+
+    logger.info("Creating new public API key for {} environment".format(space))
+    UMBRELLA_ADMIN_AUTH_TOKEN = env.get_credential("UMBRELLA_ADMIN_AUTH_TOKEN")
+    API_KEY = env.get_credential("FEC_WEB_API_KEY_PUBLIC")
+
+    header = {
+        "X-Admin-Auth-Token": UMBRELLA_ADMIN_AUTH_TOKEN,
+        "X-Api-Key": API_KEY,
+        "Content-Type": "application/json; charset=UTF-8",
+    }
+
+    create_api_key_params = {
+        "first_name": space,
+        "last_name": "Public API Key",
+        "email": env.get_credential("FEC_EMAIL"),
+        "use_description": "FEC_WEB_API_KEY_PUBLIC for prod environment. Rate limited key per IP. Created {}".format(
+            datetime.datetime.today()),
+        "registration_source": "update_public_api_key task",
+        "throttle_by_ip": True,
+        "terms_and_conditions": True,
+        "created_at": datetime.datetime.now().isoformat(),
+        "creator": {
+            "username": "auto-generated"
+        },
+        "settings": {
+            "rate_limit_mode": "custom",
+            "rate_limits": [{
+                "limit_by": "apiKey",
+                "response_headers": True,
+                "limit": first_rate_limit,
+                "duration": first_rate_limit_duration
+                },
+                {
+                "limit_by": "apiKey",
+                "response_headers": False,
+                "limit": second_rate_limit,
+                "duration": second_rate_limit_duration,
+                }
+            ]
+        }
+    }
+
+    url = "https://api.data.gov/api-umbrella/v1/users.json"
+
+    response = requests.post(url, json=create_api_key_params, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        error_message = "Error occured when creating API key, check logs"
+        slack_message(error_message)
+        logger.error("Error occured with creating API key: {}".format(error))
+        raise
+
+    response_json = response.json()
+    new_api_key = response_json["user"]["api_key"]
+
+    logger.info("New API key: {}".format(new_api_key))
+
+    return new_api_key
+
+
+def get_space_guid(token, space):
+    space_guid = ""
+
+    error_message = "Error occured when retrieving space GUID, check logs"
+
+    header = {
+        "Authorization": token,
+    }
+
+    data = {
+        "names": [space.lower(), ]
+    }
+
+    url = "https://api.fr.cloud.gov/v3/spaces"
+
+    response = requests.get(url, params=data, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        if response.status_code == 401:
+            logger.error("Token may be expired, try generating new bearer token using `cf oauth-token > token.txt`")
+        slack_message(error_message)
+        logger.error(error)
+        raise
+
+    response_json = response.json()
+
+    if response_json["resources"][0]["name"] == space.lower():
+        space_guid = response_json["resources"][0]["guid"]
+
+    if space_guid == "":
+        raise Exception("Space GUID not found")
+
+    return space_guid
+
+
+def get_service_instance_guid(token, space_guid, service_instance_name):
+    GUID = ""
+
+    error_message = "Error occured when retrieving service instance GUID, check logs"
+
+    header = {
+        "Authorization": token,
+    }
+
+    data = {
+        "names": [service_instance_name,],
+        "space_guids": [space_guid,]
+    }
+
+    url = "https://api.fr.cloud.gov/v3/service_instances"
+
+    response = requests.get(url, params=data, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        if response.status_code == 401:
+            logger.error("Token may be expired, try generating new bearer token using `cf oauth-token > token.txt`")
+        slack_message(error_message)
+        logger.error("Error occured with retrieving service instances: {}".format(error))
+        raise
+
+    response_json = response.json()
+
+    if response_json["resources"][0]["name"] == service_instance_name:
+        GUID = response_json["resources"][0]["guid"]
+
+    if GUID == "":
+        slack_message(error_message)
+        raise Exception("Service instance GUID not found for service instance: {}".format(service_instance_name))
+
+    return GUID
+
+
+def get_credentials_by_guid(token, GUID):
+
+    error_message = "Error occured when retrieving credentials, check logs"
+
+    header = {
+        "Authorization": token,
+    }
+
+    url = "https://api.fr.cloud.gov/v3/service_instances/{}/credentials".format(GUID)
+
+    response = requests.get(url, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        if response.status_code == 401:
+            logger.error("Token may be expired, try generating new bearer token using `cf oauth-token > token.txt`")
+        slack_message(error_message)
+        logger.error("Error occured with retrieving credentials: {}".format(error))
+        raise
+
+    creds = response.json()
+
+    logger.info("Existing Credentials:")
+    logger.info(creds)
+
+    return creds
+
+
+def update_credentials(creds, update_data):
+    creds.update(update_data)
+
+    logger.info("Updated Credentials:")
+    logger.info(creds)
+
+    return {"credentials": creds}
+
+
+def update_credentials_by_guid(token, GUID, merged_creds):
+    error_message = "Error occured when updating environment variables, check logs"
+
+    header = {
+        "Authorization": token,
+        "Content-Type": "application/json"
+    }
+
+    url = "https://api.fr.cloud.gov/v3/service_instances/{}".format(GUID)
+
+    response = requests.patch(url, json=merged_creds, headers=header)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as error:
+        if response.status_code == 401:
+            logger.error("Token may be expired, try generating new bearer token using `cf oauth-token > token.txt`")
+        slack_message(error_message)
+        logger.error("Error occured with updating credentials: {}".format(error))
+        raise
+
+
+def create_and_update_public_api_key(
+        space,
+        service_instance_name,
+        token,
+        first_rate_limit,
+        first_rate_limit_duration,
+        second_rate_limit,
+        second_rate_limit_duration):
+
+    new_api_key = create_public_api_key(
+        space,
+        first_rate_limit,
+        first_rate_limit_duration,
+        second_rate_limit,
+        second_rate_limit_duration)
+
+    update_env_vars(space, service_instance_name, token, {"FEC_WEB_API_KEY_PUBLIC": new_api_key})
+
+
+def update_env_vars(space, service_instance_name, token, credentials_dict):
+
+    logger.info("Updating environment variable(s) for {} service instance in {} space."
+                .format(service_instance_name, space))
+
+    space_guid = get_space_guid(token, space)
+
+    service_guid = get_service_instance_guid(token, space_guid, service_instance_name)
+
+    creds = get_credentials_by_guid(token, service_guid)
+
+    merged_creds = update_credentials(creds, credentials_dict)
+
+    update_credentials_by_guid(token, service_guid, merged_creds)
+
+    message = "Environment variables have been updated for {} service instance in {} space".format(
+        service_instance_name,
+        space)
+
+    slack_message(message)
+
+    logger.info(message)
 
 
 def cf_startup():

--- a/manage.py
+++ b/manage.py
@@ -210,7 +210,7 @@ def create_public_api_key(
     response_json = response.json()
     new_api_key = response_json["user"]["api_key"]
 
-    logger.info("New API key: {}".format(new_api_key))
+    logger.info("New API key: {}".format(new_api_key[:5]))
 
     return new_api_key
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5802 

This ticket adds a the new `update_public_api_key` task. The PMs decided that this task should only create a new API key and add it to our environment variables. After that, the developer can manually re-stage the app and disable the old key. [Here](https://github.com/fecgov/openFEC/wiki/Rotating-Public-API-Key-Using-Task) is the wiki page. 

The new command is: 
`cf run-task api --command "python cli.py update_public_api_key <space> <service_instance> '$(< token.txt)'  <first_rate_limit> <first_rate_limit_duration> <second_rate_limit> <second_rate_limit_duration>" --name update_public_api_key`

The arguments are: 
`space`: [Required] the space that you want to update
`service_instance`: [Required] the user provided service you want to update
`token`: [Required] your cf oath token
`first_rate_limit`: [Optional] the limit of the first rate limit on the new key
`first_rate_limit_duration` [Optional] the duration of the first rate limit on the new key
`second_rate_limit` [Optional] the limit of the second rate limit on the new key
`second_rate_limit_duration` [Optional] the duration of the second rate limit on the new key

A typical example would be: 
`cf run-task api --command "python cli.py update_public_api_key dev tricia-test '$(< token.txt)' " --name update_public_api_key`

I also added these new environment variables: 
`FEC_EMAIL`: currently set to my email for testing purposes, I'll change this once testing is completed 
`UMBRELLA_ADMIN_AUTH_TOKEN`: Auth token to access API Umbrella 

### Required reviewers 2 - 3 developers

## Impacted areas of the application

General components of the application that this PR will affect:

- tasks

## How to test

Locally:
 - I recommend using this [test branch](https://github.com/fecgov/openFEC/tree/test-create-api-key) for testing since it uses the #test-bot slack channel 
1. `git checkout test-create-api-key`
2. `pyenv activate <your virtual environment>`
3. Set the following env variables: `SLACK_HOOK`, `UMBRELLA_ADMIN_AUTH_TOKEN`, `FEC_EMAIL`, `FEC_WEB_API_KEY_PUBLIC`
4. login to cf cli: `cf login -a api.fr.cloud.gov --sso` (space does not matter when testing locally)
5. put oauth token in txt file named token.txt `cf oauth-token > token.txt`
6. Run `python cli.py update_public_api_key dev tricia-test "$(< token.txt)"`

On Dev: 
1. Deploy this [branch](https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-create-api-key)
2. login to cloud.gov dev space `cf login -a api.fr.cloud.gov  --sso`
3. put oauth token in txt file named token.txt `cf oauth-token > token.txt`
4. Run `cf run-task api --command "python cli.py update_public_api_key dev tricia-test '$(< token.txt)' " --name update_public_api_key`
5. check logs and/or [kibana](https://logs.fr.cloud.gov/app/dashboards#/view/App-Overview?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(description:'',filters:!(),fullScreenMode:!f,options:(darkTheme:!f),query:(language:kuery,query:%22update_public_api_key%22),timeRestore:!f,title:'App%20-%20Overview',viewMode:view)) 


NOTE: Cf tokens last for about 4 minutes before needing another one
