### PR TITLE
Allow zero input from integer filters in legal search

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -450,11 +450,11 @@ def apply_af_specific_query_params(query, **kwargs):
         date_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", final_determination_date=date_range))
 
-    if kwargs.get("af_rtb_fine_amount"):
+    if kwargs.get("af_rtb_fine_amount") is not None:
         must_clauses.append(
             Q("term", reason_to_believe_fine_amount=kwargs.get("af_rtb_fine_amount"))
         )
-    if kwargs.get("af_fd_fine_amount"):
+    if kwargs.get("af_fd_fine_amount") is not None:
         must_clauses.append(
             Q("term", final_determination_amount=kwargs.get("af_fd_fine_amount"))
         )


### PR DESCRIPTION
## Summary (required)

- Resolves #6121 

This PR fixes a bug where inputting zero returns all results in legal search. This affects `max_gaps` (fixed in other PR),  `af_rtb_fine_amount`, and `af_fd_fine_amount`. 

### Required reviewers 1 developer


## Impacted areas of the application

General components of the application that this PR will affect:

- legal search


## How to test

- checkout this branch 
- activate virtualenv
- `pytest`
- load admin fines `python cli.py load_admin_fines`
- flask run 

Example URLs:
http://127.0.0.1:5000/v1/legal/search/?af_rtb_fine_amount=0

http://127.0.0.1:5000/v1/legal/search/?af_fd_fine_amount=0

Compare to dev:
https://fec-dev-api.app.cloud.gov/v1/legal/search/?af_rtb_fine_amount=0

https://fec-dev-api.app.cloud.gov/v1/legal/search/?af_fd_fine_amount=0
