### PR TITLE
6070-Fix pytest test_efile issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def reset_schema():
         "real_pfile",
         "rohan",
         "staging",
+        "test_efile",
     ]:
         rest.db.engine.execute('drop schema if exists %s cascade;' % schema)
     rest.db.engine.execute('create schema public;')


### PR DESCRIPTION
## Summary (required)
This PR fix issue that backend develop have to drop and recreate their local test database every time run pytest.

Note: 
When we add new schema, remember to add schema name into reset_schema() of tests/conftest.py

- Resolves #6070 

### Required reviewers
1 dev

## Impacted areas of the application
pytest

## How to test
1) checkout branch
2) run `pytest` twice (don't need drop cfdm_unit_test)