### PR TITLE
validate legal/search endpoint filters

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -58,8 +58,8 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         assert all(requestor in doc["requestor_names"] for doc in response)
         self.check_incorrect_values({"ao_requestor": "Incorrect"}, False)
 
-        types = [5, 15]
-        requstor_type_full = [REQUESTOR_TYPES[5], REQUESTOR_TYPES[15]]
+        types = ["5", "15"]
+        requstor_type_full = [REQUESTOR_TYPES["5"], REQUESTOR_TYPES["15"]]
         response = self._results_ao(api.url_for(UniversalSearch, ao_requestor_type=types))
         # logging.info(response)
 
@@ -67,13 +67,13 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
                        for requestor in doc["requestor_types"])
                    for doc in response)
 
-        type = 15
+        type = "15"
         response = self._results_ao(api.url_for(UniversalSearch, ao_requestor_type=type))
         # logging.info(response)
 
         assert all(REQUESTOR_TYPES[type] in doc["requestor_types"] for doc in response)
 
-        self.check_incorrect_values({"ao_requestor_type": 22}, True)
+        self.check_incorrect_values({"ao_requestor_type": "22"}, True)
 
     def test_ao_entity_name_filter(self):
         entity_name = "Francis Beaver"

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -384,12 +384,12 @@ legal_universal_search = {
     'primary_subject_id': fields.List(IStr(
         validate=validate.OneOf(
             ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
-                '12', '13',  '14', '15', '16',  '17', '18', '19', '20'])),
+                '12', '13', '14', '15', '16', '17', '18', '19', '20'])),
             description=docs.PRIMARY_SUBJECT_DESCRIPTION),
     'secondary_subject_id': fields.List(IStr(
         validate=validate.OneOf(
             ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
-                '12', '13',  '14', '15', '16',  '17', '18'])),
+                '12', '13', '14', '15', '16', '17', '18'])),
             description=docs.SECONDARY_SUBJECT_DESCRIPTION),
     'case_max_open_date': Date(required=False, description=docs.CASE_MAX_OPEN_DATE),
     'case_min_close_date': Date(required=False, description=docs.CASE_MIN_CLOSE_DATE),
