### PR TITLE
6006/6019/5986--Move adr citations to dispositions, add filters

### DIFF
--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -127,13 +127,12 @@ class TestLoadCurrentCases(BaseTestCase):
             'respondents': [],
             'documents': [],
             'commission_votes': [],
-            'adr_dispositions': [],
+            'dispositions': [],
             'close_date': None,
             'open_date': None,
             'url': '/legal/alternative-dispute-resolution/1/',
             'complainant': [],
             'case_status': [],
-            'citations': [],
             'sort1': -1,
             'sort2': None,
         }
@@ -226,9 +225,9 @@ class TestLoadCurrentCases(BaseTestCase):
             'url': '/legal/administrative-fine/1/',
             'civil_penalty_due_date': None,
             'civil_penalty_payment_status': 'Paid In Full',
-            'af_dispositions': [
+            'dispositions': [
                 {
-                    'amount': Decimal('350'),
+                    'penalty': Decimal('350'),
                     'disposition_description': 'Challenged',
                     "disposition_date": date(2021, 6, 25)
                 }
@@ -238,7 +237,7 @@ class TestLoadCurrentCases(BaseTestCase):
         }
 
         expected_af_case_disposition = {
-            'amount': Decimal('350'),
+            'penalty': Decimal('350'),
             'disposition_description': 'Challenged',
             'disposition_date': date(2021, 6, 25),
         }
@@ -272,7 +271,7 @@ class TestLoadCurrentCases(BaseTestCase):
 
         self.create_af_case_disposition(
             case_id,
-            expected_af_case_disposition['amount'],
+            expected_af_case_disposition['penalty'],
             expected_af_case_disposition['disposition_description'],
             expected_af_case_disposition['disposition_date'],
         )

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -400,6 +400,8 @@ legal_universal_search = {
     'af_max_fd_date': Date(required=False, description=docs.AF_MAX_FD_DATE),
     'af_fd_fine_amount': fields.Int(required=False, description=docs.AF_FD_FINE_AMOUNT),
     'sort': IStr(required=False, description=docs.SORT),
+    'min_penalty_amount': fields.Str(required=False, description=docs.MIN_PENALTY_AMOUNT),
+    'max_penalty_amount': fields.Str(required=False, description=docs.MAX_PENALTY_AMOUNT),
 }
 
 citation = {

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -400,8 +400,8 @@ legal_universal_search = {
     'af_max_fd_date': Date(required=False, description=docs.AF_MAX_FD_DATE),
     'af_fd_fine_amount': fields.Int(required=False, description=docs.AF_FD_FINE_AMOUNT),
     'sort': IStr(required=False, description=docs.SORT),
-    'min_penalty_amount': fields.Str(required=False, description=docs.MIN_PENALTY_AMOUNT),
-    'max_penalty_amount': fields.Str(required=False, description=docs.MAX_PENALTY_AMOUNT),
+    'case_min_penalty_amount': fields.Str(required=False, description=docs.CASE_MIN_PENALTY_AMOUNT),
+    'case_max_penalty_amount': fields.Str(required=False, description=docs.CASE_MAX_PENALTY_AMOUNT),
 }
 
 citation = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2366,6 +2366,15 @@ Secondary Subject Description:\n\
     - 17 - Limits\n\
     - 18 - Prohibitions\n\
 '''
+
+MIN_PENALTY_AMOUNT = '''
+Show cases with a penalty greater than this amount
+'''
+
+MAX_PENALTY_AMOUNT = '''
+Show cases with a penalty less than this amount
+
+'''
 # ======== legal end =========
 
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2367,11 +2367,11 @@ Secondary Subject Description:\n\
     - 18 - Prohibitions\n\
 '''
 
-MIN_PENALTY_AMOUNT = '''
+CASE_MIN_PENALTY_AMOUNT = '''
 Show cases with a penalty greater than this amount
 '''
 
-MAX_PENALTY_AMOUNT = '''
+CASE_MAX_PENALTY_AMOUNT = '''
 Show cases with a penalty less than this amount
 
 '''

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -477,8 +477,7 @@ def get_single_case(case_type, case_no, bucket):
                 case["complainant"] = get_adr_complainant(case_id)
                 case["non_monetary_terms"] = get_adr_non_monetary_terms(case_id)
                 case["non_monetary_terms_respondents"] = get_adr_non_monetary_terms_respondents(case_id)
-                case["citations"] = get_adr_citations(case_id)
-                case["adr_dispositions"] = get_adr_dispositions(case_id)
+                case["dispositions"] = get_adr_dispositions(case_id)
                 case["case_status"] = get_adr_case_status(case_id)
 
             elif case_type == "MUR":
@@ -535,7 +534,7 @@ def get_af_specific_fields(case_id):
             case["petition_court_decision_date"] = row["petition_court_decision_date"]
             case["civil_penalty_due_date"] = row["civil_penalty_due_date"]
             case["civil_penalty_payment_status"] = row["civil_penalty_pymt_status_flg"]
-            case["af_dispositions"] = get_af_dispositions(case_id)
+            case["dispositions"] = get_af_dispositions(case_id)
     return case
 
 
@@ -545,7 +544,7 @@ def get_af_dispositions(case_id):
         disposition_data = []
         for row in rs:
             disposition_data.append({"disposition_description": row["description"],
-                                     "disposition_date": row["dates"], "amount": row["amount"]})
+                                     "disposition_date": row["dates"], "penalty": row["amount"]})
         return disposition_data
 
 
