### PR TITLE
Add integration tests for AOs and Statutes

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -165,6 +165,16 @@ class ElasticSearchBaseTest(BaseTestCase):
         self.assertNotEqual(response["total_admin_fines"], 0)
         return response
 
+    def _results_ao(self, qry):
+        response = self._response(qry)
+        self.assertNotEqual(response["total_advisory_opinions"], 0)
+        return response["advisory_opinions"]
+
+    def _results_statute(self, qry):
+        response = self._response(qry)
+        self.assertNotEqual(response["total_statutes"], 0)
+        return response["statutes"]
+
 
 def _create_all_indices():
     for index in ALL_INDICES:

--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -1,0 +1,265 @@
+from tests.common import ElasticSearchBaseTest
+from webservices.resources.legal import UniversalSearch, REQUESTOR_TYPES, CATEGORIES
+from webservices.rest import api
+from datetime import datetime
+# import logging
+
+
+class TestAODocsElasticsearch(ElasticSearchBaseTest):
+    wrong_date_format = "01/20/24"
+
+    def check_filters(self, params, field_name, multiple):
+        response = self._results_ao(api.url_for(UniversalSearch, **params))
+        # logging.info(response)
+
+        if multiple:
+            assert all(x[field_name] in list(params.values())[0] for x in response)
+        else:
+            assert all(x[field_name] == list(params.values())[0] for x in response)
+
+    def check_incorrect_values(self, params, raiseError):
+        response = self.app.get(api.url_for(UniversalSearch, **params))
+        # logging.info(response.json)
+
+        if raiseError:
+            assert response.status_code == 422
+        else:
+            assert response.status_code == 200
+            assert response.json["total_advisory_opinions"] == 0
+
+    def check_doc_filters(self, params, field_name, compare_values):
+        response = self._results_ao(api.url_for(UniversalSearch, **params))
+        # logging.info(response)
+
+        assert all(any(
+            doc[field_name] in compare_values
+            for doc in ao["documents"])
+            for ao in response)
+
+    def test_ao_filters(self):
+        filters = [
+            [{"ao_no": "2014-19"}, "no", False, False],
+            [{"ao_no": ["2014-22", "2024-12"]}, "no", True, False],
+            [{"ao_name": "McCutcheon"}, "name", False, False],
+            [{"ao_name": ["Fake Name", "ActBlue"]}, "name", True, False],
+            [{"ao_is_pending": True}, "is_pending", False, True],
+            [{"ao_status": "Final"}, "status", False, False],
+        ]
+
+        for filter in filters:
+            self.check_filters(filter[0], filter[1], filter[2])
+            self.check_incorrect_values({list(filter[0].keys())[0]: "Incorrect"}, filter[3])
+
+    def test_ao_requestor_filter(self):
+        requestor = "Jane Doe"
+        response = self._results_ao(api.url_for(UniversalSearch, ao_requestor=requestor))
+        # logging.info(response)
+
+        assert all(requestor in doc["requestor_names"] for doc in response)
+        self.check_incorrect_values({"ao_requestor": "Incorrect"}, False)
+
+        types = [5, 15]
+        requstor_type_full = [REQUESTOR_TYPES[5], REQUESTOR_TYPES[15]]
+        response = self._results_ao(api.url_for(UniversalSearch, ao_requestor_type=types))
+        # logging.info(response)
+
+        assert all(any(requestor in requstor_type_full
+                       for requestor in doc["requestor_types"])
+                   for doc in response)
+
+        type = 15
+        response = self._results_ao(api.url_for(UniversalSearch, ao_requestor_type=type))
+        # logging.info(response)
+
+        assert all(REQUESTOR_TYPES[type] in doc["requestor_types"] for doc in response)
+
+        self.check_incorrect_values({"ao_requestor_type": 22}, True)
+
+    def test_ao_entity_name_filter(self):
+        entity_name = "Francis Beaver"
+        response = self._results_ao(api.url_for(UniversalSearch, ao_entity_name=entity_name))
+        # logging.info(response)
+
+        assert all(entity_name in doc["commenter_names"] or entity_name in doc["representative_names"]
+                   for doc in response)
+
+        entity_names = ["Jake Brown", "Francis Beaver"]
+        response = self._results_ao(api.url_for(UniversalSearch, ao_entity_name=entity_names))
+        # logging.info(response)
+
+        assert all(set(entity_names).intersection(doc["commenter_names"]) or set(entity_names).intersection(
+            doc["representative_names"])
+                   for doc in response)
+
+        self.check_incorrect_values({"ao_entity_name": "Bad Value"}, False)
+
+    def test_doc_cat_id_filter(self):
+        ao_doc_cat_id = "C"
+        self.check_doc_filters({"ao_doc_category_id": ao_doc_cat_id}, "ao_doc_category_id", ao_doc_cat_id)
+
+        ao_doc_cat_ids = ["C", "V"]
+        self.check_doc_filters({"ao_doc_category_id": ao_doc_cat_ids}, "ao_doc_category_id", ao_doc_cat_ids)
+
+        self.check_incorrect_values({"ao_doc_category_id": "P"}, True)
+
+    def test_ao_category_filter(self):
+        ao_category = "W"
+        self.check_doc_filters({"ao_category": ao_category}, "category", CATEGORIES[ao_category])
+
+        ao_categories = ["V", "D"]
+        ao_categories_full = [CATEGORIES["V"], CATEGORIES["D"]]
+        self.check_doc_filters({"ao_category": ao_categories}, "category", ao_categories_full)
+
+        self.check_incorrect_values({"ao_category": "P"}, True)
+
+    def test_ao_sort(self):
+        sort = "-ao_no"
+        response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
+        # logging.info(response)
+        self.assertEqual(response[0]["ao_no"], "2024-12")
+
+        sort = "ao_no"
+        response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
+        # logging.info(response)
+        self.assertEqual(response[0]["ao_no"], "2014-19")
+
+    def test_q_filters(self):
+        q = "fourth"
+        response = self._results_ao(api.url_for(UniversalSearch, q=q))
+        # logging.info(response)
+
+        assert all(
+            all(q in highlight
+                for highlight in ao["highlights"])
+            for ao in response
+        )
+        q_exclude = "Random"
+        response = self._results_ao(api.url_for(UniversalSearch, q_exclude=q_exclude))
+        # logging.info(response)
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]["ao_no"], "2014-19")
+
+    def test_citation_filters(self):
+        statutory_title = 52
+        statutory_section = "30101"
+        regulatory_title = 11
+        regulatory_section = 3
+        regulatory_part = 101
+        stat_citation = "{} U.S.C. §{}".format(statutory_title, statutory_section)
+        reg_citation = "{} CFR §{}.{}".format(regulatory_title, regulatory_part, regulatory_section)
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_statutory_citation=stat_citation,
+                                                ao_regulatory_citation=reg_citation))
+        # logging.info(response)
+
+        for ao in response:
+            found = any(
+                (citation["title"] == regulatory_title and citation["part"] == regulatory_part and
+                 citation["section"] == regulatory_section)
+                for citation in ao["regulatory_citations"]
+            ) or any(
+                (citation["title"] == statutory_title and citation["section"] == statutory_section)
+                for citation in ao["statutory_citations"]
+            )
+            assert found
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_statutory_citation=stat_citation,
+                                                ao_regulatory_citation=reg_citation,
+                                                ao_citation_require_all="true"))
+        # logging.info(response)
+
+        for ao in response:
+
+            statutory_found = any(
+                (citation["title"] == statutory_title and citation["section"] == statutory_section)
+                for citation in ao["statutory_citations"]
+            )
+
+            regulatory_found = any(
+                (citation["title"] == regulatory_title and citation["part"] == regulatory_part and
+                 citation["section"] == regulatory_section)
+                for citation in ao["regulatory_citations"]
+            )
+        assert statutory_found and regulatory_found
+
+        filters = [
+            ["ao_statutory_citation", "524 U.S.C. §30106444"],
+            ["ao_regulatory_citation", "1111 CFR §112.4111"]
+        ]
+        for filter in filters:
+            self.check_incorrect_values({filter[0]: filter[1]}, False)
+
+    def check_date(self, ao_column, query_date, response, is_min):
+
+        if is_min:
+            assert all(
+                datetime.strptime(ao[ao_column], "%Y-%m-%d") >= query_date
+                for ao in response
+            )
+        else:
+            assert all(
+                datetime.strptime(ao[ao_column], "%Y-%m-%d") <= query_date
+                for ao in response
+            )
+
+    def test_issue_date_filter(self):
+        issue_date = "2020-01-01"
+        query_date = datetime.strptime(issue_date, "%Y-%m-%d")
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_min_issue_date=issue_date))
+        # logging.info(response)
+        self.check_date("issue_date", query_date, response, True)
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_max_issue_date=issue_date))
+        # logging.info(response)
+        self.check_date("issue_date", query_date, response, False)
+
+        filters = ["ao_min_issue_date", "ao_max_issue_date"]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, True)
+
+    def test_request_date_filter(self):
+        request_date = "2020-01-01"
+        query_date = datetime.strptime(request_date, "%Y-%m-%d")
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_min_request_date=request_date))
+        # logging.info(response)
+        self.check_date("request_date", query_date, response, True)
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_max_request_date=request_date))
+        # logging.info(response)
+        self.check_date("request_date", query_date, response, False)
+
+        filters = ["ao_min_request_date", "ao_max_request_date"]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, True)
+
+    def test_doc_date_filter(self):
+        document_date = "2022-12-01"
+        query_date = datetime.strptime(document_date, "%Y-%m-%d")
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_min_document_date=document_date))
+        # logging.info(response)
+
+        assert all(any(
+                datetime.strptime(doc["date"], "%Y-%m-%dT%H:%M:%S") >= query_date
+                for doc in ao["documents"])
+            for ao in response
+        )
+
+        response = self._results_ao(api.url_for(UniversalSearch, ao_max_document_date=document_date))
+        # logging.info(response)
+
+        assert all(any(
+                datetime.strptime(doc["date"], "%Y-%m-%dT%H:%M:%S") <= query_date
+                for doc in ao["documents"])
+            for ao in response
+        )
+
+        filters = ["ao_min_document_date", "ao_max_document_date",]
+
+        for filter in filters:
+            self.check_incorrect_values({filter: self.wrong_date_format}, True)

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -239,7 +239,7 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
         # logging.info(response)
 
         self.assertEqual(response["total_admin_fines"], 0)