@@ -406,7 +406,7 @@ legal_universal_search = {
         description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
 
     'mur_type': fields.Str(
-        required=False, validate=validate.OneOf(["archived", "current"]), description=docs.MUR_TYPE),
+        required=False, validate=validate.OneOf(['', 'archived', 'current']), description=docs.MUR_TYPE),
     'mur_disposition_category_id': fields.List(IStr(
         validate=validate.OneOf([
             '', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
@@ -434,7 +434,7 @@ legal_universal_search = {
 
 citation = {
     'doc_type': fields.Str(
-                required=False, validate=validate.OneOf(["adrs", "advisory_opinions", "murs"]),
+                required=False, validate=validate.OneOf(['', 'adrs', 'advisory_opinions', 'murs']),
                 description=docs.CITATION_DOC_TYPE
             )
 }

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -368,9 +368,10 @@ legal_universal_search = {
     'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
     'ao_status': fields.Str(description=docs.AO_STATUS),
     'ao_requestor': fields.Str(description=docs.AO_REQUESTOR),
-    'ao_requestor_type': fields.List(
-        fields.Integer(validate=validate.OneOf(range(1, 17))),
-        description=docs.AO_REQUESTOR_TYPE),
+    'ao_requestor_type': fields.List(IStr(
+        validate=validate.OneOf(['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
+                                '12', '13', '14', '15', '16'])),
+                                description=docs.AO_REQUESTOR_TYPE),
     'ao_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'ao_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'ao_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -350,8 +350,8 @@ legal_universal_search = {
     'from_hit': fields.Int(required=False, description=docs.FROM_HIT),
     'hits_returned': fields.Int(required=False, description=docs.HITS_RETURNED),
     'type': fields.Str(
-            validate=validate.OneOf(["admin_fines", "adrs", "advisory_opinions",
-                                     "murs", "statutes"]),
+            validate=validate.OneOf(['', 'admin_fines', 'adrs', 'advisory_opinions',
+                                     'murs', 'statutes']),
             description=docs.LEGAL_DOC_TYPE),
 
     'ao_no': fields.List(IStr, required=False, description=docs.AO_NUMBER),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2150,6 +2150,23 @@ The requestor of the advisory opinion
 
 AO_REQUESTOR_TYPE = '''
 Code of the advisory opinion requestor type.
+Select one or more codes to filter by advisory opinion requestor type:\n\
+        - 1 - Federal candidate/candidate committee/officeholder\n\
+        - 2 - Publicly funded candidates/committees\n\
+        - 3 - Party committee, national\n\
+        - 4 - Party committee, state or local\n\
+        - 5 - Nonconnected political committee\n\
+        - 6 - Separate segregated fun \n\
+        - 7 - Labor Organization\n\
+        - 8 - Trade Association\n\
+        - 9 - Membership Organization, Cooperative, Corporation W/O Capital Stocks\n\
+        - 10 - Corporation (including LLCs electing corporate status)\n\
+        - 11 - Partnership (including LLCs electing partnership status)\n\
+        - 12 - Governmental entity \n\
+        - 13 - Research/Public Interest/Educational Institution\n\
+        - 14 - Law Firm\n\
+        - 15 - Individual\n\
+        - 16 - Other\n\
 '''
 
 CITATION_DOC_TYPE = '''

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -183,3 +183,19 @@ def get_cycle(kwargs):
             )
         return kwargs['cycle'][0]
     return kwargs['cycle']
+
+
+ao_requestor_type_valid_filter_values = ['1', '2', '3', '4', '5', '6', '7', '8', '9',
+                                         '10', '11', '12', '13', '14', '15', '16']
+
+
+def validate_ao_requestor_type(ao_requestor_type):
+    valid_values = []
+
+    # Validate each value in ao_requestor_type
+    for value in ao_requestor_type:
+        if isinstance(value, str) and ' ' not in value:
+            if value in ao_requestor_type_valid_filter_values:
+                valid_values.append(value)
+
+        return valid_values

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -185,17 +185,12 @@ def get_cycle(kwargs):
     return kwargs['cycle']
 
 
-ao_requestor_type_valid_filter_values = ['1', '2', '3', '4', '5', '6', '7', '8', '9',
-                                         '10', '11', '12', '13', '14', '15', '16']
+def validate_multiselect_filter(filter, valid_values):
+    valid_results = []
 
-
-def validate_ao_requestor_type(ao_requestor_type):
-    valid_values = []
-
-    # Validate each value in ao_requestor_type
-    for value in ao_requestor_type:
+    # Validate each value in filter
+    for value in filter:
         if isinstance(value, str) and ' ' not in value:
-            if value in ao_requestor_type_valid_filter_values:
-                valid_values.append(value)
-
-        return valid_values
+            if value in valid_values:
+                valid_results.append(value)
+    return valid_results

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -49,22 +49,22 @@ ALL_DOCUMENT_TYPES = [
 ACCEPTED_DATE_FORMATS = "strict_date_optional_time_nanos||MM/dd/yyyy||M/d/yyyy||MM/d/yyyy||M/dd/yyyy"
 
 REQUESTOR_TYPES = {
-            1: "Federal candidate/candidate committee/officeholder",
-            2: "Publicly funded candidates/committees",
-            3: "Party committee, national",
-            4: "Party committee, state or local",
-            5: "Nonconnected political committee",
-            6: "Separate segregated fund",
-            7: "Labor Organization",
-            8: "Trade Association",
-            9: "Membership Organization, Cooperative, Corporation W/O Capital Stock",
-            10: "Corporation (including LLCs electing corporate status)",
-            11: "Partnership (including LLCs electing partnership status)",
-            12: "Governmental entity",
-            13: "Research/Public Interest/Educational Institution",
-            14: "Law Firm",
-            15: "Individual",
-            16: "Other",
+            "1": "Federal candidate/candidate committee/officeholder",
+            "2": "Publicly funded candidates/committees",
+            "3": "Party committee, national",
+            "4": "Party committee, state or local",
+            "5": "Nonconnected political committee",
+            "6": "Separate segregated fund",
+            "7": "Labor Organization",
+            "8": "Trade Association",
+            "9": "Membership Organization, Cooperative, Corporation W/O Capital Stock",
+            "10": "Corporation (including LLCs electing corporate status)",
+            "11": "Partnership (including LLCs electing partnership status)",
+            "12": "Governmental entity",
+            "13": "Research/Public Interest/Educational Institution",
+            "14": "Law Firm",
+            "15": "Individual",
+            "16": "Other",
 }
 
 # endpoint path: /legal/docs/<doc_type>/<no>
@@ -736,8 +736,7 @@ def apply_ao_specific_query_params(query, **kwargs):
     else:
         must_clauses.append(Q("bool", should=citation_queries, minimum_should_match=1))
 
-    if kwargs.get("ao_requestor_type"):
-
+    if check_filter_exists(kwargs, "ao_requestor_type"):
         must_clauses.append(
             Q(
                 "terms",

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -129,8 +129,8 @@ class UniversalSearch(Resource):
             "adrs": case_query_builder,
             "admin_fines": case_query_builder,
         }
-
-        if kwargs.get("type", "all") == "all":
+        # Get the type from kwargs, defaulting to '' if not present
+        if kwargs.get("type", "") == "":
             doc_types = ALL_DOCUMENT_TYPES
         else:
             doc_types = [kwargs.get("type")]
@@ -739,9 +739,12 @@ def apply_ao_specific_query_params(query, **kwargs):
 
     # Get 'ao_requestor_type' from kwargs
     ao_requestor_type = kwargs.get("ao_requestor_type", [])
+    ao_requestor_type_valid_values = ['1', '2', '3', '4', '5', '6', '7', '8', '9',
+                                      '10', '11', '12', '13', '14', '15', '16']
 
-    # Validate 'ao_requestor_type'
-    valid_requestor_types = filters.validate_ao_requestor_type(ao_requestor_type)
+    # Validate 'ao_requestor_type filter'
+    valid_requestor_types = filters.validate_multiselect_filter(
+        ao_requestor_type, ao_requestor_type_valid_values)
 
     # Always include valid values in the query construction
     if valid_requestor_types:

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -236,13 +236,33 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if check_filter_exists(kwargs, "case_no"):
         must_clauses.append(Q("terms", no=kwargs.get("case_no")))
 
-    if kwargs.get("primary_subject_id") and '' not in kwargs.get("primary_subject_id"):
-        must_clauses.append(Q("nested", path="subjects",
-                            query=Q("terms", subjects__primary_subject_id=kwargs.get("primary_subject_id"))))
+    # Get 'primary_subject_id' from kwargs
+    primary_subject_id = kwargs.get("primary_subject_id", [])
+    primary_subject_id_valid_values = ['1', '2', '3', '4', '5', '6', '7', '8', '9',
+                                       '10', '11', '12', '13', '14', '15', '16',
+                                       '17', '18', '19', '20']
 
-    if kwargs.get("secondary_subject_id") and '' not in kwargs.get("secondary_subject_id"):
+    # Validate 'primary_subject_id filter'
+    valid_primary_subject_id = filters.validate_multiselect_filter(
+        primary_subject_id, primary_subject_id_valid_values)
+
+    if valid_primary_subject_id:
         must_clauses.append(Q("nested", path="subjects",
-                            query=Q("terms", subjects__secondary_subject_id=kwargs.get("secondary_subject_id"))))
+                            query=Q("terms", subjects__primary_subject_id=valid_primary_subject_id)))
+
+    # Get 'secondary_subject_id' from kwargs
+    secondary_subject_id = kwargs.get("secondary_subject_id", [])
+    secondary_subject_id_valid_values = ['1', '2', '3', '4', '5', '6', '7', '8', '9',
+                                         '10', '11', '12', '13', '14', '15', '16',
+                                         '17', '18']
+
+    # Validate 'secondary_subject_id filter'
+    valid_secondary_subject_id = filters.validate_multiselect_filter(
+        secondary_subject_id, secondary_subject_id_valid_values)
+
+    if valid_secondary_subject_id:
+        must_clauses.append(Q("nested", path="subjects",
+                            query=Q("terms", subjects__secondary_subject_id=valid_secondary_subject_id)))
 
     if kwargs.get("case_respondents"):
         must_clauses.append(Q("simple_query_string",


### PR DESCRIPTION
## Summary (required)

- Resolves #6024

- Update the [type=all](https://github.com/fecgov/openFEC/blob/develop/webservices/resources/legal.py#L132) logic to return all types when the search is empty
- Update `ao_requestor_type` filter from int to  a string 
- Validate filters: type, mur_type, ao_requestor_type, primary_subject_id, secondary_subject_id 
- Update tests
- Update docs.py

### Required reviewers

2 developers

## Impacted areas of the application

- legal/search endpoints

## How to test

### on local:

- `git checkout feature/6024-legal-search-validate-dropdown-filters`
- pyenv activate <your python  virtual env>
- run elasticsearch service 
- run `pytest`
- run `python cli.py create_index ao_index`
- run  `python cli.py create_index arch_mur_index`
- run `python cli.py create_index case_index`

- run `python cli.py load_advisory_opinions 2023-01` (13 AO's upload to local ES service)
- run `python cli.py load_archived_murs`
- run `python cli.py load_current_murs`

- run `flask run`

### **test filters**
---
1. type= (empty string):

**Prod:**
- https://api.open.fec.gov/v1/legal/search/?type=&api_key=DEMO_KEY   (Throws 422 error)

**Local**
- http://localhost:5000/v1/legal/search/?type="" (return all types)
---

2. ao_requestor_type:

**Prod:**
- https://api.open.fec.gov/v1/legal/search/?type=advisory_opinions&ao_requestor_type=1&ao_requestor_type=&api_key=DEMO_KEY   (Throws 422 error)

**Local**
- http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_requestor_type=1&ao_requestor_type= (return 8 results)
---

3. primary_subject_id:

**Prod:**
- https://api.open.fec.gov/v1/legal/search/?type=murs&primary_subject_id=2&primary_subject_id=&api_key=DEMO_KEY   (return all 7577 results)

**Local**
- http://127.0.0.1:5000/v1/legal/search/?type=murs&primary_subject_id=2&primary_subject_id=
(returns results for primary_subject_id=2)
---

4. secondary_subject_id:

**Prod:**
- https://api.open.fec.gov/v1/legal/search/?type=murs&secondary_subject_id=2&secondary_subject_id=&api_key=DEMO_KEY (returns 7578 results)

**Local**
- http://127.0.0.1:5000/v1/legal/search/?type=murs&secondary_subject_id=6&secondary_subject_id= 
(returns results for secondary_subject_id=6)
--