### PR TITLE
Feature/add case respondents and exclude

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -361,6 +361,7 @@ legal_universal_search = {
     'case_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'case_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
+    'q_exclude': IStr(required=False, description=docs.Q_EXCLUDE),
 
     # case_doc_category_id is the key of case_document_category
     'case_doc_category_id': fields.List(IStr(

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2169,6 +2169,10 @@ CASE_ELECTION_CYCLES = '''
 Cases election cycles
 '''
 
+Q_EXCLUDE = '''
+Exclude documents containing this term
+'''
+
 CASE_MIN_OPEN_DATE = '''
 The earliest date opened of case
 '''


### PR DESCRIPTION
## Summary (required)

- Resolves #5830, #5888
This PR switches to simple_query_string from query_string, switches case_respondents to simple_query_string, and adds a second filter q_exclude to fix the negation issues we found

### Required reviewers

2-3 devs

## Impacted areas of the application
legal search


## How to test
This branch is currently on feature/dev and works with the current cms branch on feature. 
- To test with the CMS you can try these queries or build your own using feature
- https://docs.google.com/spreadsheets/d/1MCj4r21mMnLr7DGEPw3gaeLMCnAckSLNGREMGJIj_MU/edit?gid=2042722194#gid=2042722194

- You need the docs loaded for testing locally. This PR is also on dev.
- activate your virtualenv
- pytest

http://127.0.0.1:5000/v1/legal/search/
http://127.0.0.1:5000/v1/legal/search/?case_respondents=jackson
http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Aaron%20Woolf%20for%20Congress%22
http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Friends%20of%20Jack%20Kingston%22
http://127.0.0.1:5000/v1/legal/search/?case_respondents=%22Casey%20|%20Michael%22
http://127.0.0.1:5000/v1/legal/search/?case_respondents=Fratto%20|%20Elissa