@@ -637,12 +636,13 @@ def clean_mur_citation_text(text, cit_type):
 def get_adr_dispositions(case_id):
     with db.engine.connect() as conn:
         rs = conn.execute(MUR_ADR_DISPOSITION_DATA.format(case_id))
-        adr_dispositions = []
+        dispositions = []
+        citations = []
+        citations = get_adr_citations(case_id)
         for row in rs:
-            adr_dispositions.append({"disposition": row["event_name"], "penalty": row["final_amount"],
-                                     "respondent": row["name"]})
-
-        return adr_dispositions
+            dispositions.append({"disposition": row["event_name"], "penalty": row["final_amount"],
+                                "respondent": row["name"], "citations": citations})
+        return dispositions
 
 
 def get_adr_case_status(case_id):

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -129,7 +129,8 @@ ADMIN_FINE_MAPPING = {
                 "format": "dateOptionalTime",
             },
             "penalty": {
-                "type": "integer",
+                "type": "scaled_float",
+                "scaling_factor": 100,
                 "index": False,
                 "null_value": -1
             },
@@ -190,7 +191,7 @@ MUR_MAPPING = {
                 }
             },
             "disposition": {"type": "text"},
-            "penalty": {"type": "integer", "null_value": -1},
+            "penalty": {"type": "scaled_float", "scaling_factor": 100, "null_value": -1},
             "respondent": {"type": "text"},
             "mur_disposition_catagory_id": {"type": "keyword"},
         }
@@ -250,7 +251,7 @@ ADR_MAPPING = {
                 }
             },
             "disposition": {"type": "text"},
-            "penalty": {"type": "integer", "null_value": -1},
+            "penalty": {"type": "scaled_float", "scaling_factor": 100, "null_value": -1},
             "respondent": {"type": "text"},
         }
     },

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -118,7 +118,7 @@ ADMIN_FINE_MAPPING = {
         "type": "date",
         "format": "dateOptionalTime",
     },
