### PR TITLE
fix q_exclude for statutes

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -197,6 +197,8 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if kwargs.get("q_exclude"):
         must_not = []
         must_not.append(Q("nested", path="documents", query=Q("match", documents__text=kwargs.get("q_exclude"))))
+        if type_ == "statutes":
+            must_not.append(Q("match", name=kwargs.get("q_exclude")))
         query = query.query("bool", must_not=must_not)
 
     # logging.warning("generic_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))


### PR DESCRIPTION
## Summary (required)

- Resolves #6133 

This PR fixes q_exclude filter for statutes

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-statutes keyword search q_exclude filter

## How to test

- pull this branch
- start elasticsearch
- pytest
- python cli.py load_statutes
-  http://127.0.0.1:5000/v1/legal/search/?q=%22federal%20funds%22 (1 result)
-  http://127.0.0.1:5000/v1/legal/search/?q=%22federal%20funds%22&q_exclude=prohibition (0 results) 
compare with prod:
https://api.open.fec.gov/v1/legal/search/?q=%22federal%20funds%22&q_exclude=prohibition&api_key=DEMO_KEY
- try out another query with q_exclude 
