### PR TITLE
Add 'total' property to schema to return a float data type instead of string type

### DIFF
--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -303,6 +303,9 @@ def augment_itemized_aggregate_models(factory, committee_model, *models, namespa
     for model in models:
         schema = factory(
             model,
+            fields={
+                'total': ma.fields.Float()
+            },
             options={
                 'exclude': ('idx', 'committee',),
                 'relationships': [
@@ -1084,6 +1087,7 @@ ScheduleAByEmployerSchema = make_schema(
     fields={
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'employer': ma.fields.Str(),
+        'total': ma.fields.Float(),
     },
     options={'exclude': ('idx', 'committee', 'employer_text',)}
 )
@@ -1096,6 +1100,7 @@ ScheduleAByOccupationSchema = make_schema(
     fields={
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'occupation': ma.fields.Str(),
+        'total': ma.fields.Float(),
     },
     options={'exclude': ('idx', 'committee', 'occupation_text',)}
 )


### PR DESCRIPTION
## Summary (required)

`total` property in`schedules/schedule_a/by_size` endpoint was returning `total` as string data type in the result set. After adding `total` property to `schemas.py`, `schedules/schedule_a/by_size` returns float value. Fixed 4 other SA endpoints that share the same `total` property.

### Resolves #6073

| Endpoint  | Prod URL |
| ------------- | ------------- |
| schedules/schedule_a/by_size | https://api.open.fec.gov/v1/schedules/schedule_a/by_size?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY |
| schedules/schedule_a/by_state | https://api.open.fec.gov/v1/schedules/schedule_a/by_state?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY  |
| schedules/schedule_a/by_zip | https://api.open.fec.gov/v1/schedules/schedule_a/by_zip?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY  |
| schedules/schedule_a/by_employer | https://api.open.fec.gov/v1/schedules/schedule_a/by_employer/?page=1&per_page=20&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY  |
| schedules/schedule_a/by_occupation | https://api.open.fec.gov/v1/schedules/schedule_a/by_occupation?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY  |

### Screenshots
**Before:**
<img width="914" alt="Screenshot 2025-01-22 at 8 49 09 AM" src="https://github.com/user-attachments/assets/6871335f-45f5-4865-92d1-76bd0d3fbd82" />

**After:**
<img width="785" alt="Screenshot 2025-01-22 at 8 49 30 AM" src="https://github.com/user-attachments/assets/4daf9a6b-a3b1-4f83-bb7e-7a045f62d997" />



### Required reviewers

2 developers

## Impacted areas of the application

SA endpoints:

1. schedules/schedule_a/by_size
2. schedules/schedule_a/by_state
3. schedules/schedule_a/by_zip
4. schedules/schedule_a/by_employer
5. schedules/schedule_a/by_occupation


## How to test

- run `git checkout feature/6073-update-sa-total-to-float`
- run `pytest`
- run `flask run` 
- test the following SA endpoints on local and verify the `total` property in the result set  is NOT a string. Compare Local with the Prod links provided below:

1. schedules/schedule_a/by_size:

Prod: https://api.open.fec.gov/v1/schedules/schedule_a/by_size? committee_id=C00703975&cycle=2024&api_key=DEMO_KEY
Local: http://localhost:5000/v1/schedules/schedule_a/by_size?committee_id=C00703975&cycle=2024

2. schedules/schedule_a/by_state:

Prod: https://api.open.fec.gov/v1/schedules/schedule_a/by_state?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY
Local: http://localhost:5000/v1/schedules/schedule_a/by_state?committee_id=C00703975&cycle=2024

3. schedules/schedule_a/by_zip:

Prod: https://api.open.fec.gov/v1/schedules/schedule_a/by_zip?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY
Local: http://localhost:5000/v1/schedules/schedule_a/by_zip?committee_id=C00703975&cycle=2024

5. schedules/schedule_a/by_employer:

Prod: https://api.open.fec.gov/v1/schedules/schedule_a/by_employer/?page=1&per_page=20&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY
Local: http://localhost:5000/v1/schedules/schedule_a/by_employer/?page=1&per_page=100&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

6. schedules/schedule_a/by_occupation:

Prod: https://api.open.fec.gov/v1/schedules/schedule_a/by_occupation?committee_id=C00703975&cycle=2024&api_key=DEMO_KEY
Local: http://localhost:5000/v1/schedules/schedule_a/by_occupation?committee_id=C00703975&cycle=2024

