### PR TITLE
5982-Fix arch mur and current mur sort

### DIFF
--- a/webservices/legal_docs/archived_murs.py
+++ b/webservices/legal_docs/archived_murs.py
@@ -25,6 +25,8 @@ ALL_ARCHIVED_MURS = """
         mur_number as mur_no,
         mur_id as case_serial
     FROM MUR_ARCH.ARCHIVED_MURS
+    JOIN fecmur.arch_current_mur_sorting_vw mur_sort on mur_id = mur_sort.case_serial
+    WHERE mur_sort.mur_type = 'archived'
     ORDER BY mur_id desc
 """
 
@@ -37,6 +39,7 @@ SINGLE_MUR = """
         open_date,
         close_date
     FROM MUR_ARCH.ARCHIVED_MURS
+    JOIN fecmur.arch_current_mur_sorting_vw mur_sort on mur_id = mur_sort.case_serial
     WHERE mur_number = %s
 """
 

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -410,12 +410,10 @@ def get_cases(case_type, case_no=None):
 
             if case_type in ("ADR", "AF"):
                 rs = conn.execute(ALL_ADR_AF_CASES, case_type)
-                for row in rs:
-                    yield get_single_case(case_type, row["case_no"], bucket)
             elif case_type in ("MUR"):
                 rs = conn.execute(ALL_MUR_CASES, case_type)
-                for row in rs:
-                    yield get_single_case(case_type, row["case_no"], bucket)
+            for row in rs:
+                yield get_single_case(case_type, row["case_no"], bucket)
     else:
         yield get_single_case(case_type, case_no, bucket)
 

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # for debug, uncomment this line
 # logger.setLevel(logging.DEBUG)
 
-ALL_CASES = """
+ALL_ADR_AF_CASES = """
     SELECT
         case_id,
         case_no,
@@ -30,6 +30,22 @@ ALL_CASES = """
         published_flg
     FROM fecmur.cases_with_parsed_case_serial_numbers_vw
     WHERE case_type = %s
+    ORDER BY case_serial desc
+"""
+
+ALL_MUR_CASES = """
+    SELECT
+        current_case.case_id,
+        current_case.case_no,
+        current_case.case_serial,
+        name,
+        case_type,
+        published_flg
+    FROM fecmur.cases_with_parsed_case_serial_numbers_vw current_case
+    JOIN fecmur.arch_current_mur_sorting_vw mur_sort on current_case.case_serial = mur_sort.case_serial
+    WHERE case_type = %s
+    AND mur_sort.mur_type ='current'
+    AND current_case.case_no = mur_sort.case_no
     ORDER BY case_serial desc
 """
 
@@ -391,9 +407,15 @@ def get_cases(case_type, case_no=None):
 
     if case_no is None:
         with db.engine.connect() as conn:
-            rs = conn.execute(ALL_CASES, case_type)
-            for row in rs:
-                yield get_single_case(case_type, row["case_no"], bucket)
+
+            if case_type in ("ADR", "AF"):
+                rs = conn.execute(ALL_ADR_AF_CASES, case_type)
+                for row in rs:
+                    yield get_single_case(case_type, row["case_no"], bucket)
+            elif case_type in ("MUR"):
+                rs = conn.execute(ALL_MUR_CASES, case_type)
+                for row in rs:
+                    yield get_single_case(case_type, row["case_no"], bucket)
     else:
         yield get_single_case(case_type, case_no, bucket)
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -190,11 +190,11 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     # descending order: 'sort=-case_no'; ascending order; sort=case_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&sort=-case_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&sort=case_no
-    if kwargs.get("sort"):
-        if kwargs.get("sort").upper() == "CASE_NO":
-            query = query.sort({"case_serial": {"order": "asc"}})
-        else:
-            query = query.sort({"case_serial": {"order": "desc"}})
+
+    if kwargs.get("sort") and kwargs.get("sort").upper() == "CASE_NO":
+        query = query.sort({"case_serial": {"order": "asc"}, "mur_type": {"order": "desc"}})
+    else:
+        query = query.sort({"case_serial": {"order": "desc"}, "mur_type": {"order": "desc"}})
 
     should_query = [
         get_case_document_query(q, **kwargs),


### PR DESCRIPTION
## Summary (required)
This PR will fix incorrect order for current MURs and Arch MURs.

### Notes:
1)after merge, we should reload all case legal document and archived MURs documents in dev
2)after cut, we should reload all case legal document and archived MURs documents in stage
3)after deploy production, we should reload all case legal document and archived MURs documents in prod.

- Resolves #5982 

### Required reviewers

1-2 devs

## Impacted areas of the application
'/legal/search/'

General components of the application that this PR will affect:
current_cases.py
archived_murs.py
legal.py

Ref [add test in legal/search](https://github.com/fecgov/openFEC/issues/6009)

## How to test
1)Check branch
2)setup local ES
3)load some arch mur and current mur data to local ES
```
python cli.py display_index_alias
python cli.py create_index case_index
python cli.py create_index arch_mur_index

python cli.py delete_index case_index
python cli.py delete_index arch_mur_index

python cli.py load_current_murs 4250
python cli.py load_current_murs 4012
python cli.py load_current_murs 3987
python cli.py load_current_murs 3774
python cli.py load_current_murs 3620
python cli.py load_current_murs 2804R
python cli.py load_current_murs 2314

python cli.py load_archived_murs 2465
python cli.py load_archived_murs 2455
python cli.py load_archived_murs 2454
python cli.py load_archived_murs 2446
python cli.py load_archived_murs 2445
python cli.py load_archived_murs 2444
python cli.py load_archived_murs 2443
python cli.py load_archived_murs 2441
python cli.py load_archived_murs 2439
python cli.py load_archived_murs 2435
python cli.py load_archived_murs 2431
python cli.py load_archived_murs 2429
python cli.py load_archived_murs 2423
```
4)Test mur sort
http://127.0.0.1:5000/v1/legal/search/?type=murs&sort=-case_no
http://127.0.0.1:5000/v1/legal/search/?type=murs&sort=case_no

5)load some `adr` and `admin_fines` data and test sort
python cli.py load_adrs
python cli.py load_admin_fines

http://127.0.0.1:5000/v1/legal/search/?type=admin_fines&sort=-case_no
http://127.0.0.1:5000/v1/legal/search/?type=admin_fines&sort=case_no
http://127.0.0.1:5000/v1/legal/search/?type=adrs&sort=-case_no
http://127.0.0.1:5000/v1/legal/search/?type=adrs&sort=case_no

6)load some `ao` data and test sort
python cli.py load_advisory_opinions
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&sort=ao_no
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&sort=-ao_no

7)Test in dev compare with prod
in prod:
https://www.fec.gov/data/legal/search/murs/?search=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=3080&limit=20&sort=#results-murs

in dev:
https://dev.fec.gov/data/legal/search/murs/?search=&case_respondents=&case_min_open_date=&case_max_open_date=&case_min_close_date=&case_max_close_date=&offset=3080&limit=20&sort=#results-murs
