### PR TITLE
add tests for legal/docs and legal/citations endpoints

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -138,12 +138,16 @@ class ElasticSearchBaseTest(BaseTestCase):
     def tearDown(self):
         self.request_context.pop()
 
-    def _response(self, qry):
+    def _results(self, qry):
         response = self.app.get(qry)
         self.assertEqual(response.status_code, 200)
         result = json.loads(codecs.decode(response.data))
-        self.assertNotEqual(result["total_all"], 0)
         return result
+
+    def _response(self, qry):
+        response = self._results(qry)
+        self.assertNotEqual(response["total_all"], 0)
+        return response
 
     def _results_case(self, qry):
         response = self._response(qry)
@@ -175,6 +179,16 @@ class ElasticSearchBaseTest(BaseTestCase):
         self.assertNotEqual(response["total_statutes"], 0)
         return response["statutes"]
 
+    def _results_docs(self, qry):
+        response = self._results(qry)
+        self.assertEqual(len(response["docs"]), 1)
+        return response["docs"]
+
+    def _results_citations(self, qry):
+        response = self._results(qry)
+        self.assertNotEqual(len(response["citations"]), 0)
+        return response["citations"]
+
 
 def _create_all_indices():
     for index in ALL_INDICES:
@@ -196,6 +210,8 @@ def _insert_all_documents(es_client):
     insert_documents("admin_fines", CASE_ALIAS, es_client)
     insert_documents("statutes", AO_ALIAS, es_client)
     insert_documents("advisory_opinions", AO_ALIAS, es_client)
+    insert_documents("ao_citations", AO_ALIAS, es_client)
+    insert_documents("mur_citations", CASE_ALIAS, es_client)
 
 
 def insert_documents(doc_type, index, es_client):

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -44,16 +44,19 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
     def test_all_doc_types(self):
         response = self._results_case(api.url_for(UniversalSearch))
         # logging.info(response)
+        all_legal_docs = document_dictionary.copy()
+        all_legal_docs.pop("ao_citations")
+        all_legal_docs.pop("mur_citations")
 
         total_all = 0
-        total_all += sum(len(document_dictionary[doc_type]) for doc_type in document_dictionary)
+        total_all += sum(len(all_legal_docs[doc_type]) for doc_type in all_legal_docs)
 
-        all_murs = len(document_dictionary["archived_murs"]) + len(document_dictionary["murs"])
+        all_murs = len(all_legal_docs["archived_murs"]) + len(all_legal_docs["murs"])
 
         self.assertEqual(response["total_all"], total_all)
         self.assertEqual(response["total_murs"], all_murs)
-        self.assertEqual(response["total_adrs"], len(document_dictionary["adrs"]))
-        self.assertEqual(response["total_admin_fines"], len(document_dictionary["admin_fines"]))
+        self.assertEqual(response["total_adrs"], len(all_legal_docs["adrs"]))
+        self.assertEqual(response["total_admin_fines"], len(all_legal_docs["admin_fines"]))
 
     def test_type_filter(self):
         for type in ALL_DOCUMENT_TYPES:

--- a/tests/integration/test_citations_elasticsearch.py
+++ b/tests/integration/test_citations_elasticsearch.py
@@ -1,0 +1,50 @@
+from tests.common import ElasticSearchBaseTest
+from webservices.rest import api
+from webservices.resources.legal import GetLegalCitation
+# import logging
+
+
+class TestCitationsElasticsearch(ElasticSearchBaseTest):
+    def test_citations(self):
+
+        citations = [
+            ["statute", "10"],
+            ["regulation", "16"]
+        ]
+        for citation in citations:
+            response = self._results_citations(api.url_for(GetLegalCitation, citation_type=citation[0],
+                                                           citation=citation[1]))
+            # logging.info(response)
+
+            for res in response:
+                self.assertEqual(res["citation_type"], citation[0])
+                assert citation[1] in res["citation_text"]
+
+    def test_incorrect_citations(self):
+        response = self.app.get(api.url_for(GetLegalCitation, citation_type="abc", citation="10"))
+        # logging.info(response.json)
+
+        self.assertEqual(len(response.json["citations"]), 0)
+
+        response = self.app.get(api.url_for(GetLegalCitation, citation_type="statute", citation="444444444"))
+        # logging.info(response.json)
+
+        self.assertEqual(len(response.json["citations"]), 0)
+
+    def test_doc_type_filter(self):
+        cit = "12"
+        doc_type = "murs"
+
+        response = self._results_citations(api.url_for(GetLegalCitation, citation_type="regulation", citation=cit,
+                                                       doc_type=doc_type))
+        # logging.info(response)
+
+        assert all(
+            citation["doc_type"] == doc_type
+            for citation in response
+        )
+
+        response = self.app.get(api.url_for(GetLegalCitation, citation_type="statute", citation=cit,
+                                            doc_type="wrong_type"))
+
+        self.assertEqual(response.status_code, 422)

