### PR TITLE
Remove undisplay MUR disposition category

### DIFF
--- a/data/migrations/V0305__add_ref_case_disposition_category.sql
+++ b/data/migrations/V0305__add_ref_case_disposition_category.sql
@@ -1,0 +1,22 @@
+/*
+This is for issue #6041, Add a new table to ref case(MUR, ADR, AF) disposition category.
+*/
+
+CREATE TABLE IF NOT EXISTS fecmur.ref_case_disposition_category
+ (
+    category_id integer NOT NULL,
+    category_name varchar(200) NOT NULL,
+    display_category_name varchar(200) NOT NULL,
+    doc_type varchar(8) NOT NULL,
+    published_flg boolean DEFAULT true,
+    upload_date timestamp without time zone DEFAULT now(),
+    CONSTRAINT ref_category_pkey PRIMARY KEY (category_id)
+);
+
+ALTER TABLE IF EXISTS fecmur.ref_case_disposition_category OWNER to fec;
+
+GRANT SELECT ON TABLE fecmur.ref_case_disposition_category TO aomur_usr;
+
+GRANT ALL ON TABLE fecmur.ref_case_disposition_category TO fec;
+
+GRANT SELECT ON TABLE fecmur.ref_case_disposition_category TO fec_read;

--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -429,6 +429,20 @@ class TestLoadCurrentCases(BaseTestCase):
             commission_id, agenda_date, vote_date, action, case_id, pg_date
         )
 
+        category_id = 1
+        category_name = "Conciliation-PPC"
+        display_category_name = "Conciliation-PPC"
+        published_flg = True
+        doc_type = "MUR"
+
+        self.create_disposition_category(
+            category_id,
+            category_name,
+            display_category_name,
+            published_flg,
+            doc_type
+        )
+
         load_mur_citations()
 
         actual_mur = next(get_cases('MUR'))
