### PR TITLE
Add MV for national party aggregate data

### DIFF
--- a/data/migrations/V0297__add_ofec_totals_national_party_mv.sql
+++ b/data/migrations/V0297__add_ofec_totals_national_party_mv.sql
@@ -1,0 +1,52 @@
+/*
+This migration file is for #5787
+
+1) Create ofec_totals_national_party_mv 
+*/
+
+DROP MATERIALIZED VIEW IF EXISTS public.ofec_totals_national_party_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.ofec_totals_national_party_mv
+AS
+WITH cmte_list AS (
+        SELECT DISTINCT cmte_id, cmte_nm, two_year_transaction_period
+        FROM ofec_sched_a_national_party_vw
+        UNION
+        SELECT DISTINCT cmte_id, cmte_nm, two_year_transaction_period
+        FROM ofec_sched_b_national_party_vw
+    ), 
+    sa_total AS (
+        SELECT cmte_id, cmte_nm, two_year_transaction_period, 
+               sum(contb_receipt_amt) AS contribution
+        FROM ofec_sched_a_national_party_vw
+        WHERE upper(party_account) <> 'UNKNOWN'
+        GROUP BY cmte_id, cmte_nm, two_year_transaction_period
+    ), 
+    sb_total AS (
+        SELECT cmte_id, cmte_nm, two_year_transaction_period,
+               sum(disb_amt) AS disbursement
+        FROM ofec_sched_b_national_party_vw
+        WHERE upper(party_account) <> 'UNKNOWN'
+        GROUP BY cmte_id, cmte_nm, two_year_transaction_period
+    )
+    SELECT l.cmte_id, l.cmte_nm, l.two_year_transaction_period,
+        (SELECT sa_total.contribution
+           FROM sa_total
+          WHERE sa_total.cmte_id = l.cmte_id 
+            AND sa_total.two_year_transaction_period = l.two_year_transaction_period) AS contribution,
+        (SELECT sb_total.disbursement
+           FROM sb_total
+          WHERE sb_total.cmte_id = l.cmte_id
+            AND sb_total.two_year_transaction_period = l.two_year_transaction_period) AS disbursement
+   FROM cmte_list l
+WITH DATA;
+
+
+ALTER TABLE IF EXISTS public.ofec_totals_national_party_mv OWNER TO fec;
+
+GRANT ALL ON TABLE public.ofec_totals_national_party_mv TO fec;
+GRANT SELECT ON TABLE public.ofec_totals_national_party_mv TO fec_read;
+
+CREATE UNIQUE INDEX idx_ofec_totals_national_party_mv_cmteid_cycle
+    ON public.ofec_totals_national_party_mv USING btree
+    (cmte_id, two_year_transaction_period);

--- a/manage.py
+++ b/manage.py
@@ -96,6 +96,8 @@ def refresh_materialized(concurrent=True):
         "ofec_pcc_to_pac": ["ofec_pcc_to_pac_mv"],
         "ofec_sched_a_agg_state": ["ofec_sched_a_agg_state_mv"],
         "ofec_sched_e_mv": ["ofec_sched_e_mv"],
+        "ofec_sched_a_aggregate_employer": ["ofec_sched_a_aggregate_employer_mv"],
+        "ofec_sched_a_aggregate_occupation": ["ofec_sched_a_aggregate_occupation_mv"],
         "reports_house_senate": ["ofec_reports_house_senate_mv"],
         "reports_ie": ["ofec_reports_ie_only_mv"],
         "reports_pac_party": ["ofec_reports_pac_party_mv"],
@@ -105,18 +107,17 @@ def refresh_materialized(concurrent=True):
             "ofec_sched_a_aggregate_state_recipient_totals_mv"
         ],
         "sched_e_by_candidate": ["ofec_sched_e_aggregate_candidate_mv"],
+        "schedule_a_national_party": ["ofec_sched_a_national_party_mv"],
+        "schedule_b_national_party": ["ofec_sched_b_national_party_mv"],
+        "sched_b_by_recipient": ["ofec_sched_b_aggregate_recipient_mv"],
+        "sched_h4": ["ofec_sched_h4_mv"],
+        "schedule_d": ["ofec_sched_d_mv"],
         "totals_combined": ["ofec_totals_combined_mv"],
         "totals_house_senate": ["ofec_totals_house_senate_mv"],
         "totals_ie": ["ofec_totals_ie_only_mv"],
         "totals_presidential": ["ofec_totals_presidential_mv"],
-        "sched_b_by_recipient": ["ofec_sched_b_aggregate_recipient_mv"],
         "totals_inaugural_donations": ["ofec_totals_inaugural_donations_mv"],
-        "sched_h4": ["ofec_sched_h4_mv"],
-        "schedule_d": ["ofec_sched_d_mv"],
-        "schedule_a_national_party": ["ofec_sched_a_national_party_mv"],
-        "schedule_b_national_party": ["ofec_sched_b_national_party_mv"],
-        "ofec_sched_a_aggregate_employer": ["ofec_sched_a_aggregate_employer_mv"],
-        "ofec_sched_a_aggregate_occupation": ["ofec_sched_a_aggregate_occupation_mv"]
+        "totals_national_party": ["ofec_totals_national_party_mv"]
     }
 
     graph = flow.get_graph()

--- a/webservices/flow.py
+++ b/webservices/flow.py
@@ -35,6 +35,8 @@ def get_graph():
         'ofec_pcc_to_pac',
         'ofec_sched_a_agg_state',
         'ofec_sched_e_mv',
+        'ofec_sched_a_aggregate_employer',
+        'ofec_sched_a_aggregate_occupation',
         'reports_house_senate',
         'reports_ie',
         'reports_pac_party',
@@ -42,18 +44,17 @@ def get_graph():
         'sched_a_by_size_merged',
         'sched_a_by_state_recipient_totals',
         'sched_e_by_candidate',
+        'sched_b_by_recipient',
+        'schedule_a_national_party',
+        'schedule_b_national_party',
+        'sched_h4',
+        'schedule_d',
         'totals_combined',
         'totals_house_senate',
         'totals_ie',
         'totals_presidential',
-        'sched_b_by_recipient',
         'totals_inaugural_donations',
-        'sched_h4',
-        'schedule_d',
-        'schedule_a_national_party',
-        'schedule_b_national_party',
-        'ofec_sched_a_aggregate_employer',
-        'ofec_sched_a_aggregate_occupation'
+        'totals_national_party'
     ]
     graph.add_nodes_from(MATERIALIZED_VIEWS)
 
@@ -132,5 +133,10 @@ def get_graph():
 
     graph.add_edge('ofec_pcc_to_pac', 'committee_history'),
     graph.add_edge('totals_combined', 'sched_b_by_recipient'),
+
+    graph.add_edges_from([
+        ('schedule_a_national_party', 'totals_national_party'),
+        ('schedule_b_national_party', 'totals_national_party'),
+    ])
 
     return graph


### PR DESCRIPTION
## Summary (required)

- Resolves #5787 
The new MV includes aggregate contribution and disbursement of national party accounts.  This MV will be used for committee profile page.

### Required reviewers
1-2 developers

## How to test
1. Download feature branch and run `pytest`
2. Run `flyway migrate` to test migration
3. Run these commands to test MV refreshing.  Make sure `ofec_totals_national_party_mv` is refreshed after `ofec_sched_a_national_party_mv` and `ofec_sched_b_national_party_mv`

dropdb cfdm_test
createdb cfdm_test
invoke create_sample_db