### PR TITLE
Upgrade setuptools to v70.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,5 +50,5 @@ importlib-metadata==3.10.1 #pinned to fix the pytest deprecation warning: Select
 nplusone==0.8.0
 pytest==8.0.2
 pytest-cov==4.1.0
-setuptools==68.0.0 #pin to remediate snyk ReDoS#5477
+setuptools==70.3.0 #pin to remediate snyk vulnerability 
 webtest==2.0.34


### PR DESCRIPTION
## Summary (required)

- Resolves #5907 

This PR upgrades setuptools to v70.3 to remove a snyk vulnerability. We need to make changes to marshmallow pagination if we ever want to upgrade to 71 or above. I created a ticket [here](https://github.com/fecgov/marshmallow-pagination/issues/18). 
 
### Required reviewers 1 developer 


## Impacted areas of the application

General components of the application that this PR will affect:

- package installation during deploy


## How to test

- checkout this branch 
- activate your virtualenv 
- `pip install -r requirements.txt`
- `snyk test --file=requirements.txt --package-manager=pip` (vulnerability should be gone)
- deploy to dev or stage. You can use [this](https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-unpin-setuptools-stage) test branch 

