### PR TITLE
upgrade cf cli 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.9.0" | tar xzv -C $HOME/bin
 
       - add_ssh_keys # add Bastion host private keys configured in the UI
       - run: echo $FEC_BASTION_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts # copy Bastion host public key


### PR DESCRIPTION
## Summary

The Cloud.gov v2 API for Cloud Foundry is reaching its end-of-life. CF CLI versions 6 and 7 still rely on Cloud Foundry API v2 and will no longer work at some point with foundations that have disabled it. However, CF CLI v8 no longer uses Cloud FoundryAPI v2. For more details, refer to this [link](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#impact-and-consequences).


circleci/config.yml, is upgraded to CF CLI v8.9.0. This version supports Cloud Foundry API v3. Deploying to a cloud.gov space should work smoothly with this update.


## Resolves #6110

### Required reviewers

1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

- install cf cli section
- deploy api (to cloud.gov space)

## Screenshots

**Before:**
[cf cli v7.1.0 circleci build ](https://app.circleci.com/pipelines/github/fecgov/openFEC/3262/workflows/6b5beac7-f395-4348-8602-b15c2b8581a2/jobs/6129)

<img width="1139" alt="Screenshot 2025-01-28 at 3 57 08 PM" src="https://github.com/user-attachments/assets/4c88337a-5a32-4dc2-820c-ddb5f592ff77" />

**After:**
[cf cli v8.9.0 circleci build](https://app.circleci.com/pipelines/github/fecgov/openFEC/3264/workflows/1e231fe6-645c-4efe-a965-f1535717630f/jobs/6132)


<img width="1124" alt="Screenshot 2025-01-28 at 2 44 00 PM" src="https://github.com/user-attachments/assets/0d9947e2-a61b-44bd-84cc-6326c2e04bf9" />

<img width="768" alt="Screenshot 2025-01-28 at 2 44 39 PM" src="https://github.com/user-attachments/assets/1c54d98c-a1d3-4491-8034-c97842ab126e" />


## Related PRs

Related PRs against other branches:

- fec-cms: https://github.com/fecgov/fec-cms/pull/6657
- fec-proxy-redirect: https://github.com/fecgov/fec-proxy-redirect/pull/20
- fec-pattern-library: https://github.com/fecgov/fec-pattern-library/pull/229
- fec-proxy - https://github.com/fecgov/fec-proxy/pull/416

## How to test
- Follow [these](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) instructions to install cf CLI v8 on your local terminal or  run: `brew install cloudfoundry/tap/cf-cli@8`
- verify cf cli version: run `cf version`

```
F612211M:~ pkasireddy$ cf version
cf version 8.9.0+c23186c.2024-12-02
```

- rerun [this](https://app.circleci.com/pipelines/github/fecgov/openFEC/3264/workflows/1e231fe6-645c-4efe-a965-f1535717630f) build in circleci
- **OR** 
- create a test branch, update tasks.py(DEPLOY_RULES) with the test branch and deploy to dev space
- Observe the following in circleci: 
- 1. In `install cf cli` section, verify that cf cli v8.9.0 is downloaded and no errors there
- 2. In `deploy api` section,  verify that  api app deployed to cloud.space successfully without any errors 
- 3. In`deploy api` section` confirm that API app is using [Cloud Foundry v3 API](https://v3-apidocs.cloudfoundry.org/version/3.185.0/):

```
API endpoint:   https://api.fr.cloud.gov
API version:    3.185.0
```
