### PR TITLE
Change before and after filters in legal proximity search

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -134,7 +134,7 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
 
     def test_q_proximity_filters(self):
         search_phrase = "Random document third ao"
-        proximity_filter = "before"
+        proximity_filter = "after"
         proximity_filter_term = "document"
         max_gaps = 3
 

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -253,7 +253,7 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
     def test_q_proximity_filters(self):
         # for archived and current murs, advisory_opinions, adrs, and afs
         search_phrase = "first document archived mur"
-        proximity_filter = "after"
+        proximity_filter = "before"
         proximity_filter_term = "sample text"
         max_gaps = 2
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -302,7 +302,7 @@ def get_proximity_query(**kwargs):
 
     if kwargs.get("proximity_filter") and kwargs.get("proximity_filter_term"):
         contains_filter = True
-        filter = kwargs.get("proximity_filter")
+        filter = "before" if kwargs.get("proximity_filter") == "after" else "after"
         filters = {filter: {'match': {'query': kwargs.get("proximity_filter_term")}}}
 
     if len(q_proximity) == 1:


### PR DESCRIPTION
## Summary (required)

- Resolves #6127 

This PR changes the meaning of the proximity_filter to mean that the proximity_filter_term comes before or after the q_proximity terms.


### Required reviewers 1 - 2 developers


## Impacted areas of the application

General components of the application that this PR will affect:

- legal search

## How to test

- checkout this branch
- start elasticsearch `./elasticsearch`
- `pytest`
- create case index: `python cli.py create_index case_index`
- load sample data for mur ) : `python cli.py load_current_murs`
- see test URLs below 

Test URLs reference the following documents: MUR 8285


http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=after&proximity_filter_term=remediation

http://127.0.0.1:5000/v1/legal/search/?q_proximity=Dowell%20daunting&max_gaps=2&proximity_filter=before&proximity_filter_term=remediation

