### PR TITLE
[WIP] Feature/switch to simple query string

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -205,6 +205,9 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         must_clauses = [
             Q("terms", documents__category=kwargs.get("case_document_category"))
         ]
+
+    if kwargs.get("case_respondents"):
+        must_clauses.append(Q("query_string", query=kwargs.get("case_respondents"), fields=["respondents"]))
     query = query.query("bool", must=must_clauses)
 
     logger.debug("case_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
@@ -307,8 +310,6 @@ def apply_mur_specific_query_params(query, **kwargs):
 
     if kwargs.get("mur_type"):
         must_clauses.append(Q("match", mur_type=kwargs.get("mur_type")))
-    if kwargs.get("case_respondents"):
-        must_clauses.append(Q("match", respondents=kwargs.get("case_respondents")))
     if kwargs.get("case_dispositions"):
         must_clauses.append(
             Q("term", disposition__data__disposition=kwargs.get("case_dispositions"))
@@ -443,8 +444,6 @@ def apply_adr_specific_query_params(query, **kwargs):
 
     if kwargs.get("mur_type"):
         must_clauses.append(Q("match", mur_type=kwargs.get("mur_type")))
-    if kwargs.get("case_respondents"):
-        must_clauses.append(Q("match", respondents=kwargs.get("case_respondents")))
     if kwargs.get("case_dispositions"):
         must_clauses.append(
             Q("term", disposition__data__disposition=kwargs.get("case_dispositions"))

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -157,7 +157,7 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     must_query = [Q("term", type=type_)]
 
     if q:
-        must_query.append(Q("query_string", query=q))
+        must_query.append(Q("simple_query_string", query=q))
 
     query = (
         Search()
@@ -193,7 +193,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
     should_query = [
         get_case_document_query(q, **kwargs),
-        Q("query_string", query=q, fields=["no", "name"]),
+        Q("simple_query_string", query=q, fields=["no", "name"]),
     ]
     query = query.query("bool", should=should_query, minimum_should_match=1)
 
@@ -207,7 +207,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         ]
 
     if kwargs.get("case_respondents"):
-        must_clauses.append(Q("query_string", query=kwargs.get("case_respondents"), fields=["respondents"]))
+        must_clauses.append(Q("simple_query_string", query=kwargs.get("case_respondents"), fields=["respondents"]))
     query = query.query("bool", must=must_clauses)
 
     logger.debug("case_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
@@ -253,7 +253,7 @@ def get_case_document_query(q, **kwargs):
     combined_query.append(Q("bool", should=category_queries, minimum_should_match=1))
 
     if q:
-        combined_query.append(Q("query_string", query=q, fields=["documents.text"]))
+        combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
 
     return Q(
         "nested",
@@ -496,7 +496,7 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
     should_query = [
         get_ao_document_query(q, **kwargs),
-        Q("query_string", query=q, fields=["no", "name", "summary"]),
+        Q("simple_query_string", query=q, fields=["no", "name", "summary"]),
     ]
     query = query.query("bool", should=should_query, minimum_should_match=1)
     logger.debug("ao_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
@@ -521,7 +521,7 @@ def get_ao_document_query(q, **kwargs):
         combined_query = []
 
     if q:
-        combined_query.append(Q("query_string", query=q, fields=["documents.text"]))
+        combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
 
     return Q(
         "nested",


### PR DESCRIPTION
Draft PR adding the case_respondents query_string and then also switching everything over to simple_query_string as it doesn't seem like ES recommends using query_string in search boxes in production. 

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html


Questions for Monday: 
When a filter is added--the current behavior is to include all documents where that field is not present. Is that what we want? 
Because highlight and document highlight are attached to query, this will show highlights for any searched term. Is this what we want? 
If we switch to simple, we lose the ability to specify field in the search. Is this something we need? 
Would this improve downtime? 
[API umbrella 400's](https://api.data.gov/admin/#/stats/logs?end_at=2024-06-28&query=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%7B%22id%22%3A%22request_path%22%2C%22field%22%3A%22request_path%22%2C%22type%22%3A%22string%22%2C%22input%22%3A%22text%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%22legal%22%7D%2C%7B%22id%22%3A%22response_status%22%2C%22field%22%3A%22response_status%22%2C%22type%22%3A%22integer%22%2C%22input%22%3A%22number%22%2C%22operator%22%3A%22equal%22%2C%22value%22%3A400%7D%5D%2C%22valid%22%3Atrue%7D&start_at=2024-01-01)
Legal search[ downtime comparison ](https://docs.google.com/document/d/1a4BjykL5v0tmnZzCOi9z1PKeeOprua4aPGfT5JQpfZU/edit)
Would the syntax changes be hard to deal with in the FE? AND/OR to +/|? 
      notices? 
Need to improve testing
if we stick with query_string are the 400's currently being handled correctly? 


Should we allow wildcard? 
 analyze_wildcard
    (Optional, Boolean) If true, the query attempts to analyze wildcard terms in the query string. Defaults to false. 

We should keep this in mind if there's issues with standard:
https://www.elastic.co/guide/en/elasticsearch/reference/current/mixing-exact-search-with-stemming.html

## Summary (required)

- Resolves #5830

Switches from query_string to simple_query_string for our keyword search and switches case_respondents to simple_query_string from match

### Required reviewers

2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- legal search

## How to test

- You need the docs loaded for testing locally. Pat and I have been testing on dev with the standard analyzer. 
- activate your virtualenv
- pytest

http://127.0.0.1:5000/v1/legal/search/
http://127.0.0.1:5000/v1/legal/search/?case_respondents=jackson
http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Aaron%20Woolf%20for%20Congress%22
http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Friends%20of%20Jack%20Kingston%22

http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Casey%20|%20Michael%22
http://127.0.0.1:5000/v1/legal/search/?case_respondents=Fratto%20|%20Elissa

