### PR TITLE
6031- fix requestor_names bug with individual entities

### DIFF
--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -169,7 +169,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
         actual_ao = next(get_advisory_opinions(None))
         assert actual_ao["entities"] == [
             {"role": "Commenter",
-                "name": " Tom Dolan ",
+                "name": "Tom Dolan",
                 "type": "Individual"}]
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")


### PR DESCRIPTION
## Summary (required)

- Resolves #6031 

Some name fields for AO entites are not populating correctly for individuals. There's currently a ticket in with ITSS to fix the name field, but this needs to be fixed now so this PR uses the parsed name fields for requestor_names, commenter_names, and representative_names. It also improves the logic for combining the name fields so that there are no longer leading and trailing whitespaces. 

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

- AO requestor_names, representative_names, commenter_names

## Screenshots
BEFORE:
https://api.open.fec.gov/v1/legal/search/?api_key=DEMO_KEY&ao_no=2024-15
AFTER:
<img width="874" alt="Screenshot 2024-11-14 at 3 35 39 PM" src="https://github.com/user-attachments/assets/eabab7eb-1382-4d65-b96c-ad9c83afca22">

## How to test

start elasticsearch
- python cli.py delete_index ao_index
- python cli.py create_index ao_index
- python cli.py load_advisory_opinions 2024-15
- python cli.py load_advisory_opinions 2023-08
- flask run
- http://127.0.0.1:5000/v1/legal/search/?ao_no=2024-15&type=advisory_opinions
-  http://127.0.0.1:5000/v1/legal/search/?ao_no=2023-08&type=advisory_opinions
compare with 
https://api.open.fec.gov/v1/legal/search/?api_key=DEMO_KEY&ao_no=2024-15&type=advisory_opinions
https://api.open.fec.gov/v1/legal/search/?api_key=DEMO_KEY&ao_no=2023-08&type=advisory_opinions
NULL for representative_names