-        self.assertEqual(response["total_all"], 8)
+        self.assertEqual(response["total_all"], 10)
 
     def test_sort(self):
         sort_value = "case_no"
@@ -461,7 +461,7 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
 
     def test_mur_disposition_filter(self):
         # filter for current murs
-        categories = ["7", "8"]
+        categories = [7, 8]
         response = self._results_mur(api.url_for(UniversalSearch, mur_disposition_category_id=categories))
         # logging.info(response)
 
@@ -473,7 +473,7 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
             for mur in response["murs"]
         )
 
-        category = "14"
+        category = 1
         response = self._results_mur(api.url_for(UniversalSearch, mur_disposition_category_id=category))
         # logging.info(response)
 

--- a/tests/integration/test_statute_elasticsearch.py
+++ b/tests/integration/test_statute_elasticsearch.py
@@ -1,0 +1,18 @@
+from tests.common import ElasticSearchBaseTest
+from webservices.rest import api
+from webservices.resources.legal import UniversalSearch
+# import logging
+
+
+class TestStatuteDocsElasticsearch(ElasticSearchBaseTest):
+
+    def test_q_search(self):
+        q = "Payments"
+        response = self._results_statute(api.url_for(UniversalSearch, q=q))
+        # logging.info(response)
+
+        assert all(
+            all(q in highlight
+                for highlight in statute["highlights"])
+            for statute in response
+        )

