### PR TITLE
5965-add subject filters

### DIFF
--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -35,7 +35,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'case_serial': 1,
             'published_flg': True,
             'participants': [],
-            'subjects': [mur_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],
@@ -59,7 +64,7 @@ class TestLoadCurrentCases(BaseTestCase):
 
     @patch('webservices.legal_docs.current_cases.get_bucket')
     def test_unpublished_mur(self, get_bucket):
-        mur_subject = 'Unpublished MUR'
+        mur_subject = 'Allocation'
         expected_mur = {
             "type": "murs",
             'no': '101',
@@ -70,7 +75,13 @@ class TestLoadCurrentCases(BaseTestCase):
             'case_serial': 101,
             'published_flg': False,
             'participants': [],
-            'subjects': [mur_subject],
+
+            'subjects': [
+                {
+                    'primary_subject_id': '1',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],
@@ -107,7 +118,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'participants': [],
             'non_monetary_terms': [],
             'non_monetary_terms_respondents': ['Commander Data'],
-            'subjects': [adr_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '16',
+                    'subject': adr_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],
@@ -290,7 +306,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'published_flg': True,
             'election_cycles': [2016],
             'doc_id': 1,
-            'subjects': [mur_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': ["Bilbo Baggins", "Thorin Oakenshield"],
             "documents": [expected_document],
         }
@@ -441,7 +462,12 @@ class TestLoadCurrentCases(BaseTestCase):
                     ],
                 }
             ],
-            'subjects': ['Fraudulent misrepresentation'],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'participants': [],
@@ -473,7 +499,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'case_serial': 1,
             'published_flg': True,
             'participants': [],
-            'subjects': [mur_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],
@@ -494,7 +525,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'case_serial': 2,
             'published_flg': True,
             'participants': [],
-            'subjects': [mur_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],
@@ -515,7 +551,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'case_serial': 3,
             'published_flg': True,
             'participants': [],
-            'subjects': [mur_subject],
+            'subjects': [
+                {
+                    'primary_subject_id': '10',
+                    'subject': mur_subject,
+                }
+            ],
             'respondents': [],
             'documents': [],
             'commission_votes': [],

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -351,9 +351,19 @@ legal_universal_search = {
     'ao_entity_name': fields.List(IStr, required=False, description=docs.AO_ENTITY_NAME),
 
     'case_no': fields.List(IStr, required=False, description=docs.CASE_NO),
-    'case_respondents': IStr(required=False, description=docs.CASE_RESPONDONTS),
+    'case_respondents': IStr(required=False, description=docs.CASE_RESPONDENTS),
     'case_election_cycles': fields.Int(required=False, description=docs.CASE_ELECTION_CYCLES),
     'case_min_open_date': Date(required=False, description=docs.CASE_MIN_OPEN_DATE),
+    'primary_subject_id': fields.List(IStr(
+        validate=validate.OneOf(
+            ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+                '12', '13',  '14', '15', '16',  '17', '18', '19', '20'])),
+            description=docs.PRIMARY_SUBJECT_DESCRIPTION),
+    'secondary_subject_id': fields.List(IStr(
+        validate=validate.OneOf(
+            ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+                '12', '13',  '14', '15', '16',  '17', '18'])),
+            description=docs.SECONDARY_SUBJECT_DESCRIPTION),
     'case_max_open_date': Date(required=False, description=docs.CASE_MAX_OPEN_DATE),
     'case_min_close_date': Date(required=False, description=docs.CASE_MIN_CLOSE_DATE),
     'case_max_close_date': Date(required=False, description=docs.CASE_MAX_CLOSE_DATE),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2164,7 +2164,7 @@ CASE_DOCUMENT_CATEGORY = '''
 Case category of associated documents
 '''
 
