### PR TITLE
6131 add fuzziness to q_exclude

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -199,7 +199,8 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         if not isinstance(q_exclude, list):
             q_exclude = [q_exclude]
         must_not = []
-        fuzziness = kwargs.get("q_exclude_fuzziness", 0)
+        fuzziness = 0
+        # grabs terms and fuzziness parameter if available
         pattern = re.compile(r'^(.*)~(\d+)$')
         last_term = q_exclude[-1]
         match = pattern.match(last_term)


### PR DESCRIPTION
## Summary (required)

- Resolves #6131 

This PR adds fuzziness to q_exclude

You should be able have a singular term, multiple terms, or either with a fuzziness set at the end of the string for q_exclude
EX: q_exclude=Limon
`q_exclude=Limon Federa`
`q_exclude=Limon Federa~1`
`q_exclude=Limon~2`

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-legal search exclusions for the keyword search 


## How to test
-pull this branch
-start your venv
-pytest
-python cli.py delete_index ao_index 
-python cli.py delete_index case_index 
-python cli.py delete_index arch_mur_index
-python cli.py create_index ao_index 
-python cli.py create_index case_index 
-python cli.py create_index arch_mur_index
-python cli.py load_statutes
-python cli.py load_advisory_opinions 2024-15
-python cli.py load_admin_fines 4771 
python cli.py load_admin_fines 4775
python cli.py load_admin_fines 4777
-python cli.py load_current_murs 
(I loaded until 8285)
-python cli.py load_archived_murs 
(loaded until 4784) 
-python cli.py load_adrs
(loaded until 1177) 
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federal
should be zero results
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federa
2 statutes 
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federa~1
zero results
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians
should see AO 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unified
zero results 
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unifie
should see AO 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unifie~1
zero results
-http://127.0.0.1:5000/v1/legal/search/?q=Mike
should see admin fine 4777 and ao 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Mike&q_exclude=Massachuses~2
should not see ao 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q_exclude=Wied+ActBlue
should not see MURS 8324 or 8299 
http://127.0.0.1:5000/v1/legal/search/?q_exclude=Wie%20AtBlue%20~1
should see zero murs



You can also push to dev and test the FE 
https://app.circleci.com/pipelines/github/fecgov/openFEC/3319/workflows/f5279f50-8ec4-41c2-9fa0-79093934d60a/jobs/6197