### PR TITLE
Upgrade flyway to 10.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/10.12.0/flyway-commandline-10.12.0-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-10.12.0:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/10.17.1/flyway-commandline-10.17.1-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-10.17.1:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-   - Flyway 10.12.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
+   - Flyway 10.17.1 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
-     - After downloading, create a .toml file in the following location: `flyway-10.12.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
+     - After downloading, create a .toml file in the following location: `flyway-10.17.1/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
 
        ```
        [environments.local]

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "10.12.0"
-    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "10.12.0") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "10.17.1"
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "10.17.1") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-10.12.0.jar:app/gradle/lib/flyway-core-10.12.0.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-10.17.1.jar:app/gradle/lib/flyway-core-10.17.1.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)
- Resolves #5936 

Upgrades flyway to 10.17.1

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-flyway

## How to test
1. Checkout this branch 
2. Update flyway `brew update flyway`
3. Install the latest version of flyway through brew
`brew install flyway`
4. Confirm flyway version 10.17.1: `flyway -v` 
5. `dropdb cfdm_test`
6. `createdb cfdm_test`
7. `invoke create_sample_db`
8. `pytest`
9. run `snyk test --file=data/flyway/build.gradle` and make sure no vulnerability.
