### PR TITLE
5961 add ao_doc_category_id filter

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -336,8 +336,8 @@ legal_universal_search = {
     'ao_max_issue_date': Date(description=docs.AO_MAX_ISSUE_DATE),
     'ao_min_request_date': Date(description=docs.AO_MIN_REQUEST_DATE),
     'ao_max_request_date': Date(description=docs.AO_MAX_REQUEST_DATE),
-    'ao_category': fields.List(
-        IStr(validate=validate.OneOf(['F', 'V', 'D', 'R', 'W', 'C', 'S'])),
+    'ao_doc_category_id': fields.List(
+        IStr(validate=validate.OneOf(['', 'F', 'V', 'D', 'R', 'W', 'C', 'S'])),
         description=docs.AO_CATEGORY),
     'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
     'ao_status': fields.Str(description=docs.AO_STATUS),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2115,6 +2115,13 @@ Latest request date of advisory opinion
 
 AO_CATEGORY = '''
 Category of the document
+F - Final Opinion
+V - Votes
+D - Draft Documents
+R - AO Request, Supplemental Material, and Extensions of Time
+W - Withdrawal of Request
+C - Comments and Ex parte Communications
+S - Commissioner Statements
 '''
 
 AO_IS_PENDING = '''

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -209,6 +209,17 @@ def get_advisory_opinions(from_ao_no):
             yield ao
 
 
+CATEGORY_MAP = {
+    "Final Opinion": "F",
+    "Votes": "V",
+    "Draft Documents": "D",
+    "AO Request, Supplemental Material, and Extensions of Time": "R",
+    "Withdrawal of Request": "W",
+    "Comments and Ex parte Communications": "C",
+    "Commissioner Statements": "S",
+    }
+
+
 def get_entities(ao_id):
     requestor_names = []
     commenter_names = []
@@ -260,6 +271,7 @@ def get_documents(ao_id, bucket):
             document = {
                 "document_id": row["document_id"],
                 "category": row["category"],
+                "ao_doc_category_id": CATEGORY_MAP.get(row["category"]),
                 "description": row["description"],
                 "text": row["ocrtext"],
                 "date": row["document_date"],

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -302,6 +302,7 @@ AO_MAPPING = {
             "type": "nested",
             "properties": {
                 "document_id": {"type": "long"},
+                "ao_doc_category_id": {"type": "keyword"},
                 "category": {"type": "keyword"},
                 "description": {"type": "text"},
                 "text": {

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -511,21 +511,13 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
 
 def get_ao_document_query(q, **kwargs):
-    categories = {
-        "F": "Final Opinion",
-        "V": "Votes",
-        "D": "Draft Documents",
-        "R": "AO Request, Supplemental Material, and Extensions of Time",
-        "W": "Withdrawal of Request",
-        "C": "Comments and Ex parte Communications",
-        "S": "Commissioner Statements",
-    }
-
-    if kwargs.get("ao_category"):
-        ao_category = [categories[c] for c in kwargs.get("ao_category")]
-        combined_query = [Q("terms", documents__category=ao_category)]
-    else:
-        combined_query = []
+    category_query = []
+    combined_query = []
+    if kwargs.get("ao_doc_category_id") and (len(kwargs.get("ao_doc_category_id")) > 0):
+        for ao_doc_category_id in kwargs.get("ao_doc_category_id"):
+            if len(ao_doc_category_id) > 0:
+                category_query.append(Q("term", documents__ao_doc_category_id=ao_doc_category_id))
+        combined_query.append(Q("bool", should=category_query, minimum_should_match=1))
 
     if q:
         combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))


### PR DESCRIPTION
## Summary (required)

- Resolves #5961 

Adds ao_doc_category_id field and switches the filter to use ao_doc_category_id 

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- AOs 

## Screenshots
![Screenshot 2024-09-10 at 12 41 29 PM](https://github.com/user-attachments/assets/197af4b3-f5fa-45ba-9294-be7712e6df33)

## How to test

- You must reload your AO's to see these changes
- activate your venv
- activate ES 
- python cli.py initialize_legal_data ao_index
 
- flask run
- http://127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=C
- http://127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=D
- http://127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=validation error
