### PR TITLE
Set allowed allowed referers in api key creation task

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -179,6 +179,7 @@ def create_public_api_key(
             "username": "auto-generated"
         },
         "settings": {
+            "allowed_referers": ["*",],
             "rate_limit_mode": "custom",
             "rate_limits": [{
                 "limit_by": "apiKey",
@@ -192,7 +193,8 @@ def create_public_api_key(
                 "limit": second_rate_limit,
                 "duration": second_rate_limit_duration,
                 }
-            ]
+            ],
+
         }
     }
 


### PR DESCRIPTION
## Summary (required)

- Resolves #5917 

This PR modifies the api key creation task to set the `Restrict Access to HTTP Referers` setting.
 
### Required reviewers 1 developer

## Impacted areas of the application


- api key creation task

## How to test
Link to branch for testing: https://github.com/fecgov/openFEC/tree/test-update-referrers
1. checkout test branch `git checkout test-update-referrers`
2. set the UMBRELLA_ADMIN_AUTH_TOKEN env var `export UMBRELLA_ADMIN_AUTH_TOKEN="<your umbrella token>"`
3. set the FEC_WEB_API_KEY_PUBLIC env var `export FEC_WEB_API_KEY_PUBLIC="<your api key>"`
5. Run the task `python cli.py update_public_api_key dev fec-creds-dev fake-token123`
6. Check that the `Restrict Access to HTTP Referers` setting is set to `*` in API umbrella
7. disable the api key in API umbrella
