### PR TITLE
Release PR -  Add missing columns to test efile table

### DIFF
--- a/data/migrations/V0302__add_test_efile_schema_and_table.sql
+++ b/data/migrations/V0302__add_test_efile_schema_and_table.sql
@@ -118,7 +118,9 @@ CREATE TABLE test_efile.test_f1 (
     url character varying(90),
     fax character varying(12),
     imageno numeric,
-    create_dt timestamp without time zone
+    create_dt timestamp without time zone,
+    super_pac_lobbyist varchar(1),
+    hybrid_pac_lobbyist varchar(1)
 );
 
 


### PR DESCRIPTION
## Summary

- Part of #5860 

Add missing columns to  `test_efile` schema and `test_f1` table for future test webforms table/endpoint in #5860 

- [x] Remove Schema: `test_efile` and Table: `test_f1` manually in stage database
- [x] Remove migration `V0302__add_test_efile_schema_and_table.sql` from flyway history manually
- [x] Merge PR, which will run migration again

## Impacted areas of the application

General components of the application that this PR will affect:

- None yet

## Screenshots

(Include a screenshot of the new/updated features in context (“in the wild”). If it is an interface change, include both before and after screenshots)

## Related PRs

WIP PR: https://github.com/fecgov/openFEC/pull/5861 (will remove migration)

## How to test

- Run migrations