@@ -444,7 +458,7 @@ class TestLoadCurrentCases(BaseTestCase):
             'dispositions': [
                 {
                     'disposition': 'Conciliation-PPC',
-                    'mur_disposition_category_id': '7',
+                    'mur_disposition_category_id': 1,
                     'respondent': 'Open Elections LLC',
                     'penalty': Decimal('50000.00'),
                     'citations': [
@@ -798,6 +812,25 @@ class TestLoadCurrentCases(BaseTestCase):
             is_key_date,
             check_primary_respondent,
             pg_date,
+        )
+
+    def create_disposition_category(
+            self,
+            category_id,
+            category_name,
+            display_category_name,
+            published_flg,
+            doc_type,
+     ):
+        self.connection.execute(
+            "INSERT INTO fecmur.ref_case_disposition_category (category_id, category_name, "
+            "display_category_name, published_flg, doc_type) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            category_id,
+            category_name,
+            display_category_name,
+            published_flg,
+            doc_type,
         )
 
     def create_relatedobjects(self, master_key, detail_key, relation_id):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -387,11 +387,8 @@ legal_universal_search = {
     'mur_disposition_category_id': fields.List(IStr(
         validate=validate.OneOf([
             '', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-            '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
-            '21', '22', '23', '24', '25', '26', '27', '28', '29', '30',
-            '31', '32', '33', '34', '35', '36', '37', '38', '39', '40',
-            '41', '42', '43', '44', '45', '46', '47', '48'])),
-        description=docs.MUR_DISPOSITION_CATEGORY_DISCRIPTION
+            '11', '12', '13', '14', '15', '16', '17', '18'])),
+        description=docs.MUR_DISPOSITION_CATEGORY_DESCRIPTION
     ),
 
     'af_name': fields.List(IStr, required=False, description=docs.AF_NAME),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2246,56 +2246,27 @@ Select one or more case document category id to filter by corresponding case doc
         - 2001 - Administrative Fine Case\n\
 '''
 
-MUR_DISPOSITION_CATEGORY_DISCRIPTION = '''
+
+MUR_DISPOSITION_CATEGORY_DESCRIPTION = '''
 Select one or more MUR disposition category id to filter by corresponding MUR disposition category:\n\
-        - 1 - Approved by Commission\n\
-        - 2 - Approved In Part Recs.\n\
-        - 3 - Approved Recs.\n\
-        - 4 - Case Activated\n\
-        - 5 - Case Activation\n\
-        - 6 - Conciliation-PC\n\
-        - 7 - Conciliation-PPC\n\
-        - 8 - Dismiss and Remind\n\
-        - 9 - Dismissed\n\
-        - 10 - Dismissed - Agreement Rejected\n\
-        - 11 - Dismissed-Low Rated\n\
-        - 12 - Dismissed-Other\n\
-        - 13 - Dismissed-Stale\n\
-        - 14 - Dismiss pursuant to prosecutorial discretion\n\
-        - 15 - Dismiss pursuant to prosecutorial discretion, and caution\n\
-        - 16 - Enforcement - Disposition - Dismissed "Dismiss" - Dismiss and Caution\n\
-        - 17 - Failed to Approve Recs.\n\
-        - 18 - First General Counsel Report\n\
-        - 19 - Formal Discovery Authorized\n\
-        - 20 - Investigative Activity\n\
-        - 21 - Mailed to Respondent\n\
-        - 22 - Merged\n\
-        - 23 - No PCTB\n\
-        - 24 - No RTB\n\
-        - 25 - Offer from Respondent Received\n\
-        - 26 - Other\n\
-        - 27 - PC Brief\n\
-        - 28 - PC Conciliation Approved\n\
-        - 29 - PC/NFA\n\
-        - 30 - PCTB Finding\n\
-        - 31 - Pre-PCC Commenced\n\
-        - 32 - Received\n\
-        - 33 - Received from Audit Division\n\
-        - 34 - Received from Commission\n\
-        - 35 - Received from OGC\n\
-        - 36 - Received from RAD\n\
-        - 37 - Request for Extension of Time Approved\n\
-        - 38 - Request for Extension of Time Approved/Denied\n\
-        - 39 - Request for Extension of Time Received\n\
-        - 40 - Response Received\n\
-        - 41 - RTB Finding\n\
-        - 42 - RTB/NFA\n\
-        - 43 - Settlement Agreement\n\
-        - 44 - Suit Authorization\n\
-        - 45 - Take no action\n\
-        - 46 - Take No Further Action\n\
-        - 47 - To Respondent\n\
-        - 48 - Transferred to ADR\n\
+        - 1 - Conciliation-PPC\n\
+        - 2 - Conciliation-PC\n\
+        - 3 - Dismiss and Remind\n\
+        - 4 - Dismissed\n\
+        - 5 - Dismissed-Low Rated\n\
+        - 6 - Dismissed-Other\n\
+        - 7 - Dismissed-Stale\n\
+        - 8 - Dismiss pursuant to prosecutorial discretion\n\
+        - 9 - Dismiss pursuant to prosecutorial discretion, and caution\n\
+        - 10 - Enforcement - Disposition - Dismissed Dismiss - Dismiss and Caution\n\
+        - 11 - No PCTB\n\
+        - 12 - No RTB\n\
+        - 13 - PCTB Finding\n\
+        - 14 - PC/NFA\n\
+        - 15 - RTB Finding\n\
+        - 16 - RTB/NFA\n\
+        - 17 - Take no action\n\
+        - 18 - Take No Further Action\n\
 '''
 
 MUR_TYPE = '''

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -623,26 +623,7 @@ def get_mur_dispositions(case_id):
 
         # Get the allowed displayed MUR disposition category list from table fecmur.ref_case_disposition_category
         category_list = [dict(row) for row in conn.execute(CASE_DISPOSITION_CATEGORY, "MUR")]
-        # print(category_list):
-        # [{'category': 'Conciliation-PPC', 'category_id': 1},
-        # {'category': 'Conciliation-PC', 'category_id': 2},
-        # {'category': 'Dismiss and Remind', 'category_id': 3},
-        # {'category': 'Dismissed', 'category_id': 4},
-        # {'category': 'Dismissed-Low Rated', 'category_id': 5},
-        # {'category': 'Dismissed-Other', 'category_id': 6},
-        # {'category': 'Dismissed-Stale', 'category_id': 7},
-        # {'category': 'Dismiss pursuant to prosecutorial discretion', 'category_id': 8},
-        # {'category': 'Dismiss pursuant to prosecutorial discretion, and caution', 'category_id': 9},
-        # {'category': 'Enforcement - Disposition - Dismissed Dismiss - Dismiss and Caution', 'category_id': 10},
-        # {'category': 'No PCTB', 'category_id': 11},
-        # {'category': 'No RTB', 'category_id': 12},
-        # {'category': 'PCTB Finding', 'category_id': 13},
-        # {'category': 'PC/NFA', 'category_id': 14},
-        # {'category': 'RTB Finding', 'category_id': 15},
-        # {'category': 'RTB/NFA', 'category_id': 16},
-        # {'category': 'Take no action', 'category_id': 17},
-        # {'category': 'Take No Further Action', 'category_id': 18}]
-
+        logger.debug("category_list =" + json.dumps(category_list, indent=3, cls=DateTimeEncoder))
         disposition_data = []
         for row in rs:
             category_id = get_display_case_disposition_category_id(category_list, row["event_name"], "MUR")


### PR DESCRIPTION
## Summary (required)
This PR add a new table (**fecmur.ref_case_disposition_category**)  to store displayed final disposition categories for three cases (MUR, ADR and AF)

The new MUR disposition category list:
[ref_case_disposition_category.csv](https://github.com/user-attachments/files/17682305/ref_case_disposition_category.csv)


- Resolves #6041 

### Required reviewers

1-2 developers

## Impacted areas of the application
legal search endpoint

### Completion criteria
- [x] Remove some unpublished mur disposition categories
- [x] reload all MUR documents on dev, stage, prod after deploy. 

## Related PRs
[https://github.com/fecgov/openFEC/pull/5988](https://github.com/fecgov/openFEC/pull/5988)
[https://github.com/fecgov/openFEC/pull/5991](https://github.com/fecgov/openFEC/pull/5991)

## How to test
1)Checkout branch
2)Setup local ES
3Upload legal doc on local ES.
These commands for reference:
`python cli.py create_index case_index`
`python cli.py delete_index case_index`
`python cli.py load_adrs`
`python cli.py load_admin_fines`
`python cli.py load_current_murs`

`python cli.py load_current_murs 8182`

4)`pytest` and `flask run`

5)Test urls
http://127.0.0.1:5000/v1/legal/search/?type=murs&case_no=8182
there are 8 items under `dispositions` section that all `mur_disposition_category_id": 6,`

compare with prod:
https://api.open.fec.gov/v1/legal/search?type=murs&case_no=8182
&api_key=DEMO_KEY
There are 9 items under `dispositions` section (`mur_disposition_category_id": 12,`)
that include one unpublished dispositon `mur_disposition_category_id": "37"`,

6)make sure filter by mur_disposition_category_id work correctly
http://127.0.0.1:5000/v1/legal/search/?type=murs&mur_disposition_category_id=6

7)test in dev (MUR documents already are upload to dev)
https://fec-dev-api.app.cloud.gov/v1/legal/search?type=murs&case_no=8182&api_key=DEMO_KEY