### PR TITLE
Add test indices for pytest

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -11,15 +11,15 @@ from jdbc_utils import to_jdbc_url
 from webservices import rest
 from webservices import __API_VERSION__
 
-from webservices.legal_docs import (create_index, CASE_INDEX, ARCH_MUR_INDEX, AO_INDEX,
-                                    CASE_ALIAS, ARCH_MUR_ALIAS, AO_ALIAS)
+from webservices.legal_docs import (create_test_indices, TEST_CASE_INDEX, TEST_ARCH_MUR_INDEX, TEST_AO_INDEX,
+                                    TEST_CASE_ALIAS, TEST_ARCH_MUR_ALIAS, TEST_AO_ALIAS)
 from webservices.utils import create_es_client
 from tests.test_legal_data import document_dictionary
 
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
 rest.app.config['NPLUSONE_RAISE'] = True
 NPlusOne(rest.app)
-ALL_INDICES = [CASE_INDEX, AO_INDEX, ARCH_MUR_INDEX]
+ALL_INDICES = [TEST_CASE_INDEX, TEST_AO_INDEX, TEST_ARCH_MUR_INDEX]
 
 
 def _setup_extensions():
@@ -191,12 +191,11 @@ class ElasticSearchBaseTest(BaseTestCase):
 
 
 def _create_all_indices():
-    for index in ALL_INDICES:
-        create_index(index)
+    create_test_indices()
 
 
 def _delete_all_indices(es_client):
-    es_client.indices.delete("*")
+    es_client.indices.delete(index=ALL_INDICES, ignore_unavailable=True)
 
 
 def wait_for_refresh(es_client, index_name):
@@ -204,14 +203,14 @@ def wait_for_refresh(es_client, index_name):
 
 
 def _insert_all_documents(es_client):
-    insert_documents("murs", CASE_ALIAS, es_client)
-    insert_documents("archived_murs", ARCH_MUR_ALIAS, es_client)
-    insert_documents("adrs", CASE_ALIAS, es_client)
-    insert_documents("admin_fines", CASE_ALIAS, es_client)
-    insert_documents("statutes", AO_ALIAS, es_client)
-    insert_documents("advisory_opinions", AO_ALIAS, es_client)
-    insert_documents("ao_citations", AO_ALIAS, es_client)
-    insert_documents("mur_citations", CASE_ALIAS, es_client)
+    insert_documents("murs", TEST_CASE_ALIAS, es_client)
+    insert_documents("archived_murs", TEST_ARCH_MUR_ALIAS, es_client)
+    insert_documents("adrs", TEST_CASE_ALIAS, es_client)
+    insert_documents("admin_fines", TEST_CASE_ALIAS, es_client)
+    insert_documents("statutes", TEST_AO_ALIAS, es_client)
+    insert_documents("advisory_opinions", TEST_AO_ALIAS, es_client)
+    insert_documents("ao_citations", TEST_AO_ALIAS, es_client)
+    insert_documents("mur_citations", TEST_CASE_ALIAS, es_client)
 
 
 def insert_documents(doc_type, index, es_client):

--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -2,9 +2,13 @@ from tests.common import ElasticSearchBaseTest
 from webservices.resources.legal import UniversalSearch, REQUESTOR_TYPES
 from webservices.rest import api
 from datetime import datetime
+from webservices.legal_docs import TEST_SEARCH_ALIAS
+
+import unittest.mock as mock
 # import logging
 
 
+@mock.patch("webservices.resources.legal.SEARCH_ALIAS", TEST_SEARCH_ALIAS)
 class TestAODocsElasticsearch(ElasticSearchBaseTest):
     wrong_date_format = "01/20/24"
 

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -1,11 +1,15 @@
 from datetime import datetime
 from webservices.resources.legal import ALL_DOCUMENT_TYPES
 from tests.common import ElasticSearchBaseTest, ALL_INDICES, document_dictionary
+from webservices.legal_docs import TEST_SEARCH_ALIAS
 from webservices.rest import api
 from webservices.resources.legal import UniversalSearch
+
+import unittest.mock as mock
 # import logging
 
 
+@mock.patch("webservices.resources.legal.SEARCH_ALIAS", TEST_SEARCH_ALIAS)
 class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
     wrong_date_format = "01/20/24"
 

--- a/tests/integration/test_citations_elasticsearch.py
+++ b/tests/integration/test_citations_elasticsearch.py
@@ -1,9 +1,13 @@
 from tests.common import ElasticSearchBaseTest
 from webservices.rest import api
 from webservices.resources.legal import GetLegalCitation
+from webservices.legal_docs import TEST_SEARCH_ALIAS
+
+import unittest.mock as mock
 # import logging
 
 
+@mock.patch("webservices.resources.legal.SEARCH_ALIAS", TEST_SEARCH_ALIAS)
 class TestCitationsElasticsearch(ElasticSearchBaseTest):
     def test_citations(self):
 

