### PR TITLE
Update AO mapping to include citation fields

### DIFF
--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -326,6 +326,8 @@ AO_MAPPING = {
         "requestor_types": {"type": "keyword"},
         "commenter_names": {"type": "text"},
         "representative_names": {"type": "text"},
+        "citation_type": {"type": "keyword"},
+        "citation_text": {"type": "text"},
         "entities": {
             "properties": {
                 "role": {"type": "keyword"},


### PR DESCRIPTION
## Summary (required)

- Resolves #5690 

This PR fixes a bug with the citation endpoint where no results are being returned. This was happening due to the AO mappings not including the citation fields, so they weren't searchable. Once this PR is merged I will go through the process of updating our mappings on dev. 

 
### Required reviewers 2 - 3 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

- ES mappings 


## How to test

Before: 

1. Setup and start elastic search by following [this](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally) wiki 
2. In another terminal: `git checkout develop`
3. `python cli.py create_index ao_index`
4. `python cli.py load_advisory_opinions 2020-05`
5. See that citation_type does not exist as a field for AOs: http://localhost:9200/ao_index/_field_caps?fields=citation_type
8. `flask run`
9. See that citation endpoint returns no results: http://127.0.0.1:5000/v1/legal/citation/regulation/100.13

After: 

8. `git checkout feature/5690-fix-citations`
12. recreate index: `python cli.py create_index ao_index`
13. reload AOs: `python cli.py load_advisory_opinions 2020-05`
14. See that citation_type is now a searchable field: http://localhost:9200/ao_index/_field_caps?fields=citation_type
15. `flask run`
16. Test citation endpoint

Sample URLs:

http://127.0.0.1:5000/v1/legal/citation/statute/100
http://127.0.0.1:5000/v1/legal/citation/regulation/100.13
 
 
