### PR TITLE
Increase size for inner hits

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -787,6 +787,12 @@ class Tasks(TaskSet):
             )
         log_response(self, "ao202312", params, resp)
 
+    @task
+    def get_mur_inner_hits(self):
+        params = {"q": "reason", "type": "murs", "case_no": "4530", "case_doc_category_id": "1", "api_key": API_KEY}
+        resp = self.client.get("legal/search", name="get_mur_inner_hits", params=params, timeout=timeout)
+        log_response(self, "mur_inner_hits", params, resp)
+
 
 class Swarm(user.HttpUser):
     tasks = [Tasks]

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -35,6 +35,7 @@ INNER_HITS = {
         "require_field_match": False,
         "fields": {"documents.text": {}, "documents.description": {}},
     },
+    "size": 100,
 }
 
 ALL_DOCUMENT_TYPES = [


### PR DESCRIPTION
## Summary (required)

- Resolves #5817 

This ticket increases the inner hit size so that it can return up to 100 hits. If we want more than 100 hits we'd have to change the [max_inner_result_window](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html) setting in elasticsearch. This is not recommended because it would have negative impacts on performance because inner_hits can be costly.

[Here](https://docs.google.com/spreadsheets/d/11UqvbnAJPxt9iPVFY9QdDPEXbGlf9MANhV4NjOjALXg/edit#gid=0) is a document showing the load testing results. I see a bit of an increase in the average response time. 


### Required reviewers 2 - 3 devs 


## Impacted areas of the application

General components of the application that this PR will affect:

- legal search

## How to test

1. deploy this branch to dev
2. check that document highlights return more than three results: https://fec-dev-api.app.cloud.gov/v1/legal/search?case_no=4530&case_doc_category_id=1&type=murs&q=%22Reason+to+believe%22&api_key=DEMO_KEY
3. Go to legal search on dev.fec.gov and compare results to prod
example: https://dev.fec.gov/data/legal/search/murs/?search_type=murs&sort=&search=election&case_no=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=