--- a/tests/test_legal_data.py
+++ b/tests/test_legal_data.py
@@ -66,7 +66,7 @@ first_test_mur = {
                   }
               ],
               "disposition": "Conciliation-PPC",
-              "mur_disposition_category_id": "7",
+              "mur_disposition_category_id": 1,
               "penalty": 70000,
               "respondent": "Democratic Executive Committee of Florida"
           },
@@ -98,7 +98,7 @@ first_test_mur = {
                   }
               ],
               "disposition": "Conciliation-PPC",
-              "mur_disposition_category_id": "7",
+              "mur_disposition_category_id": 1,
               "penalty": 70000,
               "respondent": "Garcia, Fran"
               }
@@ -316,7 +316,7 @@ second_test_mur = {
             }
           ],
           "disposition": "Dismiss pursuant to prosecutorial discretion",
-          "mur_disposition_category_id": "14",
+          "mur_disposition_category_id": 8,
           "penalty": None,
           "respondent": "Ohio Democratic Party"
         },
@@ -336,7 +336,7 @@ second_test_mur = {
             }
           ],
           "disposition": "Dismiss pursuant to prosecutorial discretion",
-          "mur_disposition_category_id": "14",
+          "mur_disposition_category_id": 8,
           "penalty": None,
           "respondent": "Frost-Brooks, Patricia"
         },
