### PR TITLE
Feature/6009 add case tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: cfdm_unit_test
 
+      # elasticsearch
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+        environment:
+          cluster.name: elasticsearch
+          xpack.security.enabled: false
+          transport.host: localhost
+          network.host: 127.0.0.1
+          http.port: 9200
+          discovery.type: single-node
+
     steps:
       - checkout
 
@@ -77,6 +87,10 @@ jobs:
       - run:
           name: Ensure database is available
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      - run:
+          name: Wait for Elasticsearch
+          command: dockerize -wait http://localhost:9200 -timeout 1m
 
       - run:
           name: Run tests

--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ export SQLA_TEST_CONN=<psql:address-to-box>
 
 The connection URL has to strictly adhere to the structure `postgresql://<username>:<password>@<hostname>:<port>/<database_name>`. Note that the database_name should be specified explicitly, unlike URLs for SQLAlchemy connections.
 
+Start the elasticsearch server locally:
+
+```
+./elasticsearch
+```
+
 Running the tests:
 
 ```

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,9 +11,15 @@ from jdbc_utils import to_jdbc_url
 from webservices import rest
 from webservices import __API_VERSION__
 
+from webservices.legal_docs import (create_index, CASE_INDEX, ARCH_MUR_INDEX, AO_INDEX,
+                                    CASE_ALIAS, ARCH_MUR_ALIAS, AO_ALIAS)
+from webservices.utils import create_es_client
+from tests.test_legal_data import document_dictionary
+
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
 rest.app.config['NPLUSONE_RAISE'] = True
 NPlusOne(rest.app)
+ALL_INDICES = [CASE_INDEX, AO_INDEX, ARCH_MUR_INDEX]
 
 
 def _setup_extensions():
@@ -108,6 +114,85 @@ class ApiBaseTest(BaseTestCase):
     def _results(self, qry):
         response = self._response(qry)
         return response['results']
+
+
+class ElasticSearchBaseTest(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ElasticSearchBaseTest, cls).setUpClass()
+        cls.es_client = create_es_client()
+        # ensure environment is completely clean before starting
+        _delete_all_indices(cls.es_client)
+        _create_all_indices()
+        _insert_all_documents(cls.es_client)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(ElasticSearchBaseTest, cls).tearDownClass()
+        _delete_all_indices(cls.es_client)
+
+    def setUp(self):
+        self.request_context = rest.app.test_request_context()
+        self.request_context.push()
+
+    def tearDown(self):
+        self.request_context.pop()
+
+    def _response(self, qry):
+        response = self.app.get(qry)
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(codecs.decode(response.data))
+        self.assertNotEqual(result["total_all"], 0)
+        return result
+
+    def _results_case(self, qry):
+        response = self._response(qry)
+        assert response["total_murs"] != 0 or response["total_adrs"] != 0 or response["total_admin_fines"] != 0
+        return response
+
+    def _results_adr_mur(self, qry):
+        response = self._response(qry)
+        assert response["total_murs"] != 0 or response["total_adrs"] != 0
+        return response
+
+    def _results_mur(self, qry):
+        response = self._response(qry)
+        self.assertNotEqual(response["total_murs"], 0)
+        return response
+
+    def _results_af(self, qry):
+        response = self._response(qry)
+        self.assertNotEqual(response["total_admin_fines"], 0)
+        return response
+
+
+def _create_all_indices():
+    for index in ALL_INDICES:
+        create_index(index)
+
+
+def _delete_all_indices(es_client):
+    es_client.indices.delete("*")
+
+
+def wait_for_refresh(es_client, index_name):
+    es_client.indices.refresh(index=index_name)
+
+
+def _insert_all_documents(es_client):
+    insert_documents("murs", CASE_ALIAS, es_client)
+    insert_documents("archived_murs", ARCH_MUR_ALIAS, es_client)
+    insert_documents("adrs", CASE_ALIAS, es_client)
+    insert_documents("admin_fines", CASE_ALIAS, es_client)
+    insert_documents("statutes", AO_ALIAS, es_client)
+    insert_documents("advisory_opinions", AO_ALIAS, es_client)
+
+
+def insert_documents(doc_type, index, es_client):
+    for doc in document_dictionary[doc_type]:
+        es_client.index(index=index, body=doc)
+
+    wait_for_refresh(es_client, index)
 
 
 def assert_dicts_subset(first, second):

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -1,0 +1,556 @@
+from datetime import datetime
+from webservices.resources.legal import ALL_DOCUMENT_TYPES
+from tests.common import ElasticSearchBaseTest, ALL_INDICES, document_dictionary
+from webservices.rest import api
+from webservices.resources.legal import UniversalSearch
+# import logging
+
+
+class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
+    wrong_date_format = "01/20/24"
+
+    def check_filters(self, params, field_name, doc_type):
+        response = self._results_case(api.url_for(UniversalSearch, **params))
+        # logging.info(list(params.values())[0])
+        # logging.info(response[doc_type])
+        self.assertNotEqual(response["total_" + doc_type], 0)
+        assert all(x[field_name] == list(params.values())[0] for x in response[doc_type])
+
+    def check_incorrect_values(self, params, doc_type, raiseError):
+        response = self.app.get(api.url_for(UniversalSearch, **params))
+        # logging.info(response.json)
+
+        if raiseError:
+            assert response.status_code == 422
+        else:
+            assert response.status_code == 200
+            assert response.json[doc_type] == 0
+
+    def check_sort_asc(self, doc_dict):
+        for i in range(len(doc_dict) - 1):
+            assert doc_dict[i]["case_serial"] <= doc_dict[i + 1]["case_serial"]
+
+    def check_sort_desc(self, doc_dict):
+        for i in range(len(doc_dict) - 1):
+            assert doc_dict[i]["case_serial"] >= doc_dict[i + 1]["case_serial"]
+# ---------------------- Start tests  ------------------------------------------------
+
+    def test_index_creation(self):
+        for index in ALL_INDICES:
+            exists = self.es_client.indices.get(index)
+            assert exists, f"Error creating {index}"
+
+# ---------------------- Start all case filters  ------------------------------------------------
+    def test_all_doc_types(self):
+        response = self._results_case(api.url_for(UniversalSearch))
+        # logging.info(response)
+
+        total_all = 0
+        total_all += sum(len(document_dictionary[doc_type]) for doc_type in document_dictionary)
+
+        all_murs = len(document_dictionary["archived_murs"]) + len(document_dictionary["murs"])
+
+        self.assertEqual(response["total_all"], total_all)
+        self.assertEqual(response["total_murs"], all_murs)
+        self.assertEqual(response["total_adrs"], len(document_dictionary["adrs"]))
+        self.assertEqual(response["total_admin_fines"], len(document_dictionary["admin_fines"]))
+
+    def test_type_filter(self):
+        for type in ALL_DOCUMENT_TYPES:
+            response = self._response(api.url_for(UniversalSearch, type=type))
+            # logging.info(response)
+
+            if type == "murs":
+                total = len(document_dictionary["archived_murs"]) + len(document_dictionary["murs"])
+            elif document_dictionary[type]:
+                total = len(document_dictionary[type])
+            else:
+                total = 0
+
+            self.assertEqual(response["total_all"], total)
+            self.assertEqual(response["total_" + type], total)
+
+        self.check_incorrect_values({"type": "Wrong Type"}, None, True)
+
+    def test_case_no(self):
+        # archived and current murs, adrs, and afs
+        case_numbers = ["108", "101", "104", "106"]
+
+        response = self._results_case(api.url_for(UniversalSearch, case_no=case_numbers))
+        # logging.info(response)
+
+        assert all(
+            mur["no"] in case_numbers
+            for mur in response["murs"]
+        ) and all(
+            af["no"] in case_numbers
+            for af in response["admin_fines"]
+        ) and all(
+            adr["no"] in case_numbers
+            for adr in response["adrs"]
+        )
+
+        response = self._results_case(api.url_for(UniversalSearch, case_no="105"))
+        # logging.info(response)
+
+        self.assertEqual(response["adrs"][0]["no"], document_dictionary["adrs"][0]["no"])
+
+    def test_penalty_filter(self):
+        # for current murs, adrs, and afs
+        penalty = -1
+
+        response = self._results_case(api.url_for(UniversalSearch, case_max_penalty_amount=penalty))
+        # logging.info(response)
+
+        assert all(
+            any(doc["penalty"] is None
+                for doc in mur["dispositions"])
+            for mur in response["murs"]
+        ) and all(
+            any(doc["penalty"] is None
+                for doc in adr["dispositions"])
+            for adr in response["adrs"]
+        ) and all(
+            any(doc["penalty"] is None
+                for doc in af["dispositions"])
+            for af in response["admin_fines"])
+
+        min_penalty = 1250.50
+        max_penalty = 5500
+
+        response = self._results_case(api.url_for(UniversalSearch,
+                                                  case_min_penalty_amount=min_penalty,
+                                                  case_max_penalty_amount=max_penalty))
+        # logging.info(response)
+
+        assert all(
+            any(doc["penalty"] >= min_penalty and doc["penalty"] <= max_penalty
+                for doc in mur["dispositions"])
+            for mur in response["murs"]
+        ) and all(
+            any(doc["penalty"] >= min_penalty and doc["penalty"] <= max_penalty
+                for doc in adr["dispositions"])
+            for adr in response["adrs"]
+        ) and all(
+            any(doc["penalty"] >= min_penalty and doc["penalty"] <= max_penalty
+                for doc in af["dispositions"])
+            for af in response["admin_fines"])
+
+        params = {
+            "case_min_penalty_amount": 999999
+        }
+
+        self.check_incorrect_values(params, "total_murs", False)
+        self.check_incorrect_values(params, "total_admin_fines", False)
+        self.check_incorrect_values(params, "total_adrs", False)
+
+    def test_case_doc_cat_id_filter(self):
+        # for archived and current murs, adrs, and afs
+        case_doc_category_ids = [2, 1, 2001]
+        response = self._results_case(api.url_for(UniversalSearch, case_doc_category_id=case_doc_category_ids))
+        # logging.info(response)
+
+        assert all(
+            any(doc["doc_order_id"] in case_doc_category_ids
+                for doc in mur["documents"])
+            for mur in response["murs"]
+        ) and all(
+            any(doc["doc_order_id"] in case_doc_category_ids
+                for doc in adr["documents"])
+            for adr in response["adrs"]
+        ) and all(
+            any(doc["doc_order_id"] in case_doc_category_ids
+                for doc in af["documents"])
+            for af in response["admin_fines"])
+
+        self.check_incorrect_values({"case_doc_category_id": 5555}, None, True)
+
+    def test_case_doc_date(self):
+        # for current murs, adrs, and afs
+        document_date = "2022-12-01"
+        query_date = datetime.strptime(document_date, "%Y-%m-%d")
+
+        response = self._results_case(api.url_for(UniversalSearch, case_min_document_date=document_date))
+        # logging.info(response)
+
+        assert all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+                for doc in mur["documents"])
+            for mur in response["murs"]
+        ) and all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+                for doc in adr["documents"])
+            for adr in response["adrs"]
+        ) and all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+                for doc in af["documents"])
+            for af in response["admin_fines"]
+        )
+
+        response = self._results_case(api.url_for(UniversalSearch, case_max_document_date=document_date))
+        # logging.info(response)
+
+        assert all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+                for doc in mur["documents"])
+            for mur in response["murs"]
+        ) and all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+                for doc in adr["documents"])
+            for adr in response["adrs"]
+        ) and all(any(
+                datetime.strptime(doc["document_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+                for doc in af["documents"])
+            for af in response["admin_fines"]
+        )
+
+        filters = ["case_min_document_date", "case_max_document_date",]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, None, True)
+
+    def test_q_filters(self):
+        # for archived and current murs, advisory_opinions, adrs, and afs
+
+        search_phrase = "sample"
+        response = self._results_case(api.url_for(UniversalSearch, q=search_phrase))
+        # logging.info(response)
+
+        self.assertEqual(response["total_all"], 8)
+        assert all(
+            all(search_phrase in highlight
+                for highlight in mur["highlights"])
+            for mur in response["murs"]
+        ) and all(
+            all(search_phrase in highlight
+                for highlight in adr["highlights"])
+            for adr in response["adrs"]
+        ) and all(
+            all(search_phrase in highlight
+                for highlight in af["highlights"])
+            for af in response["admin_fines"]
+        ) and all(
+            all(search_phrase in highlight
+                for highlight in ao["highlights"])
+            for ao in response["advisory_opinions"])
+
+        exclude_phrase = "admin_fine"
+        response = self._results_case(api.url_for(UniversalSearch, q_exclude=exclude_phrase))
+        # logging.info(response)
+
+        self.assertEqual(response["total_admin_fines"], 0)
+        self.assertEqual(response["total_all"], 8)
+
+    def test_sort(self):
+        sort_value = "case_no"
+        ignore_type = ["advisory_opinions", "statutes"]
+        response = self._results_case(api.url_for(UniversalSearch, sort=sort_value))
+        # logging.info(response)
+
+        for doc_type in ALL_DOCUMENT_TYPES:
+            if doc_type not in ignore_type:
+                self.check_sort_asc(response[doc_type])
+
+        response = self._results_case(api.url_for(UniversalSearch, sort="-" + sort_value))
+        # logging.info(response)
+
+        for doc_type in ALL_DOCUMENT_TYPES:
+            if doc_type not in ignore_type:
+                self.check_sort_desc(response[doc_type])
+
+# ---------------------- End all case filters  ------------------------------------------------
+# ---------------------- Start MUR and ADR filters ------------------------------------------------
+    def test_election_cycles_filter(self):
+        # for current murs and adrs
+        election_cycle = 2020
+        response = self._results_adr_mur(api.url_for(UniversalSearch, case_election_cycles=election_cycle))
+        # logging.info(response)
+
+        assert all(
+            election_cycle in mur["election_cycles"] and mur["mur_type"] == "current"
+            for mur in response["murs"]
+        ) and all(
+            election_cycle in adr["election_cycles"]
+            for adr in response["adrs"]
+        )
+
+        self.check_incorrect_values({"case_election_cycles": "abc"}, None, True)
+
+    def test_case_date_filters(self):
+        # for archived murs, current murs, and adrs
+        open_date = "2020-10-01"
+        query_date = datetime.strptime(open_date, "%Y-%m-%d")
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, case_min_open_date=open_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(mur["open_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for mur in response["murs"]
+        ) and all(
+            datetime.strptime(adr["open_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for adr in response["adrs"]
+        )
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, case_max_open_date=open_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(mur["open_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for mur in response["murs"]
+        ) and all(
+            datetime.strptime(adr["open_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for adr in response["adrs"]
+        )
+
+        close_date = "2022-11-29"
+        query_date = datetime.strptime(close_date, "%Y-%m-%d")
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, case_min_close_date=close_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(mur["close_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for mur in response["murs"]
+        ) and all(
+            datetime.strptime(adr["close_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for adr in response["adrs"]
+        )
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, case_max_close_date=close_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(mur["close_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for mur in response["murs"]
+        ) and all(
+            datetime.strptime(adr["close_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for adr in response["adrs"]
+        )
+
+        filters = ["case_min_close_date", "case_max_close_date", "case_min_open_date", "case_max_open_date"]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, None, True)
+
+    def test_subject_id(self):
+        # for current murs and adrs
+        primary = ["3", "16", "19"]
+        secondary = ["13", "15"]
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, primary_subject_id=primary))
+        # logging.info(response)
+
+        assert all(
+            mur["mur_type"] == "current" and any(
+                subject["primary_subject_id"] in primary
+                for subject in mur["subjects"]
+            )
+            for mur in response["murs"]
+        ) and (any(
+            subject["primary_subject_id"] in primary
+            for subject in adr["subjects"]
+        )
+            for adr in response["adrs"]
+        )
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch, secondary_subject_id=secondary))
+        # logging.info(response)
+
+        assert all(
+            mur["mur_type"] == "current" and any(
+                subject["secondary_subject_id"] in secondary
+                for subject in mur["subjects"]
+            )
+            for mur in response["murs"]
+        ) and all(any(
+            subject["secondary_subject_id"] in secondary
+            for subject in adr["subjects"]
+        )
+            for adr in response["adrs"]
+        )
+
+        filters = ["primary_subject_id", "secondary_subject_id"]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: "555"}, None, True)
+
+    def test_case_respondents(self):
+        #  archived and current murs, and adrs
+        respondents = ["John", "Jayme", "Naolitano"]
+
+        for respondent in respondents:
+            response = self._results_adr_mur(api.url_for(UniversalSearch, case_respondents=respondent))
+            # logging.info(response)
+            assert all(any(respondent in rsp
+                           for rsp in mur["respondents"])
+                       for mur in response["murs"]
+                       ) and all(any(respondent in rsp
+                                     for rsp in adr["respondents"]
+                                     ) for adr in response["adrs"])
+
+        self.check_incorrect_values({"case_respondents": "Bad value"}, "total_murs", False)
+        self.check_incorrect_values({"case_respondents": "Bad value"}, "total_adrs", False)
+
+    def test_citation_filters(self):
+        # filter for current murs and adrs
+        statutory_title = "52"
+        statutory_text = "30116"
+        regulatory_title = "11"
+        regulatory_text = "104.3"
+        stat_citation = "{} U.S.C. §{}".format(statutory_title, statutory_text)
+        reg_citation = "{} CFR §{}".format(regulatory_title, regulatory_text)
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch,
+                                                     case_statutory_citation=stat_citation,
+                                                     case_regulatory_citation=reg_citation))
+        # logging.info(response)
+
+        for source in [response["murs"], response["adrs"]]:
+            for item in source:
+                found = any(
+                    (citations["title"] == statutory_title and statutory_text in citations["text"]) or
+                    (citations["title"] == regulatory_title and regulatory_text in citations["text"])
+                    for dispositions in item["dispositions"]
+                    for citations in dispositions["citations"]
+                )
+                assert found
+
+        response = self._results_adr_mur(api.url_for(UniversalSearch,
+                                                     case_statutory_citation=stat_citation,
+                                                     case_regulatory_citation=reg_citation,
+                                                     case_citation_require_all="true"))
+        # logging.info(response)
+
+        for source in [response["murs"], response["adrs"]]:
+            for item in source:
+
+                statutory_found = any(
+                    citations["title"] == statutory_title and statutory_text in citations["text"]
+                    for dispositions in item["dispositions"]
+                    for citations in dispositions["citations"]
+                )
+
+                regulatory_found = any(
+                    citations["title"] == regulatory_title and regulatory_text in citations["text"]
+                    for dispositions in item["dispositions"]
+                    for citations in dispositions["citations"]
+                )
+
+                assert statutory_found and regulatory_found
+
+        filters = [
+            ["case_statutory_citation", "524 U.S.C. §30106444"],
+            ["case_regulatory_citation", "1111 CFR §112.4111"]
+        ]
+        for filter in filters:
+            self.check_incorrect_values({filter[0]: filter[1]}, "total_murs", False)
+            self.check_incorrect_values({filter[0]: filter[1]}, "total_adrs", False)
+
+# ---------------------- End MUR and ADR filters ------------------------------------------------
+# ---------------------- Start MUR  filters ------------------------------------------------
+    def test_mur_type_filter(self):
+        filters = [
+            [{"mur_type": "current"}, "mur_type", True],
+            [{"mur_type": "archived"}, "mur_type", True]
+        ]
+
+        for filter in filters:
+            self.check_filters(filter[0], filter[1], "murs")
+            self.check_incorrect_values({"mur_type": "wrongType"}, "total_murs", filter[2])
+
+    def test_mur_disposition_filter(self):
+        # filter for current murs
+        categories = ["7", "24"]
+        response = self._results_mur(api.url_for(UniversalSearch, mur_disposition_category_id=categories))
+        # logging.info(response)
+
+        assert all(
+            mur["mur_type"] == "current" and any(
+                dispositions["mur_disposition_category_id"] in categories
+                for dispositions in mur["dispositions"]
+            )
+            for mur in response["murs"]
+        )
+
+        category = "14"
+        response = self._results_mur(api.url_for(UniversalSearch, mur_disposition_category_id=category))
+        # logging.info(response)
+
+        assert all(
+            mur["mur_type"] == "current" and any(
+                category == dispositions["mur_disposition_category_id"]
+                for dispositions in mur["dispositions"]
+            )
+            for mur in response["murs"]
+        )
+        self.check_incorrect_values({"mur_disposition_category_id": "49"}, "total_murs", True)
+
+# ---------------------- End MUR  filters ------------------------------------------------
+# ---------------------- Start AF  filters ------------------------------------------------
+    def test_af_name_multiple_filter(self):
+        names_list = ["ICE PAC", "SOCIAL PROGRESS IN UNION WITH ECONOMIC GROWTH"]
+        response = self._results_af(api.url_for(UniversalSearch, af_name=names_list))
+        # logging.info(response)
+
+        assert all(
+            af["name"] in names_list
+            for af in response["admin_fines"]
+        )
+
+    def test_af_filters(self):
+        filters = [
+            [{"af_name": "ICE PAC"}, "name", False],
+            [{"af_committee_id": "C00833665"}, "committee_id", True],
+            [{"af_report_year": "2014"}, "report_year", False],
+            [{"af_rtb_fine_amount": 3300}, "reason_to_believe_fine_amount", True],
+            [{"af_fd_fine_amount": 3300}, "final_determination_amount", True]
+        ]
+
+        for filter in filters:
+            self.check_filters(filter[0], filter[1], "admin_fines")
+            self.check_incorrect_values({list(filter[0].keys())[0]: "Incorrect"}, "total_admin_fines", filter[2])
+
+    def test_af_date_filters(self):
+        rtb = "2017-10-01"
+        query_date = datetime.strptime(rtb, "%Y-%m-%d")
+
+        response = self._results_af(api.url_for(UniversalSearch, af_min_rtb_date=rtb))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(af["reason_to_believe_action_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for af in response["admin_fines"]
+        )
+
+        response = self._results_af(api.url_for(UniversalSearch, af_max_rtb_date=rtb))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(af["reason_to_believe_action_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for af in response["admin_fines"]
+        )
+
+        fd_date = "2024-08-13"
+        query_date = datetime.strptime(fd_date, "%Y-%m-%d")
+
+        response = self._results_af(api.url_for(UniversalSearch, af_min_fd_date=fd_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(af["final_determination_date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+            for af in response["admin_fines"]
+        )
+
+        response = self._results_af(api.url_for(UniversalSearch, af_max_fd_date=fd_date))
+        # logging.info(response)
+
+        assert all(
+            datetime.strptime(af["final_determination_date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+            for af in response["admin_fines"]
+        )
+        filters = ["af_min_rtb_date", "af_max_rtb_date", "af_min_fd_date", "af_max_fd_date"]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, None, True)
+# ---------------------- End AF filters ------------------------------------------------

--- a/tests/test_legal_data.py
+++ b/tests/test_legal_data.py
@@ -1,0 +1,1753 @@
+first_test_mur = {
+      "case_serial": 100,
+      "close_date": "2024-10-07T00:00:00",
+      "commission_votes": [
+          {
+              "action": """The Commission decided by a vote of 6-0 to take the following actions in MUR 100:1.
+              Accept the signed Conciliation Agreement, as recommended in the Memorandum to the Commission dated
+              August 26, 2024.2.  Approve the appropriate letter.3.  Close the file effective 30 days from the
+              date the certification of this vote is signed (or on the next business day after the 30th day,
+              if the 30th day falls on a weekend or holiday).",
+              "vote_date": "2024-09-04T00:00:00"""
+          },
+          {
+              "action": """The Commission decided by a vote of 5-0 to:a. Open a Matter Under Review.b. Find reason
+              to believe that Democratic Executive Committee of Florida and Fran Garcia in her official capacity
+              as treasurer violated 52 U.S.C. § 30104(b)(2), (4) and 11 C.F.R. § 104.3(a), (b) by failing to
+              timely and accurately disclose receipts and disbursements.c. Find reason to believe that Democratic
+              Executive Committee of Florida and Fran Garcia in her official capacity as treasurer violated
+              52 U.S.C. § 30116(f) and 11 C.F.R. § 110.9 by knowingly accepting excessive contributions.d.
+              Approve the Factual and Legal Analysis, as recommended in the First General Counsel’s Report dated
+              April 17, 2024.e. Authorize conciliation prior to a finding of probable cause to believe.f. Approve
+              the Conciliation Agreement, as recommended in the First General Counsel’s Report dated April 17,
+              2024, ...REDACTED...g. Approve the appropriate letter.""",
+              "vote_date": "2024-05-14T00:00:00"
+          },
+          {
+              "action": """The Commission failed by a vote of 2-3 to:a. Open a Matter Under Review.b. Find reason
+              to believe that Democratic Executive Committee of Florida and Fran Garcia in her official capacity
+              as treasurer violated 52 U.S.C. § 30104(b)(2), (4) and 11 C.F.R. § 104.3(a), (b) by failing to
+              timely and accurately disclose receipts and disbursements.c. Find reason to believe that Democratic
+              Executive Committee of Florida and Fran Garcia in her official capacity as treasurer violated 52
+              U.S.C. § 30116(f) and 11 C.F.R. § 110.9 by knowingly accepting excessive contributions.d. Approve
+              the Factual and Legal Analysis, as recommended in the First General Counsel’s Report dated April 17,
+              2024.e. Authorize conciliation prior to a finding of probable cause to believe.f. Approve the
+              Conciliation Agreement, as recommended in the First General Counsel’s Report dated April 17, 2024.g.
+              Approve the appropriate letter.""",
+              "vote_date": "2024-05-14T00:00:00"
+          }
+      ],
+      "dispositions": [
+          {
+              "citations": [
+                  {
+                          "text": "30104(b)(2), (4)",
+                          "title": "52",
+                          "type": "statute",
+                          "url": "https://www.govinfo.gov/link/uscode/52/30104"
+                  },
+                  {
+                          "text": "30116(f)",
+                          "title": "52",
+                          "type": "statute",
+                          "url": "https://www.govinfo.gov/link/uscode/52/30116"
+                  },
+                  {
+                          "text": "104.3(a), (b)",
+                          "title": "11",
+                          "type": "regulation",
+                          "url": "/regulations/104-3/CURRENT"
+                  },
+                  {
+                          "text": "110.9",
+                          "title": "11",
+                          "type": "regulation",
+                          "url": "/regulations/110-9/CURRENT"
+                  }
+              ],
+              "disposition": "Conciliation-PPC",
+              "mur_disposition_category_id": "7",
+              "penalty": 70000,
+              "respondent": "Democratic Executive Committee of Florida"
+          },
+          {
+              "citations": [
+                  {
+                          "text": "30104(b)(2), (4)",
+                          "title": "52",
+                          "type": "statute",
+                          "url": "https://www.govinfo.gov/link/uscode/52/30104"
+                  },
+                  {
+                          "text": "30116(f)",
+                          "title": "52",
+                          "type": "statute",
+                          "url": "https://www.govinfo.gov/link/uscode/52/30116"
+                  },
+                  {
+                          "text": "104.3(a), (b)",
+                          "title": "11",
+                          "type": "regulation",
+                          "url": "/regulations/104-3/CURRENT"
+                  },
+                  {
+                          "text": "110.9",
+                          "title": "11",
+                          "type": "regulation",
+                          "url": "/regulations/110-9/CURRENT"
+                  }
+              ],
+              "disposition": "Conciliation-PPC",
+              "mur_disposition_category_id": "7",
+              "penalty": 70000,
+              "respondent": "Garcia, Fran"
+              }
+      ],
+      "doc_id": "mur_100",
+      "documents": [
+          {
+              "category": "Conciliation and Settlement Agreements",
+              "description": "Democratic Executive Committee of Florida",
+              "doc_order_id": 1,
+              "document_date": "2024-10-07T00:00:00",
+              "document_id": 100512624,
+              "length": 1679517,
+              "url": "/files/legal/murs/100/100_11.pdf",
+              "text": "This is sample text for document one"
+          },
+          {
+              "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+              "description": """Response from Democratic Executive Committee of Florida Party and Fran Garcia in
+              her official capacity as treasurer""",
+              "doc_order_id": 2,
+              "document_date": "2023-12-08T00:00:00",
+              "document_id": 100512623,
+              "length": 740526,
+              "url": "/files/legal/murs/100/100_05.pdf",
+              "text": "This is sample text for document two"
+          },
+          {
+              "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+              "description": """Grant of Extension of Time to Democratic Executive Committee of Florida and Fran
+              Garcia in her official capacity as treasurer""",
+              "doc_order_id": 2,
+              "document_date": "2023-11-09T00:00:00",
+              "document_id": 100512622,
+              "length": 808056,
+              "url": "/files/legal/murs/100/100_04.pdf",
+              "text": "This is sample text for document three"
+          },
+          {
+              "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+              "description": "Request for Extension of Time from Democratic Executive Committee of Florida",
+              "doc_order_id": 2,
+              "document_date": "2023-11-08T00:00:00",
+              "document_id": 100512621,
+              "length": 683122,
+              "url": "/files/legal/murs/100/100_03.pdf",
+              "text": "This is sample text for document four"
+          },
+          {
+              "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+              "description": """Notification to Democratic Executive Committee of Florida and Fran Garcia in her
+              official capacity as treasurer""",
+              "doc_order_id": 2,
+              "document_date": "2023-10-24T00:00:00",
+              "document_id": 100512620,
+              "length": 804482,
+              "url": "/files/legal/murs/100/100_02.pdf",
+              "text": "This is sample text for document five"
+          },
+          {
+              "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+              "description": "Reports Analysis Division Referral to Office of General Counsel",
+              "doc_order_id": 2,
+              "document_date": "2023-10-18T00:00:00",
+              "document_id": 100512619,
+              "length": 769982,
+              "url": "/files/legal/murs/100/100_01.pdf",
+              "text": "This is sample text for document six"
+          },
+          {
+              "category": "General Counsel Reports, Briefs, Notifications and Responses",
+              "description": "Recommendation to Accept Signed Conciliation Agreement",
+              "doc_order_id": 3,
+              "document_date": "2024-08-26T00:00:00",
+              "document_id": 100512627,
+              "length": 789682,
+              "url": "/files/legal/murs/100/100_09.pdf",
+              "text": "This is sample text for document seven"
+          },
+          {
+              "category": "General Counsel Reports, Briefs, Notifications and Responses",
+              "description": """Notification with Factual and Legal Analysis to Democratic Executive Committee of
+              Florida and Fran Garcia in her official capacity as treasurer""",
+              "doc_order_id": 3,
+              "document_date": "2024-05-23T00:00:00",
+              "document_id": 100512626,
+              "length": 969084,
+              "url": "/files/legal/murs/100/100_08.pdf",
+              "text": "This is sample text for document eight"
+          },
+          {
+              "category": "General Counsel Reports, Briefs, Notifications and Responses",
+              "description": "First General Counsel's Report",
+              "doc_order_id": 3,
+              "document_date": "2024-04-17T00:00:00",
+              "document_id": 100512625,
+              "length": 1069740,
+              "url": "/files/legal/murs/100/100_06.pdf",
+              "text": "This is sample text for document nine"
+          },
+          {
+              "category": "Certifications",
+              "description": """Democratic Executive Committee of Florida (Recommendation to Accept Signed
+              Conciliation Agreement)""",
+              "doc_order_id": 4,
+              "document_date": "2024-09-04T00:00:00",
+              "document_id": 100512618,
+              "length": 718416,
+              "url": "/files/legal/murs/100/100_10.pdf",
+              "text": "This is sample text for document ten"
+          },
+          {
+              "category": "Certifications",
+              "description": """Democratic Executive Committee of Florida and Fran Garcia in her official capacity
+              as treasurer""",
+              "doc_order_id": 4,
+              "document_date": "2024-05-14T00:00:00",
+              "document_id": 100512617,
+              "length": 737820,
+              "url": "/files/legal/murs/100/100_07.pdf",
+              "text": "This is sample text for document eleven"
+          }
+      ],
+      "election_cycles": [2022],
+      "mur_type": "current",
+      "name": "Democratic Executive Committee of Florida",
+      "no": "100",
+      "open_date": "2023-10-18T00:00:00",
+      "participants": [
+          {
+              "name": "Democratic Executive Committee of Florida",
+              "role": "Primary Respondent"
+          },
+          {
+              "name": "Smith, John",
+              "role": "Previous Respondent"
+          }
+      ],
+      "published_flg": True,
+      "respondents": [
+          "Democratic Executive Committee of Florida",
+          "Smith, John"
+      ],
+      "subjects": [
+          {
+              "primary_subject_id": "3",
+              "secondary_subject_id": "13",
+              "subject": "Contributions-Limitations"
+          },
+          {
+              "primary_subject_id": "18",
+              "subject": "Reporting"
+          }
+      ],
+      "type": "murs",
+      "url": "/legal/matter-under-review/100/",
+      "sort1": -100,
+      "sort2": None,
+    }
+
+second_test_mur = {
+      "case_serial": 101,
+      "close_date": "2022-11-29T00:00:00",
+      "commission_votes": [
+        {
+          "action": """The Commission decided by a vote of 5-0 to take the following actions in MUR 101:1.
+          Close the file.2. Issue the appropriate letters.""",
+          "vote_date": "2022-11-29T00:00:00"
+        },
+        {
+          "action": """The Commission failed by a vote of 3-2 to take the following actions in MUR 101:1. Accept the
+          conciliation agreement with Alaina Shearer for Congress and Scott M.  Hubay in his official capacity as
+          treasurer, as recommended in the Memorandum to the Commission dated October 6, 2022.2. Accept the
+          conciliation agreement with Gem City Rise PAC (f/k/a Friends of Desiree Tims) and Scott M. Hubay in his
+          official capacity as treasurer, as recommended in the Memorandum to the Commission dated October 6, 2022.3.
+          Approve the appropriate letters.4. Close the file.""",
+          "vote_date": "2022-11-15T00:00:00"
+        },
+        {
+          "action": """The Commission decided by a vote of 4-2 to take the following actions in MUR 101:1.  Find no
+          reason to believe that the Ohio Democratic Party and Patricia Frost- Brooks in her official capacity as
+          treasurer violated 52 U.S.C. § 30114(b)(2) or 52 U.S.C. § 30116(a)(2)(A).2.  Find no reason to believe that
+          Alaina Shearer and Alaina Shearer for Congress and Scott M. Hubay in his official capacity as treasurer
+          violated 52 U.S.C.§ 30114(b)(2), 52 U.S.C. § 30116(a)(2)(A), or 52 U.S.C. § 30116(f).3.].""",
+          "vote_date": "2022-04-26T00:00:00"
+        },
+        {
+          "action": """The Commission failed by a vote of 2-4 to:a. Find no reason to believe that the Ohio Democratic
+          arty and Patricia Frost- Brooks in her official capacity as treasurer violated 52 U.S.C. § 30114(b)(2) or 52
+          U.S.C. § 30116(a)(2)(A).b. Find no reason to believe that Alaina Shearer and Alaina Shearer for Congress and
+          Scott M. Hubay in his official capacity as treasurer violated 52 U.S.C. § 30114(b)(2), 52 U.S.C. § 30116(a)(2)
+          (A), or 52 U.S.C. § 30116(f).c.""",
+          "vote_date": "2022-04-05T00:00:00"
+        },
+        {
+          "action": """The Commission failed by a vote of 2-4 to:a. Dismiss the allegation pursuant to Heckler v.
+          Chaney.b. Close the file.c. Issue the appropriate letters.""",
+          "vote_date": "2022-04-05T00:00:00"
+        }
+      ],
+      "dispositions": [
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "Dismiss pursuant to prosecutorial discretion",
+          "mur_disposition_category_id": "14",
+          "penalty": None,
+          "respondent": "Ohio Democratic Party"
+        },
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "Dismiss pursuant to prosecutorial discretion",
+          "mur_disposition_category_id": "14",
+          "penalty": None,
+          "respondent": "Frost-Brooks, Patricia"
+        },
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2).",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A), or",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            },
+            {
+              "text": "30116(f)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Shearer, Alaina"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Hubay, Scott M."
+        },
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Frost-Brooks, Patricia"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Alaina Shearer for Congress"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Gem City Rise PAC (f/k/a Friends of Desiree Tims)"
+        },
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A) or",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            },
+            {
+              "text": "30116(f)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Tims, Desiree"
+        },
+        {
+          "citations": [
+            {
+              "text": "30114(b)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30114"
+            },
+            {
+              "text": "30116(a)(2)(A)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30116"
+            }
+          ],
+          "disposition": "No RTB",
+          "mur_disposition_category_id": "24",
+          "penalty": None,
+          "respondent": "Ohio Democratic Party"
+        }
+      ],
+      "doc_id": "mur_101",
+      "documents": [
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Designation of Counsel from Gem City Rise PAC and Scott Hubay, Treasurer",
+          "doc_order_id": 2,
+          "document_date": "2022-06-10T00:00:00",
+          "document_id": 100507731,
+          "length": 688461,
+          "url": "/files/legal/murs/101/101_21.pdf",
+          "text": "This is some sample text for the first document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Designation of Counsel from Alaina Shearer for Congress and Scott Hubay, Treasurer",
+          "doc_order_id": 2,
+          "document_date": "2022-06-10T00:00:00",
+          "document_id": 100507711,
+          "length": 687489,
+          "url": "/files/legal/murs/101/101_20.pdf",
+          "text": "This is some sample text for the second document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Response from Friends of Desiree Tims and Alaina Shearer for Congress",
+          "doc_order_id": 2,
+          "document_date": "2020-11-03T00:00:00",
+          "document_id": 100507729,
+          "length": 979677,
+          "url": "/files/legal/murs/101/101_11.pdf",
+          "text": "This is some sample text for the third document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Response from Ohio Democratic Party",
+          "doc_order_id": 2,
+          "document_date": "2020-11-03T00:00:00",
+          "document_id": 100507728,
+          "length": 815585,
+          "url": "/files/legal/murs/101/101_10.pdf"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Grant of Extension of Time to Friends of Desiree Tims and Desiree Tims",
+          "doc_order_id": 2,
+          "document_date": "2020-10-01T00:00:00",
+          "document_id": 100507727,
+          "length": 656371,
+          "url": "/files/legal/murs/101/101_09.pdf",
+          "text": "This is some sample text for the fourth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Grant of Extension of Time to Ohio Democratic Party and Fran Alberty, Treasurer",
+          "doc_order_id": 2,
+          "document_date": "2020-10-01T00:00:00",
+          "document_id": 100507726,
+          "length": 656413,
+          "url": "/files/legal/murs/101/101_08.pdf",
+          "text": "This is some sample text for the fifth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Designation of Counsel and Request for Extension of Time from Ohio Democratic Party",
+          "doc_order_id": 2,
+          "document_date": "2020-10-01T00:00:00",
+          "document_id": 100507725,
+          "length": 717698,
+          "url": "/files/legal/murs/101/101_07.pdf",
+          "text": "This is some sample text for the sixth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Notification of Complaint to Desiree Tims",
+          "doc_order_id": 2,
+          "document_date": "2020-09-17T00:00:00",
+          "document_id": 100507724,
+          "length": 653992,
+          "url": "/files/legal/murs/101/101_06.pdf",
+          "text": "This is some sample text for the seventh document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Notification of Complaint toScott Hubay in his official capacity as treasurer",
+          "doc_order_id": 2,
+          "document_date": "2020-09-17T00:00:00",
+          "document_id": 100507723,
+          "length": 654041,
+          "url": "/files/legal/murs/101/101_05.pdf",
+          "text": "This is some sample text for the eigth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Notification of Complaint to Alaina Shearer",
+          "doc_order_id": 2,
+          "document_date": "2020-09-17T00:00:00",
+          "document_id": 100507722,
+          "length": 653757,
+          "url": "/files/legal/murs/101/101_04.pdf",
+          "text": "This is some sample text for the ninth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": """Notification of Complaint to Alaina Shearer for Congress and Scott M. Hubay in his official
+          capacity as treasurer""",
+          "doc_order_id": 2,
+          "document_date": "2020-09-17T00:00:00",
+          "document_id": 100507721,
+          "length": 654240,
+          "url": "/files/legal/murs/101/101_03.pdf",
+          "text": "This is some sample text for the eleventh document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Notification of Complaint  Ohio Democratic Party Fran in her official capacity as treasurer",
+          "doc_order_id": 2,
+          "document_date": "2020-09-17T00:00:00",
+          "document_id": 100507720,
+          "length": 654120,
+          "url": "/files/legal/murs/101/101_02.pdf",
+          "text": "This is some sample text for the twelfth document"
+        },
+        {
+          "category": "Complaint, Responses, Designation of Counsel and Extensions of Time",
+          "description": "Complaint",
+          "doc_order_id": 2,
+          "document_date": "2020-09-09T00:00:00",
+          "document_id": 100507719,
+          "length": 640469,
+          "url": "/files/legal/murs/101/101_01.pdf",
+          "text": "This is some sample text for the thirteenth document"
+        },
+        {
+          "category": "General Counsel Reports, Briefs, Notifications and Responses",
+          "description": "Notification with Factual and Legal Anlaysis to Desiree Tims",
+          "doc_order_id": 3,
+          "document_date": "2023-01-04T00:00:00",
+          "document_id": 100507717,
+          "length": 917345,
+          "url": "/files/legal/murs/101/101_30.pdf",
+          "text": "This is some sample text for the fourteenth document"
+        },
+        {
+          "category": "General Counsel Reports, Briefs, Notifications and Responses",
+          "description": "Notification with Factual and Legal Analysis to Alaina Shearer",
+          "doc_order_id": 3,
+          "document_date": "2023-01-04T00:00:00",
+          "document_id": 100507716,
+          "length": 914846,
+          "url": "/files/legal/murs/101/101_29.pdf",
+          "text": "This is some sample text for the fifteenth document"
+        },
+        {
+          "category": "General Counsel Reports, Briefs, Notifications and Responses",
+          "description": "Notification to Ohio Democratic Party",
+          "doc_order_id": 3,
+          "document_date": "2022-12-16T00:00:00",
+          "document_id": 100507715,
+          "length": 780367,
+          "url": "/files/legal/murs/101/101_28.pdf",
+          "text": "This is some sample text for the sixteenth document"
+        }
+      ],
+      "election_cycles": [2020, 2020],
+      "mur_type": "current",
+      "name": "Alaina Shearer for Congress",
+      "no": "101",
+      "open_date": "2020-09-10T00:00:00",
+      "participants": [
+        {
+          "name": "Alaina Shearer for Congress",
+          "role": "Primary Respondent"
+        },
+        {
+          "name": "Gem City Rise PAC (f/k/a Friends of Desiree Tims)",
+          "role": "Previous Respondent"
+        },
+        {
+          "name": "Ohio Democratic Party",
+          "role": "Previous Respondent"
+        },
+        {
+          "name": "Ohio Republican Party",
+          "role": "Complainant"
+        },
+        {
+          "name": "Secaur, Robert",
+          "role": "Complainant"
+        },
+        {
+          "name": "West, N. Zachary",
+          "role": "Respondent's Counsel"
+        },
+        {
+          "name": "Reiff, Neil P.",
+          "role": "Respondent's Counsel"
+        },
+        {
+          "name": "Sandler, Reiff, Lamb, Rosenstein & Birkenstock, P.C.",
+          "role": "Respondent's Counsel"
+        },
+        {
+          "name": "O'Connor, Haseley, & Wilhelm LLC",
+          "role": "Respondent's Counsel"
+        },
+        {
+          "name": "Hubay, Scott M.",
+          "role": "Previous Respondent"
+        },
+        {
+          "name": "Shearer, Alaina",
+          "role": "Previous Respondent"
+        },
+        {
+          "name": "Tims, Desiree",
+          "role": "Previous Respondent"
+        },
+        {
+          "name": "Frost-Brooks, Patricia",
+          "role": "Previous Respondent"
+        }
+      ],
+      "published_flg": True,
+      "respondents": [
+        "Alaina Shearer for Congress",
+        "Frost-Brooks, Patricia",
+        "Gem City Rise PAC (f/k/a Friends of Desiree Tims)",
+        "Hubay, Scott M.",
+        "Ohio Democratic Party",
+        "Shearer, Alaina",
+        "Tims, Desiree"
+      ],
+      "subjects": [
+        {
+          "primary_subject_id": "2",
+          "secondary_subject_id": "5",
+          "subject": "Committees-Party"
+        },
+        {
+          "primary_subject_id": "2",
+          "secondary_subject_id": "1",
+          "subject": "Committees-Candidate"
+        },
+        {
+          "primary_subject_id": "3",
+          "secondary_subject_id": "9",
+          "subject": "Contributions-Excessive"
+        },
+        {
+          "primary_subject_id": "16",
+          "subject": "Personal use"
+        },
+        {
+          "primary_subject_id": "18",
+          "subject": "Reporting"
+        }
+      ],
+      "type": "murs",
+      "url": "/legal/matter-under-review/101/"
+    }
+
+first_archived_mur = {
+      "case_serial": 103,
+      "citations": {
+        "regulations": [
+          {
+            "text": "11 C.F.R. 110.11",
+            "url": "/regulations/110-11/CURRENT"
+          }
+        ],
+        "us_code": [
+          {
+            "text": "52 U.S.C. 30120(a)(1)",
+            "url": "https://www.govinfo.gov/link/uscode/52/30120"
+          }
+        ]
+      },
+      "close_date": "1998-10-27T00:00:00",
+      "complainants": [
+        "Internal"
+      ],
+      "doc_id": "mur_103",
+      "documents": [
+        {
+          "document_id": 1,
+          "length": 2657609,
+          "url": "/files/legal/murs/103.pdf",
+          "text": "This is sample text for the first document for an archived mur"
+        }
+      ],
+      "mur_name": 'Fake Mur Name',
+      "mur_type": "archived",
+      "no": "103",
+      "open_date": "1998-06-18T00:00:00",
+      "respondents": [
+        "Dyer, Yolanda; treasurer",
+        "Naolitano, Grace Flores for Congress Committee"
+      ],
+      "subject": [
+        {
+          "children": [
+            {
+              "text": "Authorization/nonauthorization notice"
+            },
+            {
+              "text": "Campaign materials"
+            },
+            {
+              "text": "Direct Mail"
+            },
+            {
+              "text": "Disclaimers"
+            }
+          ],
+          "text": "Advertising/Solicitation"
+        },
+        {
+          "children": [
+            {
+              "text": "No Action"
+            },
+            {
+              "text": "Enforcement/statement of reasons"
+            }
+          ],
+          "text": "enforcement"
+        },
+        {
+          "text": "Vendor"
+        }
+      ],
+      "type": "murs",
+      "url": "/legal/matter-under-review/103/"
+}
+
+second_archived_mur = {
+    "case_serial": 104,
+    "citations": {
+      "regulations": [],
+      "us_code": [
+        {
+          "text": "52 U.S.C. 30101(4)",
+          "url": "https://www.govinfo.gov/link/uscode/52/30101"
+        },
+        {
+          "text": "52 U.S.C. 30104(a)(4)(A)(ii)",
+          "url": "https://www.govinfo.gov/link/uscode/52/30104"
+        }
+      ]
+    },
+    "close_date": "1988-03-09T00:00:00",
+    "complainants": [
+      "Internal"
+    ],
+    "doc_id": "mur_104",
+    "documents": [
+      {
+        "document_id": 1,
+        "length": 4983645,
+        "url": "/files/legal/murs/104.pdf",
+        "text": "This is sample text for the first document of the second archived mur"
+      }
+    ],
+    "mur_name": "NATIONAL ASSOCIATION OF SOCIAL WORKERS POLITICAL ACTION FOR CANDIDATE ELECTION",
+    "mur_type": "archived",
+    "no": "104",
+    "open_date": "1987-05-22T00:00:00",
+    "respondents": [
+      "National Assoc of Social Workers Pol Action for Candidate Election",
+      "Spencer, Betty M; Treasurer"
+    ],
+    "subject": [
+      {
+        "children": [
+          {
+            "text": "Political committee"
+          }
+        ],
+        "text": "Definitions"
+      },
+      {
+        "children": [
+          {
+            "text": "Civil Penalty"
+          },
+          {
+            "text": "Conciliation Agreement"
+          },
+          {
+            "text": "Knowing and willful"
+          }
+        ],
+        "text": "enforcement"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "text": "untimely reporting"
+              }
+            ],
+            "text": "Report"
+          }
+        ],
+        "text": "Reports/Reporting"
+      }
+    ],
+    "type": "murs",
+    "url": "/legal/matter-under-review/104/"
+}
+
+first_adr = {
+    "dispositions": [
+        {
+          "citations": [
+            {
+              "text": "30104(a)(1)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.1",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-1/CURRENT"
+            },
+            {
+              "text": "104.3(b)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-3/CURRENT"
+            }
+          ],
+          "disposition": "Received from RAD",
+          "penalty": 1250.50,
+          "respondent": "Jayme Stevenson for Congress"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(a)(1)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.1",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-1/CURRENT"
+            },
+            {
+              "text": "104.3(b)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-3/CURRENT"
+            }
+          ],
+          "disposition": "Received from RAD",
+          "penalty": 1250,
+          "respondent": "Parrett, William G."
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(a)(1)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.1",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-1/CURRENT"
+            },
+            {
+              "text": "104.3(b)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-3/CURRENT"
+            }
+          ],
+          "disposition": "Settlement Agreement",
+          "penalty": 1250,
+          "respondent": "Jayme Stevenson for Congress"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(a)(1)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "30104(b)(4)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.1",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-1/CURRENT"
+            },
+            {
+              "text": "104.3(b)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-3/CURRENT"
+            }
+          ],
+          "disposition": "Settlement Agreement",
+          "penalty": 1250,
+          "respondent": "Parrett, William G."
+        }
+    ],
+    "case_serial": 105,
+    "case_status": "No status found",
+    "close_date": "2024-06-20T00:00:00",
+    "commission_votes": [
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Broussard, Shana M.",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      },
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Cooksey, Sean J.",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      },
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Dickerson, Allen",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      },
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Lindenbaum, Dara",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      },
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Trainor, James E. \"Trey\"",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      },
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR 105/RAD 24L-04 and ADR
+        1158/MUR 8121:Approve the Negotiated Settlement of Jayme Stevenson for Congress and William G. Parrett,
+        Treasurer, as recommended in the Memorandum from the Chief Compliance Officer and the ADR Office dated June 11,
+        2024.Approve the appropriate letters.Close the file on these matters.""",
+        "commissioner_name": "Weintraub, Ellen L.",
+        "vote_date": "2024-06-20T00:00:00",
+        "vote_type": "Affirmed"
+      }
+    ],
+    "complainant": [],
+    "doc_id": "adr_105",
+    "documents": [
+      {
+        "category": "ADR Settlement Agreements",
+        "description": "Jayme Stevenson for Congress and William G. Parrett, Treasurer",
+        "doc_order_id": 1001,
+        "document_date": "2024-06-25T00:00:00",
+        "document_id": 200511727,
+        "length": 911706,
+        "url": "/files/legal/adrs/105/105_07.pdf",
+        "text": "This is sample document text for the first document of the first adr"
+      },
+      {
+        "category": "ADR Memoranda, Notifications and Responses",
+        "description": "Recommendation to Approve Negotiated Settlement",
+        "doc_order_id": 1003,
+        "document_date": "2024-06-11T00:00:00",
+        "document_id": 200511726,
+        "length": 891799,
+        "url": "/files/legal/adrs/105/105_05.pdf",
+        "text": "This is sample document text for the second document of the first adr"
+      },
+      {
+        "category": "ADR Memoranda, Notifications and Responses",
+        "description": """Commitment to Submit Matter to ADR Program and Statement of Designation of
+        Representative/Counsel""",
+        "doc_order_id": 1003,
+        "document_date": "2024-03-19T00:00:00",
+        "document_id": 200511725,
+        "length": 809756,
+        "url": "/files/legal/adrs/105/105_04.pdf",
+        "text": "This is sample document text for the third document of the first adr"
+      },
+      {
+        "category": "ADR Memoranda, Notifications and Responses",
+        "description": "Notification to Jayme Stevenson for Congress and William G. Parrett, Treasurer",
+        "doc_order_id": 1003,
+        "document_date": "2024-03-05T00:00:00",
+        "document_id": 200511724,
+        "length": 877712,
+        "url": "/files/legal/adrs/105/105_03.pdf",
+        "text": "This is sample document text for the fourth document of the first adr"
+      },
+      {
+        "category": "ADR Memoranda, Notifications and Responses",
+        "description": "Informational Memo on Assignment",
+        "doc_order_id": 1003,
+        "document_date": "2024-02-14T00:00:00",
+        "document_id": 200511723,
+        "length": 920679,
+        "url": "/files/legal/adrs/105/105_02.pdf",
+        "text": "This is sample document text for the fifth document of the first adr"
+      },
+      {
+        "category": "ADR Memoranda, Notifications and Responses",
+        "description": "Reports Analysis Division Referral to Alternative Dispute Resolution Office",
+        "doc_order_id": 1003,
+        "document_date": "2024-01-23T00:00:00",
+        "document_id": 200511722,
+        "length": 698048,
+        "url": "/files/legal/adrs/105/105_01.pdf",
+        "text": "This is sample document text for the sixth document of the first adr"
+      },
+      {
+        "category": "Certifications",
+        "description": """Jayme Stevenson for Congress and William G. Parrett, Treasurer (RAD 24L-04) (MUR 8121)
+        (C00807610) (Recommendation to Approve Negotiated Settlement)""",
+        "doc_order_id": 1004,
+        "document_date": "2024-06-20T00:00:00",
+        "document_id": 200511728,
+        "length": 737484,
+        "url": "/files/legal/adrs/105/105_06.pdf",
+        "text": "This is sample document text for the seventh document of the first adr"
+      }
+    ],
+    "election_cycles": [2016],
+    "name": "Jayme Stevenson for Congress",
+    "no": "105",
+    "non_monetary_terms": [
+      "Committee will file for termination"
+    ],
+    "non_monetary_terms_respondents": [
+      "Jayme Stevenson for Congress",
+      "Parrett, William G."
+    ],
+    "open_date": "2024-01-23T00:00:00",
+    "participants": [
+      {
+        "name": "Tyrrell, III, James E.",
+        "role": "Representative"
+      },
+      {
+        "name": "Jayme Stevenson for Congress",
+        "role": "Respondent"
+      },
+      {
+        "name": "Parrett, William G.",
+        "role": "Treasurer"
+      }
+    ],
+    "published_flg": True,
+    "respondents": [
+      "Jayme Stevenson for Congress"
+    ],
+    "subjects": [],
+    "type": "adrs",
+    "url": "/legal/alternative-dispute-resolution/105/"
+}
+
+second_adr = {
+  "dispositions": [
+        {
+          "citations": [
+            {
+              "text": "30104(g)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.4(b)(2)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-4/CURRENT"
+            }
+          ],
+          "disposition": "Received from RAD",
+          "penalty": 2700,
+          "respondent": "Helgesen, Francis Xavier"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(g)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.4(b)(2)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-4/CURRENT"
+            }
+          ],
+          "disposition": "Received from RAD",
+          "penalty": 2700,
+          "respondent": "Hometown Values PAC"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(g)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.4(b)(2)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-4/CURRENT"
+            }
+          ],
+          "disposition": "Settlement Agreement",
+          "penalty": 2700,
+          "respondent": "Hometown Values PAC"
+        },
+        {
+          "citations": [
+            {
+              "text": "30104(g)(2)",
+              "title": "52",
+              "type": "statute",
+              "url": "https://www.govinfo.gov/link/uscode/52/30104"
+            },
+            {
+              "text": "104.4(b)(2)",
+              "title": "11",
+              "type": "regulation",
+              "url": "/regulations/104-4/CURRENT"
+            }
+          ],
+          "disposition": "Settlement Agreement",
+          "penalty": 2700,
+          "respondent": "Helgesen, Francis Xavier"
+        }
+  ],
+  "case_serial": 106,
+  "case_status": "No status found",
+  "close_date": "2021-06-08T00:00:00",
+  "commission_votes": [
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR
+      \r\n106 (RAD 20L-30):\r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier
+      \r\nHelgesen, Treasurer, as recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR
+      Office dated May 19, 2021.\r\n\r\n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.\r
+      \n\r\n""",
+      "commissioner_name": "Broussard, Shana M.",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    },
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR
+      \r\n106 (RAD 20L-30):\r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier
+      \r\nHelgesen, Treasurer, as recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR
+      Office dated May 19, 2021.\r\n\r\n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.
+      \r\n\r\n""",
+      "commissioner_name": "Cooksey, Sean J.",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    },
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR \r\n106 (RAD 20L-30):
+      \r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier \r\nHelgesen, Treasurer, as
+      recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR Office dated May 19, 2021.\r\n\r\
+      n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.\r\n\r\n""",
+      "commissioner_name": "Dickerson, Allen",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    },
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR \r\n106 (RAD 20L-30):
+      \r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier \r\nHelgesen, Treasurer, as
+      recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR Office dated May 19, 2021.\r\n\r
+      \n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.\r\n\r\n""",
+      "commissioner_name": "Trainor, James E. \"Trey\"",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    },
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR \r\n106 (RAD 20L-30):
+      \r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier \r\nHelgesen, Treasurer, as
+      recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR Office dated May 19, 2021.
+      \r\n\r\n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.\r\n\r\n""",
+      "commissioner_name": "Walther, Steven T.",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    },
+    {
+      "action": """The Commission decided by a vote of 6-0 to take the following actions in ADR \r\n106 (RAD 20L-30):
+      \r\n1. Approve the Negotiated Settlement of Hometown Values PAC and Francis Xavier \r\nHelgesen, Treasurer, as
+      recommended in the Memorandum from the Chief Compliance \r\nOfficer and the ADR Office dated May 19, 2021
+      \r\n\r\n2. Approve the appropriate letters.\r\n\r\n3. Close the file on this matter.\r\n\r\n""",
+      "commissioner_name": "Weintraub, Ellen L.",
+      "vote_date": "2021-06-08T00:00:00",
+      "vote_type": "Affirmed"
+    }
+  ],
+  "complainant": [],
+  "doc_id": "adr_106",
+  "documents": [
+    {
+      "category": "ADR Settlement Agreements",
+      "description": "Hometown Values PAC and Francis Xavier Helgesen, Treasurer",
+      "doc_order_id": 1001,
+      "document_date": "2021-06-14T00:00:00",
+      "document_id": 200498052,
+      "length": 1065613,
+      "url": "/files/legal/adrs/106/106_07.pdf",
+      "text": "This is sample text for the first document of the second adr"
+    },
+    {
+      "category": "ADR Memoranda, Notifications and Responses",
+      "description": "Recommendation to Approve Negotiated Settlement",
+      "doc_order_id": 1003,
+      "document_date": "2021-05-19T00:00:00",
+      "document_id": 200498051,
+      "length": 884639,
+      "url": "/files/legal/adrs/106/106_05.pdf",
+      "text": "This is sample text for the second document of the second adr"
+    },
+    {
+      "category": "ADR Memoranda, Notifications and Responses",
+      "description": "Commitment to Submit Matter to ADR Program",
+      "doc_order_id": 1003,
+      "document_date": "2021-03-04T00:00:00",
+      "document_id": 200498050,
+      "length": 696467,
+      "url": "/files/legal/adrs/106/106_04.pdf",
+      "text": "This is sample text for the third document of the second adr"
+    },
+    {
+      "category": "ADR Memoranda, Notifications and Responses",
+      "description": "Notification to Hometown Values PAC and Francis Xavier Helgesen, Treasurer",
+      "doc_order_id": 1003,
+      "document_date": "2021-02-10T00:00:00",
+      "document_id": 200498049,
+      "length": 757846,
+      "url": "/files/legal/adrs/106/106_03.pdf",
+      "text": "This is sample text for the fourth document of the second adr"
+    },
+    {
+      "category": "ADR Memoranda, Notifications and Responses",
+      "description": "Informational Memo on Assignment",
+      "doc_order_id": 1003,
+      "document_date": "2021-02-02T00:00:00",
+      "document_id": 200498048,
+      "length": 824859,
+      "url": "/files/legal/adrs/106/106_02.pdf",
+      "text": "This is sample text for the fifth document of the second adr"
+    },
+    {
+      "category": "ADR Memoranda, Notifications and Responses",
+      "description": "Reports Analysis Division Referral to Alternative Dispute Resolution Office",
+      "doc_order_id": 1003,
+      "document_date": "2021-01-21T00:00:00",
+      "document_id": 200498047,
+      "length": 1390051,
+      "url": "/files/legal/adrs/106/106_01.pdf",
+      "text": "This is sample text for the sixth document of the second adr"
+    },
+    {
+      "category": "Certifications",
+      "description": """Hometown Values PAC and Francis Xavier Helgesen, Treasurer (RAD 20L-30) (C00721886)
+      (Recommendation to Approve Negotiated Settlement)""",
+      "doc_order_id": 1004,
+      "document_date": "2021-06-08T00:00:00",
+      "document_id": 200498053,
+      "length": 709165,
+      "url": "/files/legal/adrs/106/106_06.pdf",
+      "text": "This is sample text for the seventh document of the second adr"
+    }
+  ],
+  "election_cycles": [2020],
+  "name": "Hometown Values PAC",
+  "no": "106",
+  "non_monetary_terms": [
+    "Committee will file for termination"
+  ],
+  "non_monetary_terms_respondents": [
+    "Hometown Values PAC",
+    "Helgesen, Francis Xavier"
+  ],
+  "open_date": "2021-01-21T00:00:00",
+  "participants": [
+    {
+      "name": "Helgesen, Francis Xavier",
+      "role": "Treasurer"
+    },
+    {
+      "name": "Hometown Values PAC",
+      "role": "Respondent"
+    }
+  ],
+  "published_flg": True,
+  "respondents": [
+    "Hometown Values PAC"
+  ],
+  "subjects": [
+      {
+        "primary_subject_id": "3",
+        "secondary_subject_id":  "15",
+        "subject": "Contributions-Prohibited"
+      },
+      {
+        "primary_subject_id": "3",
+        "secondary_subject_id":  "8",
+        "subject": "Contributions-Corporations"
+      },
+      {
+        "primary_subject_id": "18",
+        "subject": "Reporting"
+      }
+  ],
+  "type": "adrs",
+  "url": "/legal/alternative-dispute-resolution/106/"
+}
+
+first_admin_fine = {
+    "dispositions": [
+        {
+          "penalty": 5258,
+          "disposition_date": "2024-03-22",
+          "disposition_description": "Initial finding and penalty assessed"
+        },
+        {
+          "penalty": None,
+          "disposition_date": "2024-03-25",
+          "disposition_description": "Challenged"
+        },
+        {
+          "penalty": 5258,
+          "disposition_date": "2024-08-14",
+          "disposition_description": "Initial finding and penalty upheld"
+        }
+      ],
+    "case_serial": 107,
+    "challenge_outcome": "RTB Finding and Fine Upheld",
+    "challenge_receipt_date": "2024-03-25T00:00:00",
+    "civil_penalty_due_date": "2024-10-27T00:00:00",
+    "civil_penalty_payment_status": "Paid In Full",
+    "commission_votes": [
+      {
+        "action": """The Commission decided by a vote of 6-0 to take the following actions in AF 107: Adopt the
+        Reviewing Officer recommendation for AF# 107 involving Social Progress in Union with Economic Growth and Trina
+        Estelle, in their official capacity as Treasurer, in making the final determination. Make a final determination
+        in AF# 107 that Social Progress in Union with Economic Growth and Trina Estelle, in their official capacity as
+        Treasurer, violated 52 U.S.C. § 30104(a) and assess a $5,258 civil money penalty.
+        Send the appropriate letter.""",
+        "vote_date": "2024-08-14T00:00:00"
+      }
+    ],
+    "committee_id": "C00833665",
+    "doc_id": "af_107",
+    "documents": [
+      {
+        "category": "Administrative Fine Case",
+        "description": "Status of Payment",
+        "doc_order_id": 2001,
+        "document_date": "2024-09-30T00:00:00",
+        "document_id": 300512738,
+        "length": 582505,
+        "url": "/files/legal/admin_fines/107/107_02.pdf",
+        "text": "sample text for the first document of the first admin_fine"
+      },
+      {
+        "category": "Administrative Fine Case",
+        "description": "AF 107",
+        "doc_order_id": 2001,
+        "document_date": "2024-09-17T00:00:00",
+        "document_id": 300512538,
+        "length": 4919211,
+        "url": "/files/legal/admin_fines/107/107_01.pdf",
+        "text": "sample text for the second document of the first admin_fine"
+      }
+    ],
+    "final_determination_amount": 5258,
+    "final_determination_date": "2024-08-14T00:00:00",
+    "name": "SOCIAL PROGRESS IN UNION WITH ECONOMIC GROWTH",
+    "no": "107",
+    "payment_amount": None,
+    "petition_court_decision_date": None,
+    "petition_court_filing_date": None,
+    "published_flg": True,
+    "reason_to_believe_action_date": "2024-03-22T00:00:00",
+    "reason_to_believe_fine_amount": 5258,
+    "report_type": "YE",
+    "report_year": "2023",
+    "treasury_referral_amount": None,
+    "treasury_referral_date": None,
+    "type": "admin_fines",
+    "url": "/legal/administrative-fine/107/"
+    }
+
+second_admin_fine = {
+      "dispositions": [
+        {
+          "penalty": 3300,
+          "disposition_date": "2015-03-31",
+          "disposition_description": "Initial finding and penalty assessed"
+        },
+        {
+          "penalty": 3300,
+          "disposition_date": "2015-06-12",
+          "disposition_description": "Initial finding and penalty upheld"
+        }
+      ],
+      "case_serial": 108,
+      "challenge_outcome": None,
+      "challenge_receipt_date": None,
+      "civil_penalty_due_date": "2015-07-15T00:00:00",
+      "civil_penalty_payment_status": "Paid In Full",
+      "commission_votes": [
+        {
+          "action": """(1) find reason to believe that ICE PAC, and LEBEAU, REID as treasurer violated 52 U.S.C.
+          30104(a) (formerly 2 U.S.C. 434(a)) and make a preliminary determination that the civil money penalty would
+          be the amount indicated on the report; (2) send the appropriate letter.""",
+          "vote_date": "2015-03-31T00:00:00"
+        }
+      ],
+      "committee_id": "C00484667",
+      "doc_id": "af_108",
+      "documents": [
+        {
+          "category": "Administrative Fine Case",
+          "description": "AF 108",
+          "doc_order_id": 2001,
+          "document_date": "2015-07-13T00:00:00",
+          "document_id": 111134,
+          "length": 1026328,
+          "url": "/files/legal/admin_fines/108/15092703776.pdf",
+          "text": "sample text for the first document of the second admin_fine"
+        }
+      ],
+      "final_determination_amount": 3300,
+      "final_determination_date": "2015-06-12T00:00:00",
+      "name": "ICE PAC",
+      "no": "108",
+      "payment_amount": 3300,
+      "petition_court_decision_date": None,
+      "petition_court_filing_date": None,
+      "published_flg": True,
+      "reason_to_believe_action_date": "2015-03-31T00:00:00",
+      "reason_to_believe_fine_amount": 3300,
+      "report_type": "12G",
+      "report_year": "2014",
+      "treasury_referral_amount": None,
+      "treasury_referral_date": None,
+      "type": "admin_fines",
+      "url": "/legal/administrative-fine/108/"
+}
+
+first_statute = {
+      "chapter": "95",
+      "doc_id": "/us/usc/t26/s9001",
+      "name": "Short title",
+      "no": "9001",
+      "title": "26",
+      "type": "statutes",
+      "url": "https://www.govinfo.gov/link/uscode/26/9001"
+}
+
+first_ao = {
+      "ao_citations": [
+        {
+          "name": "Farrell",
+          "no": "2004-20"
+        },
+        {
+          "name": "Busby",
+          "no": "2006-06"
+        },
+        {
+          "name": "National Republican Congressional Committee",
+          "no": "2022-08"
+        }
+      ],
+      "ao_no": "2024-12",
+      "ao_serial": 12,
+      "ao_year": 2024,
+      "aos_cited_by": [],
+      "commenter_names": [],
+      "doc_id": "advisory_opinions_2024-12",
+      "documents": [
+        {
+          "ao_doc_category_id": "V",
+          "category": "Votes",
+          "date": "2024-09-19T00:00:00",
+          "description": "Vote",
+          "document_id": 88638,
+          "text": "Random document text for first document",
+          "url": "/files/legal/aos/2024-12/202412V_1.pdf"
+        },
+        {
+          "ao_doc_category_id": "C",
+          "category": "Comments and Ex parte Communications",
+          "date": "2024-09-18T00:00:00",
+          "description": "Comment on Draft AO 2024-12, Agenda Document Nos. 24-38-A and 24-38-B, by Shaun McCutcheon",
+          "document_id": 88639,
+          "text": "Random document text for the second document",
+          "url": "/files/legal/aos/2024-12/202412C_3.pdf"
+        },
+        {
+          "ao_doc_category_id": "R",
+          "category": "AO Request, Supplemental Material, and Extensions of Time",
+          "date": "2024-07-23T00:00:00",
+          "description": "Request by Shaun McCutcheon (Comments due on August 19, 2024)",
+          "document_id": 88640,
+          "text": "Random document text for the third document",
+          "url": "/files/legal/aos/2024-12/202412R_1.pdf"
+        },
+        {
+          "ao_doc_category_id": "C",
+          "category": "Comments and Ex parte Communications",
+          "date": "2024-08-19T00:00:00",
+          "description": "Comment on AOR 2024-12 by League of Women Voters of Maine, RepresentUS, and Fair Vote",
+          "document_id": 88641,
+          "text": "Random document text for the fourth document",
+          "url": "/files/legal/aos/2024-12/202412C_1.pdf"
+        },
+        {
+          "ao_doc_category_id": "F",
+          "category": "Final Opinion",
+          "date": "2024-09-19T00:00:00",
+          "description": "AO 2024-12",
+          "document_id": 88637,
+          "text": "Random document text for the fifth document",
+          "url": "/files/legal/aos/2024-12/2024-12.pdf"
+        },
+        {
+          "ao_doc_category_id": "C",
+          "category": "Comments and Ex parte Communications",
+          "date": "2024-08-19T00:00:00",
+          "description": "Comment on AOR 2024-12 by Campaign Legal Center",
+          "document_id": 88642,
+          "text": "Random document text for the sixth document",
+          "url": "/files/legal/aos/2024-12/202412C_2.pdf"
+        },
+        {
+          "ao_doc_category_id": "D",
+          "category": "Draft Documents",
+          "date": "2024-09-12T00:00:00",
+          "description": "Draft AO, Agenda Document No. 24-38-A (Comments due on September 18, 2024 by 12:00pm ET)",
+          "document_id": 88643,
+          "text": "Random document text for the seventh document",
+          "url": "/files/legal/aos/2024-12/202412.pdf"
+        },
+        {
+          "ao_doc_category_id": "D",
+          "category": "Draft Documents",
+          "date": "2024-09-12T00:00:00",
+          "description": "Draft AO, Agenda Document No. 24-38-B (Comments due on September 18, 2024 by 12:00pm ET)",
+          "document_id": 88644,
+          "text": "Random document text for the eighth document",
+          "url": "/files/legal/aos/2024-12/202412_1.pdf"
+        }
+      ],
+      "entities": [
+        {
+          "name": "Mr. Shaun McCutcheon ",
+          "role": "Requestor",
+          "type": "Individual"
+        },
+        {
+          "name": "Chalmers, Adams, Backer & Kaufman, LLC",
+          "role": "Counsel/Representative",
+          "type": "Law Firm"
+        },
+        {
+          "name": "Mr. Dan Backer Esq.",
+          "role": "Counsel/Representative",
+          "type": "Individual"
+        }
+      ],
+      "is_pending": False,
+      "issue_date": "2024-09-19",
+      "name": "McCutcheon",
+      "no": "2024-12",
+      "regulatory_citations": [
+        {
+          "part": 100,
+          "section": 2,
+          "title": 11
+        },
+        {
+          "part": 110,
+          "section": 1,
+          "title": 11
+        }
+      ],
+      "representative_names": [
+        "Chalmers, Adams, Backer & Kaufman, LLC",
+        ""
+      ],
+      "request_date": "2024-07-23",
+      "requestor_names": [
+        ""
+      ],
+      "requestor_types": [
+        "Individual"
+      ],
+      "status": "Final",
+      "statutory_citations": [
+        {
+          "section": "30101",
+          "title": 52
+        },
+        {
+          "section": "30108",
+          "title": 52
+        }
+      ],
+      "summary": """Whether for purposes of contribution limits the first round of a ranked choice voting election
+      constitutes a general election, and each subsequent round, if any, is a distinct runoff election.""",
+      "type": "advisory_opinions"
+}
+
+
+document_dictionary = {
+    "murs": [first_test_mur, second_test_mur],
+    "archived_murs": [first_archived_mur, second_archived_mur],
+    "adrs": [first_adr, second_adr],
+    "admin_fines": [first_admin_fine, second_admin_fine],
+    "statutes": [first_statute,],
+    "advisory_opinions": [first_ao,]
+}

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -42,6 +42,10 @@ from .es_management import (  # noqa
     delete_murs_from_s3,
     delete_doctype_from_es,
     delete_single_doctype_from_es,
+    CASE_ALIAS,
+    AO_ALIAS,
+    ARCH_MUR_ALIAS,
+    SEARCH_ALIAS
 )
 
 from .show_legal_data import ( # noqa


### PR DESCRIPTION
## Summary (required)

- Resolves #6009 

This ticket adds integration testing with Elasticsearch to test all case filters. I will make separate PRs for AOs, statutes, and the other legal endpoints. 


### Required reviewers 2 - 3 backend developers


## Impacted areas of the application

General components of the application that this PR will affect:

- circleci pipeline
- pytest


## How to test

- checkout this branch
- start elasticsearch in new terminal 
- run `pytest` in another terminal
- to see output from any individual test uncomment the logging statements and run ` pytest tests/integration/test_cases_elasticsearch.py -s` 

Note: running locally will clear out your elasticsearch environment 
- look at codecov to see increase in coverage https://app.codecov.io/gh/fecgov/openFEC/blob/feature%2F6009-add-case-tests/webservices%2Fresources%2Flegal.py


