### PR TITLE
Remove line number filter

### DIFF
--- a/tests/test_national_party.py
+++ b/tests/test_national_party.py
@@ -454,23 +454,6 @@ class TestNationalPartyScheduleB(ApiBaseTest):
         )
         self.assertEqual(len(results), 2)
 
-    def test_line_number(self):
-        [
-            factories.NationalParty_ScheduleBFactory(line_number='21b', filing_form='F3X'),
-            factories.NationalParty_ScheduleBFactory(line_number='29', filing_form='F3X'),
-        ]
-
-        results = self._results(
-            api.url_for(NationalParty_ScheduleBView, line_number='F3X-29')
-        )
-        self.assertEqual(len(results), 1)
-
-        # invalid line_number
-        response = self.app.get(
-            api.url_for(NationalParty_ScheduleBView, line_number='123')
-        )
-        self.assertEqual(response.status_code, 400)
-
 
 class TestNationalPartyTotals(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2024}

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1409,7 +1409,6 @@ national_party_schedule_b = {
     'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
     'disbursement_purpose_category': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
                                                  description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
-    'line_number': fields.Str(description=docs.NATIONAL_PARTY_SB_LINE_NUMBER),
     'min_disbursement_amount': Currency(description=docs.MIN_DISBURSEMENT_AMOUNT),
     'max_disbursement_amount': Currency(description=docs.MAX_DISBURSEMENT_AMOUNT),
     'min_disbursement_date': Date(description=docs.MIN_DISBURSEMENT_DATE),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2520,10 +2520,6 @@ DISBURSEMENT_TYPE_CODES = 'National party account disbursement types:\n\
     -42Y RECOUNT ACCOUNT REFUND - INDIVIDUAL\n\
     -42Z RECOUNT ACCOUNT REFUND - REGISTERED FILER\n\
 '
-NATIONAL_PARTY_SB_LINE_NUMBER = '''Filter for form and line number using the following format:
-`<form_number-line_number>`. For example F3X-21b or F3X-29 would filter
-down to all entries from form `F3X` and line number `21b` or form `F3X` and line number `29`.
-'''
 
 MIN_DISBURSEMENT_DATE = '''
 Selects all disbursements received after this date(MM/DD/YYYY or YYYY-MM-DD)


### PR DESCRIPTION
## Summary (required)

- Resolves #5852 

Remove `line_number` filter from `/v1/national_party/schedule_b/` endpoint

### Required reviewers

1 developer

## Impacted areas of the application

- Swagger UI -->`/v1/national_party/schedule_b/` endpoint


## How to test
On local:

- run `git checkout feature/5852-npa-sb-line-number`
- run `pyenv activate venv-api`
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-dev.txt` 
- run `pytest`
- run `flask run`
- On this branch, on swagger ui, verify that `line_number` filter is no longer available on `national_party/schedule_b` endpoint:
http://127.0.0.1:5000/v1/national_party/schedule_b/?page=1&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false

- vs Dev API (with `line_number` filter):
https://fec-dev-api.app.cloud.gov/v1/national_party/schedule_b/?page=1&per_page=20&line_number=f3x-29&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false



**OR**

Deploy a test branch to Dev space,  and on swagger ui, verify that `line_number` filter is no longer available on `national_party/schedule_b` endpoint
