### PR TITLE
Fix bug in CandidateList and CommitteeList when passing q and sort by receipts

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -141,14 +141,14 @@ class TestDownloadResource(ApiBaseTest):
     def test_download(self, export, get_cached):
         get_cached.return_value = None
         res = self.client.post_json(
-            api.url_for(resource.DownloadView, path='candidates', office='S')
+            api.url_for(resource.DownloadView, path='candidates', office='S', q='joh', sort='receipts')
         )
         assert res.json == {'status': 'queued'}
         get_cached.assert_called_once_with(
-            '/v1/candidates/', b'office=S', filename=None
+            '/v1/candidates/', b'office=S&q=joh&sort=receipts', filename=None
         )
         export.delay.assert_called_once_with(
-            '/v1/candidates/', base64.b64encode(b'office=S').decode('UTF-8')
+            '/v1/candidates/', base64.b64encode(b'office=S&q=joh&sort=receipts').decode('UTF-8')
         )
 
     @mock.patch('webservices.resources.download.get_cached_file')
@@ -181,9 +181,9 @@ class TestDownloadResource(ApiBaseTest):
         [factories.CandidateFactory() for _ in range(5)]
         db.session.commit()
         res = self.client.post_json(
-            api.url_for(resource.DownloadView, path='candidates'), expect_errors=True,
+            api.url_for(resource.DownloadView, path='/candidates', expect_errors=True)
         )
-        assert res.status_code == 403
+        assert res.status_code == 308
         assert not export.delay.called
 
     @mock.patch('webservices.resources.download.get_download_url')

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -63,19 +63,17 @@ class CandidateList(ApiResource):
         )
 
     def build_query(self, **kwargs):
+        if "q" not in kwargs and kwargs["sort"] in {"receipts", "-receipts"}:
+            raise exceptions.ApiError(
+                "Cannot sort on receipts when parameter 'q' is not set",
+                status_code=422,
+            )
+
         if kwargs.get('name'):
             kwargs['q'] = kwargs['name']
 
         query = super().build_query(**kwargs)
         candidate_detail = models.Candidate
-
-        if {'receipts', '-receipts'}.intersection(
-            kwargs.get('sort', [])
-        ) and 'q' not in kwargs:
-            raise exceptions.ApiError(
-                'Cannot sort on receipts when parameter "q" is not set',
-                status_code=422,
-            )
 
         if 'has_raised_funds' in kwargs:
             query = query.filter(

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -83,14 +83,13 @@ class CommitteeList(ApiResource):
         )
 
     def build_query(self, **kwargs):
-        query = super().build_query(**kwargs)
-
-        if {"receipts", "-receipts"}.intersection(kwargs.get("sort", [])) and "q" not in kwargs:
+        if "q" not in kwargs and kwargs["sort"] in {"receipts", "-receipts"}:
             raise exceptions.ApiError(
                 "Cannot sort on receipts when parameter 'q' is not set",
                 status_code=422,
             )
 
+        query = super().build_query(**kwargs)
         if kwargs.get("candidate_id"):
             query = query.filter(
                 models.Committee.candidate_ids.overlap(kwargs["candidate_id"])


### PR DESCRIPTION
## Summary (required)
This PR will fix sql error in slack #bots-db-alerts-aurora
<img width="400" alt="Screenshot 2024-11-07 at 3 46 33 PM" src="https://github.com/user-attachments/assets/a566c95f-6164-4969-814a-eb875783cb2e">

<img width="400" alt="Screenshot 2024-11-07 at 2 23 27 PM" src="https://github.com/user-attachments/assets/75414894-34b2-4e14-ba2a-1c1ef9742ada">

- Resolves #6043 


### Required reviewers
1-2 developer


## Impacted areas of the application
`/candidates/` and `candidate/search`
`/committees/` and `committee/search`

## How to test
1) checkout branch, run 'pytest'
2) test urls
test CandidateList urls: without 'q' should get 422
http://127.0.0.1:5000/v1/candidates/?sort=receipts
http://127.0.0.1:5000/v1/candidates/?&sort=-receipts

tet CandidateList urls: should return some results
http://127.0.0.1:5000/v1/candidates/?q=joh&sort=receipts
http://127.0.0.1:5000/v1/candidates/?q=joh&sort=-receipts
http://127.0.0.1:5000/v1/candidates/?q=joh&sort=name

test CommitteeList urls: without 'q' should get 422
http://127.0.0.1:5000/v1/committees/?sort=receipts
http://127.0.0.1:5000/v1/committees/?sort=-receipts

tet CommitteeList urls: should return some results
http://127.0.0.1:5000/v1/committees/?sort=receipts&q=joh
http://127.0.0.1:5000/v1/committees/?sort=-receipts&q=joh
http://127.0.0.1:5000/v1/committees/?sort=name

