### PR TITLE
6092 split entity filters

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -75,23 +75,21 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
 
         self.check_incorrect_values({"ao_requestor_type": 22}, True)
 
-    def test_ao_entity_name_filter(self):
-        entity_name = "Francis Beaver"
-        response = self._results_ao(api.url_for(UniversalSearch, ao_entity_name=entity_name))
+    def test_ao_commenter_filter(self):
+        commenter = "Francis Beaver"
+        response = self._results_ao(api.url_for(UniversalSearch, ao_commenter=commenter))
         # logging.info(response)
 
-        assert all(entity_name in doc["commenter_names"] or entity_name in doc["representative_names"]
-                   for doc in response)
+        assert all(commenter in doc["commenter_names"] for doc in response)
+        self.check_incorrect_values({"ao_commenter": "Incorrect"}, False)
 
-        entity_names = ["Jake Brown", "Francis Beaver"]
-        response = self._results_ao(api.url_for(UniversalSearch, ao_entity_name=entity_names))
+    def test_ao_representative_filter(self):
+        representative = "Chalmers, Adams, Backer & Kaufman, LLC"
+        response = self._results_ao(api.url_for(UniversalSearch, ao_representative=representative))
         # logging.info(response)
 
-        assert all(set(entity_names).intersection(doc["commenter_names"]) or set(entity_names).intersection(
-            doc["representative_names"])
-                   for doc in response)
-
-        self.check_incorrect_values({"ao_entity_name": "Bad Value"}, False)
+        assert all(representative in doc["representative_names"] for doc in response)
+        self.check_incorrect_values({"ao_representative": "Incorrect"}, False)
 
     def test_doc_cat_id_filter(self):
         ao_doc_cat_id = "C"

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -374,8 +374,8 @@ legal_universal_search = {
     'ao_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
     'ao_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
     'ao_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
-    'ao_entity_name': fields.List(IStr, required=False, description=docs.AO_ENTITY_NAME),
-
+    'ao_commenter': fields.Str(description=docs.AO_COMMENTER),
+    'ao_representative': fields.Str(description=docs.AO_REPRESENTATIVE),
     'case_no': fields.List(IStr, required=False, description=docs.CASE_NO),
     'case_respondents': IStr(required=False, description=docs.CASE_RESPONDENTS),
     'case_election_cycles': fields.Int(required=False, description=docs.CASE_ELECTION_CYCLES),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2168,8 +2168,12 @@ CITATION_REQUIRE_ALL = '''
 Require all citations to be in document (default behavior is any)
 '''
 
-AO_ENTITY_NAME = '''
-Name of commenter or representative
+AO_COMMENTER = '''
+Name of commenter
+'''
+
+AO_REPRESENTATIVE = '''
+Name of representative
 '''
 
 CASE_NO = '''

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -663,6 +663,12 @@ def apply_ao_specific_query_params(query, **kwargs):
     if kwargs.get("ao_requestor"):
         must_clauses.append(Q("match", requestor_names=kwargs.get("ao_requestor")))
 
+    if kwargs.get("ao_commenter"):
+        must_clauses.append(Q("match", commenter_names=kwargs.get("ao_commenter")))
+
+    if kwargs.get("ao_representative"):
+        must_clauses.append(Q("match", representative_names=kwargs.get("ao_representative")))
+
     citation_queries = []
     if kwargs.get("ao_regulatory_citation"):
         for citation in kwargs.get("ao_regulatory_citation"):
@@ -764,21 +770,6 @@ def apply_ao_specific_query_params(query, **kwargs):
     if date_range:
         date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", request_date=date_range))
-
-    if check_filter_exists(kwargs, "ao_entity_name"):
-        must_clauses.append(
-            Q(
-                "bool",
-                should=[
-                    Q("match", commenter_names=" ".join(kwargs.get("ao_entity_name"))),
-                    Q(
-                        "match",
-                        representative_names=" ".join(kwargs.get("ao_entity_name")),
-                    ),
-                ],
-                minimum_should_match=1,
-            )
-        )
 
     query = query.query("bool", must=must_clauses)
     # logger.debug("apply_ao_specific_query_params =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))


### PR DESCRIPTION
## Summary (required)

- Resolves #6092 

This removes the entity filter and adds commenter and representative filters to match the ao_requestor filter. I confirmed with design that this should not be a list input filter. 

I checked for any usage (to send a dep notice) and there was a singular external use in the last three months that was pretty clearly a bot (added all filters empty) so I think we should be ok to make this change. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-AO filters

## How to test

activate pyenv
gh pr checkout 6098
pytest
python cli.py create_index ao_index
python cli.py create_index arch_mur_index
python cli.py create_index case_index
python cli.py load_advisory_opinions 2024-03
python cli.py load_archived_murs
python cli.py load_current_murs
flask run

http://127.0.0.1:5000/v1/legal/search/?ao_commenter=mr (2)
http://127.0.0.1:5000/v1/legal/search/?ao_representative=Jacquelyn (3)
http://127.0.0.1:5000/v1/legal/search/?q=Montana&ao_commenter=mr (1)

