### PR TITLE
Add doc_type filter to citations

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -390,6 +390,13 @@ legal_universal_search = {
     'sort': IStr(required=False, description=docs.SORT),
 }
 
+citation = {
+    'doc_type': fields.Str(
+                required=False, validate=validate.OneOf(["adrs", "advisory_opinions", "murs"]),
+                description=docs.CITATION_DOC_TYPE
+            )
+}
+
 candidate_detail = {
     'cycle': fields.List(fields.Int, description=docs.CANDIDATE_CYCLE),
     'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2140,6 +2140,10 @@ AO_REQUESTOR_TYPE = '''
 Code of the advisory opinion requestor type.
 '''
 
+CITATION_DOC_TYPE = '''
+The document type that referenced a citation.
+'''
+
 REGULATORY_CITATION = '''
 Regulatory citations
 '''

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -436,6 +436,7 @@ def get_citations(ao_names):
             "type": "citations",
             "citation_text": "%d CFR §%d.%d" % (citation[0], citation[1], citation[2]),
             "citation_type": "regulation",
+            "doc_type": "advisory_opinions",
         }
         es_client.index(AO_ALIAS, entry, id=entry["citation_text"])
 
@@ -444,6 +445,7 @@ def get_citations(ao_names):
             "type": "citations",
             "citation_text": "%d U.S.C. §%s" % (citation[0], citation[1]),
             "citation_type": "statute",
+            "doc_type": "advisory_opinions",
         }
         es_client.index(AO_ALIAS, entry, id=entry["citation_text"])
     logger.info(" AO Citations loaded.")

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -140,6 +140,7 @@ CITATION_MAPPING = {
     "type": {"type": "keyword"},
     "citation_type": {"type": "keyword"},
     "citation_text": {"type": "text"},
+    "doc_type": {"type": "keyword"},
 }
 
 MUR_MAPPING = {
@@ -320,6 +321,7 @@ AO_MAPPING = {
         "representative_names": {"type": "text"},
         "citation_type": {"type": "keyword"},
         "citation_text": {"type": "text"},
+        "doc_type": {"type": "keyword"},
         "entities": {
             "properties": {
                 "role": {"type": "keyword"},


### PR DESCRIPTION
## Summary (required)

- Resolves #5979 

This ticket adds a doc_type filter to the` legal/citation` endpoint. Currently there are no MUR or ADR citations, this follow up ticket will populate them https://github.com/fecgov/openFEC/issues/5996.

### Required reviewers 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

- AO mappings 
- legal/citations endpoint 

## How to test

- checkout this branch 
- start your virtualenv 
- start elasticsearch in new terminal 
- `python cli.py create_index ao_index`
- `python cli.py load_advisory_opinions 2020-05`
- `flask run`
- Test endpoint

Sample URLs: 

http://127.0.0.1:5000/v1/legal/citation/regulation/100.13
http://127.0.0.1:5000/v1/legal/citation/statute/10
http://127.0.0.1:5000/v1/legal/citation/statute/10/?doc_type=advisory_opinions
http://127.0.0.1:5000/v1/legal/citation/regulation/100.13/?doc_type=advisory_opinions
http://127.0.0.1:5000/v1/legal/citation/regulation/100.13/?doc_type=abc
http://127.0.0.1:5000/v1/legal/citation/regulation/100.13/?doc_type=murs (no murs yet)
http://127.0.0.1:5000/v1/legal/citation/abcd/abc (invalid citation_type and citation)

