### PR TITLE
5849 add image number filter

### DIFF
--- a/tests/test_national_party.py
+++ b/tests/test_national_party.py
@@ -471,6 +471,17 @@ class TestNationalPartyScheduleB(ApiBaseTest):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_image_number(self):
+        [
+            factories.NationalParty_ScheduleBFactory(image_number='202405209646237729'),
+            factories.NationalParty_ScheduleBFactory(image_number='202405209646231234'),
+        ]
+
+        results = self._results(
+            api.url_for(NationalParty_ScheduleBView, image_number='202405209646237729')
+        )
+        self.assertEqual(len(results), 1)
+
 
 class TestNationalPartyTotals(ApiBaseTest):
     kwargs = {'two_year_transaction_period': 2024}

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -1409,6 +1409,7 @@ national_party_schedule_b = {
     'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
     'disbursement_purpose_category': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
                                                  description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
+    'image_number': fields.List(IStr, description=docs.IMAGE_NUMBER),
     'line_number': fields.Str(description=docs.NATIONAL_PARTY_SB_LINE_NUMBER),
     'min_disbursement_amount': Currency(description=docs.MIN_DISBURSEMENT_AMOUNT),
     'max_disbursement_amount': Currency(description=docs.MAX_DISBURSEMENT_AMOUNT),


### PR DESCRIPTION
## Summary (required)

- Resolves #5849 

Adds image number filter to national party schedule b endpoint

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

- National party schedule b endpoint


## How to test

- start your API virtualenv
- pytest tests/test_national_party.py
- flask run
- test image number filter
http://127.0.0.1:5000/v1/national_party/schedule_b/?page=1&per_page=20&image_number=202405209646237729&image_number=202405209646237803&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
http://127.0.0.1:5000/v1/national_party/schedule_b/?page=1&per_page=20&image_number=202405209646237729&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
http://127.0.0.1:5000/v1/national_party/schedule_b/?page=1&per_page=20&sort=-disbursement_date&sort_hide_null=false&sort_null_only=false
