### PR TITLE
Change citation_text to keyword field

### DIFF
--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -139,7 +139,7 @@ ADMIN_FINE_MAPPING = {
 CITATION_MAPPING = {
     "type": {"type": "keyword"},
     "citation_type": {"type": "keyword"},
-    "citation_text": {"type": "text"},
+    "citation_text": {"type": "keyword"},
     "doc_type": {"type": "keyword"},
 }
 
@@ -334,7 +334,7 @@ AO_MAPPING = {
         "commenter_names": {"type": "text"},
         "representative_names": {"type": "text"},
         "citation_type": {"type": "keyword"},
-        "citation_text": {"type": "text"},
+        "citation_text": {"type": "keyword"},
         "doc_type": {"type": "keyword"},
         "entities": {
             "properties": {


### PR DESCRIPTION
## Summary (required)

- Resolves #6001 

This ticket fixes the citation autosuggest by changing the `citation_text` field to keyword. We can now enter letters and receive results. 

### Required reviewers 1 developer 

## Impacted areas of the application

General components of the application that this PR will affect:

- ao mappings 
- citation mappings

## How to test

- checkout this branch 
- start your virtualenv 
- start elasticsearch in new terminal 
- `python cli.py create_index ao_index`
- `python cli.py load_advisory_opinions 2024-11`
- `flask run`
- Test endpoint

Sample URLs: 

http://127.0.0.1:5000/v1/legal/citation/regulation/CFR%20%C2%A7100.5

http://127.0.0.1:5000/v1/legal/citation/statute/52%20U

http://127.0.0.1:5000/v1/legal/citation/statute/52%20U.S.C

http://127.0.0.1:5000/v1/legal/citation/statute/2%20U.S.C

http://127.0.0.1:5000/v1/legal/citation/regulation/29%20CFR