-CASE_RESPONDONTS = '''
+CASE_RESPONDENTS = '''
 Cases respondents
 '''
 
@@ -2302,7 +2302,53 @@ The latest Final Determination date
 '''
 
 AF_FD_FINE_AMOUNT = '''
-Final Determination fine amount
+   Final Determination fine amount
+'''
+
+PRIMARY_SUBJECT_DESCRIPTION = '''
+Primary Subject Description:\n\
+    - 1 - Allocation\n\
+    - 2 - Committees\n\
+    - 3 - Contributions\n\
+    - 4 - Disclaimer\n\
+    - 5 - Disbursements
+    - 6 - Electioneering\n\
+    - 7 - Expenditures\n\
+    - 8 - Express Advocacy\n\
+    - 9 - Foreign Nationals\n\
+    - 10 - Fraudulent misrepresentation\n\
+    - 11 - Issue Advocacy\n\
+    - 12 - Knowing and Willful\n\
+    - 13 - Loans\n\
+    - 14 - Non-federal\n\
+    - 15 - Other\n\
+    - 16 - Personal use\n\
+    - 17 - Presidential\n\
+    - 18 - Reporting\n\
+    - 19 - Soft Money\n\
+    - 20 - Solicitation\n\
+'''
+
+SECONDARY_SUBJECT_DESCRIPTION = '''
+Secondary Subject Description:\n\
+    - 1 - Candidate\n\
+    - 2 - Multi-candidate\n\
+    - 3 - Non-party\n\
+    - 4 - PAC\n\
+    - 5 - Party\n\
+    - 6 - Political\n\
+    - 7 - Presidential\n\
+    - 8 - Corporations\n\
+    - 9 - Excessive\n\
+    - 10 - Exemptions\n\
+    - 11 - In the name of another\n\
+    - 12 - Labor unions\n\
+    - 13 - Limitations\n\
+    - 14 - National bank\n\
+    - 15 - Prohibited\n\
+    - 16 - Coordinated\n\
+    - 17 - Limits\n\
+    - 18 - Prohibitions\n\
 '''
 # ======== legal end =========
 

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -158,7 +158,14 @@ MUR_MAPPING = {
     "documents": CASE_DOCUMENT_MAPPING,
     "url": {"type": "text", "index": False},
     "mur_type": {"type": "keyword"},
-    "subjects": {"type": "text"},
+    "subjects": {
+        "type": "nested",
+        "properties": {
+            "subject": {"type": "text"},
+            "primary_subject_id": {"type": "keyword"},
+            "secondary_subject_id": {"type": "keyword"},
+        }
+    },
     "election_cycles": {"type": "long"},
     "participants": {
         "properties": {
@@ -211,7 +218,14 @@ ADR_MAPPING = {
     "documents": CASE_DOCUMENT_MAPPING,
     "url": {"type": "text", "index": False},
     "mur_type": {"type": "keyword"},
-    "subjects": {"type": "text"},
+    "subjects": {
+        "type": "nested",
+        "properties": {
+            "subject": {"type": "text"},
+            "primary_subject_id": {"type": "keyword"},
+            "secondary_subject_id": {"type": "keyword"},
+        }
+    },
     "election_cycles": {"type": "long"},
     "participants": {
         "properties": {

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -212,10 +212,13 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if kwargs.get("case_no"):
         must_clauses.append(Q("terms", no=kwargs.get("case_no")))
 
-    if kwargs.get("case_document_category"):
-        must_clauses = [
-            Q("terms", documents__category=kwargs.get("case_document_category"))
-        ]
+    if kwargs.get("primary_subject_id") and '' not in kwargs.get("primary_subject_id"):
+        must_clauses.append(Q("nested", path="subjects",
+                            query=Q("terms", subjects__primary_subject_id=kwargs.get("primary_subject_id"))))
+
+    if kwargs.get("secondary_subject_id") and '' not in kwargs.get("secondary_subject_id"):
+        must_clauses.append(Q("nested", path="subjects",
+                            query=Q("terms", subjects__secondary_subject_id=kwargs.get("secondary_subject_id"))))
 
     if kwargs.get("case_respondents"):
         must_clauses.append(Q("simple_query_string",


### PR DESCRIPTION
## Summary (required)

- Resolves #5965 

This PR adds primary and secondary subject filters for ADR and MUR subjects 

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- ADR and MUR (current cases)


## How to test
1)Checkout branch
2)Setup local ES
3Upload legal doc on local ES.
These commands for reference:
`python cli.py create_index case_index`
`python cli.py delete_index case_index`
`python cli.py load_adrs`
`python cli.py load_admin_fines`. (Don't really need to load these for this work) 
`python cli.py load_current_murs`
you can terminate(Ctr+C) in the middle of loading.

4)`pytest` and `flask run`

5)Test urls
http://127.0.0.1:5000/v1/legal/search/?primary_subject_id=18
http://127.0.0.1:5000/v1/legal/search/?primary_subject_id=7
http://127.0.0.1:5000/v1/legal/search/?primary_subject_id=7&primary_subject_id=18
http://127.0.0.1:5000/v1/legal/search/?secondary_subject_id=4
http://127.0.0.1:5000/v1/legal/search/?secondary_subject_id=1
http://127.0.0.1:5000/v1/legal/search/?secondary_subject_id=1&secondary_subject_id=4
http://127.0.0.1:5000/v1/legal/search/?secondary_subject_id=2&primary_subject_id=18
http://127.0.0.1:5000/v1/legal/search/?secondary_subject_id=
http://127.0.0.1:5000/v1/legal/search/?primary_subject_id=

on dev:
https://fec-dev-api.app.cloud.gov/v1/legal/search?api_key=DEMO_KEY&secondary_subject_id=1&primary_subject_id=18

