### PR TITLE
Hotfix to add ao_category deprecated filter

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -338,7 +338,9 @@ legal_universal_search = {
     'ao_max_request_date': Date(description=docs.AO_MAX_REQUEST_DATE),
     'ao_doc_category_id': fields.List(
         IStr(validate=validate.OneOf(['', 'F', 'V', 'D', 'R', 'W', 'C', 'S'])),
-        description=docs.AO_CATEGORY),
+        description=docs.AO_DOC_CATEGORY_ID),
+    'ao_category': fields.List(
+        IStr(validate=validate.OneOf(['F', 'V', 'D', 'R', 'W', 'C', 'S'])), description=docs.AO_CATEGORY),
     'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
     'ao_status': fields.Str(description=docs.AO_STATUS),
     'ao_requestor': fields.Str(description=docs.AO_REQUESTOR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2114,6 +2114,18 @@ Latest request date of advisory opinion
 '''
 
 AO_CATEGORY = '''
+`DEPRECATED` please use AO_DOC_CATEGORY_ID
+Category of the document
+F - Final Opinion
+V - Votes
+D - Draft Documents
+R - AO Request, Supplemental Material, and Extensions of Time
+W - Withdrawal of Request
+C - Comments and Ex parte Communications
+S - Commissioner Statements
+'''
+
+AO_DOC_CATEGORY_ID = '''
 Category of the document
 F - Final Opinion
 V - Votes

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -544,6 +544,20 @@ def get_ao_document_query(q, **kwargs):
                 category_query.append(Q("term", documents__ao_doc_category_id=ao_doc_category_id))
         combined_query.append(Q("bool", should=category_query, minimum_should_match=1))
 
+    categories = {
+        "F": "Final Opinion",
+        "V": "Votes",
+        "D": "Draft Documents",
+        "R": "AO Request, Supplemental Material, and Extensions of Time",
+        "W": "Withdrawal of Request",
+        "C": "Comments and Ex parte Communications",
+        "S": "Commissioner Statements",
+    }
+
+    if kwargs.get("ao_category"):
+        ao_category = [categories[c] for c in kwargs.get("ao_category")]
+        combined_query = [Q("terms", documents__category=ao_category)]
+
     if q:
         combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6012

Adds back deprecated ao_category filter 

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-ao category legal search


## How to test

- start your venv
- flask run
- check your totals
- pytest
- flask run
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=V should equal
127.0.0.1:5000/v1/legal/search/?ao_category=V
- 127.0.0.1:5000/v1/legal/search/?q=many&ao_doc_category_id=V  should equal
127.0.0.1:5000/v1/legal/search/?q=many&ao_category=V
- 127.0.0.1:5000/v1/legal/search/?q=two&ao_doc_category_id=D  should equal
127.0.0.1:5000/v1/legal/search/?q=two&ao_category=D
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=W  should equal
127.0.0.1:5000/v1/legal/search/?ao_category=W
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=D&ao_doc_category_id=S  should equal
127.0.0.1:5000/v1/legal/search/?ao_category=D&ao_category=S