@@ -362,7 +362,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Shearer, Alaina"
         },
@@ -376,7 +376,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Hubay, Scott M."
         },
@@ -396,7 +396,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Frost-Brooks, Patricia"
         },
@@ -410,7 +410,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Alaina Shearer for Congress"
         },
@@ -424,7 +424,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Gem City Rise PAC (f/k/a Friends of Desiree Tims)"
         },
@@ -450,7 +450,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Tims, Desiree"
         },
@@ -470,7 +470,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": "24",
+          "mur_disposition_category_id": 12,
           "penalty": None,
           "respondent": "Ohio Democratic Party"
         }
@@ -1587,6 +1587,16 @@ first_statute = {
       "url": "https://www.govinfo.gov/link/uscode/26/9001"
 }
 
+second_statute = {
+      "chapter": "96",
+      "doc_id": "/us/usc/t26/s9037",
+      "name": "Payments to eligible candidates",
+      "no": "9037",
+      "title": "26",
+      "type": "statutes",
+      "url": "https://www.govinfo.gov/link/uscode/26/9037"
+}
+
 first_ao = {
       "ao_citations": [
         {
@@ -1606,7 +1616,7 @@ first_ao = {
       "ao_serial": 12,
       "ao_year": 2024,
       "aos_cited_by": [],
-      "commenter_names": [],
+      "commenter_names": ["Francis Beaver"],
       "doc_id": "advisory_opinions_2024-12",
       "documents": [
         {
@@ -1615,7 +1625,7 @@ first_ao = {
           "date": "2024-09-19T00:00:00",
           "description": "Vote",
           "document_id": 88638,
-          "text": "Random document text for first document",
+          "text": "Random document text for first ao document",
           "url": "/files/legal/aos/2024-12/202412V_1.pdf"
         },
         {
@@ -1624,7 +1634,7 @@ first_ao = {
           "date": "2024-09-18T00:00:00",
           "description": "Comment on Draft AO 2024-12, Agenda Document Nos. 24-38-A and 24-38-B, by Shaun McCutcheon",
           "document_id": 88639,
-          "text": "Random document text for the second document",
+          "text": "Random document text for the second ao document",
           "url": "/files/legal/aos/2024-12/202412C_3.pdf"
         },
         {
@@ -1633,7 +1643,7 @@ first_ao = {
           "date": "2024-07-23T00:00:00",
           "description": "Request by Shaun McCutcheon (Comments due on August 19, 2024)",
           "document_id": 88640,
-          "text": "Random document text for the third document",
+          "text": "Random document text for the third ao document",
           "url": "/files/legal/aos/2024-12/202412R_1.pdf"
         },
         {
@@ -1642,7 +1652,7 @@ first_ao = {
           "date": "2024-08-19T00:00:00",
           "description": "Comment on AOR 2024-12 by League of Women Voters of Maine, RepresentUS, and Fair Vote",
           "document_id": 88641,
-          "text": "Random document text for the fourth document",
+          "text": "Random document text for the fourth ao document",
           "url": "/files/legal/aos/2024-12/202412C_1.pdf"
         },
         {
@@ -1651,7 +1661,7 @@ first_ao = {
           "date": "2024-09-19T00:00:00",
           "description": "AO 2024-12",
           "document_id": 88637,
-          "text": "Random document text for the fifth document",
+          "text": "Random document text for the fifth ao document",
           "url": "/files/legal/aos/2024-12/2024-12.pdf"
         },
         {
@@ -1660,7 +1670,7 @@ first_ao = {
           "date": "2024-08-19T00:00:00",
           "description": "Comment on AOR 2024-12 by Campaign Legal Center",
           "document_id": 88642,
-          "text": "Random document text for the sixth document",
+          "text": "Random document text for the sixth ao document",
           "url": "/files/legal/aos/2024-12/202412C_2.pdf"
         },
         {
@@ -1669,7 +1679,7 @@ first_ao = {
           "date": "2024-09-12T00:00:00",
           "description": "Draft AO, Agenda Document No. 24-38-A (Comments due on September 18, 2024 by 12:00pm ET)",
           "document_id": 88643,
-          "text": "Random document text for the seventh document",
+          "text": "Random document text for the seventh ao document",
           "url": "/files/legal/aos/2024-12/202412.pdf"
         },
         {
@@ -1678,13 +1688,13 @@ first_ao = {
           "date": "2024-09-12T00:00:00",
           "description": "Draft AO, Agenda Document No. 24-38-B (Comments due on September 18, 2024 by 12:00pm ET)",
           "document_id": 88644,
-          "text": "Random document text for the eighth document",
+          "text": "Random document text for the eighth ao document",
           "url": "/files/legal/aos/2024-12/202412_1.pdf"
         }
       ],
       "entities": [
         {
-          "name": "Mr. Shaun McCutcheon ",
+          "name": "Mr. Shaun McCutcheon",
           "role": "Requestor",
           "type": "Individual"
         },
@@ -1721,7 +1731,8 @@ first_ao = {
       ],
       "request_date": "2024-07-23",
       "requestor_names": [
-        ""
+        "Jane Doe",
+        "Jack Brown"
       ],
       "requestor_types": [
         "Individual"
@@ -1742,12 +1753,176 @@ first_ao = {
       "type": "advisory_opinions"
 }
 
+second_ao = {
+      "ao_citations": [
+        {
+          "name": "Iowa 1980 U.S. Senate Campaign Committee",
+          "no": "1977-16"
+        },
+        {
+          "name": "Westchester Citizens for Good Government",
+          "no": "1982-23"
+        },
+        {
+          "name": "WE LEAD",
+          "no": "2003-23"
+        },
+        {
+          "name": "ActBlue",
+          "no": "2006-30"
+        },
+        {
+          "name": "ActBlue",
+          "no": "2014-13"
+        }
+      ],
+      "ao_no": "2014-19",
+      "ao_serial": 19,
+      "ao_year": 2014,
+      "aos_cited_by": [
+        {
+          "name": "Gary Johnson Victory Fund",
+          "no": "2016-15"
+        },
+        {
+          "name": "It Starts Today",
+          "no": "2019-01"
+        },
+        {
+          "name": "Pro-Life Democratic Candidate PAC",
+          "no": "2019-11"
+        },
+        {
+          "name": "Democratic Party of Wisconsin Federal",
+          "no": "2022-09"
+        },
+        {
+          "name": "VoteDown PAC",
+          "no": "2023-11"
+        }
+      ],
+      "commenter_names": ["Jake Brown"],
+      "doc_id": "advisory_opinions_2014-19",
+      "documents": [
+        {
+          "ao_doc_category_id": "R",
+          "category": "AO Request, Supplemental Material, and Extensions of Time",
+          "date": "2014-12-03T00:00:00",
+          "description": "Request by ActBlue",
+          "document_id": 80835,
+          "text": "Document text for the first ao document",
+          "url": "/files/legal/aos/2014-19/1308389.pdf"
+        },
+        {
+          "ao_doc_category_id": "D",
+          "category": "Draft Documents",
+          "date": "2015-01-09T00:00:00",
+          "description": "Draft AO, Agenda Document No. 15-03-A",
+          "document_id": 80836,
+          "text": "Document text for the second ao document",
+          "url": "/files/legal/aos/2014-19/201419.pdf"
+        },
+        {
+          "ao_doc_category_id": "V",
+          "category": "Withdrawal of Request",
+          "date": "2015-01-15T00:00:00",
+          "description": "Vote",
+          "document_id": 80837,
+          "text": "Document text for the third ao document",
+          "url": "/files/legal/aos/2014-19/1310405.pdf"
+        },
+        {
+          "ao_doc_category_id": "F",
+          "category": "Final Opinion",
+          "date": "2015-01-16T00:00:00",
+          "description": "2014-19",
+          "document_id": 80838,
+          "text": "Document text for the fourth ao document",
+          "url": "/files/legal/aos/2014-19/AO_2014-19_(ActBlue)_Final_(1.15.15).pdf"
+        }
+      ],
+      "entities": [
+        {
+          "name": "ActBlue",
+          "role": "Requestor",
+          "type": "Nonconnected political committee"
+        },
+        {
+          "name": "Steven Gold Esq.",
+          "role": "Counsel/Representative",
+          "type": "Individual"
+        },
+        {
+          "name": "Melissa Flores Esq.",
+          "role": "Counsel/Representative",
+          "type": "Individual"
+        }
+      ],
+      "is_pending": True,
+      "issue_date": "2015-01-15",
+      "name": "ActBlue",
+      "no": "2014-19",
+      "regulatory_citations": [
+        {
+          "part": 101,
+          "section": 2,
+          "title": 11
+        },
+        {
+          "part": 101,
+          "section": 3,
+          "title": 11
+        },
+        {
+          "part": 110,
+          "section": 6,
+          "title": 11
+        }
+      ],
+      "representative_names": [
+        "Gold, Steven",
+        "Flores, Melissa"
+      ],
+      "request_date": "2014-12-03",
+      "requestor_names": [
+        "ActBlue"
+      ],
+      "requestor_types": [
+        "Nonconnected political committee",
+        "Federal candidate/candidate committee/officeholder",
+      ],
+      "status": "Pending",
+      "statutory_citations": [
+        {
+          "section": "30101",
+          "title": 52
+        },
+        {
+          "section": "30102",
+          "title": 52
+        },
+        {
+          "section": "30108",
+          "title": 52
+        },
+        {
+          "section": "30116",
+          "title": 52
+        },
+        {
+          "section": "30146",
+          "title": 52
+        }
+      ],
+      "summary": "Contributions to nominee and draft funds for potential presidential candidates.",
+      "type": "advisory_opinions"
+}
 
 document_dictionary = {
     "murs": [first_test_mur, second_test_mur],
     "archived_murs": [first_archived_mur, second_archived_mur],
     "adrs": [first_adr, second_adr],
     "admin_fines": [first_admin_fine, second_admin_fine],
-    "statutes": [first_statute,],
-    "advisory_opinions": [first_ao,]
+    "statutes": [first_statute, second_statute],
+    "advisory_opinions": [first_ao, second_ao]
 }

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -48,6 +48,35 @@ ALL_DOCUMENT_TYPES = [
 
 ACCEPTED_DATE_FORMATS = "strict_date_optional_time_nanos||MM/dd/yyyy||M/d/yyyy||MM/d/yyyy||M/dd/yyyy"
 
+REQUESTOR_TYPES = {
+            1: "Federal candidate/candidate committee/officeholder",
+            2: "Publicly funded candidates/committees",
+            3: "Party committee, national",
+            4: "Party committee, state or local",
+            5: "Nonconnected political committee",
+            6: "Separate segregated fund",
+            7: "Labor Organization",
+            8: "Trade Association",
+            9: "Membership Organization, Cooperative, Corporation W/O Capital Stock",
+            10: "Corporation (including LLCs electing corporate status)",
+            11: "Partnership (including LLCs electing partnership status)",
+            12: "Governmental entity",
+            13: "Research/Public Interest/Educational Institution",
+            14: "Law Firm",
+            15: "Individual",
+            16: "Other",
+}
+
+CATEGORIES = {
+        "F": "Final Opinion",
+        "V": "Votes",
+        "D": "Draft Documents",
+        "R": "AO Request, Supplemental Material, and Extensions of Time",
+        "W": "Withdrawal of Request",
+        "C": "Comments and Ex parte Communications",
+        "S": "Commissioner Statements",
+    }
+
 # endpoint path: /legal/docs/<doc_type>/<no>
 # under tag: legal
 # test urls:
@@ -555,18 +584,8 @@ def get_ao_document_query(q, **kwargs):
                 category_query.append(Q("term", documents__ao_doc_category_id=ao_doc_category_id))
         combined_query.append(Q("bool", should=category_query, minimum_should_match=1))
 
-    categories = {
-        "F": "Final Opinion",
-        "V": "Votes",
-        "D": "Draft Documents",
-        "R": "AO Request, Supplemental Material, and Extensions of Time",
-        "W": "Withdrawal of Request",
-        "C": "Comments and Ex parte Communications",
-        "S": "Commissioner Statements",
-    }
-
     if kwargs.get("ao_category"):
-        ao_category = [categories[c] for c in kwargs.get("ao_category")]
+        ao_category = [CATEGORIES[c] for c in kwargs.get("ao_category")]
         combined_query = [Q("terms", documents__category=ao_category)]
 
     ao_document_date_range = {}
@@ -680,29 +699,12 @@ def apply_ao_specific_query_params(query, **kwargs):
         must_clauses.append(Q("bool", should=citation_queries, minimum_should_match=1))
 
     if kwargs.get("ao_requestor_type"):
-        requestor_types = {
-            1: "Federal candidate/candidate committee/officeholder",
-            2: "Publicly funded candidates/committees",
-            3: "Party committee, national",
-            4: "Party committee, state or local",
-            5: "Nonconnected political committee",
-            6: "Separate segregated fund",
-            7: "Labor Organization",
-            8: "Trade Association",
-            9: "Membership Organization, Cooperative, Corporation W/O Capital Stock",
-            10: "Corporation (including LLCs electing corporate status)",
-            11: "Partnership (including LLCs electing partnership status)",
-            12: "Governmental entity",
-            13: "Research/Public Interest/Educational Institution",
-            14: "Law Firm",
-            15: "Individual",
-            16: "Other",
-        }
+
         must_clauses.append(
             Q(
                 "terms",
                 requestor_types=[
-                    requestor_types[r] for r in kwargs.get("ao_requestor_type")
+                    REQUESTOR_TYPES[r] for r in kwargs.get("ao_requestor_type")
                 ],
             )
         )


### PR DESCRIPTION
## Summary (required)

- Resolves #6027 

This PR adds integration testing for AOs and Statutes. I also make a small change for the mur_disposition_category since they are stored as numbers and not strings.

### Required reviewers 2 - 3 developers


## Impacted areas of the application

General components of the application that this PR will affect:

- pytest


## How to test

- checkout this branch 
- start elasticsearch 
- test AOs: `pytest tests/integration/test_ao_elasticsearch.py -s`
- test cases: `pytest tests/integration/test_cases_elasticsearch.py -s`
- test statutes: `pytest tests/integration/test_statute_elasticsearch.py -s`
- test all: `pytest`