--- a/tests/integration/test_legal_docs_elasticsearch.py
+++ b/tests/integration/test_legal_docs_elasticsearch.py
@@ -1,9 +1,13 @@
 from tests.common import ElasticSearchBaseTest
 from webservices.rest import api
 from webservices.resources.legal import GetLegalDocument
+from webservices.legal_docs import TEST_SEARCH_ALIAS
+
+import unittest.mock as mock
 # import logging
 
 
+@mock.patch("webservices.resources.legal.SEARCH_ALIAS", TEST_SEARCH_ALIAS)
 class TestLegalDocsElasticsearch(ElasticSearchBaseTest):
     def test_legal_docs(self):
 

--- a/tests/integration/test_statute_elasticsearch.py
+++ b/tests/integration/test_statute_elasticsearch.py
@@ -1,9 +1,13 @@
 from tests.common import ElasticSearchBaseTest
 from webservices.rest import api
 from webservices.resources.legal import UniversalSearch
+from webservices.legal_docs import TEST_SEARCH_ALIAS
+
+import unittest.mock as mock
 # import logging
 
 
+@mock.patch("webservices.resources.legal.SEARCH_ALIAS", TEST_SEARCH_ALIAS)
 class TestStatuteDocsElasticsearch(ElasticSearchBaseTest):
 
     def test_q_search(self):

--- a/webservices/legal_docs/__init__.py
+++ b/webservices/legal_docs/__init__.py
@@ -45,7 +45,15 @@ from .es_management import (  # noqa
     CASE_ALIAS,
     AO_ALIAS,
     ARCH_MUR_ALIAS,
-    SEARCH_ALIAS
+    SEARCH_ALIAS,
+    TEST_CASE_INDEX,
+    TEST_CASE_ALIAS,
+    TEST_AO_INDEX,
+    TEST_AO_ALIAS,
+    TEST_SEARCH_ALIAS,
+    TEST_ARCH_MUR_INDEX,
+    TEST_ARCH_MUR_ALIAS,
+    create_test_indices
 )
 
 from .show_legal_data import ( # noqa

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -38,6 +38,14 @@ SEARCH_ALIAS = "search_alias"
 S3_BACKUP_DIRECTORY = "es-backups"
 S3_PRIVATE_SERVICE_INSTANCE_NAME = "fec-s3-snapshot"
 
+TEST_CASE_INDEX = "test_case_index"
+TEST_CASE_ALIAS = "test_case_alias"
+TEST_AO_INDEX = "test_ao_index"
+TEST_AO_ALIAS = "test_ao_alias"
+TEST_ARCH_MUR_INDEX = "test_arch_mur_index"
+TEST_ARCH_MUR_ALIAS = "test_arch_mur_alias"
+TEST_SEARCH_ALIAS = "test_search_alias"
+
 DOCS_PATH = "docs"
 
 SORT_MAPPING = {
@@ -449,6 +457,12 @@ INDEX_DICT = {
     ARCH_MUR_SWAP_INDEX: (ARCH_MUR_MAPPING, "", "", "", "", ""),
 }
 
+TEST_INDEX_DICT = {
+        TEST_CASE_INDEX: (CASE_MAPPING, TEST_CASE_ALIAS, TEST_SEARCH_ALIAS),
+        TEST_AO_INDEX: (AO_MAPPING, TEST_AO_ALIAS, TEST_SEARCH_ALIAS),
+        TEST_ARCH_MUR_INDEX: (ARCH_MUR_MAPPING, TEST_ARCH_MUR_ALIAS, TEST_SEARCH_ALIAS)
+    }
+
 
 def create_index(index_name=None):
     """
@@ -511,6 +525,15 @@ def create_index(index_name=None):
                 alias2))
     else:
         logger.error(" Invalid index '{0}'.".format(index_name))
+
+
+def create_test_indices():
+
+    INDEX_DICT.update(TEST_INDEX_DICT)
+
+    for index_name in TEST_INDEX_DICT:
+        create_index(index_name)
+        INDEX_DICT.pop(index_name)
 
 
 def display_index_alias():


### PR DESCRIPTION
## Summary (required)

- Resolves #6099 

This PR fixes the issue where documents and indices are deleted after running pytest. Now when running pytest, new test indices will be created then deleted after the tests have completed 

### Required reviewers - 2 developers


## Impacted areas of the application

General components of the application that this PR will affect:

- pytest

## How to test

- check out this branch 
- activate your virtual environment 
- start elasticsearch in another terminal 
- create an index: `python cli.py create_index case_index`
- load some documents: `python cli.py load_current_murs`
- `pytest`
- check that case_index and documents are still there and test indices are gone: https://app.elasticvue.com/cluster/0/indices
- try to create a test index: `python cli.py create_index test_case_index` (Should get an error)