### PR TITLE
Add Mur disposition category filter

### DIFF
--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -422,6 +422,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'dispositions': [
                 {
                     'disposition': 'Conciliation-PPC',
+                    'mur_disposition_category_id': '7',
                     'respondent': 'Open Elections LLC',
                     'penalty': Decimal('50000.00'),
                     'citations': [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -352,7 +352,6 @@ legal_universal_search = {
 
     'case_no': fields.List(IStr, required=False, description=docs.CASE_NO),
     'case_respondents': IStr(required=False, description=docs.CASE_RESPONDONTS),
-    'case_dispositions': fields.List(IStr, required=False, description=docs.CASE_DISPOSTIONS),
     'case_election_cycles': fields.Int(required=False, description=docs.CASE_ELECTION_CYCLES),
     'case_min_open_date': Date(required=False, description=docs.CASE_MIN_OPEN_DATE),
     'case_max_open_date': Date(required=False, description=docs.CASE_MAX_OPEN_DATE),
@@ -362,15 +361,22 @@ legal_universal_search = {
     'case_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
     'q_exclude': IStr(required=False, description=docs.Q_EXCLUDE),
-
-    # case_doc_category_id is the key of case_document_category
     'case_doc_category_id': fields.List(IStr(
         validate=validate.OneOf(
-            ['1', '2', '3', '4', '5', '6', '1001', '1002', '1003', '1004', '1005', '1006', '2001'])),
+            ['', '1', '2', '3', '4', '5', '6', '1001', '1002', '1003', '1004', '1005', '1006', '2001'])),
         description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
 
     'mur_type': fields.Str(
         required=False, validate=validate.OneOf(["archived", "current"]), description=docs.MUR_TYPE),
+    'mur_disposition_category_id': fields.List(IStr(
+        validate=validate.OneOf([
+            '', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+            '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
+            '21', '22', '23', '24', '25', '26', '27', '28', '29', '30',
+            '31', '32', '33', '34', '35', '36', '37', '38', '39', '40',
+            '41', '42', '43', '44', '45', '46', '47', '48'])),
+        description=docs.MUR_DISPOSITION_CATEGORY_DISCRIPTION
+    ),
 
     'af_name': fields.List(IStr, required=False, description=docs.AF_NAME),
     'af_committee_id': Committee_ID(required=False, description=docs.AF_COMMITTEE_ID),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2190,7 +2190,7 @@ The latest date closed of case
 '''
 
 CASE_DOCUMENT_CATEGORY_DESCRIPTION = '''
-Select one or more case_doc_category_id to filter by corresponding CASE_DOCUMENT_CATEGORY:\n\
+Select one or more case document category id to filter by corresponding case document category:\n\
         - 1 - Conciliation and Settlement Agreements\n\
         - 2 - Complaint, Responses, Designation of Counsel and Extensions of Time\n\
         - 3 - General Counsel Reports, Briefs, Notifications and Responses\n\
@@ -2204,6 +2204,58 @@ Select one or more case_doc_category_id to filter by corresponding CASE_DOCUMENT
         - 1005 - Civil Penalties, Disgorgements, Other Payments and Letters of Compliance\n\
         - 1006 - Statement of Reasons \n\
         - 2001 - Administrative Fine Case\n\
+'''
+
+MUR_DISPOSITION_CATEGORY_DISCRIPTION = '''
+Select one or more MUR disposition category id to filter by corresponding MUR disposition category:\n\
+        - 1 - Approved by Commission\n\
+        - 2 - Approved In Part Recs.\n\
+        - 3 - Approved Recs.\n\
+        - 4 - Case Activated\n\
+        - 5 - Case Activation\n\
+        - 6 - Conciliation-PC\n\
+        - 7 - Conciliation-PPC\n\
+        - 8 - Dismiss and Remind\n\
+        - 9 - Dismissed\n\
+        - 10 - Dismissed - Agreement Rejected\n\
+        - 11 - Dismissed-Low Rated\n\
+        - 12 - Dismissed-Other\n\
+        - 13 - Dismissed-Stale\n\
+        - 14 - Dismiss pursuant to prosecutorial discretion\n\
+        - 15 - Dismiss pursuant to prosecutorial discretion, and caution\n\
+        - 16 - Enforcement - Disposition - Dismissed "Dismiss" - Dismiss and Caution\n\
+        - 17 - Failed to Approve Recs.\n\
+        - 18 - First General Counsel Report\n\
+        - 19 - Formal Discovery Authorized\n\
+        - 20 - Investigative Activity\n\
+        - 21 - Mailed to Respondent\n\
+        - 22 - Merged\n\
+        - 23 - No PCTB\n\
+        - 24 - No RTB\n\
+        - 25 - Offer from Respondent Received\n\
+        - 26 - Other\n\
+        - 27 - PC Brief\n\
+        - 28 - PC Conciliation Approved\n\
+        - 29 - PC/NFA\n\
+        - 30 - PCTB Finding\n\
+        - 31 - Pre-PCC Commenced\n\
+        - 32 - Received\n\
+        - 33 - Received from Audit Division\n\
+        - 34 - Received from Commission\n\
+        - 35 - Received from OGC\n\
+        - 36 - Received from RAD\n\
+        - 37 - Request for Extension of Time Approved\n\
+        - 38 - Request for Extension of Time Approved/Denied\n\
+        - 39 - Request for Extension of Time Received\n\
+        - 40 - Response Received\n\
+        - 41 - RTB Finding\n\
+        - 42 - RTB/NFA\n\
+        - 43 - Settlement Agreement\n\
+        - 44 - Suit Authorization\n\
+        - 45 - Take no action\n\
+        - 46 - Take No Further Action\n\
+        - 47 - To Respondent\n\
+        - 48 - Transferred to ADR\n\
 '''
 
 MUR_TYPE = '''

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -13,7 +13,7 @@ from webservices.env import env
 from webservices.tasks.utils import get_bucket
 
 logger = logging.getLogger(__name__)
-# for debug, uncomment this line
+# To debug, uncomment the line below:
 # logger.setLevel(logging.DEBUG)
 
 CASE_INDEX = "case_index"
@@ -183,6 +183,7 @@ MUR_MAPPING = {
             "disposition": {"type": "text"},
             "penalty": {"type": "double"},
             "respondent": {"type": "text"},
+            "mur_disposition_catagory_id": {"type": "keyword"},
         }
     },
     "open_date": {"type": "date", "format": "dateOptionalTime"},


### PR DESCRIPTION
### Summary
Add filter by **mur_disposition_category_id** in the /legal/search/ endpoint. 
Here is the list of [Mur dispostion category list](https://fecgov.slack.com/files/U3R9P66LC/F07NJETRRK7/mur_disposition_category_list.csv)

- Resolves #5966 

### Required reviewers

2 devs

### Impacted areas of the application
/legal/search/

### Completion criteria
- [ ] Filter by mur_disposition_category_id on MURs work.
- [ ] reload all case documents on dev, stage, prod after deploy. 

### How to test
1)Checkout branch
2)Setup local ES
3Upload legal doc on local ES.
These commands for reference:
`python cli.py create_index case_index`
`python cli.py delete_index case_index`
`python cli.py load_adrs`
`python cli.py load_admin_fines`
`python cli.py load_current_murs`
you can terminate(Ctr+C) in the middle of loading.

4)`pytest` and `flask run`

5)Test urls
http://127.0.0.1:5000/v1/legal/search/?type=murs&mur_disposition_category_id=12
http://127.0.0.1:5000/v1/legal/search/?type=murs&mur_disposition_category_id=7

http://127.0.0.1:5000/v1/legal/search/?type=murs&mur_disposition_category_id=12&mur_disposition_category_id=7


