### PR TITLE
6081- add ISO8601 validation

### DIFF
--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -76,10 +76,7 @@ class TestElectionDates(ApiBaseTest):
 class TestCalendarDates(ApiBaseTest):
     def test_filters(self):
         factories.CalendarDateFactory(start_date=datetime.datetime(2016, 1, 2))
-        factories.CalendarDateFactory(location='Mississippi, CA')
         factories.CalendarDateFactory(event_id=123)
-        # deprecated while we figure out a better way to generate the data
-        # factories.CalendarDateFactory(state=['CA'])
         factories.CalendarDateFactory(calendar_category_id=7)
         factories.CalendarDateFactory(description='a really interesting event')
         factories.CalendarDateFactory(
@@ -91,8 +88,7 @@ class TestCalendarDates(ApiBaseTest):
             ('min_start_date', '01/01/2015'),
             ('calendar_category_id', 7),
             ('min_end_date', '2014-01-01'),
-            # this is not passing or working :/
-            # ('state', 'CA'),
+            ('max_end_date', '2023-12-27T14:30:00+05:30'),
             ('description', 'interesting event'),
             ('summary', 'solve all the problems'),
             ('event_id', 123),

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -99,6 +99,30 @@ class Date(fields.Str):
                     status_code=422)
 
 
+class FullDate(fields.Str):
+
+    def _validate(self, value):
+        value = value.strip()
+        super()._validate(value)
+        try:
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            # Try parsing ISO 8601 format
+            datetime.datetime.fromisoformat(value)
+        except (TypeError, ValueError):
+            try:
+                # Try parsing YYYY-MM-DD
+                datetime.datetime.strptime(value, '%Y-%m-%d')
+            except (TypeError, ValueError):
+                try:
+                    # Try parsing MM/DD/YYYY
+                    datetime.datetime.strptime(value, '%m/%d/%Y')
+                except (TypeError, ValueError):
+                    raise exceptions.ApiError(
+                        exceptions.FULLDATE_ERROR,
+                        status_code=422)
+
+
 class ImageNumber(fields.Str):
 
     def _validate(self, value):
@@ -675,10 +699,10 @@ calendar_dates = {
     'calendar_category_id': fields.List(fields.Int, description=docs.CATEGORY),
     'description': fields.List(Keyword, description=docs.CAL_DESCRIPTION),
     'summary': fields.List(Keyword, description=docs.SUMMARY),
-    'min_start_date': Date(description=docs.MIN_START_DATE),
-    'min_end_date': Date(description=docs.MIN_END_DATE),
-    'max_start_date': Date(description=docs.MAX_START_DATE),
-    'max_end_date': Date(description=docs.MAX_END_DATE),
+    'min_start_date': FullDate(description=docs.MIN_START_DATE),
+    'min_end_date': FullDate(description=docs.MIN_END_DATE),
+    'max_start_date': FullDate(description=docs.MAX_START_DATE),
+    'max_end_date': FullDate(description=docs.MAX_END_DATE),
     'event_id': fields.Int(description=docs.EVENT_ID),
 }
 

--- a/webservices/exceptions.py
+++ b/webservices/exceptions.py
@@ -27,6 +27,10 @@ NEXT_IN_CHAIN_DATA_ERROR = """next_in_chain data error, please contact apiinfo@f
 DATE_ERROR = """Invalid date. Date must be formatted as MM/DD/YYYY or YYYY-MM-DD.\
 """
 
+FULLDATE_ERROR = """Invalid date. Date must be formatted as MM/DD/YYYY, YYYY-MM-DD,\
+or ISO 8601 (YYYY-MM-DDTHH:MM:SS[+|-]HH:MM).\
+"""
+
 COMMITTEE_ID_ERROR = """Invalid committee_id. A valid committee_id begins with a 'C'\
  followed by 8 digits. For example: C00100005.\
 """


### PR DESCRIPTION
## Summary 

- Resolves #6081 

Adds ISO8601 as an option for calendar-dates and calendar-dates/export

My current understanding is that election-dates and reporting-dates are not to be changed yet--but can be changed easily using this class later. 

### Required reviewers

2-3 devs, would like FE to take a look

## Impacted areas of the application

General components of the application that this PR will affect:

-calendar-dates
-calendar-dates/exports

## How to test
- activate your venv
- pytest
- flask run

- [Here's the branch](https://app.circleci.com/pipelines/github/fecgov/openFEC/3210/workflows/be4317c9-61c8-498c-b656-ccf23271d3a0/jobs/6073) pushed to dev (feel free to rebuild)

Old format YYYY-MM-DD:
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

Old format MM/DD/YYYY:
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&min_start_date=12/27/2018&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&min_start_date=12/27/2018&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=12/27/2018&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT testing min_start_date:
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&min_start_date=2018-12-28&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT testing export:
- http://127.0.0.1:5000/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27T14%3A30%3A00%2B05%3A30&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT with timezone testing max_end_date:
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&min_end_date=2023-12-27T14%3A30%3A00%2B10%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&min_end_date=2023-12-27T14%3A30%3A00%2B10%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&min_end_date=2023-12-27T14%3A30%3A00%2B10%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&min_end_date=2023-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT with fractional seconds max_start_date:
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&max_start_date=2023-12-27T14%3A30%3A00.123%2B02%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&max_start_date=2023-12-27T14%3A30%3A00.123%2B02%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&max_start_date=2023-12-27T14%3A30%3A00.123%2B02%3A00&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&max_start_date=2023-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT with Zulu for UTC (2023-12-27T23:59:59Z):
- http://127.0.0.1:5000/v1/calendar-dates/?page=1&per_page=20&max_end_date=2023-12-27T23%3A59%3A59Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/?page=1&per_page=20&max_end_date=2023-12-27T23%3A59%3A59Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&max_end_date=2023-12-27T23%3A59%3A59Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/?page=1&per_page=20&max_end_date=2023-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

NEW FORMAT with Zulu for UTC (2023-12-27T00:00:00Z) w/export:
- http://127.0.0.1:5000/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&max_end_date=2023-12-27T00%3A00%3A00Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
- https://fec-dev-api.app.cloud.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&max_end_date=2023-12-27T00%3A00%3A00Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&max_end_date=2023-12-27T00%3A00%3A00Z&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Old format with prod (to check numbers):
- https://api.open.fec.gov/v1/calendar-dates/export/?renderer=ics&page=1&per_page=20&min_start_date=2018-12-27&max_end_date=2023-12-27&sort=-start_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

Push to dev and test downloads 
https://www.fec.gov/calendar/?category=EC+Periods&category=FEA+Periods&category=IE+Periods&category=election&category=report-E&category=report-M&category=report-Q

Maybe see if Robert can push the full calendar upgrade to CMS dev to further test? 