### PR TITLE
Switch analyzer to standard

### DIFF
--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -68,7 +68,7 @@ ADMIN_FINE_MAPPING = {
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
     "case_serial": {"type": "integer"},
-    "name": {"type": "text", "analyzer": "english"},
+    "name": {"type": "text"},
     "published_flg": {"type": "boolean"},
     "commission_votes": {
         "properties": {
@@ -147,7 +147,7 @@ MUR_MAPPING = {
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
     "case_serial": {"type": "integer"},
-    "name": {"type": "text", "analyzer": "english"},
+    "name": {"type": "text"},
     "published_flg": {"type": "boolean"},
     "commission_votes": {
         "properties": {
@@ -194,7 +194,7 @@ ADR_MAPPING = {
     "doc_id": {"type": "keyword"},
     "no": {"type": "keyword"},
     "case_serial": {"type": "integer"},
-    "name": {"type": "text", "analyzer": "english"},
+    "name": {"type": "text"},
     "published_flg": {"type": "boolean"},
     "complainant": {"type": "text"},
     "commission_votes": {
@@ -235,8 +235,8 @@ ADR_MAPPING = {
 STATUTE_MAPPING = {
     "type": {"type": "keyword"},
     "doc_id": {"type": "keyword"},
-    "name": {"type": "text", "analyzer": "english"},
-    "text": {"type": "text", "analyzer": "english"},
+    "name": {"type": "text"},
+    "text": {"type": "text"},
     "no": {"type": "keyword"},
     "title": {"type": "text"},
     "chapter": {"type": "text"},
@@ -265,8 +265,8 @@ AO_MAPPING = {
         "ao_serial": {"type": "integer"},
         "ao_year": {"type": "integer"},
         "doc_id": {"type": "keyword"},
-        "name": {"type": "text", "analyzer": "english"},
-        "summary": {"type": "text", "analyzer": "english"},
+        "name": {"type": "text"},
+        "summary": {"type": "text"},
         "request_date": {"type": "date", "format": "dateOptionalTime"},
         "issue_date": {"type": "date", "format": "dateOptionalTime"},
         "is_pending": {"type": "boolean"},
@@ -399,7 +399,7 @@ ANALYZER_SETTING = {
     "analysis": {
         "analyzer": {
             "default": {
-                "type": "english"
+                "type": "standard"
             }
         }
     },

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -83,7 +83,7 @@ class GetLegalDocument(Resource):
         )
 
         results = {"docs": [hit.to_dict() for hit in es_results]}
-        logger.debug("GetLegalDocument() results =" + json.dumps(results, indent=3, cls=DateTimeEncoder))
+        # logger.debug("GetLegalDocument() results =" + json.dumps(results, indent=3, cls=DateTimeEncoder))
 
         if len(results["docs"]) > 0:
             return results
@@ -170,7 +170,7 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         .sort("sort1", "sort2")
     )
 
-    logger.debug("generic_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("generic_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
     return query
 
 
@@ -204,7 +204,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         ]
     query = query.query("bool", must=must_clauses)
 
-    logger.debug("case_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("case_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     if type_ == "admin_fines":
         return apply_af_specific_query_params(query, **kwargs)
@@ -294,7 +294,7 @@ def apply_af_specific_query_params(query, **kwargs):
         )
 
     query = query.query("bool", must=must_clauses)
-    logger.debug("apply_af_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("apply_af_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     return query
 
@@ -336,7 +336,7 @@ def apply_mur_specific_query_params(query, **kwargs):
         must_clauses.append(Q("range", close_date=date_range))
 
     query = query.query("bool", must=must_clauses)
-    logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     if kwargs.get("case_regulatory_citation") or kwargs.get("case_statutory_citation"):
         return case_apply_citation_params(
@@ -431,7 +431,7 @@ def case_apply_citation_params(query, regulatory_citation, statutory_citation, c
         must_clauses.append(Q("bool", should=citation_queries, minimum_should_match=1))
 
     query = query.query("bool", must=must_clauses)
-    logger.debug("apply_citation_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("apply_citation_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
     return query
 
 
@@ -472,7 +472,7 @@ def apply_adr_specific_query_params(query, **kwargs):
         must_clauses.append(Q("range", close_date=date_range))
 
     query = query.query("bool", must=must_clauses)
-    logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     return query
 
@@ -497,7 +497,7 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         Q("query_string", query=q, fields=["no", "name", "summary"]),
     ]
     query = query.query("bool", should=should_query, minimum_should_match=1)
-    logger.debug("ao_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("ao_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
     return apply_ao_specific_query_params(query, **kwargs)
 
 
@@ -681,15 +681,15 @@ def apply_ao_specific_query_params(query, **kwargs):
         )
 
     query = query.query("bool", must=must_clauses)
-    logger.debug("apply_ao_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("apply_ao_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
 
     return query
 
 
 def execute_query(query):
     es_results = query.execute()
-    logger.debug("UniversalSearch() execute_query() es_results =" + json.dumps(
-        es_results.to_dict(), indent=3, cls=DateTimeEncoder))
+    # logger.debug("UniversalSearch() execute_query() es_results =" + json.dumps(
+    #     es_results.to_dict(), indent=3, cls=DateTimeEncoder))
 
     formatted_hits = []
     for hit in es_results:
@@ -720,7 +720,7 @@ def execute_query(query):
                     # put "highlights" in return hit
                     for key in inner_hit.meta.highlight:
                         formatted_hit["highlights"].extend(inner_hit.meta.highlight[key])
-    logger.debug("formatted_hits =" + json.dumps(formatted_hits, indent=3, cls=DateTimeEncoder))
+    # logger.debug("formatted_hits =" + json.dumps(formatted_hits, indent=3, cls=DateTimeEncoder))
 
 # Since ES7 the `total` becomes an object : "total": {"value": 1,"relation": "eq"}
 # We can set rest_total_hits_as_int=true, default is false.


### PR DESCRIPTION
## Summary (required)
This PR will switch Elasticsearch English analyzer to the Standard analyzer. This analyzer performs exact string matching without altering terms by stemming and ignoring common words.
Also comment out some debug option in legal.py.

- Resolves #5872 

### Required reviewers
1 dev

## Impacted areas of the application
legal search

## How to test
1) Setup local Elastic search to Standard analyzer.
2) Test legal keyword search without altering terms by stemming and ignoring common words.

- [ ] Reindex and upload documents(case_index, ao_index) to elasticsearch service on Dev space