--- a/tests/integration/test_legal_docs_elasticsearch.py
+++ b/tests/integration/test_legal_docs_elasticsearch.py
@@ -1,0 +1,34 @@
+from tests.common import ElasticSearchBaseTest
+from webservices.rest import api
+from webservices.resources.legal import GetLegalDocument
+# import logging
+
+
+class TestLegalDocsElasticsearch(ElasticSearchBaseTest):
+    def test_legal_docs(self):
+
+        docs = [
+            ["statutes", "9001"],
+            ["advisory_opinions", "2024-12"],
+            ["murs", "103"],  # archived mur
+            ["adrs", "106"],
+            ["admin_fines", "108"],
+            ["murs", "101"],  # current mur
+        ]
+
+        for doc in docs:
+            response = self._results_docs(api.url_for(GetLegalDocument, doc_type=doc[0], no=doc[1]))
+            # logging.info(response)
+
+            self.assertEqual(response[0]["no"], doc[1])
+
+    def test_legal_docs_incorrect(self):
+        response = self.app.get(api.url_for(GetLegalDocument, doc_type="wrong_type", no="100"))
+
+        self.assertEqual(response.status_code, 404)
+        # logging.info(response.json)
+
+        response = self.app.get(api.url_for(GetLegalDocument, doc_type="murs", no="555555555"))
+        # logging.info(response.json)
+
+        self.assertEqual(response.status_code, 404)

--- a/tests/test_legal_data.py
+++ b/tests/test_legal_data.py
@@ -1918,11 +1918,42 @@ second_ao = {
       "type": "advisory_opinions"
 }
 
+first_citation = {
+      "citation_text": "2 U.S.C. §31021",
+      "citation_type": "statute",
+      "doc_type": "murs",
+      "type": "citations"
+    }
+
+
+second_citation = {
+      "citation_text": "18 U.S.C. 603",
+      "citation_type": "statute",
+      "doc_type": "advisory_opinions",
+      "type": "citations"
+    }
+
+third_citation = {
+      "citation_text": "11 CFR §104.12",
+      "citation_type": "regulation",
+      "doc_type": "murs",
+      "type": "citations"
+    }
+
+fourth_citation = {
+      "citation_text": "11 CFR §116.12",
+      "citation_type": "regulation",
+      "doc_type": "advisory_opinions",
+      "type": "citations"
+    }
+
 document_dictionary = {
     "murs": [first_test_mur, second_test_mur],
     "archived_murs": [first_archived_mur, second_archived_mur],
     "adrs": [first_adr, second_adr],
     "admin_fines": [first_admin_fine, second_admin_fine],
     "statutes": [first_statute, second_statute],
-    "advisory_opinions": [first_ao, second_ao]
+    "advisory_opinions": [first_ao, second_ao],
+    "ao_citations": [second_citation, fourth_citation],
+    "mur_citations": [first_citation, third_citation]
 }


### PR DESCRIPTION
## Summary (required)

- Resolves #6028 

This PR adds tests for the legal/docs and legal/citations endpoints. 

### Required reviewers 1 developer


## Impacted areas of the application

General components of the application that this PR will affect:

- pytest


## How to test

- checkout this branch 
- start elasticsearch 
- test legal/docs: `pytest tests/integration/test_legal_docs_elasticsearch.py -s`
- test legal/citations: `pytest tests/integration/test_citations_elasticsearch.py -s`
- test all: `pytest`
