### PR TITLE
6078- remove deprecated filter

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -1,5 +1,5 @@
 from tests.common import ElasticSearchBaseTest
-from webservices.resources.legal import UniversalSearch, REQUESTOR_TYPES, CATEGORIES
+from webservices.resources.legal import UniversalSearch, REQUESTOR_TYPES
 from webservices.rest import api
 from datetime import datetime
 # import logging
@@ -101,16 +101,6 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         self.check_doc_filters({"ao_doc_category_id": ao_doc_cat_ids}, "ao_doc_category_id", ao_doc_cat_ids)
 
         self.check_incorrect_values({"ao_doc_category_id": "P"}, True)
-
-    def test_ao_category_filter(self):
-        ao_category = "W"
-        self.check_doc_filters({"ao_category": ao_category}, "category", CATEGORIES[ao_category])
-
-        ao_categories = ["V", "D"]
-        ao_categories_full = [CATEGORIES["V"], CATEGORIES["D"]]
-        self.check_doc_filters({"ao_category": ao_categories}, "category", ao_categories_full)
-
-        self.check_incorrect_values({"ao_category": "P"}, True)
 
     def test_ao_sort(self):
         sort = "-ao_no"

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -341,8 +341,6 @@ legal_universal_search = {
     'ao_doc_category_id': fields.List(
         IStr(validate=validate.OneOf(['', 'F', 'V', 'D', 'R', 'W', 'C', 'S'])),
         description=docs.AO_DOC_CATEGORY_ID),
-    'ao_category': fields.List(
-        IStr(validate=validate.OneOf(['F', 'V', 'D', 'R', 'W', 'C', 'S'])), description=docs.AO_CATEGORY),
     'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
     'ao_status': fields.Str(description=docs.AO_STATUS),
     'ao_requestor': fields.Str(description=docs.AO_REQUESTOR),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2125,18 +2125,6 @@ Selects all advisory opinion documents dated on or before this date. Date must b
 formatted as MM/DD/YYYY or YYYY-MM-DD."
 '''
 
-AO_CATEGORY = '''
-`DEPRECATED` please use AO_DOC_CATEGORY_ID
-Category of the document
-F - Final Opinion
-V - Votes
-D - Draft Documents
-R - AO Request, Supplemental Material, and Extensions of Time
-W - Withdrawal of Request
-C - Comments and Ex parte Communications
-S - Commissioner Statements
-'''
-
 AO_DOC_CATEGORY_ID = '''
 Category of the document
 F - Final Opinion

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -67,16 +67,6 @@ REQUESTOR_TYPES = {
             16: "Other",
 }
 
-CATEGORIES = {
-        "F": "Final Opinion",
-        "V": "Votes",
-        "D": "Draft Documents",
-        "R": "AO Request, Supplemental Material, and Extensions of Time",
-        "W": "Withdrawal of Request",
-        "C": "Comments and Ex parte Communications",
-        "S": "Commissioner Statements",
-    }
-
 # endpoint path: /legal/docs/<doc_type>/<no>
 # under tag: legal
 # test urls:
@@ -583,10 +573,6 @@ def get_ao_document_query(q, **kwargs):
             if len(ao_doc_category_id) > 0:
                 category_query.append(Q("term", documents__ao_doc_category_id=ao_doc_category_id))
         combined_query.append(Q("bool", should=category_query, minimum_should_match=1))
-
-    if kwargs.get("ao_category"):
-        ao_category = [CATEGORIES[c] for c in kwargs.get("ao_category")]
-        combined_query = [Q("terms", documents__category=ao_category)]
 
     ao_document_date_range = {}
     if kwargs.get("ao_min_document_date"):


### PR DESCRIPTION
## Summary (required)

- Resolves #6078 

ao_category has been deprecated and should be removed. ao_doc_category_id is being used by the FE 

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

- ao_category filter 

## How to test

- activate your venv
- start ES and load docs if needed (./bin/elasticsearch) [ES instructions](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-management-instruction)
- flask run on dev, check totals for each doc type

- pull this branch
- pytest
- flask run
- check your totals 
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=V
- 127.0.0.1:5000/v1/legal/search/?q=committee&ao_doc_category_id=V
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=W
- 127.0.0.1:5000/v1/legal/search/?ao_doc_category_id=D&ao_doc_category_id=S
