### PR TITLE
Add description to contributor_aggregate_ytd

### DIFF
--- a/webservices/common/models/large_aggregates.py
+++ b/webservices/common/models/large_aggregates.py
@@ -12,7 +12,7 @@ class EntityReceiptDisbursementTotals(db.Model):
     cycle = db.Column(db.Integer, doc=docs.RECORD_CYCLE)
     month = db.Column(db.Integer, doc="Numeric representation of year")
     year = db.Column(db.Integer, doc="Numeric representation of month")
-    end_date = db.Column(db.Date, doc="Date representation of the month and year")
+    end_date = db.Column(db.Date)
     cumulative_candidate_receipts = db.Column(
         db.Float,
         doc="Cumulative candidate receipts in a two year period, adjusted to avoid double counting.",

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -714,6 +714,10 @@ The minimum date this record was last updated.(MM/DD/YYYY or YYYY-MM-DD)
 MAX_UPDATE_DATE = '''
 The maximum date this record was last updated.(MM/DD/YYYY or YYYY-MM-DD)
 '''
+
+CANDIDATE_PCC_ID = 'The candidate\'s primary campaign committee ID'
+
+CANDIDATE_PCC_NAME = 'The candidate\'s primary campaign committee name'
 # ======== election end ===========
 
 
@@ -1270,6 +1274,8 @@ END_DATE = '''
 Date the event ends(MM/DD/YYYY or YYYY-MM-DD)
 '''
 
+END_DATE_ENTITY_CHART = 'The cumulative total for this month.'
+
 CALENDAR_EXPORT = '''
 Returns CSV or ICS for downloading directly into calendar applications like Google, Outlook or other applications.
 
@@ -1542,6 +1548,8 @@ CONTRIBUTOR_STATE = 'State of contributor'
 CONTRIBUTOR_EMPLOYER = 'Employer of contributor, filers need to make an effort to gather this information'
 CONTRIBUTOR_OCCUPATION = 'Occupation of contributor, filers need to make an effort to gather this information'
 CONTRIBUTOR_ZIP = 'Zip code of contributor'
+CONTRIBUTOR_AGGREGATE_YTD = 'Total amount received from this source for the year to date. \
+Starting 2000, it is aggregated on an election-cycle basis in F3 and F3P, and calendar year in F3X.'
 IS_INDIVIDUAL = 'Restrict to non-earmarked individual contributions where memo code is true. \
 Filtering individuals is useful to make sure contributions are not double reported and in creating \
 breakdowns of the amount of money coming from individuals.'

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -7,7 +7,7 @@ import marshmallow as ma
 from marshmallow_sqlalchemy import SQLAlchemySchema, SQLAlchemyAutoSchema
 from marshmallow_pagination import schemas as paging_schemas
 
-from webservices import utils, decoders
+from webservices import utils, decoders, docs
 from webservices.spec import spec
 from webservices.common import models
 from webservices import __API_VERSION__
@@ -999,7 +999,7 @@ ScheduleASchema = make_schema(
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'contributor': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'contribution_receipt_amount': ma.fields.Float(),
-        'contributor_aggregate_ytd': ma.fields.Float(),
+        'contributor_aggregate_ytd': ma.fields.Float(description=docs.CONTRIBUTOR_AGGREGATE_YTD),
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
@@ -1610,8 +1610,8 @@ class ElectionSchema(ma.Schema):
     incumbent_challenge_full = ma.fields.Str()
     party_full = ma.fields.Str()
     committee_ids = ma.fields.List(ma.fields.Str)
-    candidate_pcc_id = ma.fields.Str(doc="The candidate's primary campaign committee ID")
-    candidate_pcc_name = ma.fields.Str(doc="The candidate's primary campaign committee name")
+    candidate_pcc_id = ma.fields.Str(description=docs.CANDIDATE_PCC_ID)
+    candidate_pcc_name = ma.fields.Str(description=docs.CANDIDATE_PCC_NAME)
     total_receipts = ma.fields.Float()
     total_disbursements = ma.fields.Float()
     cash_on_hand_end_period = ma.fields.Float()
@@ -1675,7 +1675,7 @@ register_schema(RadAnalystPageSchema)
 EntityReceiptDisbursementTotalsSchema = make_schema(
     models.EntityReceiptDisbursementTotals,
     options={'exclude': ('idx', 'month', 'year')},
-    fields={'end_date': ma.fields.Date(doc='The cumulative total for this month.')},
+    fields={'end_date': ma.fields.Date(description=docs.END_DATE_ENTITY_CHART)}
 )
 EntityReceiptDisbursementTotalsPageSchema = make_page_schema(EntityReceiptDisbursementTotalsSchema)
 register_schema(EntityReceiptDisbursementTotalsSchema)


### PR DESCRIPTION
## Summary (required)

- Resolves #5765

Add description to contributor_aggregate_ytd

### Required reviewers

1 dev

## How to test
1. Download feature branch
2. Run `pytest`
3. Start API on local, and test with these endpoints. Scroll down and click on `model` to check the description.
4. Schedule A endpoint, check `contributor_aggregate_ytd`
    http://127.0.0.1:5000/developers/#/receipts/get_v1_schedules_schedule_a_
<img width="450" alt="Screenshot 2025-01-21 at 4 56 25 PM" src="https://github.com/user-attachments/assets/269da433-4565-4f5c-a24a-39065c7ab462" />

5. Election endpoint, check these two fields in model
     `candidate_pcc_id`
     `candidate_pcc_name`
  http://127.0.0.1:5000/developers/#/financial/get_v1_elections_

6. /v1/totals/by_entity/,  check `end_date`
http://127.0.0.1:5000/developers/#/financial/get_v1_totals_by_entity_
