### PR TITLE
Combine nested queries

### DIFF
--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -136,6 +136,7 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "1111",
                             "case_serial": 1111,
                             "highlights": [],
+                            "source": [],
                             "document_highlights": {},
                             "documents": [
                                 {
@@ -148,6 +149,7 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "2222",
                             "case_serial": 2222,
                             "highlights": [],
+                            "source": [],
                             "document_highlights": {},
                             "documents": [
                                 {
@@ -182,6 +184,7 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "1111",
                             "case_serial": 1111,
                             "highlights": [],
+                            "source": [],
                             "document_highlights": {},
                             "documents": [
                                 {
@@ -194,6 +197,7 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "2222",
                             "case_serial": 2222,
                             "highlights": [],
+                            "source": [],
                             "document_highlights": {},
                             "documents": [
                                 {
@@ -225,6 +229,7 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "1111",
                             "case_serial": 1111,
                             "highlights": [],
+                            "source": [],
                             "document_highlights": {},
                             "documents": [
                                 {
@@ -237,6 +242,8 @@ class TestLegalSearch(unittest.TestCase):
                             "no": "2222",
                             "case_serial": 2222,
                             "highlights": [],
+                            "source": [],
+                            ""
                             "document_highlights": {},
                             "documents": [
                                 {

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -172,7 +172,7 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if q:
         must_query.append(Q("simple_query_string", query=q))
 
-    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps") is not None:
         proximity_query = True
 
     query = (
@@ -374,7 +374,7 @@ def get_case_document_query(q, **kwargs):
         q_query = Q("simple_query_string", query=q, fields=["documents.text"])
         combined_query.append(q_query)
 
-    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps") is not None:
         combined_query.append(get_proximity_query(**kwargs))
         proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
 
@@ -669,7 +669,7 @@ def get_ao_document_query(q, **kwargs):
         q_query = Q("simple_query_string", query=q, fields=["documents.text"])
         combined_query.append(q_query)
 
-    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps") is not None:
         combined_query.append(get_proximity_query(**kwargs))
         proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -167,9 +167,13 @@ class UniversalSearch(Resource):
 
 def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     must_query = [Q("term", type=type_)]
+    proximity_query = False
 
     if q:
         must_query.append(Q("simple_query_string", query=q))
+
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+        proximity_query = True
 
     query = (
         Search()
@@ -181,12 +185,8 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         .index(SEARCH_ALIAS)
         .sort("sort1", "sort2")
     )
-    proximity_search = False
 
-    if kwargs.get("q_proximity") and kwargs.get("max_gaps") and type_ != "statutes":
-        proximity_search = True
-
-    if not proximity_search:
+    if not proximity_query:
         if type_ == "advisory_opinions":
             query = query.highlight("summary", "documents.text", "documents.description")
         elif type_ == "statutes":
@@ -198,9 +198,6 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         must_not = []
         must_not.append(Q("nested", path="documents", query=Q("match", documents__text=kwargs.get("q_exclude"))))
         query = query.query("bool", must_not=must_not)
-
-    if proximity_search:
-        query = get_proximity_query(q, query, **kwargs)
 
     # logging.warning("generic_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))
     return query
@@ -297,7 +294,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         return apply_adr_specific_query_params(query, **kwargs)
 
 
-def get_proximity_query(q, query, **kwargs):
+def get_proximity_query(**kwargs):
     q_proximity = kwargs.get("q_proximity")
     max_gaps = kwargs.get("max_gaps")
     intervals_list = []
@@ -330,13 +327,7 @@ def get_proximity_query(q, query, **kwargs):
             intervals_inner_query = Q('intervals', documents__text={
                     'all_of':  {'max_gaps': max_gaps, "intervals": intervals_list}
                     })
-
-    intervals_query = Q(
-            "nested",
-            path="documents",
-            query=intervals_inner_query)
-
-    return query.query("bool", must=intervals_query)
+    return intervals_inner_query
 
 # Select one or more case_doc_category_id to filter by corresponding case_document_category
 # - 1 - Conciliation and Settlement Agreements
@@ -380,7 +371,26 @@ def get_case_document_query(q, **kwargs):
         case_document_date_range["format"] = ACCEPTED_DATE_FORMATS
         combined_query.append(Q("range", documents__document_date=case_document_date_range))
     if q:
-        combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
+        q_query = Q("simple_query_string", query=q, fields=["documents.text"])
+        combined_query.append(q_query)
+
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+        combined_query.append(get_proximity_query(**kwargs))
+        proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
+
+        if q:
+            proximity_inner_hits["highlight"] = {
+                "require_field_match": False,
+                "fields": {"documents.text": {}, "documents.description": {}, },
+                "highlight_query": q_query.to_dict()
+                }
+
+        return Q(
+            "nested",
+            path="documents",
+            inner_hits=proximity_inner_hits,
+            query=Q("bool", must=combined_query),
+        )
 
     return Q(
         "nested",
@@ -656,7 +666,26 @@ def get_ao_document_query(q, **kwargs):
         combined_query.append(Q("range", documents__date=ao_document_date_range))
 
     if q:
-        combined_query.append(Q("simple_query_string", query=q, fields=["documents.text"]))
+        q_query = Q("simple_query_string", query=q, fields=["documents.text"])
+        combined_query.append(q_query)
+
+    if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps"):
+        combined_query.append(get_proximity_query(**kwargs))
+        proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
+
+        if q:
+            proximity_inner_hits["highlight"] = {
+                "require_field_match": False,
+                "fields": {"documents.text": {}, "documents.description": {}, },
+                "highlight_query": q_query.to_dict()
+                }
+
+        return Q(
+            "nested",
+            path="documents",
+            inner_hits=proximity_inner_hits,
+            query=Q("bool", must=combined_query),
+        )
 
     return Q(
         "nested",
@@ -817,6 +846,7 @@ def execute_query(query):
         formatted_hit = hit.to_dict()
         formatted_hit["highlights"] = []
         formatted_hit["document_highlights"] = {}
+        formatted_hit["source"] = []
         formatted_hits.append(formatted_hit)
 
         # 1)When doc_type=[statutes], The 'highlight' section is in hit.meta
@@ -841,6 +871,11 @@ def execute_query(query):
                     # put "highlights" in return hit
                     for key in inner_hit.meta.highlight:
                         formatted_hit["highlights"].extend(inner_hit.meta.highlight[key])
+
+                if len(inner_hit.to_dict()) > 0:
+                    source = inner_hit.to_dict()
+                    formatted_hit["source"].append(source)
+
     # logger.debug("formatted_hits =" + json.dumps(formatted_hits, indent=3, cls=DateTimeEncoder))
 
 # Since ES7 the `total` becomes an object : "total": {"value": 1,"relation": "eq"}


### PR DESCRIPTION
## Summary (required)

- Resolves #6119 

This PR fixes the proximity search and allows us to determine which document the hit came from. 

When a user inputs q_proximity only, document_highlights and highlights will be empty and source will contain the documents that matches the proximity query. 

When a user inputs both a q_proximity and q the highlights will be from q only and source will contain the documents that match the proximity query. 

### Required reviewers 1 - 2 developers, 1 project manager

## Impacted areas of the application

- legal search

## How to test

- checkout this branch
- start elasticsearch `./elasticsearch`
- `pytest`
- create case index: `python cli.py create_index case_index`
- create ao index: `python cli.py create_index ao_index`
- load sample data for ao, mur, af, and adrs(at least three of each) : `python cli.py load_current_murs` `python cli.py load_admin_fines` `python cli.py load_advisory_opinions` `python cli.py load_adrs`
- `flask run`
- see test URLs below 

Test URLs reference the following documents: MUR 8285, ADR 1175, AF 4774, AO 2024-15

Test that q search is unaffected:

http://127.0.0.1:5000/v1/legal/search/?q=federal&type=murs


Test q_proximity combined with q:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=McGuire%20Virginia&q=committee&max_gaps=2&type=admin_fines

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20congress&q=federal&max_gaps=7&type=murs


MUR: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20congress&max_gaps=7&type=murs 

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=daunting%20task&q_proximity=actively%20campaigning&q_proximity=represent%20Illinois&max_gaps=12

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=after&proximity_filter_term=remediation


http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=before&proximity_filter_term=remediation

ADR: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=RAD%20Wisconsin&max_gaps=5

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13&proximity_filter=after&proximity_filter_term=RAD

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Polls%20Wisconsin&q_proximity=twenty-two&max_gaps=13&proximity_filter=before&proximity_filter_term=RAD


AF: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4

Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=%20Thomas%20Datwyler&q_proximity=reason%20to%20believe&max_gaps=5

With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4&proximity_filter=after&proximity_filter_term=%20Pre-Primary%20Report

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Datwyler%20McGuire&max_gaps=4&proximity_filter=before&proximity_filter_term=%20Pre-Primary%20Report

AO: 

One phrase: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6


Multiple phrases:

http://127.0.0.1:5000/v1/legal/search/?q_proximity=misappropriation%20&q_proximity=membership%20dues&max_gaps=2


With filter: 

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6&proximity_filter=before&proximity_filter_term=misappropriation

http://127.0.0.1:5000/v1/legal/search/?q_proximity=LAMA%20illegitimate%20&max_gaps=6&proximity_filter=after&proximity_filter_term=misappropriation
