### PR TITLE
Filter by document date (AO, AF, ADR and MUR documents)

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -336,6 +336,8 @@ legal_universal_search = {
     'ao_max_issue_date': Date(description=docs.AO_MAX_ISSUE_DATE),
     'ao_min_request_date': Date(description=docs.AO_MIN_REQUEST_DATE),
     'ao_max_request_date': Date(description=docs.AO_MAX_REQUEST_DATE),
+    'ao_min_document_date': Date(description=docs.AO_MIN_DOCUMENT_DATE),
+    'ao_max_document_date': Date(description=docs.AO_MAX_DOCUMENT_DATE),
     'ao_doc_category_id': fields.List(
         IStr(validate=validate.OneOf(['', 'F', 'V', 'D', 'R', 'W', 'C', 'S'])),
         description=docs.AO_DOC_CATEGORY_ID),
@@ -369,6 +371,8 @@ legal_universal_search = {
     'case_max_open_date': Date(required=False, description=docs.CASE_MAX_OPEN_DATE),
     'case_min_close_date': Date(required=False, description=docs.CASE_MIN_CLOSE_DATE),
     'case_max_close_date': Date(required=False, description=docs.CASE_MAX_CLOSE_DATE),
+    'case_min_document_date': Date(required=False, description=docs.CASE_MIN_DOCUMENT_DATE),
+    'case_max_document_date': Date(required=False, description=docs.CASE_MAX_DOCUMENT_DATE),
     'case_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'case_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2113,6 +2113,15 @@ AO_MAX_REQUEST_DATE = '''
 Latest request date of advisory opinion
 '''
 
+AO_MIN_DOCUMENT_DATE = '''
+Selects all advisory opinion documents dated on or after this date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD."
+'''
+
+AO_MAX_DOCUMENT_DATE = '''
+Selects all advisory opinion documents dated on or before this date. Date must be
+formatted as MM/DD/YYYY or YYYY-MM-DD."
+'''
+
 AO_CATEGORY = '''
 `DEPRECATED` please use AO_DOC_CATEGORY_ID
 Category of the document
@@ -2210,6 +2219,14 @@ The earliest date closed of case
 
 CASE_MAX_CLOSE_DATE = '''
 The latest date closed of case
+'''
+
+CASE_MIN_DOCUMENT_DATE = '''
+Selects all case documents dated on or after this date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD."
+'''
+
+CASE_MAX_DOCUMENT_DATE = '''
+Selects all case documents dated on or before this date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD."
 '''
 
 CASE_DOCUMENT_CATEGORY_DESCRIPTION = '''

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -267,6 +267,14 @@ def get_case_document_query(q, **kwargs):
 
         combined_query.append(Q("bool", should=category_queries, minimum_should_match=1))
 
+    case_document_date_range = {}
+    if kwargs.get("case_min_document_date"):
+        case_document_date_range["gte"] = kwargs.get("case_min_document_date")
+    if kwargs.get("case_max_document_date"):
+        case_document_date_range["lte"] = kwargs.get("case_max_document_date")
+    if case_document_date_range:
+        case_document_date_range["format"] = ACCEPTED_DATE_FORMATS
+        combined_query.append(Q("range", documents__document_date=case_document_date_range))
     if q:
         combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
 
@@ -560,6 +568,15 @@ def get_ao_document_query(q, **kwargs):
     if kwargs.get("ao_category"):
         ao_category = [categories[c] for c in kwargs.get("ao_category")]
         combined_query = [Q("terms", documents__category=ao_category)]
+
+    ao_document_date_range = {}
+    if kwargs.get("ao_min_document_date"):
+        ao_document_date_range["gte"] = kwargs.get("ao_min_document_date")
+    if kwargs.get("ao_max_document_date"):
+        ao_document_date_range["lte"] = kwargs.get("ao_max_document_date")
+    if ao_document_date_range:
+        ao_document_date_range["format"] = ACCEPTED_DATE_FORMATS
+        combined_query.append(Q("range", documents__date=ao_document_date_range))
 
     if q:
         combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))


### PR DESCRIPTION
## Summary (required)

- Resolves #5987 

This pull request gives the ability to  filter by AO and case document dates at the legal/search/ endpoint. It allows for minimum and maximum date ranges to filter by using the `ao_min_document_date` and `ao_max_document_date`  columns for AOs and `case_min_document_date` and `case_max_document_date` columns for cases (MUR, ADR, and AF).

### Required reviewers

2 backend developers

## Impacted areas of the application

- `legal/search` endpoint

## How to test
Terminal #1: 

-  follow the [wiki](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally#1-install-elasticsearch-7x0-locally-both-740-and-760-work-well) to start elasticsearch service on local 

- delete and create indexes from scratch:

ao_index:
- python cli.py delete_index ao_index
- python cli.py create_index ao_index

case_index:
- python cli.py delete_index case_index
- python cli.py create_index case_index


### Test AO `ao_min_document_date` and `ao_max_document_date` filters: 

Terminal#2: 
- run `git checkout feature/add-document-date-filter`
- run `pyenv activate <virtualenv>`
- run `pytest`

- run `python cli.py load_advisory_opinions 2024-06` (this command loads 9  AO documents onto ao_index)
- screenshot:
<img width="938" alt="Screenshot 2024-10-08 at 7 52 06 PM" src="https://github.com/user-attachments/assets/8ed0d9a5-78f4-4f24-9e30-d29fe3dce9d7">


Terminal#3:
- run `pyenv activate <virtualenv>`
- run `flask run`

- on browser look up for AO's with ao_min_document_date and ao_max_document_date filters

When `ao_min_document_date`=2024-09-17: yields 2 results
http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_min_document_date=2024-09-17&ao_category=F

When `ao_max_document_date`=2024-09-17:  yields  4 results
http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_max_document_date=2024-09-17&ao_category=F


### Test` case_min_document_date` and `case_max_document_date` filters: 

Terminal#2: (Load and test MUR's)

- run `python cli.py load_current_murs 8261`
- run `python cli.py load_current_murs 8244`
- run `python cli.py load_current_murs 8231`


Terminal#3:
- run `pyenv activate <virtualenv>`
- run `flask run`

- on browser look up for cases with `case_min_document_date` and `case_max_document_date` filters

1. http://localhost:5000/v1/legal/search/?type=murs&case_min_document_date=2024-10-07 :  2 results
2. http://localhost:5000/v1/legal/search/?type=murs&case_max_document_date=2024-10-07 : 3 results


Terminal#2: (Load and test  adminfines)

- run `python cli.py load_admin_fines 4698`
- run `python cli.py load_admin_fines 4691`
- run `python cli.py load_admin_fines 4675`

1. http://localhost:5000/v1/legal/search/?type=admin_fines&case_min_document_date=2024-09-09 : 2 results
2. http://localhost:5000/v1/legal/search/?type=admin_fines&case_max_document_date=2024-07-26 : 1 result


Terminal#2: (Load and test  adr's)

- run `python cli.py load_adrs 944`
- run `python cli.py load_adrs 721`
- run `python cli.py load_adrs 294`

http://localhost:5000/v1/legal/search/?type=adrs&case_max_document_date=2005-08-22: 1 result
http://localhost:5000/v1/legal/search/?type=adrs&case_min_document_date=2014-08-03 :  2 results

