### PR TITLE
Feature/6076 add proximity search

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -130,6 +130,34 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["ao_no"], "2014-19")
 
+    def test_q_proximity_filters(self):
+        search_phrase = "Random document third ao"
+        proximity_filter = "before"
+        proximity_filter_term = "document"
+        max_gaps = 3
+
+        response = self._results_ao(api.url_for(UniversalSearch,
+                                                q_proximity=search_phrase,
+                                                proximity_filter=proximity_filter,
+                                                proximity_filter_term=proximity_filter_term,
+                                                max_gaps=max_gaps))
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]["ao_no"], "2024-12")
+
+        multiple_phrases = ["fourth ao", "proximity document"]
+        max_gaps = 3
+
+        response = self._results_ao(api.url_for(UniversalSearch,
+                                                q_proximity=multiple_phrases,
+                                                proximity_filter=proximity_filter,
+                                                proximity_filter_term=proximity_filter_term,
+                                                max_gaps=max_gaps))
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0]["ao_no"], "2014-19")
+
+        self.check_incorrect_values({"q_proximity": search_phrase, "max_gaps": 1}, False)
+
     def test_citation_filters(self):
         statutory_title = 52
         statutory_section = "30101"

--- a/tests/test_legal_data.py
+++ b/tests/test_legal_data.py
@@ -1837,7 +1837,7 @@ second_ao = {
           "date": "2015-01-16T00:00:00",
           "description": "2014-19",
           "document_id": 80838,
-          "text": "Document text for the fourth ao document",
+          "text": "Proximity document text for the fourth ao document",
           "url": "/files/legal/aos/2014-19/AO_2014-19_(ActBlue)_Final_(1.15.15).pdf"
         }
       ],

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -401,6 +401,10 @@ legal_universal_search = {
     'sort': IStr(required=False, description=docs.SORT),
     'case_min_penalty_amount': fields.Str(required=False, description=docs.CASE_MIN_PENALTY_AMOUNT),
     'case_max_penalty_amount': fields.Str(required=False, description=docs.CASE_MAX_PENALTY_AMOUNT),
+    'q_proximity': fields.List(fields.Str, description=docs.Q_PROXIMITY),
+    'max_gaps': fields.Int(required=False, description=docs.MAX_GAPS),
+    "proximity_filter": fields.Str(validate=validate.OneOf(["after", "before"]), description=docs.PROXIMITY_FILTER),
+    'proximity_filter_term': fields.Str(required=False, description=docs.PROXIMITY_FILTER_TERM),
 }
 
 citation = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2362,7 +2362,7 @@ multiple phrases, the maximum gap is applied between the phrases themselves.
 '''
 
 MAX_GAPS = '''
-The maximum number of positions allowed between matching terms specified in q_proximity
+The maximum number of positions allowed between terms specified in `q_proximity`
 '''
 
 PROXIMITY_FILTER = '''
@@ -2370,7 +2370,8 @@ Adds additional filters to the proximity search that provides options to specify
 '''
 
 PROXIMITY_FILTER_TERM = '''
-q_proximity phrase
+Specifies the term to which the `proximity_filter` option applies to and defines what must appear in relation to the \
+`q_proximity` phrase
 '''
 
 # ======== legal end =========

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2354,6 +2354,25 @@ CASE_MAX_PENALTY_AMOUNT = '''
 Show cases with a penalty less than this amount
 
 '''
+
+Q_PROXIMITY = '''
+This search identifies documents where the specified phrases appear near each other. The field supports both a single \
+phrase or multiple phrases. For a single phrase, the maximum gap is applied between the words in the phrase. For \
+multiple phrases, the maximum gap is applied between the phrases themselves.
+'''
+
+MAX_GAPS = '''
+The maximum number of positions allowed between matching terms specified in q_proximity
+'''
+
+PROXIMITY_FILTER = '''
+Adds additional filters to the proximity search that provides options to specify positional constraints
+'''
+
+PROXIMITY_FILTER_TERM = '''
+q_proximity phrase
+'''
+
 # ======== legal end =========
 
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6076 

This PR adds a proximity search to our legal search endpoint for AO, ADR, MUR, and AFs. The four new filters are `q_proximity`, `max_gaps`, `proximity_filter`, and `proximity_filter_term`. 

Note: I removed highlighting for proximity search because it does not work with intervals queries. 
Please see the previous [research ticket](https://github.com/fecgov/openFEC/issues/5945) for an in depth breakdown.  

### Required reviewers 2 - 3 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

- legal search 


## How to test

- checkout this branch
- start elasticsearch `./elasticsearch`
- `pytest`
- create case index: `python cli.py create_index case_index`
- create ao index: `python cli.py create_index ao_index`
- load sample data for ao, mur, af, and adrs(at least three of each) : `python cli.py load_current_murs` `python cli.py load_admin_fines` `python cli.py load_advisory_opinions` `python cli.py load_adrs`
- `flask run`
- see test URLs below 

Test URLs reference the following documents: MUR 8285, ADR 1175, AF 4774, AO 2024-15

MUR: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=daunting%20task&q_proximity=actively%20campaigning&q_proximity=represent%20Illinois&max_gaps=12

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=after&proximity_filter_term=remediation


http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=before&proximity_filter_term=remediation

ADR: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=RAD%20Wisconsin&max_gaps=5

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13&proximity_filter=after&proximity_filter_term=RAD

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13&proximity_filter=before&proximity_filter_term=RAD


AF: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=%20Thomas%20Datwyler&q_proximity=reason%20to%20believe&max_gaps=5

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4&proximity_filter=after&proximity_filter_term=%20Pre-Primary%20Report

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4&proximity_filter=before&proximity_filter_term=%20Pre-Primary%20Report

AO: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6


Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=misappropriation%20&q_proximity=membership%20dues&max_gaps=2


With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6&proximity_filter=before&proximity_filter_term=misappropriation

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6&proximity_filter=after&proximity_filter_term=misappropriation