-    "af_dispositions": {
+    "dispositions": {
         "properties": {
             "disposition_description": {
                 "type": "text",
@@ -128,9 +128,10 @@ ADMIN_FINE_MAPPING = {
                 "type": "date",
                 "format": "dateOptionalTime",
             },
-            "amount": {
-                "type": "long",
+            "penalty": {
+                "type": "integer",
                 "index": False,
+                "null_value": -1
             },
         }
     },
@@ -189,7 +190,7 @@ MUR_MAPPING = {
                 }
             },
             "disposition": {"type": "text"},
-            "penalty": {"type": "double"},
+            "penalty": {"type": "integer", "null_value": -1},
             "respondent": {"type": "text"},
             "mur_disposition_catagory_id": {"type": "keyword"},
         }
@@ -236,11 +237,20 @@ ADR_MAPPING = {
     },
     "respondents": {"type": "text"},
     "case_status": {"type": "text"},
-    "adr_dispositions": {
+    "dispositions": {
         "type": "nested",
         "properties": {
+            "citations": {
+                "type": "nested",
+                "properties": {
+                    "text": {"type": "text"},
+                    "title": {"type": "text"},
+                    "type": {"type": "text"},
+                    "url": {"type": "text"},
+                }
+            },
             "disposition": {"type": "text"},
-            "penalty": {"type": "double"},
+            "penalty": {"type": "integer", "null_value": -1},
             "respondent": {"type": "text"},
         }
     },
@@ -403,7 +413,7 @@ ARCH_MUR_MAPPING = {
         "close_date": {"type": "date", "format": "dateOptionalTime"},
         "url": {"type": "text", "index": False},
         "complainants": {"type": "text"},
-        "respondent": {"type": "text"},
+        "respondents": {"type": "text"},
         "documents": ARCH_MUR_DOCUMENT_MAPPING,
         "citations": ARCH_MUR_CITATION_MAPPING,
         "subject": ARCH_MUR_SUBJECT_MAPPING,

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -223,6 +223,24 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if kwargs.get("case_respondents"):
         must_clauses.append(Q("simple_query_string",
                             query=kwargs.get("case_respondents"), fields=["respondents"]))
+
+    if kwargs.get("case_regulatory_citation") or kwargs.get("case_statutory_citation"):
+        return case_apply_citation_params(
+            query,
+            kwargs.get("case_regulatory_citation"),
+            kwargs.get("case_statutory_citation"),
+            kwargs.get("case_citation_require_all"), **kwargs)
+
+    penalty_range = {}
+    if kwargs.get("min_penalty_amount") and kwargs.get("min_penalty_amount") != '':
+        penalty_range["gte"] = kwargs.get("min_penalty_amount")
+
+    if kwargs.get("max_penalty_amount") and kwargs.get("max_penalty_amount") != '':
+        penalty_range["lte"] = kwargs.get("max_penalty_amount")
+
+    if penalty_range:
+        must_clauses.append(Q("nested", path="dispositions",
+                            query=Q("range", dispositions__penalty=penalty_range)))
     query = query.query("bool", must=must_clauses)
 
     # logger.debug("case_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
@@ -375,15 +393,7 @@ def apply_mur_specific_query_params(query, **kwargs):
 
     query = query.query("bool", must=must_clauses)
     # logger.debug("apply_mur_adr_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
-
-    if kwargs.get("case_regulatory_citation") or kwargs.get("case_statutory_citation"):
-        return case_apply_citation_params(
-            query,
-            kwargs.get("case_regulatory_citation"),
-            kwargs.get("case_statutory_citation"),
-            kwargs.get("case_citation_require_all"), **kwargs)
-    else:
-        return query
+    return query
 
 
 def case_apply_citation_params(query, regulatory_citation, statutory_citation, citation_require_all, **kwargs):

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -232,11 +232,11 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
             kwargs.get("case_citation_require_all"), **kwargs)
 
     penalty_range = {}
-    if kwargs.get("min_penalty_amount") and kwargs.get("min_penalty_amount") != '':
-        penalty_range["gte"] = kwargs.get("min_penalty_amount")
+    if kwargs.get("case_min_penalty_amount") and kwargs.get("case_min_penalty_amount") != '':
+        penalty_range["gte"] = kwargs.get("case_min_penalty_amount")
 
-    if kwargs.get("max_penalty_amount") and kwargs.get("max_penalty_amount") != '':
-        penalty_range["lte"] = kwargs.get("max_penalty_amount")
+    if kwargs.get("case_max_penalty_amount") and kwargs.get("case_max_penalty_amount") != '':
+        penalty_range["lte"] = kwargs.get("case_max_penalty_amount")
 
     if penalty_range:
         must_clauses.append(Q("nested", path="dispositions",


### PR DESCRIPTION
## Summary (required)

- Resolves #6006, #6019, #5986

- Renames adr_dispositions and af_dispositions to dispositions,  
- moves adr citations to dispositions 
- changes arch mur respondents from respondent to respondents to fix case_respondents filter
- adds min/max penalty filters 

This needs to be merged with CMS changes [here](https://github.com/fecgov/fec-cms/pull/6529)

Switched data type to [scaled-float](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html) as the most efficient way to deal with a few penalties with cents
`For floating-point types, it is often more efficient to store floating-point data into an integer using a scaling factor, which is what the scaled_float type does under the hood. For instance, a price field could be stored in a scaled_float with a scaling_factor of 100. All APIs would work as if the field was stored as a double, but under the hood Elasticsearch would be working with the number of cents, price*100, which is an integer. This is mostly helpful to save disk space since integers are way easier to compress than floating points. scaled_float is also fine to use in order to trade accuracy for disk space. For instance imagine that you are tracking cpu utilization as a number between 0 and 1. It usually does not matter much whether cpu utilization is 12.7% or 13%, so you could use a scaled_float with a scaling_factor of 100 in order to round cpu utilization to the closest percent in order to save space. `
### Required reviewers

2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-legal search



## How to test

-  follow the [wiki](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally#1-install-elasticsearch-7x0-locally-both-740-and-760-work-well) to start elasticsearch service on local 

- delete and create indexes from scratch:

case_index:
- python cli.py delete_index case_index
- python cli.py create_index case_index
- python cli.py delete_index arch_mur_index
- python cli.py create_index arch_mur_index

Reload some of the current murs, admin fines,  and adrs (stop after a minute or so)
- python cli.py load_current_murs
- python cli.py load_adrs
- python cli.py load_admin_fines
- python cli.py load_archived_murs

Testing case_respondents filter change (adrs and all murs) :
- http://127.0.0.1:5000/v1/legal/search/?case_respondents=Demaree
- http://127.0.0.1:5000/v1/legal/search/?case_no=4777&case_respondents=Hagan
- http://127.0.0.1:5000/v1/legal/search/?case_respondents=Hagan&mur_type=archived
- https://api.open.fec.gov/v1/legal/search/?api_key=DEMO_KEY&case_respondents=Hagan&mur_type=archived

Testing new penalty filters (admin fines, adrs, and current murs)
- http://127.0.0.1:5000/v1/legal/search/?case_min_penalty_amount=13489
- http://127.0.0.1:5000/v1/legal/search/?case_max_penalty_amount=-1   (null values)
- http://127.0.0.1:5000/v1/legal/search/?case_max_penalty_amount=33000

Testing citation filters (adrs and current murs)
- http://127.0.0.1:5000/v1/legal/search/?case_regulatory_citation=11%20CFR%20109.10
- http://127.0.0.1:5000/v1/legal/search/?case_regulatory_citation=11%20CFR%20114.2
- http://127.0.0.1:5000/v1/legal/search/?case_statutory_citation=52%20U.S.C.%2030104
- http://127.0.0.1:5000/v1/legal/search/?case_statutory_citation=52%20U.S.C.%2030120&case_regulatory_citation=11%20CFR%20114.2

Test the front-end (push to dev)
https://dev.fec.gov/data/legal/administrative-fine/4698/
https://dev.fec.gov/data/legal/alternative-dispute-resolution/1168/
https://dev.fec.gov/data/legal/matter-under-review/2534/
https://fec-dev-api.app.cloud.gov/v1/legal/search/?api_key=DEMO_KEY&case_respondents=C.O.R.K.


Test decimal penalties:
- python cli.py load_adrs 741
- http://127.0.0.1:5000/v1/legal/search/?case_min_penalty_amount=2853.64&case_max_penalty_amount=2853.64
- http://127.0.0.1:5000/v1/legal/search/?case_min_penalty_amount=2853.64



