### PR TITLE
Fix column name in model file

### DIFF
--- a/webservices/common/models/national_party.py
+++ b/webservices/common/models/national_party.py
@@ -192,7 +192,7 @@ class NationalParty_ScheduleB(db.Model):
     spender_committee_designation = db.Column('cmte_dsgn', db.String)
     spender_committee_designation_full = db.Column('designation_full', db.String)
     spender_committee_type = db.Column('cmte_tp', db.String, doc=docs.COMMITTEE_TYPE)
-    spender_committee_type_full = db.Column(db.String)
+    spender_committee_type_full = db.Column('committee_type_full', db.String)
     state = db.Column(db.String)
     state_full = db.Column(db.String)
     sub_id = db.Column(db.Numeric(19), primary_key=True, index=True)


### PR DESCRIPTION
## Summary (required)

- Resolves #5859 
Update column name for spender_committee_type_full in model file

### Required reviewers
1 developer

## How to test
- Download feature branch and run `pytest`
- Start api on local and run endpoint:
http://127.0.0.1:5000/v1/national_party/schedule_b/?page=1&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false