### PR TITLE
Feature/4448 switch to app factory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,7 @@ jobs:
           name: Wait for Elasticsearch
           command: dockerize -wait http://localhost:9200 -timeout 1m
 
-      - run:
-          name: Run tests
-          command: |
-            . .env/bin/activate
-            pytest
+      # temporarily remove pytest from circleci
 
       - run:
           name: Run pre-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,11 @@ jobs:
           name: Wait for Elasticsearch
           command: dockerize -wait http://localhost:9200 -timeout 1m
 
-      # temporarily remove pytest from circleci
+      - run:
+          name: Run tests
+          command: |
+            . .env/bin/activate
+            pytest
 
       - run:
           name: Run pre-commit

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ Running Redis and Celery locally:
 
 ```
 redis-server
-celery --app webservices.tasks worker
-celery --app webservices.tasks beat
+celery --app webservices.tasks.make_celery worker
+celery --app webservices.tasks.make_celery beat
 ```
 
 ## Editing Swagger

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,2 +1,2 @@
 python cli.py cf_startup
-gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 9 webservices.rest:app
+gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 9 'webservices.rest:create_app()'

--- a/cli.py
+++ b/cli.py
@@ -5,65 +5,64 @@ import logging
 import manage
 
 from flask.cli import FlaskGroup
-from webservices.common import models
-from webservices.rest import app, db
+from webservices.rest import create_app
 import webservices.legal_docs as legal_docs
 from webservices.legal_docs.es_management import CASE_REPO, CASE_INDEX
 
 
-cli = FlaskGroup(app)
+cli = FlaskGroup(create_app=create_app)
 logger = logging.getLogger("cli")
 
 
-@app.cli.command('load_statutes')
+@cli.command('load_statutes')
 def load_statutes_cli():
     legal_docs.load_statutes()
 
 
-@app.cli.command('load_advisory_opinions')
+@cli.command('load_advisory_opinions')
 @click.argument('from_ao_no', default=None, required=False)
 def load_advisory_opinions_cli(from_ao_no):
     legal_docs.load_advisory_opinions(from_ao_no)
 
 
-@app.cli.command('load_current_murs')
+@cli.command('load_current_murs')
 @click.argument('specific_mur_no', default=None, required=False)
 def load_current_murs_cli(specific_mur_no):
     legal_docs.load_current_murs(specific_mur_no)
 
 
-@app.cli.command('load_adrs')
+@cli.command('load_adrs')
 @click.argument('specific_adr_no', default=None, required=False)
 def load_adrs_cli(specific_adr_no):
     legal_docs.load_adrs(specific_adr_no)
 
 
-@app.cli.command('load_admin_fines')
+@cli.command('load_admin_fines')
 @click.argument('specific_af_no', default=None, required=False)
 def load_admin_fines_cli(specific_af_no):
     legal_docs.load_admin_fines(specific_af_no)
 
 
-@app.cli.command('load_archived_murs')
+@cli.command('load_archived_murs')
 @click.argument('mur_no', default=None, required=False)
 def load_archived_murs_cli(mur_no):
     legal_docs.load_archived_murs(mur_no)
 
 
-@app.cli.command('extract_pdf_text')
+@cli.command('extract_pdf_text')
 @click.argument('mur_no', default=None, required=False)
 def extract_pdf_text_cli(mur_no):
     legal_docs.extract_pdf_text(mur_no)
 
 
-@app.cli.command('delete_doctype_from_es')
+@cli.command('delete_doctype_from_es')
 @click.argument('index_name', default=None, required=False)
 @click.argument('doc_type', default=None, required=False)
 def delete_doctype_from_es_cli(index_name, doc_type):
     legal_docs.delete_doctype_from_es(index_name, doc_type)
 
 
-@app.cli.command('delete_single_doctype_from_es')
+@cli.command('delete_single_doctype_from_es')
 @click.argument('index_name', default=None, required=False)
 @click.argument('doc_type', default=None, required=False)
 @click.argument('num_doc_id', default=None, required=False)
@@ -71,81 +70,81 @@ def delete_single_doctype_from_es_cli(index_name, doc_type, num_doc_id):
     legal_docs.delete_single_doctype_from_es(index_name, doc_type, num_doc_id)
 
 
-@app.cli.command('delete_murs_from_s3')
+@cli.command('delete_murs_from_s3')
 def delete_murs_from_s3_cli():
     legal_docs.delete_murs_from_s3()
 
 
-@app.cli.command('show_legal_data')
+@cli.command('show_legal_data')
 def show_legal_data_cli():
     legal_docs.show_legal_data()
 
 
-@app.cli.command('create_index')
+@cli.command('create_index')
 @click.argument('index_name', default=None, required=False)
 def create_index_cli(index_name):
     legal_docs.create_index(index_name)
 
 
-@app.cli.command('delete_index')
+@cli.command('delete_index')
 @click.argument('index_name', required=True)
 def delete_index_cli(index_name):
     legal_docs.delete_index(index_name)
 
 
-@app.cli.command('display_index_alias')
+@cli.command('display_index_alias')
 def display_index_alias_cli():
     legal_docs.display_index_alias()
 
 
-@app.cli.command('display_mapping')
+@cli.command('display_mapping')
 @click.argument('index_name', default=None, required=False)
 def display_mapping_cli(index_name):
     legal_docs.display_mapping(index_name)
 
 
-@app.cli.command('reload_all_data_by_index')
+@cli.command('reload_all_data_by_index')
 @click.argument('index_name', default=None, required=False)
 def reload_all_data_by_index_cli(index_name):
     legal_docs.reload_all_data_by_index(index_name)
 
 
-@app.cli.command('initialize_legal_data')
+@cli.command('initialize_legal_data')
 @click.argument('index_name', default=None, required=False)
 def initialize_legal_data_cli(index_name):
     legal_docs.initialize_legal_data(index_name)
 
 
-@app.cli.command('update_mapping_and_reload_legal_data')
+@cli.command('update_mapping_and_reload_legal_data')
 @click.argument('index_name', default=None, required=False)
 def update_mapping_and_reload_legal_data_cli(index_name):
     legal_docs.update_mapping_and_reload_legal_data(index_name)
 
 
-@app.cli.command('configure_snapshot_repository')
+@cli.command('configure_snapshot_repository')
 @click.argument('repo_name', default=CASE_REPO, required=False)
 def configure_snapshot_repository_cli(repo_name):
     legal_docs.configure_snapshot_repository(repo_name)
 
 
-@app.cli.command('delete_repository')
+@cli.command('delete_repository')
 @click.argument('repo_name', required=True)
 def delete_repository_cli(repo_name):
     legal_docs.delete_repository(repo_name)
 
 
-@app.cli.command('display_repositories')
+@cli.command('display_repositories')
 def display_repositories_cli():
     legal_docs.display_repositories()
 
 
-@app.cli.command('create_es_snapshot')
+@cli.command('create_es_snapshot')
 @click.argument('index_name', default=CASE_INDEX, required=False)
 def create_es_snapshot_cli(index_name):
     legal_docs.create_es_snapshot(index_name)
 
 
-@app.cli.command('restore_es_snapshot')
+@cli.command('restore_es_snapshot')
 @click.argument('repo_name', default=None, required=False)
 @click.argument('snapshot_name', default=None, required=False)
 @click.argument('index_name', default=None, required=False)
@@ -153,7 +152,7 @@ def restore_es_snapshot_cli(repo_name, snapshot_name, index_name):
     legal_docs.restore_es_snapshot(repo_name, snapshot_name, index_name)
 
 
-@app.cli.command('restore_es_snapshot_downtime')
+@cli.command('restore_es_snapshot_downtime')
 @click.argument('repo_name', default=None, required=False)
 @click.argument('snapshot_name', default=None, required=False)
 @click.argument('index_name', default=None, required=False)
@@ -161,38 +160,38 @@ def restore_es_snapshot_downtime_cli(repo_name, snapshot_name, index_name):
     legal_docs.restore_es_snapshot_downtime(repo_name, snapshot_name, index_name)
 
 
-@app.cli.command('delete_snapshot')
+@cli.command('delete_snapshot')
 @click.argument('repo_name', default=None, required=False)
 @click.argument('snapshot_name', default=None, required=False)
 def delete_snapshot_cli(repo_name, snapshot_name):
     legal_docs.delete_snapshot(repo_name, snapshot_name)
 
 
-@app.cli.command('display_snapshots')
+@cli.command('display_snapshots')
 @click.argument('repo_name', default=None, required=False)
 def display_snapshots_cli(repo_name):
     legal_docs.display_snapshots(repo_name)
 
 
-@app.cli.command('display_snapshot_detail')
+@cli.command('display_snapshot_detail')
 @click.argument('repo_name', default=None, required=False)
 @click.argument('snapshot_name', default=None, required=False)
 def display_snapshot_detail_cli(repo_name, snapshot_name):
     legal_docs.display_snapshot_detail(repo_name, snapshot_name)
 
 
-@app.cli.command('refresh_materialized')
+@cli.command('refresh_materialized')
 @click.argument('concurrent', default=True, type=bool)
 def refresh_materialized_cli(concurrent=True):
     manage.refresh_materialized()
 
 
-@app.cli.command('cf_startup')
+@cli.command('cf_startup')
 def cf_startup_cli():
     manage.cf_startup()
 
 
-@app.cli.command('update_public_api_key')
+@cli.command('update_public_api_key')
 @click.argument('space', default=None, required=True)
 @click.argument('service_instance_name', default=None, required=True)
 @click.argument('token', default=None, required=True)
@@ -218,7 +217,7 @@ def create_and_update_public_api_key_cli(
         second_rate_limit_duration)
 
 
-@app.cli.command('remove_env_var')
+@cli.command('remove_env_var')
 @click.argument('space', default=None, required=True)
 @click.argument('service_instance_name', default=None, required=True)
 @click.argument('key_to_remove', required=True)
@@ -235,7 +234,7 @@ def remove_env_var_cli(
         token)
 
 
-@app.cli.command('add_update_env_var')
+@cli.command('add_update_env_var')
 @click.argument('space', default=None, required=True)
 @click.argument('service_instance_name', default=None, required=True)
 @click.argument('key', required=True)
@@ -255,15 +254,10 @@ def add_update_env_var_cli(
         token)
 
 
-@app.cli.command('slack_message')
+@cli.command('slack_message')
 @click.argument('message')
 def slack_message_cli(message):
     manage.slack_message(message)
-
-
-@app.shell_context_processor
-def make_shell_context():
-    return {'app': app, 'db': db, 'models': models}
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -1,45 +1,16 @@
 #!/usr/bin/env python
 
-import glob
 import subprocess
-import multiprocessing
 import networkx as nx
 import sqlalchemy as sa
 import datetime
 import requests
 from webservices import flow
 from webservices.env import env
-from webservices.rest import db
-from webservices.config import SQL_CONFIG, check_config
-from webservices.common.util import get_full_path
+from webservices.common.models import db
+from webservices.config import check_config
 from webservices.utils import post_to_slack
 from cli import logger
-
-
-def execute_sql_file(path):
-    """This helper is typically used within a multiprocessing pool; create a new database
-    engine for each job.
-    """
-    db.engine.dispose()
-    logger.info(("Running {}".format(path)))
-    with open(path) as fp:
-        cmd = "\n".join(
-            [line for line in fp.readlines() if not line.strip().startswith("--")]
-        )
-        db.engine.execute(sa.text(cmd), **SQL_CONFIG)
-
-
-def execute_sql_folder(path, processes):
-    sql_dir = get_full_path(path)
-    if not sql_dir.endswith("/"):
-        sql_dir += "/"
-    paths = sorted(glob.glob(sql_dir + "*.sql"))
-    if processes > 1:
-        pool = multiprocessing.Pool(processes=processes)
-        pool.map(execute_sql_file, sorted(paths))
-    else:
-        for path in paths:
-            execute_sql_file(path)
 
 
 def refresh_materialized(concurrent=True):

--- a/manifests/manifest_celery_beat_dev.yml
+++ b/manifests/manifest_celery_beat_dev.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks beat --loglevel INFO
+    command: celery --app webservices.tasks.make_celery beat --loglevel INFO
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_beat_feature.yml
+++ b/manifests/manifest_celery_beat_feature.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks beat --loglevel INFO
+    command: celery --app webservices.tasks.make_celery beat --loglevel INFO
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_beat_prod.yml
+++ b/manifests/manifest_celery_beat_prod.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks beat --loglevel INFO
+    command: celery --app webservices.tasks.make_celery beat --loglevel INFO
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_beat_stage.yml
+++ b/manifests/manifest_celery_beat_stage.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks beat --loglevel INFO
+    command: celery --app webservices.tasks.make_celery beat --loglevel INFO
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_worker_dev.yml
+++ b/manifests/manifest_celery_worker_dev.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks.make_celery worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_worker_feature.yml
+++ b/manifests/manifest_celery_worker_feature.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks.make_celery worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_worker_prod.yml
+++ b/manifests/manifest_celery_worker_prod.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 3
+    command: celery --app webservices.tasks.make_celery worker --loglevel ${LOGLEVEL:=INFO} --concurrency 3
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/manifests/manifest_celery_worker_stage.yml
+++ b/manifests/manifest_celery_worker_stage.yml
@@ -6,7 +6,7 @@ applications:
     disk_quota: 1G
     no-route: true
     health-check-type: process
-    command: celery --app webservices.tasks worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
+    command: celery --app webservices.tasks.make_celery worker --loglevel ${LOGLEVEL:=INFO} --concurrency 2
     path: ../
     stack: cflinuxfs4
     buildpacks:

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,63 +4,64 @@ import os
 import subprocess
 import unittest
 
+from flask import current_app
 from webtest import TestApp
-from nplusone.ext.flask_sqlalchemy import NPlusOne
 
-from jdbc_utils import to_jdbc_url
-from webservices import rest
+from webservices.rest import create_app, db
 from webservices import __API_VERSION__
+
 
 from webservices.legal_docs import (create_test_indices, TEST_CASE_INDEX, TEST_ARCH_MUR_INDEX, TEST_AO_INDEX,
                                     TEST_CASE_ALIAS, TEST_ARCH_MUR_ALIAS, TEST_AO_ALIAS)
 from webservices.utils import create_es_client
 from tests.test_legal_data import document_dictionary
+from jdbc_utils import to_jdbc_url
+
 
 TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
-rest.app.config['NPLUSONE_RAISE'] = True
-NPlusOne(rest.app)
 ALL_INDICES = [TEST_CASE_INDEX, TEST_AO_INDEX, TEST_ARCH_MUR_INDEX]
 
 
-def _setup_extensions():
-    rest.db.engine.execute('create extension if not exists btree_gin;')
+def _setup_extensions(db):
+    with db.engine.connect() as conn:
+        conn.execute('create extension if not exists btree_gin;')
 
 
-def _reset_schema():
-    rest.db.engine.execute('drop schema if exists public cascade;')
-    rest.db.engine.execute('drop schema if exists disclosure cascade;')
-    rest.db.engine.execute('drop schema if exists staging cascade;')
-    rest.db.engine.execute('drop schema if exists fecapp cascade;')
-    rest.db.engine.execute('drop schema if exists real_efile cascade;')
-    rest.db.engine.execute('drop schema if exists auditsearch cascade;')
-    rest.db.engine.execute('create schema public;')
-    rest.db.engine.execute('create schema disclosure;')
-    rest.db.engine.execute('create schema staging;')
-    rest.db.engine.execute('create schema fecapp;')
-    rest.db.engine.execute('create schema real_efile;')
-    rest.db.engine.execute('create schema auditsearch;')
+def _reset_schema(db):
+    if current_app.config['TESTING']:
+        with db.engine.connect() as conn:
+            conn.execute('drop schema if exists public cascade;')
+            conn.execute('drop schema if exists disclosure cascade;')
+            conn.execute('drop schema if exists staging cascade;')
+            conn.execute('drop schema if exists fecapp cascade;')
+            conn.execute('drop schema if exists real_efile cascade;')
+            conn.execute('drop schema if exists auditsearch cascade;')
+            conn.execute('create schema public;')
+            conn.execute('create schema disclosure;')
+            conn.execute('create schema staging;')
+            conn.execute('create schema fecapp;')
+            conn.execute('create schema real_efile;')
+            conn.execute('create schema auditsearch;')
 
 
 class BaseTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        rest.app.config['TESTING'] = True
-        rest.app.config['SQLALCHEMY_DATABASE_URI'] = TEST_CONN
-        rest.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
-        cls.app = rest.app.test_client()
-        cls.client = TestApp(rest.app)
-        cls.app_context = rest.app.app_context()
+        cls.application = create_app(test_config="testing")
+        cls.app = cls.application.test_client()
+        cls.client = TestApp(cls.application)
+        cls.app_context = cls.application.app_context()
         cls.app_context.push()
-        _setup_extensions()
+        _setup_extensions(db)
 
     def setUp(self):
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
         self.transaction = self.connection.begin()
 
     def tearDown(self):
         self.transaction.rollback()
+        db.session.remove()
         self.connection.close()
-        rest.db.session.remove()
 
     @classmethod
     def tearDownClass(cls):
@@ -71,7 +72,7 @@ class ApiBaseTest(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         super(ApiBaseTest, cls).setUpClass()
-        _reset_schema()
+        _reset_schema(db)
         with open(os.devnull, 'w') as null:
             subprocess.check_call(
                 [
@@ -83,20 +84,20 @@ class ApiBaseTest(BaseTestCase):
                 stdout=null,
             )
 
-        rest.db.metadata.create_all(
-            rest.db.engine,
+        db.metadata.create_all(
+            db.engine,
             tables=[
                 each.__table__
-                for each in rest.db.Model._decl_class_registry.values()
+                for each in db.Model._decl_class_registry.values()
                 if hasattr(each, '__table__')
-            ],
+            ]
         )
 
     def setUp(self):
         super(ApiBaseTest, self).setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
 
     def tearDown(self):
@@ -132,7 +133,7 @@ class ElasticSearchBaseTest(BaseTestCase):
         _delete_all_indices(cls.es_client)
 
     def setUp(self):
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
 
     def tearDown(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+'''
 import manage
 from tests import common
-from webservices import rest
+from webservices.rest import create_app
+from flask import current_app
 
 import pytest
 import subprocess
@@ -9,9 +11,9 @@ import logging
 
 @pytest.fixture(scope="session")
 def migrate_db(request):
-    with rest.app.app_context():
-        rest.app.config['TESTING'] = True
-        rest.app.config['SQLALCHEMY_DATABASE_URI'] = common.TEST_CONN
+    app = create_app(test_config="testing")
+    with app.app_context():
+
         reset_schema()
         run_migrations()
         manage.refresh_materialized(concurrent=False)
@@ -30,6 +32,7 @@ def run_migrations():
 
 
 def reset_schema():
+    db = current_app.extensions["sqlalchemy"].db
     for schema in [
         "aouser",
         "auditsearch",
@@ -44,8 +47,8 @@ def reset_schema():
         "staging",
         "test_efile",
     ]:
-        rest.db.engine.execute('drop schema if exists %s cascade;' % schema)
-    rest.db.engine.execute('create schema public;')
+        db.engine.execute(f'DROP SCHEMA IF EXISTS {schema} CASCADE;')
+    db.engine.execute('create schema public;')
 
 
 def pytest_addoption(parser):
@@ -73,3 +76,4 @@ def pytest_collection_modifyitems(session, config, items):
 def pytest_configure(config):
     """Flake8 is very verbose by default. Silence it."""
     logging.getLogger("flake8").setLevel(logging.WARNING)
+'''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,13 @@ from webservices.common.models import db
 import pytest
 import subprocess
 import logging
+from webservices.rest import create_app
 
 
-@pytest.fixture(scope="class")
-def migrate_db(request):
-    base_cls = request.cls
-    if base_cls.application.config['TESTING']:
+@pytest.fixture(scope="session")
+def migrate_db():
+    app = create_app(test_config="testing")
+    with app.app_context():
         reset_schema()
         run_migrations()
         manage.refresh_materialized(concurrent=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,17 @@
-'''
 import manage
 from tests import common
-from webservices.rest import create_app
-from flask import current_app
+from webservices.common.models import db
+
 
 import pytest
 import subprocess
 import logging
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="class")
 def migrate_db(request):
-    app = create_app(test_config="testing")
-    with app.app_context():
-
+    base_cls = request.cls
+    if base_cls.application.config['TESTING']:
         reset_schema()
         run_migrations()
         manage.refresh_materialized(concurrent=False)
@@ -32,7 +30,6 @@ def run_migrations():
 
 
 def reset_schema():
-    db = current_app.extensions["sqlalchemy"].db
     for schema in [
         "aouser",
         "auditsearch",
@@ -47,7 +44,7 @@ def reset_schema():
         "staging",
         "test_efile",
     ]:
-        db.engine.execute(f'DROP SCHEMA IF EXISTS {schema} CASCADE;')
+        db.engine.execute('drop schema if exists %s cascade;' % schema)
     db.engine.execute('create schema public;')
 
 
@@ -76,4 +73,3 @@ def pytest_collection_modifyitems(session, config, items):
 def pytest_configure(config):
     """Flake8 is very verbose by default. Silence it."""
     logging.getLogger("flake8").setLevel(logging.WARNING)
-'''

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 import factory
 from factory.alchemy import SQLAlchemyModelFactory
 
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.common import models
 
 

--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from tests.common import TEST_CONN, BaseTestCase
 
-from webservices import rest
+from webservices.common.models import db
 from webservices.legal_docs.advisory_opinions import get_advisory_opinions
 
 EMPTY_SET = set()
@@ -14,7 +14,7 @@ EMPTY_SET = set()
 @pytest.mark.usefixtures("migrate_db")
 class TestLoadAdvisoryOpinions(BaseTestCase):
     def setUp(self):
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
         subprocess.check_call(
             ["psql", TEST_CONN, "-f", "data/load_base_advisory_opinion_data.sql"]
         )
@@ -22,7 +22,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
     def tearDown(self):
         self.clear_test_data()
         self.connection.close()
-        rest.db.session.remove()
+        db.session.remove()
 
     @patch("webservices.legal_docs.advisory_opinions.get_bucket")
     @patch("webservices.legal_docs.advisory_opinions.create_es_client")

--- a/tests/integration/test_amendment_chain.py
+++ b/tests/integration/test_amendment_chain.py
@@ -6,7 +6,9 @@ import copy
 
 import manage
 from tests.common import BaseTestCase
-from webservices import rest, __API_VERSION__
+from webservices import __API_VERSION__
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.filings import FilingsView, FilingsList
 
 
@@ -46,12 +48,12 @@ class TestAmendmentChain(BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
 
     def tearDown(self):
-        rest.db.session.remove()
+        db.session.remove()
         self.request_context.pop()
         self.clear_test_data()
         super().tearDown()
@@ -80,7 +82,7 @@ class TestAmendmentChain(BaseTestCase):
         # /filings/ endpoint
 
         results = self._results(
-            rest.api.url_for(FilingsList, committee_id=expected_filing['committee_id'])
+            api.url_for(FilingsList, committee_id=expected_filing['committee_id'])
         )
         assert len(results) == 1
         list_result = results[0]
@@ -91,7 +93,7 @@ class TestAmendmentChain(BaseTestCase):
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
 
         results = self._results(
-            rest.api.url_for(FilingsView, committee_id=expected_filing['committee_id'])
+            api.url_for(FilingsView, committee_id=expected_filing['committee_id'])
         )
         assert len(results) == 1
         view_result = results[0]
@@ -110,7 +112,7 @@ class TestAmendmentChain(BaseTestCase):
         # /filings/ endpoint
 
         results = self._results(
-            rest.api.url_for(
+            api.url_for(
                 FilingsList,
                 committee_id=expected_filing['committee_id'],
                 most_recent=True,
@@ -125,7 +127,7 @@ class TestAmendmentChain(BaseTestCase):
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
 
         results = self._results(
-            rest.api.url_for(
+            api.url_for(
                 FilingsView,
                 committee_id=expected_filing['committee_id'],
                 most_recent=True,
@@ -220,7 +222,7 @@ class TestAmendmentChain(BaseTestCase):
         manage.refresh_materialized(concurrent=False)
 
         q2_results = self._results(
-            rest.api.url_for(
+            api.url_for(
                 FilingsList,
                 committee_id=form_3_q2_new['committee_id'],
                 report_type='Q2',
@@ -233,7 +235,7 @@ class TestAmendmentChain(BaseTestCase):
                     self.assert_filings_equal(result, filing)
 
         q3_results = self._results(
-            rest.api.url_for(
+            api.url_for(
                 FilingsList,
                 committee_id=form_3_q3_new['committee_id'],
                 report_type='Q3',
@@ -301,7 +303,7 @@ class TestAmendmentChain(BaseTestCase):
         manage.refresh_materialized(concurrent=False)
 
         results = self._results(
-            rest.api.url_for(FilingsList, committee_id=first_f1['committee_id'])
+            api.url_for(FilingsList, committee_id=first_f1['committee_id'])
         )
 
         for result in sorted(results, key=lambda x: x['file_number']):
@@ -339,7 +341,7 @@ class TestAmendmentChain(BaseTestCase):
         manage.refresh_materialized(concurrent=False)
 
         results = self._results(
-            rest.api.url_for(
+            api.url_for(
                 FilingsList,
                 committee_id=non_negative_f1['committee_id'],
                 most_recent=True,

--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -1,6 +1,6 @@
 from tests.common import ElasticSearchBaseTest
 from webservices.resources.legal import UniversalSearch, REQUESTOR_TYPES
-from webservices.rest import api
+from webservices.api_setup import api
 from datetime import datetime
 from webservices.legal_docs import TEST_SEARCH_ALIAS
 

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -6,7 +6,7 @@ import manage
 
 from tests import common
 from webservices import rest, __API_VERSION__
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.resources.totals import CandidateTotalsDetailView, TotalsCommitteeView
 
 

--- a/tests/integration/test_candidate_committee_totals.py
+++ b/tests/integration/test_candidate_committee_totals.py
@@ -5,8 +5,9 @@ import json
 import manage
 
 from tests import common
-from webservices import rest, __API_VERSION__
+from webservices import __API_VERSION__
 from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.totals import CandidateTotalsDetailView, TotalsCommitteeView
 
 
@@ -16,7 +17,7 @@ class TotalTestCase(common.BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
         self.connection = db.engine.connect()
 
@@ -145,7 +146,7 @@ class TotalTestCase(common.BaseTestCase):
             'committee_id': 'C00000001',
         }
         committee_totals_api = self._results(
-            rest.api.url_for(TotalsCommitteeView, **params_cmte)
+            api.url_for(TotalsCommitteeView, **params_cmte)
         )
         assert len(committee_totals_api) == 1
         assert committee_totals_api[0]['receipts'] == 300
@@ -156,7 +157,7 @@ class TotalTestCase(common.BaseTestCase):
             'election_full': True,
         }
         candidate_totals_api = self._results(
-            rest.api.url_for(CandidateTotalsDetailView, **params_cand)
+            api.url_for(CandidateTotalsDetailView, **params_cand)
         )
         assert len(candidate_totals_api) == 1
         assert candidate_totals_api[0]['receipts'] == 311
@@ -172,7 +173,7 @@ class TotalTestCase(common.BaseTestCase):
             'election_full': True,
         }
         candidate_totals_api = self._results(
-            rest.api.url_for(CandidateTotalsDetailView, **params_cand)
+            api.url_for(CandidateTotalsDetailView, **params_cand)
         )
         assert len(candidate_totals_api) == 0
 

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -6,7 +6,7 @@ import manage
 
 from tests import common
 from webservices import rest, __API_VERSION__
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.resources.candidates import CandidateList
 from webservices.resources.candidate_aggregates import TotalsCandidateView
 from webservices.resources.elections import ElectionView

--- a/tests/integration/test_candidates.py
+++ b/tests/integration/test_candidates.py
@@ -5,8 +5,9 @@ import json
 import manage
 
 from tests import common
-from webservices import rest, __API_VERSION__
+from webservices import __API_VERSION__
 from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.candidates import CandidateList
 from webservices.resources.candidate_aggregates import TotalsCandidateView
 from webservices.resources.elections import ElectionView
@@ -18,7 +19,7 @@ class CandidatesTestCase(common.BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
         self.connection = db.engine.connect()
 
@@ -146,12 +147,12 @@ class CandidatesTestCase(common.BaseTestCase):
             'state': 'MD',
             'election_year': election_year,
         }
-        candidates_api = self._results(rest.api.url_for(CandidateList, **candidate_params))
+        candidates_api = self._results(api.url_for(CandidateList, **candidate_params))
         candidates_totals_api = self._results(
-            rest.api.url_for(TotalsCandidateView, **total_params)
+            api.url_for(TotalsCandidateView, **total_params)
         )
         elections_api = self._results(
-            rest.api.url_for(ElectionView, office='house', **election_params)
+            api.url_for(ElectionView, office='house', **election_params)
         )
         assert (
             len(results_tab)

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from webservices.resources.legal import ALL_DOCUMENT_TYPES
 from tests.common import ElasticSearchBaseTest, ALL_INDICES, document_dictionary
 from webservices.legal_docs import TEST_SEARCH_ALIAS
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.legal import UniversalSearch
 
 import unittest.mock as mock

--- a/tests/integration/test_citations_elasticsearch.py
+++ b/tests/integration/test_citations_elasticsearch.py
@@ -1,5 +1,5 @@
 from tests.common import ElasticSearchBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.legal import GetLegalCitation
 from webservices.legal_docs import TEST_SEARCH_ALIAS
 

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -5,7 +5,7 @@ import json
 import manage
 from tests.common import BaseTestCase
 from webservices import rest, __API_VERSION__
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.resources.committees import CommitteeHistoryProfileView
 
 

--- a/tests/integration/test_committees.py
+++ b/tests/integration/test_committees.py
@@ -4,7 +4,8 @@ import json
 
 import manage
 from tests.common import BaseTestCase
-from webservices import rest, __API_VERSION__
+from webservices import __API_VERSION__
+from webservices.api_setup import api
 from webservices.common.models import db
 from webservices.resources.committees import CommitteeHistoryProfileView
 
@@ -15,7 +16,7 @@ class CommitteeTestCase(BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
         self.connection = db.engine.connect()
 
@@ -34,7 +35,7 @@ class CommitteeTestCase(BaseTestCase):
     def tearDown(self):
         self.clear_test_data()
         self.connection.close()
-        rest.db.session.remove()
+        db.session.remove()
 
     committee_data = [
         {
@@ -104,7 +105,7 @@ class CommitteeTestCase(BaseTestCase):
         }
 
         committee_api = self._results(
-            rest.api.url_for(CommitteeHistoryProfileView, **params_cmte)
+            api.url_for(CommitteeHistoryProfileView, **params_cmte)
         )
         self.check_nulls_in_array_column(committee_api, array_column='cycles')
         self.check_nulls_in_array_column(

--- a/tests/integration/test_current_cases.py
+++ b/tests/integration/test_current_cases.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pytest
 
 
-from webservices import rest
+from webservices.common.models import db
 from webservices.legal_docs.current_cases import get_cases, load_mur_citations
 
 from tests.common import TEST_CONN, BaseTestCase
@@ -14,13 +14,13 @@ from tests.common import TEST_CONN, BaseTestCase
 @pytest.mark.usefixtures("migrate_db")
 class TestLoadCurrentCases(BaseTestCase):
     def setUp(self):
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
         subprocess.check_call(['psql', TEST_CONN, '-f', 'data/load_base_mur_data.sql'])
 
     def tearDown(self):
         self.clear_test_data()
         self.connection.close()
-        rest.db.session.remove()
+        db.session.remove()
 
     @patch('webservices.legal_docs.current_cases.get_bucket')
     def test_simple_mur(self, get_bucket):

--- a/tests/integration/test_filings.py
+++ b/tests/integration/test_filings.py
@@ -4,7 +4,10 @@ import json
 
 import manage
 from tests.common import BaseTestCase
-from webservices import rest, __API_VERSION__
+
+from webservices import __API_VERSION__
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.filings import FilingsView, FilingsList
 
 
@@ -39,12 +42,12 @@ class TestFilings(BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
 
     def tearDown(self):
-        rest.db.session.remove()
+        db.session.remove()
         self.request_context.pop()
         self.clear_test_data()
         super().tearDown()
@@ -73,7 +76,7 @@ class TestFilings(BaseTestCase):
         # FilingsList view
         # /filings/ endpoint
         results = self._results(
-            rest.api.url_for(FilingsList, committee_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsList, committee_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         list_result = results[0]
@@ -83,7 +86,7 @@ class TestFilings(BaseTestCase):
         # FilingsView view
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
         results = self._results(
-            rest.api.url_for(FilingsView, committee_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsView, committee_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         view_result = results[0]
@@ -100,7 +103,7 @@ class TestFilings(BaseTestCase):
         # FilingsList view
         # /filings/ endpoint
         results = self._results(
-            rest.api.url_for(FilingsList, candidate_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsList, candidate_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         list_result = results[0]
@@ -110,7 +113,7 @@ class TestFilings(BaseTestCase):
         # FilingsView view
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
         results = self._results(
-            rest.api.url_for(FilingsView, candidate_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsView, candidate_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         view_result = results[0]
@@ -129,7 +132,7 @@ class TestFilings(BaseTestCase):
         # FilingsList view
         # /filings/ endpoint
         results = self._results(
-            rest.api.url_for(FilingsList, committee_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsList, committee_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         list_result = results[0]
@@ -142,7 +145,7 @@ class TestFilings(BaseTestCase):
         # FilingsView view
         # /committee/<committee_id>/filings/ and /candidate/<candidate_id>/filings/
         results = self._results(
-            rest.api.url_for(FilingsView, committee_id=expected_filing['cand_cmte_id'])
+            api.url_for(FilingsView, committee_id=expected_filing['cand_cmte_id'])
         )
         assert len(results) == 1
         view_result = results[0]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+'''
 import datetime
 
 import pytest
@@ -6,8 +7,8 @@ import sqlalchemy as sa
 
 import manage
 from tests import common, factories
-from webservices.rest import db
-from webservices.common import models
+from webservices.common.models import db
+from webservices.config import SQL_CONFIG
 from webservices.common.models import ScheduleA
 
 REPORTS_MODELS = [
@@ -43,7 +44,7 @@ class IntegrationTestCase(common.BaseTestCase):
 
     def _check_financial_model(self, model):
         count = model.query.filter(
-            model.cycle < manage.SQL_CONFIG['START_YEAR']
+            model.cycle < SQL_CONFIG['START_YEAR']
         ).count()
         self.assertEqual(count, 0)
 
@@ -55,7 +56,7 @@ class IntegrationTestCase(common.BaseTestCase):
             db.session.query(getattr(subquery.columns, key))
             .group_by(getattr(subquery.columns, key))
             .having(
-                sa.func.max(subquery.columns.cycle) < manage.SQL_CONFIG['START_YEAR']
+                sa.func.max(subquery.columns.cycle) < SQL_CONFIG['START_YEAR']
             )
             .count()
         )
@@ -178,3 +179,4 @@ class IntegrationTestCase(common.BaseTestCase):
 
         rows = ScheduleA.query.filter(is_individual).all()
         self.assertEqual(rows, individuals)
+'''

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,15 +1,13 @@
-'''
 import datetime
 
 import pytest
 
 import sqlalchemy as sa
 
-import manage
 from tests import common, factories
-from webservices.common.models import db
+from webservices.common import models
+from webservices.common.models import ScheduleA, db
 from webservices.config import SQL_CONFIG
-from webservices.common.models import ScheduleA
 
 REPORTS_MODELS = [
     models.CommitteeReportsPacParty,
@@ -179,4 +177,3 @@ class IntegrationTestCase(common.BaseTestCase):
 
         rows = ScheduleA.query.filter(is_individual).all()
         self.assertEqual(rows, individuals)
-'''

--- a/tests/integration/test_legal_docs_elasticsearch.py
+++ b/tests/integration/test_legal_docs_elasticsearch.py
@@ -1,5 +1,5 @@
 from tests.common import ElasticSearchBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.legal import GetLegalDocument
 from webservices.legal_docs import TEST_SEARCH_ALIAS
 

--- a/tests/integration/test_statute_elasticsearch.py
+++ b/tests/integration/test_statute_elasticsearch.py
@@ -1,5 +1,5 @@
 from tests.common import ElasticSearchBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.legal import UniversalSearch
 from webservices.legal_docs import TEST_SEARCH_ALIAS
 

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -9,7 +9,7 @@ from webservices.api_setup import api
 from webservices.resources.sched_a import ScheduleAView
 from webservices.resources.sched_a import ScheduleAEfileView
 from webservices.resources.sched_b import ScheduleBView
-from webservices import rest, __API_VERSION__
+from webservices import __API_VERSION__
 from webservices.common.models import db
 from webservices.utils import parse_fulltext
 
@@ -20,9 +20,9 @@ class TriggerTestCase(common.BaseTestCase):
         super().setUp()
         self.longMessage = True
         self.maxDiff = None
-        self.request_context = rest.app.test_request_context()
+        self.request_context = self.application.test_request_context()
         self.request_context.push()
-        self.connection = rest.db.engine.connect()
+        self.connection = db.engine.connect()
 
     def _response(self, qry):
         response = self.app.get(qry)

--- a/tests/integration/test_tsvector_generation.py
+++ b/tests/integration/test_tsvector_generation.py
@@ -5,12 +5,12 @@ import json
 import manage
 
 from tests import common
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.sched_a import ScheduleAView
 from webservices.resources.sched_a import ScheduleAEfileView
 from webservices.resources.sched_b import ScheduleBView
 from webservices import rest, __API_VERSION__
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.utils import parse_fulltext
 
 

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -5,7 +5,8 @@ from tests.common import ApiBaseTest, assert_dicts_subset
 from webservices.utils import get_current_cycle
 
 from webservices import schemas
-from webservices.rest import db, api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.aggregates import (
     CommunicationCostByCandidateView,
     ElectioneeringByCandidateView,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ from webservices.api_setup import api
 from webservices.resources.search import CandidateNameSearch, CommitteeNameSearch
 from webservices.resources.candidates import CandidateList
 from webservices.common.views import ApiResource
+from webservices.common.models import db
 
 
 class OverallTest(ApiBaseTest):
@@ -20,6 +21,7 @@ class OverallTest(ApiBaseTest):
         factories.CandidateSearchFactory(
             id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
+        db.session.flush()
         results = self._results(api.url_for(CandidateList, q='bartlet'))
         self.assertEqual(len(results), 1)
         self.assertIn('josiah', results[0]['name'].lower())
@@ -30,6 +32,7 @@ class OverallTest(ApiBaseTest):
             id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
         results = self._results(api.url_for(CandidateList, q='bartlet josiah'))
+        db.session.flush()
         self.assertEqual(len(results), 1)
         self.assertIn('josiah', results[0]['name'].lower())
 
@@ -90,6 +93,7 @@ class OverallTest(ApiBaseTest):
             )
             for idx in range(30)
         ]
+        db.session.flush()
         results = self._results(api.url_for(CandidateNameSearch, q='bartlet'))
         expected = [str(each.id) for each in rows[:-21:-1]]
         observed = [each['id'] for each in results]
@@ -102,6 +106,7 @@ class OverallTest(ApiBaseTest):
             name='Bartlet', fulltxt=sa.func.to_tsvector('Bartlet P0123'),
         )
         decoy = factories.CandidateSearchFactory()  # noqa
+        db.session.flush()
         results = self._results(api.url_for(CandidateNameSearch, q='P0123'))
         assert len(results) == 1
         assert results[0]['name'] == row.name
@@ -115,6 +120,7 @@ class OverallTest(ApiBaseTest):
             )
             for idx in range(30)
         ]
+        db.session.flush()
         results = self._results(api.url_for(CommitteeNameSearch, q='bartlet'))
         expected = [str(each.id) for each in rows[:-21:-1]]
         observed = [each['id'] for each in results]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,8 @@
 import sqlalchemy as sa
-
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices import rest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.search import CandidateNameSearch, CommitteeNameSearch
 from webservices.resources.candidates import CandidateList
 from webservices.common.views import ApiResource
@@ -22,7 +20,6 @@ class OverallTest(ApiBaseTest):
         factories.CandidateSearchFactory(
             id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='bartlet'))
         self.assertEqual(len(results), 1)
         self.assertIn('josiah', results[0]['name'].lower())
@@ -32,7 +29,6 @@ class OverallTest(ApiBaseTest):
         factories.CandidateSearchFactory(
             id=candidate.candidate_id, fulltxt=sa.func.to_tsvector('Josiah Bartlet'),
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='bartlet josiah'))
         self.assertEqual(len(results), 1)
         self.assertIn('josiah', results[0]['name'].lower())
@@ -94,7 +90,6 @@ class OverallTest(ApiBaseTest):
             )
             for idx in range(30)
         ]
-        rest.db.session.flush()
         results = self._results(api.url_for(CandidateNameSearch, q='bartlet'))
         expected = [str(each.id) for each in rows[:-21:-1]]
         observed = [each['id'] for each in results]
@@ -107,7 +102,6 @@ class OverallTest(ApiBaseTest):
             name='Bartlet', fulltxt=sa.func.to_tsvector('Bartlet P0123'),
         )
         decoy = factories.CandidateSearchFactory()  # noqa
-        rest.db.session.flush()
         results = self._results(api.url_for(CandidateNameSearch, q='P0123'))
         assert len(results) == 1
         assert results[0]['name'] == row.name
@@ -121,7 +115,6 @@ class OverallTest(ApiBaseTest):
             )
             for idx in range(30)
         ]
-        rest.db.session.flush()
         results = self._results(api.url_for(CommitteeNameSearch, q='bartlet'))
         expected = [str(each.id) for each in rows[:-21:-1]]
         observed = [each['id'] for each in results]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,23 @@
+from flask import current_app
+from tests.common import BaseTestCase
+
+
+class TestBaseTestCase(BaseTestCase):
+    def test_db_connection(self):
+        result = self.connection.execute("SELECT 1").scalar()
+        self.assertEqual(result, 1, "Database is not connected")
+
+    def test_app_context_exists(self):
+        self.assertIsNotNone(current_app, "BROKEN")
+
+    def test_client_is_available(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_int, 301, "Test client request failed")
+
+    def test_home_page(self):
+        response = self.client.get('/developers/')
+        assert response.status_code == 200
+
+    def test_redirect_page(self):
+        response = self.client.get('/')
+        assert response.status_code == 301

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,3 +21,8 @@ class TestBaseTestCase(BaseTestCase):
     def test_redirect_page(self):
         response = self.client.get('/')
         assert response.status_code == 301
+
+    def test_cors_headers(self):
+        response = self.client.get('/swagger')
+        assert "Access-Control-Allow-Origin" in response.headers
+        assert response.headers["Access-Control-Allow-Origin"] == "*"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 from webservices.api_setup import api
+from webservices.common.models import db
 from webservices.resources.audit import (
     AuditCaseView,
     AuditCategoryView,
@@ -62,6 +63,7 @@ class TestAuditCandidateNameSearch(ApiBaseTest):
         factories.AuditCandidateSearchFactory(
             id='H4CA33119', fulltxt=sa.func.to_tsvector('LIEU, TED')
         )
+        db.session.flush()
         results = self._results(api.url_for(AuditCandidateNameSearch, q='TED'))
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0]['id'], 'S2TX00312')
@@ -82,6 +84,7 @@ class TestAuditCommitteeNameSearch(ApiBaseTest):
         factories.AuditCommitteeSearchFactory(
             id='C00366773', fulltxt=sa.func.to_tsvector('JOHN SULLIVAN FOR CONGRESS')
         )
+        db.session.flush()
         results = self._results(api.url_for(AuditCommitteeNameSearch, q='JOHN'))
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]['id'], 'C00495622')

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,8 +1,7 @@
 import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
-from webservices import rest
+from webservices.api_setup import api
 from webservices.resources.audit import (
     AuditCaseView,
     AuditCategoryView,
@@ -63,7 +62,6 @@ class TestAuditCandidateNameSearch(ApiBaseTest):
         factories.AuditCandidateSearchFactory(
             id='H4CA33119', fulltxt=sa.func.to_tsvector('LIEU, TED')
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(AuditCandidateNameSearch, q='TED'))
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0]['id'], 'S2TX00312')
@@ -84,7 +82,6 @@ class TestAuditCommitteeNameSearch(ApiBaseTest):
         factories.AuditCommitteeSearchFactory(
             id='C00366773', fulltxt=sa.func.to_tsvector('JOHN SULLIVAN FOR CONGRESS')
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(AuditCommitteeNameSearch, q='JOHN'))
         self.assertEqual(len(results), 4)
         self.assertEqual(results[0]['id'], 'C00495622')

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -126,6 +126,7 @@ class CandidateFormatTest(ApiBaseTest):
         factories.CandidateSearchFactory(
             id=dana.candidate_id, fulltxt=sa.func.to_tsvector('Dana')
         )
+        db.session.flush()
         results = self._results(api.url_for(CandidateList, q='danielle'))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['candidate_id'], danielle.candidate_id)

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -3,10 +3,9 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices import rest
 from webservices import schemas
-from webservices.rest import db
-from webservices.rest import api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.candidates import CandidateList
 from webservices.resources.candidates import CandidateView
 from webservices.resources.candidates import CandidateSearch
@@ -127,7 +126,6 @@ class CandidateFormatTest(ApiBaseTest):
         factories.CandidateSearchFactory(
             id=dana.candidate_id, fulltxt=sa.func.to_tsvector('Dana')
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(CandidateList, q='danielle'))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['candidate_id'], danielle.candidate_id)

--- a/tests/test_committees.py
+++ b/tests/test_committees.py
@@ -6,8 +6,8 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices import utils
-from webservices.rest import db
-from webservices.rest import api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.committees import CommitteeList
 from webservices.resources.committees import CommitteeView
 from webservices.resources.committees import CommitteeHistoryProfileView

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,7 +1,7 @@
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.common.models import CommunicationCost, Electioneering
 from webservices.schemas import CommunicationCostSchema, ElectioneeringSchema
 from webservices.resources.costs import CommunicationCostView, ElectioneeringView

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -6,7 +6,7 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices.resources import sched_a, sched_e
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.common import models, counts
 
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -10,7 +10,7 @@ from icalendar import Calendar
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.common.models import db
 from webservices.resources.dates import ElectionDatesView
 from webservices.resources.dates import (

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -83,6 +83,8 @@ class TestDownloadTask(ApiBaseTest):
 
         db.session.commit()
 
+        db.session.refresh(committee)
+
         # these are the major downloadable resources, we may want to add more later
         DOWNLOADABLE_RESOURCES = {
             aggregates.ScheduleABySizeView,

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -7,7 +7,8 @@ import pytest
 from botocore.exceptions import ClientError
 
 from webservices.exceptions import ApiError
-from webservices.rest import db, api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.tasks import download as tasks
 from webservices.resources import download as resource
 from webservices.resources import (

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -2,7 +2,8 @@ import datetime
 from tests import factories
 from tests.common import ApiBaseTest, assert_dicts_subset
 
-from webservices.rest import db, api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.elections import (
     ElectionsListView,
     ElectionView,

--- a/tests/test_filing_resources.py
+++ b/tests/test_filing_resources.py
@@ -1,7 +1,7 @@
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.rad_analyst import RadAnalystView
 
 

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -1,9 +1,8 @@
 import datetime
 import sqlalchemy as sa
-from webservices import rest
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.filings import FilingsView, FilingsList, EFilingsView, F2EFilingsView, F1EFilingsView
 
 
@@ -374,7 +373,6 @@ class TestEfileFiles(ApiBaseTest):
         factories.CommitteeSearchFactory(
             id="C00000002", fulltxt=sa.func.to_tsvector("Dana")
         )
-        rest.db.session.flush()
         results = self._results(api.url_for(EFilingsView, q_filer="Danielle"))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["committee_id"], "C00000001")

--- a/tests/test_filings.py
+++ b/tests/test_filings.py
@@ -3,6 +3,7 @@ import sqlalchemy as sa
 from tests import factories
 from tests.common import ApiBaseTest
 from webservices.api_setup import api
+from webservices.common.models import db
 from webservices.resources.filings import FilingsView, FilingsList, EFilingsView, F2EFilingsView, F1EFilingsView
 
 
@@ -366,6 +367,7 @@ class TestEfileFiles(ApiBaseTest):
                 committee_name="Dana",
             ),
         ]
+        db.session.flush()
 
         factories.CommitteeSearchFactory(
             id="C00000001", fulltxt=sa.func.to_tsvector("Danielle")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,7 +3,7 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices import filters
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.common import models
 from webservices.resources.dates import CalendarDatesView
 from webservices.resources.committees import CommitteeList

--- a/tests/test_inaugural_donations.py
+++ b/tests/test_inaugural_donations.py
@@ -1,7 +1,7 @@
 from tests import factories
 from tests.common import ApiBaseTest, assert_dicts_subset
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.totals import InauguralDonationsView
 
 

--- a/tests/test_itemized.py
+++ b/tests/test_itemized.py
@@ -3,7 +3,8 @@ import sqlalchemy as sa
 
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import db, api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.schemas import ScheduleASchema
 from webservices.schemas import ScheduleBSchema
 from webservices.common.models import (

--- a/tests/test_large_aggregates.py
+++ b/tests/test_large_aggregates.py
@@ -1,7 +1,7 @@
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.large_aggregates import EntityReceiptDisbursementTotalsView
 
 

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -1,7 +1,6 @@
-from webservices import rest
 import json
 import codecs
-import unittest
+from tests.common import BaseTestCase
 from unittest.mock import patch
 from elasticsearch import RequestError
 from webservices.legal_docs.es_management import (  # noqa
@@ -112,9 +111,9 @@ def legal_invalid_search(*args, **kwargs):
     raise RequestError("invalid query")
 
 
-class TestLegalSearch(unittest.TestCase):
+class TestLegalSearch(BaseTestCase):
     def setUp(self):
-        self.app = rest.app.test_client()
+        super().setUp()
 
     @patch("webservices.rest.legal.es_client.search", legal_search_data)
     def test_default_search(self):
@@ -293,11 +292,10 @@ def legal_doc_data(*args, **kwargs):
     }
 
 
-class TestLegalDoc(unittest.TestCase):
+class TestLegalDoc(BaseTestCase):
     @patch("webservices.rest.legal.es_client.search", legal_doc_data)
     def test_legal_doc(self):
-        app = rest.app.test_client()
-        response = app.get("/v1/legal/" + DOCS_PATH + "/doc_type/1?api_key=1234")
+        response = self.app.get("/v1/legal/" + DOCS_PATH + "/doc_type/1?api_key=1234")
         assert response.status_code == 200
         result = json.loads(codecs.decode(response.data))
         assert result == {
@@ -323,7 +321,6 @@ class TestLegalDoc(unittest.TestCase):
         }
 
     def test_legal_doc_wrong_path(self):
-        app = rest.app.test_client()
-        response = app.get("/v1/legal/wrong_path/doc_type/1?api_key=1234")
+        response = self.app.get("/v1/legal/wrong_path/doc_type/1?api_key=1234")
         assert response.status_code == 404
 # =====End test endpoint: '/legal/docs/<doc_type>/<no>'=====

--- a/tests/test_national_party.py
+++ b/tests/test_national_party.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.schemas import NationalPartyTotalsSchema
 from webservices.resources.national_party import (
     NationalParty_ScheduleAView,

--- a/tests/test_operations_log.py
+++ b/tests/test_operations_log.py
@@ -2,7 +2,7 @@ import datetime
 
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.operations_log import OperationsLogView
 
 

--- a/tests/test_presidential.py
+++ b/tests/test_presidential.py
@@ -2,7 +2,7 @@ import datetime
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.presidential import (
     PresidentialByCandidateView,
     PresidentialByStateView,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -7,8 +7,8 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices import schemas
-from webservices.rest import db
-from webservices.rest import api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.reports import (
     ReportsView,
     CommitteeReportsView,

--- a/tests/test_sched_c.py
+++ b/tests/test_sched_c.py
@@ -4,7 +4,7 @@ import datetime
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.schemas import ScheduleCSchema
 from webservices.resources.sched_c import ScheduleCView, ScheduleCViewBySubId
 

--- a/tests/test_sched_d.py
+++ b/tests/test_sched_d.py
@@ -2,7 +2,7 @@ import datetime
 
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.common.models import ScheduleD
 from webservices.schemas import ScheduleDSchema
 from webservices.resources.sched_d import ScheduleDView, ScheduleDViewBySubId

--- a/tests/test_sched_e.py
+++ b/tests/test_sched_e.py
@@ -1,7 +1,7 @@
 
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.schemas import ScheduleEByCandidateSchema
 from webservices.resources.aggregates import ScheduleEByCandidateView
 

--- a/tests/test_sched_f.py
+++ b/tests/test_sched_f.py
@@ -1,7 +1,7 @@
 import datetime
 from tests import factories
 from tests.common import ApiBaseTest
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.schemas import ScheduleFSchema
 from webservices.resources.sched_f import ScheduleFView, ScheduleFViewBySubId
 

--- a/tests/test_spending_by_others.py
+++ b/tests/test_spending_by_others.py
@@ -1,7 +1,8 @@
 from tests import factories
 from tests.common import ApiBaseTest
 
-from webservices.rest import db, api
+from webservices.common.models import db
+from webservices.api_setup import api
 from webservices.resources.spending_by_others import (
     ECTotalsByCandidateView,
     IETotalsByCandidateView,

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -6,7 +6,7 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices import utils
-from webservices.rest import api
+from webservices.api_setup import api
 from webservices.resources.totals import (
     TotalsCommitteeView,
     TotalsByEntityTypeView,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,11 +8,11 @@ from tests import factories
 from tests.common import ApiBaseTest
 
 from webservices import args
-from webservices import rest
+from flask import current_app
 from webservices import sorting
 from webservices.resources import candidate_aggregates
 from webservices.resources import elections
-from webservices.rest import db
+from webservices.common.models import db
 from webservices import utils
 from webservices.common import models
 
@@ -308,9 +308,10 @@ class TestSort(ApiBaseTest):
 
 class TestArgs(TestCase):
     def test_currency(self):
-        with rest.app.test_request_context('?dollars=$24.50'):
-            parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request, location='query')
-            self.assertEqual(parsed, {'dollars': 24.50})
+        if current_app.config['TESTING']:
+            with current_app.test_request_context('?dollars=$24.50'):
+                parsed = flaskparser.parser.parse({'dollars': args.Currency()}, request, location='query')
+                self.assertEqual(parsed, {'dollars': 24.50})
 
 
 class TestEnvVarSplit(TestCase):

--- a/webservices/api_setup.py
+++ b/webservices/api_setup.py
@@ -1,0 +1,201 @@
+import flask_restful as restful
+from flask import Blueprint
+
+from webservices.resources import national_party
+from webservices.resources import totals
+from webservices.resources import reports
+from webservices.resources import sched_a
+from webservices.resources import sched_b
+from webservices.resources import sched_c
+from webservices.resources import sched_d
+from webservices.resources import sched_e
+from webservices.resources import sched_f
+from webservices.resources import sched_h4
+from webservices.resources import download
+from webservices.resources import aggregates
+from webservices.resources import candidate_aggregates
+from webservices.resources import candidates
+from webservices.resources import committees
+from webservices.resources import elections
+from webservices.resources import filings
+from webservices.resources import rad_analyst
+from webservices.resources import search
+from webservices.resources import dates
+from webservices.resources import costs
+from webservices.resources import legal
+from webservices.resources import large_aggregates
+from webservices.resources import audit
+from webservices.resources import operations_log
+from webservices.resources import presidential
+from webservices.resources import spending_by_others
+from webservices.env import env
+
+
+from webservices.common import util
+
+v1 = Blueprint('v1', __name__, url_prefix='/v1')
+api = restful.Api(v1)
+api.representations['application/json'] = util.output_json
+SHOW_TEST_F1 = env.get_credential('FEC_SHOW_TEST_F1', False)
+
+# app.api = api
+
+api.add_resource(national_party.NationalParty_ScheduleAView, '/national_party/schedule_a/')
+api.add_resource(national_party.NationalParty_ScheduleBView, '/national_party/schedule_b/')
+api.add_resource(national_party.NationalPartyTotalsView, '/national_party/totals/')
+api.add_resource(candidates.CandidateList, '/candidates/')
+api.add_resource(candidates.CandidateSearch, '/candidates/search/')
+api.add_resource(
+    candidates.CandidateView,
+    '/candidate/<string:candidate_id>/',
+    '/committee/<string:committee_id>/candidates/',
+)
+api.add_resource(
+    candidates.CandidateHistoryView,
+    '/candidate/<string:candidate_id>/history/',
+    '/candidate/<string:candidate_id>/history/<int:cycle>/',
+    '/committee/<string:committee_id>/candidates/history/',
+    '/committee/<string:committee_id>/candidates/history/<int:cycle>/',
+)
+api.add_resource(committees.CommitteeList, '/committees/')
+api.add_resource(
+    committees.CommitteeView,
+    '/committee/<string:committee_id>/',
+    '/candidate/<string:candidate_id>/committees/',
+)
+api.add_resource(
+    committees.CommitteeHistoryProfileView,
+    '/committee/<string:committee_id>/history/',
+    '/committee/<string:committee_id>/history/<int:cycle>/',
+    '/candidate/<string:candidate_id>/committees/history/',
+    '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
+)
+api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:entity_type>/')
+api.add_resource(totals.TotalsCommitteeView, '/committee/<string:committee_id>/totals/')
+api.add_resource(totals.CandidateTotalsDetailView, '/candidate/<string:candidate_id>/totals/')
+api.add_resource(reports.ReportsView, '/reports/<string:entity_type>/')
+api.add_resource(reports.CommitteeReportsView, '/committee/<string:committee_id>/reports/')
+api.add_resource(search.CandidateNameSearch, '/names/candidates/')
+api.add_resource(search.CommitteeNameSearch, '/names/committees/')
+api.add_resource(sched_a.ScheduleAView, '/schedules/schedule_a/', '/schedules/schedule_a/<string:sub_id>/')
+api.add_resource(sched_a.ScheduleAEfileView, '/schedules/schedule_a/efile/')
+api.add_resource(sched_b.ScheduleBView, '/schedules/schedule_b/', '/schedules/schedule_b/<string:sub_id>/')
+api.add_resource(sched_b.ScheduleBEfileView, '/schedules/schedule_b/efile/')
+api.add_resource(sched_c.ScheduleCView, '/schedules/schedule_c/')
+api.add_resource(sched_c.ScheduleCViewBySubId, '/schedules/schedule_c/<string:sub_id>/')
+api.add_resource(sched_d.ScheduleDView, '/schedules/schedule_d/')
+api.add_resource(sched_d.ScheduleDViewBySubId, '/schedules/schedule_d/<string:sub_id>/')
+api.add_resource(sched_e.ScheduleEView, '/schedules/schedule_e/')
+api.add_resource(sched_e.ScheduleEEfileView, '/schedules/schedule_e/efile/')
+api.add_resource(sched_f.ScheduleFView, '/schedules/schedule_f/', '/schedules/schedule_f/<string:sub_id>/')
+api.add_resource(sched_f.ScheduleFViewBySubId, '/schedules/schedule_f/<string:sub_id>/')
+api.add_resource(sched_h4.ScheduleH4View, '/schedules/schedule_h4/')
+api.add_resource(sched_h4.ScheduleH4EfileView, '/schedules/schedule_h4/efile/')
+api.add_resource(costs.CommunicationCostView, '/communication_costs/')
+api.add_resource(costs.ElectioneeringView, '/electioneering/')
+api.add_resource(elections.ElectionView, '/elections/')
+api.add_resource(elections.ElectionsListView, '/elections/search/')
+api.add_resource(elections.ElectionSummary, '/elections/summary/')
+api.add_resource(elections.StateElectionOfficeInfoView, '/state-election-office/')
+api.add_resource(dates.ElectionDatesView, '/election-dates/')
+api.add_resource(dates.ReportingDatesView, '/reporting-dates/')
+api.add_resource(dates.CalendarDatesView, '/calendar-dates/')
+api.add_resource(dates.CalendarDatesExport, '/calendar-dates/export/')
+api.add_resource(rad_analyst.RadAnalystView, '/rad-analyst/')
+api.add_resource(filings.EFilingsView, '/efile/filings/')
+api.add_resource(filings.F2EFilingsView, '/efile/form2/')
+api.add_resource(filings.F1EFilingsView, '/efile/form1/')
+api.add_resource(large_aggregates.EntityReceiptDisbursementTotalsView, '/totals/by_entity/')
+api.add_resource(audit.AuditPrimaryCategoryView, '/audit-primary-category/')
+api.add_resource(audit.AuditCategoryView, '/audit-category/')
+api.add_resource(audit.AuditCaseView, '/audit-case/')
+api.add_resource(audit.AuditCandidateNameSearch, '/names/audit_candidates/')
+api.add_resource(audit.AuditCommitteeNameSearch, '/names/audit_committees/')
+api.add_resource(aggregates.ScheduleABySizeView, '/schedules/schedule_a/by_size/')
+api.add_resource(aggregates.ScheduleAByStateView, '/schedules/schedule_a/by_state/')
+api.add_resource(aggregates.ScheduleAByZipView, '/schedules/schedule_a/by_zip/')
+api.add_resource(aggregates.ScheduleAByEmployerView, '/schedules/schedule_a/by_employer/')
+api.add_resource(aggregates.ScheduleAByOccupationView, '/schedules/schedule_a/by_occupation/')
+api.add_resource(aggregates.ScheduleBByRecipientView, '/schedules/schedule_b/by_recipient/')
+api.add_resource(aggregates.ScheduleBByRecipientIDView, '/schedules/schedule_b/by_recipient_id/')
+api.add_resource(aggregates.ScheduleBByPurposeView, '/schedules/schedule_b/by_purpose/')
+api.add_resource(aggregates.ScheduleEByCandidateView, '/schedules/schedule_e/by_candidate/')
+api.add_resource(candidate_aggregates.ScheduleABySizeCandidateView, '/schedules/schedule_a/by_size/by_candidate/')
+api.add_resource(candidate_aggregates.ScheduleAByStateCandidateView, '/schedules/schedule_a/by_state/by_candidate/')
+api.add_resource(candidate_aggregates.ScheduleAByStateCandidateTotalsView,
+                 '/schedules/schedule_a/by_state/by_candidate/totals/')
+api.add_resource(candidate_aggregates.TotalsCandidateView, '/candidates/totals/')
+api.add_resource(totals.ScheduleAByStateRecipientTotalsView, '/schedules/schedule_a/by_state/totals/')
+api.add_resource(candidate_aggregates.CandidateTotalAggregateView, '/candidates/totals/aggregates/')
+api.add_resource(totals.InauguralDonationsView, '/totals/inaugural_committees/by_contributor/')
+
+
+api.add_resource(
+    aggregates.CommunicationCostByCandidateView,
+    '/communication_costs/by_candidate/',
+)
+
+api.add_resource(
+    aggregates.CCAggregatesView,
+    '/communication_costs/aggregates/',
+)
+
+api.add_resource(
+    aggregates.ElectioneeringByCandidateView,
+    '/electioneering/by_candidate/',
+)
+
+api.add_resource(
+    aggregates.ECAggregatesView,
+    '/electioneering/aggregates/',
+)
+
+api.add_resource(
+    spending_by_others.ECTotalsByCandidateView,
+    '/electioneering/totals/by_candidate/',
+)
+
+api.add_resource(
+    spending_by_others.IETotalsByCandidateView,
+    '/schedules/schedule_e/totals/by_candidate/',
+)
+
+api.add_resource(
+    spending_by_others.CCTotalsByCandidateView,
+    '/communication_costs/totals/by_candidate/',
+)
+
+api.add_resource(
+    filings.FilingsView,
+    '/committee/<committee_id>/filings/',
+    '/candidate/<candidate_id>/filings/',
+)
+
+api.add_resource(
+    reports.EFilingHouseSenateSummaryView,
+    '/efile/reports/house-senate/',
+)
+
+api.add_resource(
+    reports.EFilingPresidentialSummaryView,
+    '/efile/reports/presidential/',
+)
+
+api.add_resource(
+    reports.EFilingPacPartySummaryView,
+    '/efile/reports/pac-party/',
+)
+
+api.add_resource(filings.FilingsList, '/filings/')
+api.add_resource(download.DownloadView, '/download/<path:path>/')
+api.add_resource(legal.UniversalSearch, '/legal/search/')
+api.add_resource(legal.GetLegalCitation, '/legal/citation/<citation_type>/<citation>')
+api.add_resource(legal.GetLegalDocument, '/legal/docs/<doc_type>/<no>')
+api.add_resource(operations_log.OperationsLogView, '/operations-log/')
+api.add_resource(presidential.PresidentialByCandidateView, '/presidential/contributions/by_candidate/')
+api.add_resource(presidential.PresidentialSummaryView, '/presidential/financial_summary/')
+api.add_resource(presidential.PresidentialBySizeView, '/presidential/contributions/by_size/')
+api.add_resource(presidential.PresidentialByStateView, '/presidential/contributions/by_state/')
+api.add_resource(presidential.PresidentialCoverageView, '/presidential/coverage_end_date/')
+if SHOW_TEST_F1:
+    api.add_resource(filings.TestF1EFilingsView, '/efile/test-form1/')

--- a/webservices/api_setup.py
+++ b/webservices/api_setup.py
@@ -38,7 +38,6 @@ api = restful.Api(v1)
 api.representations['application/json'] = util.output_json
 SHOW_TEST_F1 = env.get_credential('FEC_SHOW_TEST_F1', False)
 
-# app.api = api
 
 api.add_resource(national_party.NationalParty_ScheduleAView, '/national_party/schedule_a/')
 api.add_resource(national_party.NationalParty_ScheduleBView, '/national_party/schedule_b/')

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -3,6 +3,7 @@ import celery
 from sqlalchemy import orm
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
 from flask_sqlalchemy import SignallingSession
+from flask import current_app
 
 
 class RoutingSession(SignallingSession):
@@ -13,15 +14,15 @@ class RoutingSession(SignallingSession):
 
     @property
     def followers(self):
-        return self.app.config['SQLALCHEMY_FOLLOWERS']
+        return current_app.config.get('SQLALCHEMY_FOLLOWERS', [])
 
     @property
     def follower_tasks(self):
-        return self.app.config['SQLALCHEMY_FOLLOWER_TASKS']
+        return current_app.config.get('SQLALCHEMY_FOLLOWER_TASKS', [])
 
     @property
     def restrict_follower_traffic_to_tasks(self):
-        return self.app.config['SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS']
+        return current_app.config.get('SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS', [])
 
     @property
     def use_follower(self):

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import logging
 import re
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.utils import (
     create_es_client,
     DateTimeEncoder,

--- a/webservices/legal_docs/archived_murs.py
+++ b/webservices/legal_docs/archived_murs.py
@@ -2,7 +2,7 @@ from sqlalchemy.sql import text
 from elasticsearch_dsl import Search
 import logging
 import re
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.utils import (
     create_es_client,
     create_eregs_link,

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.utils import (
     extend,
     create_es_client,

--- a/webservices/resources/download.py
+++ b/webservices/resources/download.py
@@ -13,6 +13,7 @@ from webservices import exceptions
 from webservices.tasks import download
 from webservices.tasks import utils as task_utils
 from webservices.utils import use_kwargs_original
+from flask import current_app
 
 client = boto3.client('s3')
 
@@ -33,7 +34,7 @@ class DownloadView(utils.Resource):
                 'status': 'complete',
                 'url': cached_file,
             }
-        resource = download.call_resource(path, request.query_string.decode('UTF-8'))
+        resource = download.call_resource(current_app, path, request.query_string.decode('UTF-8'))
         if resource['count'] > MAX_RECORDS:
             raise exceptions.ApiError(
                 'Cannot request downloads with more than {} records'.format(MAX_RECORDS),

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -10,7 +10,7 @@ from marshmallow import EXCLUDE
 import ujson
 import sqlalchemy as sa
 import flask_cors as cors
-import flask_restful as restful
+from nplusone.ext.flask_sqlalchemy import NPlusOne
 
 from datetime import datetime, time
 from flask import abort
@@ -29,6 +29,7 @@ from webservices import spec
 from webservices import exceptions
 from webservices import utils
 from webservices.common import util
+from webservices.common import models
 from webservices.common.models import db
 from webservices.resources import national_party
 from webservices.resources import totals
@@ -40,7 +41,6 @@ from webservices.resources import sched_d
 from webservices.resources import sched_e
 from webservices.resources import sched_f
 from webservices.resources import sched_h4
-from webservices.resources import download
 from webservices.resources import aggregates
 from webservices.resources import candidate_aggregates
 from webservices.resources import candidates
@@ -60,80 +60,10 @@ from webservices.resources import spending_by_others
 from webservices.env import env
 from webservices.tasks.response_exception import ResponseException
 from webservices.tasks.error_code import ErrorCode
-
-app = Flask(__name__)
-app.url_map.strict_slashes = False
+from webservices.api_setup import api, v1
 
 
-def sqla_conn_string():
-    sqla_conn_string = env.get_credential('SQLA_CONN')
-    if not sqla_conn_string:
-        print("Environment variable SQLA_CONN is empty; running against " + "local `cfdm_test`")
-        sqla_conn_string = 'postgresql://:@/cfdm_test'
-    return sqla_conn_string
-
-
-# app.debug = True
-app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
-app.config['APISPEC_FORMAT_RESPONSE'] = None
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['SQLALCHEMY_POOL_SIZE'] = 50
-app.config['SQLALCHEMY_MAX_OVERFLOW'] = 50
-app.config['SQLALCHEMY_POOL_TIMEOUT'] = 120
-app.config['SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS'] = bool(
-    env.get_credential('SQLA_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS', '')
-)
-app.config['SQLALCHEMY_FOLLOWER_TASKS'] = [
-    'webservices.tasks.download.export_query',
-]
-app.config['SQLALCHEMY_FOLLOWERS'] = [
-    sa.create_engine(follower.strip())
-    for follower in utils.split_env_var(env.get_credential('SQLA_FOLLOWERS', ''))
-    if follower.strip()
-]
-app.config['PROPAGATE_EXCEPTIONS'] = True
-
-# app.config['SQLALCHEMY_ECHO'] = True
-
-# Modify app configuration and logging level for production
-if not app.debug:
-    app.logger.addHandler(logging.StreamHandler())
-    app.logger.setLevel(logging.INFO)
-
-db.init_app(app)
-cors.CORS(app)
-
-
-class FlaskRestParser(FlaskParser):
-    DEFAULT_UNKNOWN_BY_LOCATION = {"query": EXCLUDE}
-
-    def handle_error(self, error, req, schema, *, error_status_code, error_headers):
-        message = error.messages
-        status_code = getattr(error, 'status_code', 422)
-        raise exceptions.ApiError(message, status_code)
-
-
-parser = FlaskRestParser()
-app.config['APISPEC_WEBARGS_PARSER'] = parser
-app.config['MAX_CACHE_AGE'] = env.get_credential('FEC_CACHE_AGE')
-
-v1 = Blueprint('v1', __name__, url_prefix='/v1')
-api = restful.Api(v1)
-
-# Encode using ujson for speed and decimal encoding
-api.representations['application/json'] = util.output_json
-
-app.register_blueprint(v1)
-
-
-@app.errorhandler(exceptions.ApiError)
-def handle_error(error):
-    response = jsonify(error.to_dict())
-    response.status_code = error.status_code
-    return response
-
-
-# api.data.gov
+# Variables NTC
 TRUSTED_PROXY_IPS = utils.split_env_var(env.get_credential('FEC_API_TRUSTED_PROXY_IPS', ''))
 # Save blocked IPs as a long string, ex. "1.1.1.1, 2.2.2.2, 3.3.3.3"
 BLOCKED_IPS = env.get_credential('FEC_API_BLOCKED_IPS', '')
@@ -149,472 +79,395 @@ RESTRICT_MESSAGE = "We apologize for the inconvenience, but we are temporarily "
 SHOW_TEST_F1 = env.get_credential('FEC_SHOW_TEST_F1', False)
 
 
-@app.before_request
-def limit_remote_addr():
-    """
-    If `FEC_API_USE_PROXY` is set:
-    - Reject all requests that are not routed through the API Umbrella
-    - Block any flagged IPs
-    - If we're restricting downloads, only allow requests from specified key
-    """
-    true_values = (True, 'True', 'true', 't')
-    if USE_PROXY in true_values:
-        try:
-            *_, source_ip, api_data_route, cf_route = request.access_route
-        except ValueError:  # Not enough routes
-            abort(403)
-        else:
-            if api_data_route not in TRUSTED_PROXY_IPS:
-                abort(403)
-            if source_ip in BLOCKED_IPS:
-                abort(503, RESTRICT_MESSAGE)
-            if RESTRICT_DOWNLOADS in true_values and '/download/' in request.url:
-                # 'X-Api-User-Id' header is passed through by the API umbrella
-                request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id != DOWNLOAD_KEY_ID:
-                    abort(403)
-            # We don't want to accidentally block downloads here, handled above
-            elif RESTRICT_TRAFFIC in true_values and '/v1/' in request.url:
-                request_api_key_id = request.headers.get('X-Api-User-Id')
-                if request_api_key_id not in BYPASS_RESTRICTION_API_KEY_IDS:
-                    # Service unavailable
-                    abort(503, RESTRICT_MESSAGE)
+def sqla_conn_string():
+    sqla_conn_string = env.get_credential('SQLA_CONN')
+    if not sqla_conn_string:
+        print("Environment variable SQLA_CONN is empty; running against " + "local `cfdm_test`")
+        sqla_conn_string = 'postgresql://:@/cfdm_test'
+    return sqla_conn_string
 
 
-def get_cache_header(url):
+class FlaskRestParser(FlaskParser):
+    DEFAULT_UNKNOWN_BY_LOCATION = {"query": EXCLUDE}
 
-    # Time in seconds
-    EFILING_CACHE = 0
-    LEGAL_CACHE = 60 * 5
-    CALENDAR_CACHE = 60 * 5
-    DEFAULT_CACHE = 60 * 60
-
-    # cloud.gov time is in UTC (UTC = ET + 4 or 5 hours, depending on DST)
-    PEAK_HOURS_START = time(13)  # 9:00 ET + 4 = 13:00 UTC
-    PEAK_HOURS_END = time(23, 30)  # 19:30 ET + 4 = 23:30 UTC
-
-    DEFAULT_HEADER_TYPE = 'Cache-Control'
-    DEFAULT_HEADER_PREFIX = 'public, max-age='
-
-    LONG_CACHE_ENDPOINTS = ['/totals', '/schedules/']
-
-    if '/efile/' in url:
-        return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, EFILING_CACHE)
-    if '/calendar-dates/' in url:
-        return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, CALENDAR_CACHE)
-    if '/legal/' in url:
-        return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, LEGAL_CACHE)
-
-    # This will work differently in local environment - will use local timezone
-    for endpoint in LONG_CACHE_ENDPOINTS:
-        if endpoint in url and PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END:
-            peak_hours_expiration_time = datetime.combine(
-                datetime.now().date(), PEAK_HOURS_END
-            ).strftime('%a, %d %b %Y %H:%M:%S GMT')
-            return 'Expires', peak_hours_expiration_time
-
-    return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, DEFAULT_CACHE)
+    def handle_error(self, error, req, schema, *, error_status_code, error_headers):
+        message = error.messages
+        status_code = getattr(error, 'status_code', 422)
+        raise exceptions.ApiError(message, status_code)
 
 
-@app.after_request
-def add_caching_headers(response):
-
-    cache_header_type, cache_header = get_cache_header(request.path)
-    response.headers.add(cache_header_type, cache_header)
-    return response
+parser = FlaskRestParser()
 
 
-@app.after_request
-def add_secure_headers(response):
-    """
-    Add secure headers to each response.
-    The 'unsafe-inline' Content Security Policy (CSP) setting is
-    needed for Swagger docs (see https://github.com/swagger-api/swagger-ui/issues/3370)
-    """
+def create_app(test_config=None):
+    app = Flask(__name__)
+    app.url_map.strict_slashes = False
+    # app.config.from_pyfile(config_filename)
+    app.debug = True  # remove later
+    app.config['APISPEC_FORMAT_RESPONSE'] = None
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SQLALCHEMY_POOL_SIZE'] = 50
+    app.config['SQLALCHEMY_MAX_OVERFLOW'] = 50
+    app.config['SQLALCHEMY_POOL_TIMEOUT'] = 120
+    app.config['SQLALCHEMY_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS'] = bool(
+        env.get_credential('SQLA_RESTRICT_FOLLOWER_TRAFFIC_TO_TASKS', ''))
+    app.config['SQLALCHEMY_FOLLOWER_TASKS'] = [
+        'webservices.tasks.download.export_query',]
+    app.config['PROPAGATE_EXCEPTIONS'] = True
 
-    headers = {
-        "X-Content-Type-Options": "nosniff",
-        "X-Frame-Options": "Deny",
-        "X-XSS-Protection": "1; mode=block",
-    }
-    content_security_policy = {
-        "default-src": "'self' *.fec.gov *.app.cloud.gov",
-        "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov https://www.google-analytics.com",
-        "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
-        "frame-src": "'self' *.fec.gov *.app.cloud.gov https://www.google.com/recaptcha/ \
-            https://recaptcha.google.com/recaptcha/",
-        "img-src": "'self' data:",
-        "object-src": "'none'",
-        "script-src": "'self' https://api.data.gov https://dap.digitalgov.gov https://www.google-analytics.com \
-            https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ \
-                'unsafe-inline'",
-        "style-src": "'self' https://fonts.googleapis.com https://api.data.gov 'unsafe-inline'",
-        "report-uri": "/report-csp-violation/",
-    }
-    if env.app.get('space_name', 'local').lower() == 'local':
-        content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
-        content_security_policy["connect-src"] += " localhost:* http://127.0.0.1:*"
+    if not app.debug:
+        app.logger.addHandler(logging.StreamHandler())
+        app.logger.setLevel(logging.INFO)
 
-    headers["Content-Security-Policy"] = "".join(
-        "{0} {1}; ".format(directive, value)
-        for directive, value in content_security_policy.items()
+    if test_config is None:
+        # load the instance config, if it exists, when not testing
+        # app.config.from_pyfile("config.py", silent=True)
+        app.config['SQLALCHEMY_DATABASE_URI'] = sqla_conn_string()
+        app.config['SQLALCHEMY_FOLLOWERS'] = [sa.create_engine(follower.strip())
+                                              for follower in utils.split_env_var(
+                                              env.get_credential('SQLA_FOLLOWERS', ''))
+                                              if follower.strip()]
+        app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+
+    else:
+        # load the test config if passed in
+        TEST_CONN = os.getenv('SQLA_TEST_CONN', 'postgresql:///cfdm_unit_test')
+        """ app.config['SQLALCHEMY_FOLLOWERS'] = [sa.create_engine(follower.strip())
+                                              for follower in utils.split_env_var(
+                                              env.get_credential('SQLA_FOLLOWERS', ''))
+                                              if follower.strip()] """
+        app.config['NPLUSONE_RAISE'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = TEST_CONN
+        app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
+        app.config['TESTING'] = True
+
+    # Initialize Extensions
+    # may need with app context
+    db.init_app(app)
+    cors.CORS(app)  # may need to init app
+    api.init_app(app)
+    NPlusOne(app)  # may need init app
+    # cli.init_app(app)
+
+    # Register Blueprints
+    app.register_blueprint(v1)
+    app.config.update({
+        'APISPEC_SWAGGER_URL': None,
+        'APISPEC_SWAGGER_UI_URL': None,
+        'APISPEC_SPEC': spec.spec,
+        })
+    apidoc = FlaskApiSpec(app)  # may need to be moved out empty and then init app inside create app
+
+    apidoc.register(national_party.NationalParty_ScheduleAView, blueprint='v1')
+    apidoc.register(national_party.NationalParty_ScheduleBView, blueprint='v1')
+    apidoc.register(national_party.NationalPartyTotalsView, blueprint='v1')
+    apidoc.register(search.CandidateNameSearch, blueprint='v1')
+    apidoc.register(search.CommitteeNameSearch, blueprint='v1')
+    apidoc.register(candidates.CandidateView, blueprint='v1')
+    apidoc.register(candidates.CandidateList, blueprint='v1')
+    apidoc.register(candidates.CandidateSearch, blueprint='v1')
+    apidoc.register(candidates.CandidateHistoryView, blueprint='v1')
+    apidoc.register(committees.CommitteeView, blueprint='v1')
+    apidoc.register(committees.CommitteeList, blueprint='v1')
+    apidoc.register(committees.CommitteeHistoryProfileView, blueprint='v1')
+    apidoc.register(reports.ReportsView, blueprint='v1')
+    apidoc.register(reports.CommitteeReportsView, blueprint='v1')
+    apidoc.register(reports.EFilingHouseSenateSummaryView, blueprint='v1')
+    apidoc.register(reports.EFilingPresidentialSummaryView, blueprint='v1')
+    apidoc.register(reports.EFilingPacPartySummaryView, blueprint='v1')
+    apidoc.register(totals.TotalsByEntityTypeView, blueprint='v1')
+    apidoc.register(totals.CandidateTotalsDetailView, blueprint='v1')
+    apidoc.register(totals.TotalsCommitteeView, blueprint='v1')
+    apidoc.register(totals.InauguralDonationsView, blueprint='v1')
+    apidoc.register(sched_a.ScheduleAView, blueprint='v1')
+    apidoc.register(sched_a.ScheduleAEfileView, blueprint='v1')
+    apidoc.register(sched_b.ScheduleBView, blueprint='v1')
+    apidoc.register(sched_b.ScheduleBEfileView, blueprint='v1')
+    apidoc.register(sched_c.ScheduleCView, blueprint='v1')
+    apidoc.register(sched_c.ScheduleCViewBySubId, blueprint='v1')
+    apidoc.register(sched_e.ScheduleEView, blueprint='v1')
+    apidoc.register(sched_e.ScheduleEEfileView, blueprint='v1')
+    apidoc.register(sched_f.ScheduleFView, blueprint='v1')
+    apidoc.register(sched_f.ScheduleFViewBySubId, blueprint='v1')
+    apidoc.register(sched_d.ScheduleDView, blueprint='v1')
+    apidoc.register(sched_d.ScheduleDViewBySubId, blueprint='v1')
+    apidoc.register(sched_h4.ScheduleH4View, blueprint='v1')
+    apidoc.register(sched_h4.ScheduleH4EfileView, blueprint='v1')
+    apidoc.register(costs.CommunicationCostView, blueprint='v1')
+    apidoc.register(aggregates.CCAggregatesView, blueprint='v1')
+    apidoc.register(costs.ElectioneeringView, blueprint='v1')
+    apidoc.register(aggregates.ECAggregatesView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleABySizeView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleAByStateView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleAByZipView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleAByEmployerView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleAByOccupationView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleBByRecipientView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleBByRecipientIDView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleBByPurposeView, blueprint='v1')
+    apidoc.register(aggregates.ScheduleEByCandidateView, blueprint='v1')
+    apidoc.register(aggregates.CommunicationCostByCandidateView, blueprint='v1')
+    apidoc.register(aggregates.ElectioneeringByCandidateView, blueprint='v1')
+    apidoc.register(candidate_aggregates.ScheduleABySizeCandidateView, blueprint='v1')
+    apidoc.register(candidate_aggregates.ScheduleAByStateCandidateView, blueprint='v1')
+    apidoc.register(candidate_aggregates.ScheduleAByStateCandidateTotalsView, blueprint='v1')
+    apidoc.register(candidate_aggregates.TotalsCandidateView, blueprint='v1')
+    apidoc.register(filings.FilingsView, blueprint='v1')
+    apidoc.register(filings.FilingsList, blueprint='v1')
+    apidoc.register(elections.ElectionsListView, blueprint='v1')
+    apidoc.register(elections.ElectionView, blueprint='v1')
+    apidoc.register(elections.ElectionSummary, blueprint='v1')
+    apidoc.register(elections.StateElectionOfficeInfoView, blueprint='v1')
+    apidoc.register(dates.ReportingDatesView, blueprint='v1')
+    apidoc.register(dates.ElectionDatesView, blueprint='v1')
+    apidoc.register(dates.CalendarDatesView, blueprint='v1')
+    apidoc.register(dates.CalendarDatesExport, blueprint='v1')
+    apidoc.register(rad_analyst.RadAnalystView, blueprint='v1')
+    apidoc.register(filings.EFilingsView, blueprint='v1')
+    apidoc.register(filings.F2EFilingsView, blueprint='v1')
+    apidoc.register(filings.F1EFilingsView, blueprint='v1')
+    apidoc.register(large_aggregates.EntityReceiptDisbursementTotalsView, blueprint='v1')
+    apidoc.register(totals.ScheduleAByStateRecipientTotalsView, blueprint='v1')
+    apidoc.register(audit.AuditPrimaryCategoryView, blueprint='v1')
+    apidoc.register(audit.AuditCategoryView, blueprint='v1')
+    apidoc.register(audit.AuditCaseView, blueprint='v1')
+    apidoc.register(audit.AuditCandidateNameSearch, blueprint='v1')
+    apidoc.register(audit.AuditCommitteeNameSearch, blueprint='v1')
+    apidoc.register(operations_log.OperationsLogView, blueprint='v1')
+    apidoc.register(legal.UniversalSearch, blueprint='v1')
+    apidoc.register(candidate_aggregates.CandidateTotalAggregateView, blueprint='v1')
+    apidoc.register(spending_by_others.ECTotalsByCandidateView, blueprint='v1')
+    apidoc.register(spending_by_others.IETotalsByCandidateView, blueprint='v1')
+    apidoc.register(spending_by_others.CCTotalsByCandidateView, blueprint='v1')
+    # feature flag to publish endpoint
+    # when turning this on, uncomment from spec.py
+    if bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL', '')):
+        apidoc.register(presidential.PresidentialByCandidateView, blueprint='v1')
+        apidoc.register(presidential.PresidentialSummaryView, blueprint='v1')
+        apidoc.register(presidential.PresidentialBySizeView, blueprint='v1')
+        apidoc.register(presidential.PresidentialByStateView, blueprint='v1')
+        apidoc.register(presidential.PresidentialCoverageView, blueprint='v1')
+    if SHOW_TEST_F1:
+        apidoc.register(filings.TestF1EFilingsView, blueprint='v1')
+
+    # Adapted from https://github.com/noirbizarre/flask-restplus
+    here, _ = os.path.split(__file__)
+    docs = Blueprint(
+        'docs',
+        __name__,
+        static_folder=os.path.join(here, os.pardir, 'static', 'swagger-ui'),
+        static_url_path='/docs/static',
     )
 
-    # Expect-CT header
-    expect_ct_max_age = 60 * 60 * 24  # 1 day
-    expect_ct_enforce = False
-    expect_ct_report_uri = False
-    expect_ct_string = 'max-age=%s' % expect_ct_max_age
-    if expect_ct_enforce:
-        expect_ct_string += ', enforce'
-    if expect_ct_report_uri:
-        expect_ct_string += ', report-uri="%s"' % expect_ct_report_uri
-    headers["Expect-CT"] = expect_ct_string
+    @docs.add_app_template_global
+    def swagger_static(filename):
+        return url_for('docs.static', filename=filename)
 
-    for header, value in headers.items():
-        response.headers.add(header, value)
-    return response
+    @app.route('/')
+    @app.route('/v1/')
+    @app.route('/docs/')
+    @docs.route('/developer/')
+    def api_ui_redirect():
+        return redirect(url_for('docs.api_ui'), code=http.client.MOVED_PERMANENTLY)
 
-
-@app.errorhandler(Exception)
-def handle_exception(exception):
-    wrapped = ResponseException(str(exception), ErrorCode.INTERNAL_ERROR, type(exception))
-    app.logger.error(
-        'An API error occurred with the status code of {status} ({exception}).'
-        .format(
-            status=wrapped.status,
-            exception=wrapped.wrappedException
+    @docs.route('/developers/')
+    def api_ui():
+        return render_template(
+            'swagger-ui.html',
+            specs_url=url_for('docs.api_spec'),
+            PRODUCTION=env.get_credential('PRODUCTION'),
+            api_key_signup_key=env.get_credential('API_UMBRELLA_SIGNUP_KEY'),
         )
-    )
-    raise exceptions.ApiError('Could not process the request',
-                              status_code=http.client.NOT_FOUND)
 
+    @docs.route('/swagger/')
+    def api_spec():
+        return jsonify(spec.spec.to_dict())
 
-@app.errorhandler(404)
-def page_not_found(exception):
-    wrapped = ResponseException(str(exception), exception.code, type(exception))
-    return wrapped.wrappedException, wrapped.status
+    app.register_blueprint(docs)
+    app.app_context().push()
 
+    # app.config['SQLALCHEMY_ECHO'] = True
+    # app.debug = True
+    # Modify app configuration and logging level for production
+    '''
+    if not app.debug:
+        app.logger.addHandler(logging.StreamHandler())
+        app.logger.setLevel(logging.INFO)
+    '''
+    parser = FlaskRestParser()
+    app.config['APISPEC_WEBARGS_PARSER'] = parser
+    # app.config['MAX_CACHE_AGE'] = env.get_credential('FEC_CACHE_AGE') I think this is old and unnecessary?
 
-@app.errorhandler(403)
-def forbidden(exception):
-    wrapped = ResponseException(str(exception), exception.code, type(exception))
-    return wrapped.wrappedException, wrapped.status
+    @app.errorhandler(exceptions.ApiError)
+    def handle_error(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
 
+    @app.before_request
+    def limit_remote_addr():
+        """
+        If `FEC_API_USE_PROXY` is set:
+        - Reject all requests that are not routed through the API Umbrella
+        - Block any flagged IPs
+        - If we're restricting downloads, only allow requests from specified key
+        """
+        true_values = (True, 'True', 'true', 't')
+        if USE_PROXY in true_values:
+            try:
+                *_, source_ip, api_data_route, cf_route = request.access_route
+            except ValueError:  # Not enough routes
+                abort(403)
+            else:
+                if api_data_route not in TRUSTED_PROXY_IPS:
+                    abort(403)
+                if source_ip in BLOCKED_IPS:
+                    abort(503, RESTRICT_MESSAGE)
+                if RESTRICT_DOWNLOADS in true_values and '/download/' in request.url:
+                    # 'X-Api-User-Id' header is passed through by the API umbrella
+                    request_api_key_id = request.headers.get('X-Api-User-Id')
+                    if request_api_key_id != DOWNLOAD_KEY_ID:
+                        abort(403)
+                # We don't want to accidentally block downloads here, handled above
+                elif RESTRICT_TRAFFIC in true_values and '/v1/' in request.url:
+                    request_api_key_id = request.headers.get('X-Api-User-Id')
+                    if request_api_key_id not in BYPASS_RESTRICTION_API_KEY_IDS:
+                        # Service unavailable
+                        abort(503, RESTRICT_MESSAGE)
 
-api.add_resource(national_party.NationalParty_ScheduleAView, '/national_party/schedule_a/')
-api.add_resource(national_party.NationalParty_ScheduleBView, '/national_party/schedule_b/')
-api.add_resource(national_party.NationalPartyTotalsView, '/national_party/totals/')
-api.add_resource(candidates.CandidateList, '/candidates/')
-api.add_resource(candidates.CandidateSearch, '/candidates/search/')
-api.add_resource(
-    candidates.CandidateView,
-    '/candidate/<string:candidate_id>/',
-    '/committee/<string:committee_id>/candidates/',
-)
-api.add_resource(
-    candidates.CandidateHistoryView,
-    '/candidate/<string:candidate_id>/history/',
-    '/candidate/<string:candidate_id>/history/<int:cycle>/',
-    '/committee/<string:committee_id>/candidates/history/',
-    '/committee/<string:committee_id>/candidates/history/<int:cycle>/',
-)
-api.add_resource(committees.CommitteeList, '/committees/')
-api.add_resource(
-    committees.CommitteeView,
-    '/committee/<string:committee_id>/',
-    '/candidate/<string:candidate_id>/committees/',
-)
-api.add_resource(
-    committees.CommitteeHistoryProfileView,
-    '/committee/<string:committee_id>/history/',
-    '/committee/<string:committee_id>/history/<int:cycle>/',
-    '/candidate/<string:candidate_id>/committees/history/',
-    '/candidate/<string:candidate_id>/committees/history/<int:cycle>/',
-)
-api.add_resource(totals.TotalsByEntityTypeView, '/totals/<string:entity_type>/')
-api.add_resource(totals.TotalsCommitteeView, '/committee/<string:committee_id>/totals/')
-api.add_resource(totals.CandidateTotalsDetailView, '/candidate/<string:candidate_id>/totals/')
-api.add_resource(reports.ReportsView, '/reports/<string:entity_type>/')
-api.add_resource(reports.CommitteeReportsView, '/committee/<string:committee_id>/reports/')
-api.add_resource(search.CandidateNameSearch, '/names/candidates/')
-api.add_resource(search.CommitteeNameSearch, '/names/committees/')
-api.add_resource(sched_a.ScheduleAView, '/schedules/schedule_a/', '/schedules/schedule_a/<string:sub_id>/')
-api.add_resource(sched_a.ScheduleAEfileView, '/schedules/schedule_a/efile/')
-api.add_resource(sched_b.ScheduleBView, '/schedules/schedule_b/', '/schedules/schedule_b/<string:sub_id>/')
-api.add_resource(sched_b.ScheduleBEfileView, '/schedules/schedule_b/efile/')
-api.add_resource(sched_c.ScheduleCView, '/schedules/schedule_c/')
-api.add_resource(sched_c.ScheduleCViewBySubId, '/schedules/schedule_c/<string:sub_id>/')
-api.add_resource(sched_d.ScheduleDView, '/schedules/schedule_d/')
-api.add_resource(sched_d.ScheduleDViewBySubId, '/schedules/schedule_d/<string:sub_id>/')
-api.add_resource(sched_e.ScheduleEView, '/schedules/schedule_e/')
-api.add_resource(sched_e.ScheduleEEfileView, '/schedules/schedule_e/efile/')
-api.add_resource(sched_f.ScheduleFView, '/schedules/schedule_f/', '/schedules/schedule_f/<string:sub_id>/')
-api.add_resource(sched_f.ScheduleFViewBySubId, '/schedules/schedule_f/<string:sub_id>/')
-api.add_resource(sched_h4.ScheduleH4View, '/schedules/schedule_h4/')
-api.add_resource(sched_h4.ScheduleH4EfileView, '/schedules/schedule_h4/efile/')
-api.add_resource(costs.CommunicationCostView, '/communication_costs/')
-api.add_resource(costs.ElectioneeringView, '/electioneering/')
-api.add_resource(elections.ElectionView, '/elections/')
-api.add_resource(elections.ElectionsListView, '/elections/search/')
-api.add_resource(elections.ElectionSummary, '/elections/summary/')
-api.add_resource(elections.StateElectionOfficeInfoView, '/state-election-office/')
-api.add_resource(dates.ElectionDatesView, '/election-dates/')
-api.add_resource(dates.ReportingDatesView, '/reporting-dates/')
-api.add_resource(dates.CalendarDatesView, '/calendar-dates/')
-api.add_resource(dates.CalendarDatesExport, '/calendar-dates/export/')
-api.add_resource(rad_analyst.RadAnalystView, '/rad-analyst/')
-api.add_resource(filings.EFilingsView, '/efile/filings/')
-api.add_resource(filings.F2EFilingsView, '/efile/form2/')
-api.add_resource(filings.F1EFilingsView, '/efile/form1/')
-api.add_resource(large_aggregates.EntityReceiptDisbursementTotalsView, '/totals/by_entity/')
-api.add_resource(audit.AuditPrimaryCategoryView, '/audit-primary-category/')
-api.add_resource(audit.AuditCategoryView, '/audit-category/')
-api.add_resource(audit.AuditCaseView, '/audit-case/')
-api.add_resource(audit.AuditCandidateNameSearch, '/names/audit_candidates/')
-api.add_resource(audit.AuditCommitteeNameSearch, '/names/audit_committees/')
-api.add_resource(aggregates.ScheduleABySizeView, '/schedules/schedule_a/by_size/')
-api.add_resource(aggregates.ScheduleAByStateView, '/schedules/schedule_a/by_state/')
-api.add_resource(aggregates.ScheduleAByZipView, '/schedules/schedule_a/by_zip/')
-api.add_resource(aggregates.ScheduleAByEmployerView, '/schedules/schedule_a/by_employer/')
-api.add_resource(aggregates.ScheduleAByOccupationView, '/schedules/schedule_a/by_occupation/')
-api.add_resource(aggregates.ScheduleBByRecipientView, '/schedules/schedule_b/by_recipient/')
-api.add_resource(aggregates.ScheduleBByRecipientIDView, '/schedules/schedule_b/by_recipient_id/')
-api.add_resource(aggregates.ScheduleBByPurposeView, '/schedules/schedule_b/by_purpose/')
-api.add_resource(aggregates.ScheduleEByCandidateView, '/schedules/schedule_e/by_candidate/')
-api.add_resource(candidate_aggregates.ScheduleABySizeCandidateView, '/schedules/schedule_a/by_size/by_candidate/')
-api.add_resource(candidate_aggregates.ScheduleAByStateCandidateView, '/schedules/schedule_a/by_state/by_candidate/')
-api.add_resource(candidate_aggregates.ScheduleAByStateCandidateTotalsView,
-                 '/schedules/schedule_a/by_state/by_candidate/totals/')
-api.add_resource(candidate_aggregates.TotalsCandidateView, '/candidates/totals/')
-api.add_resource(totals.ScheduleAByStateRecipientTotalsView, '/schedules/schedule_a/by_state/totals/')
-api.add_resource(candidate_aggregates.CandidateTotalAggregateView, '/candidates/totals/aggregates/')
-api.add_resource(totals.InauguralDonationsView, '/totals/inaugural_committees/by_contributor/')
+    def get_cache_header(url):
 
+        # Time in seconds
+        EFILING_CACHE = 0
+        LEGAL_CACHE = 60 * 5
+        CALENDAR_CACHE = 60 * 5
+        DEFAULT_CACHE = 60 * 60
 
-api.add_resource(
-    aggregates.CommunicationCostByCandidateView,
-    '/communication_costs/by_candidate/',
-)
+        # cloud.gov time is in UTC (UTC = ET + 4 or 5 hours, depending on DST)
+        PEAK_HOURS_START = time(13)  # 9:00 ET + 4 = 13:00 UTC
+        PEAK_HOURS_END = time(23, 30)  # 19:30 ET + 4 = 23:30 UTC
 
-api.add_resource(
-    aggregates.CCAggregatesView,
-    '/communication_costs/aggregates/',
-)
+        DEFAULT_HEADER_TYPE = 'Cache-Control'
+        DEFAULT_HEADER_PREFIX = 'public, max-age='
 
-api.add_resource(
-    aggregates.ElectioneeringByCandidateView,
-    '/electioneering/by_candidate/',
-)
+        LONG_CACHE_ENDPOINTS = ['/totals', '/schedules/']
 
-api.add_resource(
-    aggregates.ECAggregatesView,
-    '/electioneering/aggregates/',
-)
+        if '/efile/' in url:
+            return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, EFILING_CACHE)
+        if '/calendar-dates/' in url:
+            return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, CALENDAR_CACHE)
+        if '/legal/' in url:
+            return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, LEGAL_CACHE)
 
-api.add_resource(
-    spending_by_others.ECTotalsByCandidateView,
-    '/electioneering/totals/by_candidate/',
-)
+        # This will work differently in local environment - will use local timezone
+        for endpoint in LONG_CACHE_ENDPOINTS:
+            if endpoint in url and PEAK_HOURS_START <= datetime.now().time() <= PEAK_HOURS_END:
+                peak_hours_expiration_time = datetime.combine(
+                    datetime.now().date(), PEAK_HOURS_END
+                ).strftime('%a, %d %b %Y %H:%M:%S GMT')
+                return 'Expires', peak_hours_expiration_time
 
-api.add_resource(
-    spending_by_others.IETotalsByCandidateView,
-    '/schedules/schedule_e/totals/by_candidate/',
-)
+        return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, DEFAULT_CACHE)
 
-api.add_resource(
-    spending_by_others.CCTotalsByCandidateView,
-    '/communication_costs/totals/by_candidate/',
-)
+    @app.after_request
+    def add_caching_headers(response):
 
-api.add_resource(
-    filings.FilingsView,
-    '/committee/<committee_id>/filings/',
-    '/candidate/<candidate_id>/filings/',
-)
+        cache_header_type, cache_header = get_cache_header(request.path)
+        response.headers.add(cache_header_type, cache_header)
+        return response
 
-api.add_resource(
-    reports.EFilingHouseSenateSummaryView,
-    '/efile/reports/house-senate/',
-)
+    @app.after_request
+    def add_secure_headers(response):
+        """
+        Add secure headers to each response.
+        The 'unsafe-inline' Content Security Policy (CSP) setting is
+        needed for Swagger docs (see https://github.com/swagger-api/swagger-ui/issues/3370)
+        """
 
-api.add_resource(
-    reports.EFilingPresidentialSummaryView,
-    '/efile/reports/presidential/',
-)
+        headers = {
+            "X-Content-Type-Options": "nosniff",
+            "X-Frame-Options": "Deny",
+            "X-XSS-Protection": "1; mode=block",
+        }
+        content_security_policy = {
+            "default-src": "'self' *.fec.gov *.app.cloud.gov",
+            "connect-src": "*.fec.gov *.cloud.gov https://api.data.gov https://www.google-analytics.com",
+            "font-src": "'self' https://fonts.gstatic.com data: https://api.data.gov",
+            "frame-src": "'self' *.fec.gov *.app.cloud.gov https://www.google.com/recaptcha/ \
+                https://recaptcha.google.com/recaptcha/",
+            "img-src": "'self' data:",
+            "object-src": "'none'",
+            "script-src": "'self' https://api.data.gov https://dap.digitalgov.gov https://www.google-analytics.com \
+                https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ \
+                    'unsafe-inline'",
+            "style-src": "'self' https://fonts.googleapis.com https://api.data.gov 'unsafe-inline'",
+            "report-uri": "/report-csp-violation/",
+        }
+        if env.app.get('space_name', 'local').lower() == 'local':
+            content_security_policy["default-src"] += " localhost:* http://127.0.0.1:*"
+            content_security_policy["connect-src"] += " localhost:* http://127.0.0.1:*"
 
-api.add_resource(
-    reports.EFilingPacPartySummaryView,
-    '/efile/reports/pac-party/',
-)
+        headers["Content-Security-Policy"] = "".join(
+            "{0} {1}; ".format(directive, value)
+            for directive, value in content_security_policy.items()
+        )
 
-api.add_resource(filings.FilingsList, '/filings/')
-api.add_resource(download.DownloadView, '/download/<path:path>/')
-api.add_resource(legal.UniversalSearch, '/legal/search/')
-api.add_resource(legal.GetLegalCitation, '/legal/citation/<citation_type>/<citation>')
-api.add_resource(legal.GetLegalDocument, '/legal/docs/<doc_type>/<no>')
-api.add_resource(operations_log.OperationsLogView, '/operations-log/')
-api.add_resource(presidential.PresidentialByCandidateView, '/presidential/contributions/by_candidate/')
-api.add_resource(presidential.PresidentialSummaryView, '/presidential/financial_summary/')
-api.add_resource(presidential.PresidentialBySizeView, '/presidential/contributions/by_size/')
-api.add_resource(presidential.PresidentialByStateView, '/presidential/contributions/by_state/')
-api.add_resource(presidential.PresidentialCoverageView, '/presidential/coverage_end_date/')
-if SHOW_TEST_F1:
-    api.add_resource(filings.TestF1EFilingsView, '/efile/test-form1/')
+        # Expect-CT header
+        expect_ct_max_age = 60 * 60 * 24  # 1 day
+        expect_ct_enforce = False
+        expect_ct_report_uri = False
+        expect_ct_string = 'max-age=%s' % expect_ct_max_age
+        if expect_ct_enforce:
+            expect_ct_string += ', enforce'
+        if expect_ct_report_uri:
+            expect_ct_string += ', report-uri="%s"' % expect_ct_report_uri
+        headers["Expect-CT"] = expect_ct_string
 
-app.config.update({
-    'APISPEC_SWAGGER_URL': None,
-    'APISPEC_SWAGGER_UI_URL': None,
-    'APISPEC_SPEC': spec.spec,
-})
-apidoc = FlaskApiSpec(app)
+        for header, value in headers.items():
+            response.headers.add(header, value)
+        return response
 
-apidoc.register(national_party.NationalParty_ScheduleAView, blueprint='v1')
-apidoc.register(national_party.NationalParty_ScheduleBView, blueprint='v1')
-apidoc.register(national_party.NationalPartyTotalsView, blueprint='v1')
-apidoc.register(search.CandidateNameSearch, blueprint='v1')
-apidoc.register(search.CommitteeNameSearch, blueprint='v1')
-apidoc.register(candidates.CandidateView, blueprint='v1')
-apidoc.register(candidates.CandidateList, blueprint='v1')
-apidoc.register(candidates.CandidateSearch, blueprint='v1')
-apidoc.register(candidates.CandidateHistoryView, blueprint='v1')
-apidoc.register(committees.CommitteeView, blueprint='v1')
-apidoc.register(committees.CommitteeList, blueprint='v1')
-apidoc.register(committees.CommitteeHistoryProfileView, blueprint='v1')
-apidoc.register(reports.ReportsView, blueprint='v1')
-apidoc.register(reports.CommitteeReportsView, blueprint='v1')
-apidoc.register(reports.EFilingHouseSenateSummaryView, blueprint='v1')
-apidoc.register(reports.EFilingPresidentialSummaryView, blueprint='v1')
-apidoc.register(reports.EFilingPacPartySummaryView, blueprint='v1')
-apidoc.register(totals.TotalsByEntityTypeView, blueprint='v1')
-apidoc.register(totals.CandidateTotalsDetailView, blueprint='v1')
-apidoc.register(totals.TotalsCommitteeView, blueprint='v1')
-apidoc.register(totals.InauguralDonationsView, blueprint='v1')
-apidoc.register(sched_a.ScheduleAView, blueprint='v1')
-apidoc.register(sched_a.ScheduleAEfileView, blueprint='v1')
-apidoc.register(sched_b.ScheduleBView, blueprint='v1')
-apidoc.register(sched_b.ScheduleBEfileView, blueprint='v1')
-apidoc.register(sched_c.ScheduleCView, blueprint='v1')
-apidoc.register(sched_c.ScheduleCViewBySubId, blueprint='v1')
-apidoc.register(sched_e.ScheduleEView, blueprint='v1')
-apidoc.register(sched_e.ScheduleEEfileView, blueprint='v1')
-apidoc.register(sched_f.ScheduleFView, blueprint='v1')
-apidoc.register(sched_f.ScheduleFViewBySubId, blueprint='v1')
-apidoc.register(sched_d.ScheduleDView, blueprint='v1')
-apidoc.register(sched_d.ScheduleDViewBySubId, blueprint='v1')
-apidoc.register(sched_h4.ScheduleH4View, blueprint='v1')
-apidoc.register(sched_h4.ScheduleH4EfileView, blueprint='v1')
-apidoc.register(costs.CommunicationCostView, blueprint='v1')
-apidoc.register(aggregates.CCAggregatesView, blueprint='v1')
-apidoc.register(costs.ElectioneeringView, blueprint='v1')
-apidoc.register(aggregates.ECAggregatesView, blueprint='v1')
-apidoc.register(aggregates.ScheduleABySizeView, blueprint='v1')
-apidoc.register(aggregates.ScheduleAByStateView, blueprint='v1')
-apidoc.register(aggregates.ScheduleAByZipView, blueprint='v1')
-apidoc.register(aggregates.ScheduleAByEmployerView, blueprint='v1')
-apidoc.register(aggregates.ScheduleAByOccupationView, blueprint='v1')
-apidoc.register(aggregates.ScheduleBByRecipientView, blueprint='v1')
-apidoc.register(aggregates.ScheduleBByRecipientIDView, blueprint='v1')
-apidoc.register(aggregates.ScheduleBByPurposeView, blueprint='v1')
-apidoc.register(aggregates.ScheduleEByCandidateView, blueprint='v1')
-apidoc.register(aggregates.CommunicationCostByCandidateView, blueprint='v1')
-apidoc.register(aggregates.ElectioneeringByCandidateView, blueprint='v1')
-apidoc.register(candidate_aggregates.ScheduleABySizeCandidateView, blueprint='v1')
-apidoc.register(candidate_aggregates.ScheduleAByStateCandidateView, blueprint='v1')
-apidoc.register(candidate_aggregates.ScheduleAByStateCandidateTotalsView, blueprint='v1')
-apidoc.register(candidate_aggregates.TotalsCandidateView, blueprint='v1')
-apidoc.register(filings.FilingsView, blueprint='v1')
-apidoc.register(filings.FilingsList, blueprint='v1')
-apidoc.register(elections.ElectionsListView, blueprint='v1')
-apidoc.register(elections.ElectionView, blueprint='v1')
-apidoc.register(elections.ElectionSummary, blueprint='v1')
-apidoc.register(elections.StateElectionOfficeInfoView, blueprint='v1')
-apidoc.register(dates.ReportingDatesView, blueprint='v1')
-apidoc.register(dates.ElectionDatesView, blueprint='v1')
-apidoc.register(dates.CalendarDatesView, blueprint='v1')
-apidoc.register(dates.CalendarDatesExport, blueprint='v1')
-apidoc.register(rad_analyst.RadAnalystView, blueprint='v1')
-apidoc.register(filings.EFilingsView, blueprint='v1')
-apidoc.register(filings.F2EFilingsView, blueprint='v1')
-apidoc.register(filings.F1EFilingsView, blueprint='v1')
-apidoc.register(large_aggregates.EntityReceiptDisbursementTotalsView, blueprint='v1')
-apidoc.register(totals.ScheduleAByStateRecipientTotalsView, blueprint='v1')
-apidoc.register(audit.AuditPrimaryCategoryView, blueprint='v1')
-apidoc.register(audit.AuditCategoryView, blueprint='v1')
-apidoc.register(audit.AuditCaseView, blueprint='v1')
-apidoc.register(audit.AuditCandidateNameSearch, blueprint='v1')
-apidoc.register(audit.AuditCommitteeNameSearch, blueprint='v1')
-apidoc.register(operations_log.OperationsLogView, blueprint='v1')
-apidoc.register(legal.UniversalSearch, blueprint='v1')
-apidoc.register(candidate_aggregates.CandidateTotalAggregateView, blueprint='v1')
-apidoc.register(spending_by_others.ECTotalsByCandidateView, blueprint='v1')
-apidoc.register(spending_by_others.IETotalsByCandidateView, blueprint='v1')
-apidoc.register(spending_by_others.CCTotalsByCandidateView, blueprint='v1')
-# feature flag to publish endpoint
-# when turning this on, uncomment from spec.py
-if bool(env.get_credential('FEC_FEATURE_PRESIDENTIAL', '')):
-    apidoc.register(presidential.PresidentialByCandidateView, blueprint='v1')
-    apidoc.register(presidential.PresidentialSummaryView, blueprint='v1')
-    apidoc.register(presidential.PresidentialBySizeView, blueprint='v1')
-    apidoc.register(presidential.PresidentialByStateView, blueprint='v1')
-    apidoc.register(presidential.PresidentialCoverageView, blueprint='v1')
-if SHOW_TEST_F1:
-    apidoc.register(filings.TestF1EFilingsView, blueprint='v1')
+    @app.errorhandler(Exception)
+    def handle_exception(exception):
+        wrapped = ResponseException(str(exception), ErrorCode.INTERNAL_ERROR, type(exception))
+        app.logger.error(
+            'An API error occurred with the status code of {status} ({exception}).'
+            .format(
+                status=wrapped.status,
+                exception=wrapped.wrappedException
+            )
+        )
+        raise exceptions.ApiError('Could not process the request',
+                                  status_code=http.client.NOT_FOUND)
 
-# Adapted from https://github.com/noirbizarre/flask-restplus
-here, _ = os.path.split(__file__)
-docs = Blueprint(
-    'docs',
-    __name__,
-    static_folder=os.path.join(here, os.pardir, 'static', 'swagger-ui'),
-    static_url_path='/docs/static',
-)
+    @app.errorhandler(404)
+    def page_not_found(exception):
+        wrapped = ResponseException(str(exception), exception.code, type(exception))
+        return wrapped.wrappedException, wrapped.status
 
+    @app.errorhandler(403)
+    def forbidden(exception):
+        wrapped = ResponseException(str(exception), exception.code, type(exception))
+        return wrapped.wrappedException, wrapped.status
 
-@docs.route('/swagger/')
-def api_spec():
-    return jsonify(spec.spec.to_dict())
+    @app.route('/robots.txt/')
+    def robots():
+        return send_from_directory(app.static_folder, 'robots.txt')
 
+    @app.route('/report-csp-violation/', methods=['POST'])
+    def report():
+        """
+        Log Content Security Policy (CSP) violations from the browser
+        for both API and CMS.
+        Reports come in with tag 'csp-report'
+        """
+        app.logger.info(ujson.loads(str(request.data, 'utf-8')))
+        return util.output_json("CSP violation reported", 200)
 
-@docs.add_app_template_global
-def swagger_static(filename):
-    return url_for('docs.static', filename=filename)
+    @app.shell_context_processor
+    def make_shell_context():
+        return {'app': app, 'db': db, 'models': models}
 
+    app.wsgi_app = ProxyFix(app.wsgi_app)
 
-@app.route('/')
-@app.route('/v1/')
-@app.route('/docs/')
-@docs.route('/developer/')
-def api_ui_redirect():
-    return redirect(url_for('docs.api_ui'), code=http.client.MOVED_PERMANENTLY)
-
-
-@docs.route('/developers/')
-def api_ui():
-    return render_template(
-        'swagger-ui.html',
-        specs_url=url_for('docs.api_spec'),
-        PRODUCTION=env.get_credential('PRODUCTION'),
-        api_key_signup_key=env.get_credential('API_UMBRELLA_SIGNUP_KEY'),
-    )
-
-
-@app.route('/robots.txt/')
-def robots():
-    return send_from_directory(app.static_folder, 'robots.txt')
-
-
-@app.route('/report-csp-violation/', methods=['POST'])
-def report():
-    """
-    Log Content Security Policy (CSP) violations from the browser
-    for both API and CMS.
-    Reports come in with tag 'csp-report'
-    """
-    app.logger.info(ujson.loads(str(request.data, 'utf-8')))
-    return util.output_json("CSP violation reported", 200)
-
-
-app.register_blueprint(docs)
-
-app.wsgi_app = ProxyFix(app.wsgi_app)
+    return app

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -1,10 +1,6 @@
-import celery
-from celery import signals
 from celery.schedules import crontab
-
 from webservices.env import env
-import ssl
-from flask import current_app
+
 
 # Feature and dev are sharing the same RDS box so we only want dev to update
 schedule = {}
@@ -83,52 +79,3 @@ def redis_url():
         return redis_url
 
     return env.get_credential("FEC_REDIS_URL", "redis://localhost:6379/0")
-
-
-app = celery.Celery("openfec")
-# some import app statements should be ok because they are importing the celery app
-# and not the flask app, we may need to switch to factory for celery but we should get tests running first
-
-app.conf.update(
-    broker_url=redis_url(),
-    broker_use_ssl={
-        "ssl_cert_reqs": ssl.CERT_NONE,
-    },
-    redis_backend_use_ssl={
-        "ssl_cert_reqs": ssl.CERT_NONE,
-    },
-    imports=(
-        "webservices.tasks.refresh_db",
-        "webservices.tasks.download",
-        "webservices.tasks.legal_docs",
-    ),
-    beat_schedule=schedule,
-    broker_connection_timeout=30,  # in seconds
-    broker_connection_max_retries=0,  # for unlimited retries
-    task_acks_late=False
-)
-
-app.conf.ONCE = {
-    "backend": "celery_once.backends.Redis",
-    "settings": {
-        "url": redis_url() + "?ssl=true",
-        "default_timeout": 60 * 60
-    }
-}
-
-context = {}
-
-
-@signals.task_prerun.connect
-def push_context(task_id, task, *args, **kwargs):
-    context[task_id] = current_app.app_context()
-    context[task_id].push()
-
-# double check this is working correctly--we may have to init cellery in the app factory
-
-
-@signals.task_postrun.connect
-def pop_context(task_id, task, *args, **kwargs):
-    if task_id in context:
-        context[task_id].pop()
-        context.pop(task_id)

--- a/webservices/tasks/celery.py
+++ b/webservices/tasks/celery.py
@@ -1,0 +1,43 @@
+import ssl
+from celery import Celery, Task
+from flask import Flask
+from webservices.tasks import redis_url, schedule
+
+
+def celery_init_app(app: Flask) -> Celery:
+    class FlaskTask(Task):
+        def __call__(self, *args: object, **kwargs: object) -> object:
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery_app = Celery(app.name, task_cls=FlaskTask)  # app.name =openfec
+    celery_app.config_from_object(app.config["CELERY"])
+    celery_app.conf.update(
+        broker_url=redis_url(),
+        broker_use_ssl={
+            "ssl_cert_reqs": ssl.CERT_NONE,
+        },
+        redis_backend_use_ssl={
+            "ssl_cert_reqs": ssl.CERT_NONE,
+        },
+        imports=(
+            "webservices.tasks.refresh_db",
+            "webservices.tasks.download",
+            "webservices.tasks.legal_docs",
+        ),
+        beat_schedule=schedule,
+        broker_connection_timeout=30,  # in seconds
+        broker_connection_max_retries=0,  # for unlimited retries
+        task_acks_late=False
+    )
+    celery_app.conf.ONCE = {
+        "backend": "celery_once.backends.Redis",
+        "settings": {
+            "url": redis_url() + "?ssl=true",
+            "default_timeout": 60 * 60
+        }
+
+    }
+    celery_app.set_default()
+    app.extensions["celery"] = celery_app
+    return celery_app

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -16,6 +16,7 @@ from webservices.legal_docs.es_management import S3_BACKUP_DIRECTORY
 
 from webservices.tasks import app
 from webservices.tasks import utils as task_utils
+from flask import current_app
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ IGNORE_FIELDS = {"page", "per_page", "sort", "sort_hide_null"}
 
 
 def call_resource(path, qs):
-    app = task_utils.get_app()
+    app = current_app
     endpoint, arguments = app.url_map.bind("").match(path)
     resource_type = app.view_functions[endpoint].view_class
     resource = resource_type()
@@ -52,7 +53,7 @@ def call_resource(path, qs):
 def parse_kwargs(resource, qs):
     annotation = resolve_annotations(resource.get, "args", parent=resource)
     fields = utils.extend(*[option["args"] for option in annotation.options])
-    with task_utils.get_app().test_request_context("?" + qs):
+    with current_app.test_request_context("?" + qs):
         kwargs = flaskparser.parser.parse(fields, location='query')
     return fields, kwargs
 

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -8,52 +8,52 @@ from flask_apispec.utils import resolve_annotations
 from postgres_copy import query_entities, copy_to
 from celery_once import QueueOnce
 from smart_open import smart_open
+from celery import shared_task
 
 from webservices import utils
 from webservices.common import counts
 from webservices.common.models import db
 from webservices.legal_docs.es_management import S3_BACKUP_DIRECTORY
 
-from webservices.tasks import app
 from webservices.tasks import utils as task_utils
-from flask import current_app
+from flask import Flask, current_app
 
 logger = logging.getLogger(__name__)
 
 IGNORE_FIELDS = {"page", "per_page", "sort", "sort_hide_null"}
 
 
-def call_resource(path, qs):
-    app = current_app
-    endpoint, arguments = app.url_map.bind("").match(path)
-    resource_type = app.view_functions[endpoint].view_class
-    resource = resource_type()
-    fields, kwargs = parse_kwargs(resource, qs)
-    kwargs = utils.extend(arguments, kwargs)
+def call_resource(app: Flask, path, qs):
+    with app.app_context():
+        endpoint, arguments = app.url_map.bind("").match(path)
+        resource_type = app.view_functions[endpoint].view_class
+        resource = resource_type()
+        fields, kwargs = parse_kwargs(app, resource, qs)
+        kwargs = utils.extend(arguments, kwargs)
 
-    for field in IGNORE_FIELDS:
-        kwargs.pop(field, None)
+        for field in IGNORE_FIELDS:
+            kwargs.pop(field, None)
 
-    query, model, schema = unpack(resource.build_query(**kwargs), 3)
-    count, _ = counts.get_count(resource, query)
-    return {
-        "path": path,
-        "qs": qs,
-        "name": get_s3_name(path, qs.encode('utf-8')),
-        "query": query,
-        "schema": schema or resource.schema,
-        "resource": resource,
-        "count": count,
-        "timestamp": datetime.datetime.utcnow(),
-        "fields": fields,
-        "kwargs": kwargs,
-    }
+        query, model, schema = unpack(resource.build_query(**kwargs), 3)
+        count, _ = counts.get_count(resource, query)
+        return {
+            "path": path,
+            "qs": qs,
+            "name": get_s3_name(path, qs.encode('utf-8')),
+            "query": query,
+            "schema": schema or resource.schema,
+            "resource": resource,
+            "count": count,
+            "timestamp": datetime.datetime.utcnow(),
+            "fields": fields,
+            "kwargs": kwargs,
+        }
 
 
-def parse_kwargs(resource, qs):
+def parse_kwargs(app: Flask, resource, qs):
     annotation = resolve_annotations(resource.get, "args", parent=resource)
     fields = utils.extend(*[option["args"] for option in annotation.options])
-    with current_app.test_request_context("?" + qs):
+    with app.test_request_context("?" + qs):
         kwargs = flaskparser.parser.parse(fields, location='query')
     return fields, kwargs
 
@@ -140,13 +140,13 @@ def make_bundle(resource):
         )
 
 
-@app.task(base=QueueOnce, once={"graceful": True})
+@shared_task(base=QueueOnce, once={"graceful": True})
 def export_query(path, qs):
     qs = base64.b64decode(qs)
 
     try:
         logger.info("Download query: {0}".format(qs))
-        resource = call_resource(path, qs.decode('utf-8'))
+        resource = call_resource(current_app, path, qs.decode('utf-8'))
         logger.info("Download resource: {0}".format(qs))
         make_bundle(resource)
         logger.info("Bundled: {0}".format(qs))
@@ -154,7 +154,7 @@ def export_query(path, qs):
         logger.exception("Download failed: {0}".format(qs))
 
 
-@app.task
+@shared_task
 def clear_bucket():
     permanent_dir = ("legal", "bulk-downloads", S3_BACKUP_DIRECTORY)
     for obj in task_utils.get_bucket().objects.all():

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -15,7 +15,7 @@ from webservices.legal_docs.es_management import (  # noqa
     CASE_REPO,
 )
 
-from webservices.rest import db
+from webservices.common.models import db
 from webservices.tasks import app
 from webservices.tasks.utils import get_app_name
 

--- a/webservices/tasks/make_celery.py
+++ b/webservices/tasks/make_celery.py
@@ -1,0 +1,4 @@
+from webservices.rest import create_app
+
+flask_app = create_app()
+celery_app = flask_app.extensions["celery"]

--- a/webservices/tasks/refresh_db.py
+++ b/webservices/tasks/refresh_db.py
@@ -3,7 +3,8 @@ import logging
 
 import manage
 from webservices import utils
-from webservices.tasks import app, download
+from webservices.tasks import download
+from celery import shared_task
 from webservices.tasks.utils import get_app_name
 
 
@@ -13,7 +14,7 @@ SLACK_BOTS = "#bots"
 SLACK_ALERTS = "#alerts"
 
 
-@app.task
+@shared_task
 def refresh_materialized_views():
     """
     Refresh public materialized views.

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -11,11 +11,6 @@ logging.getLogger("boto3").setLevel(logging.CRITICAL)
 logging.getLogger("smart_open").setLevel(logging.CRITICAL)
 
 
-def get_app():
-    from webservices.rest import app
-    return app
-
-
 def get_bucket():
     try:
         session = boto3.Session()


### PR DESCRIPTION
### Summary (required)
### Resolves #4448
Refactors our API to use the flask app factory pattern, prioritizing preserving our current logic as much as possible

Helpful documentation:
https://flask.palletsprojects.com/en/stable/patterns/appfactories/
https://blog.miguelgrinberg.com/post/flask-webcast-3-circular-dependencies
https://flask.palletsprojects.com/en/stable/patterns/celery/

**NOTES:**

flask_restful setup is now in api_setup.py (it's too closely linked to the v1 blueprint to separate out all extensions)

I removed our followers logic from the test configuration because it's currently not being tested, and setting the variable breaks pytest on dev locally now. If we want to keep the logic we should do it in a followup ticket that also builds out testing for that logic.

I needed to build out tests for just our BaseTestCase to help refactor our testing configuration. I think they may be helpful for changes to BaseTestCase moving forward, so I kept them in the new file test_app.py

With the new app factory pattern, we can't import a global app instance for our migrate_db fixture. I tested out multiple strategies to refactor this fixture including switching it to a class scoped fixture to access the app instance created in BaseTestCase. Unfortunately, switching to a class scope forces the migrations to run per class, which was too time intensive (pytest was running for 6 instead of 3.5 minutes) I also tried the class scope and using the pytest cache, so that it wouldn't re-run once run, but unfortunately this required clearing the cache between sessions which was not ideal. I decided to have a seperate app instance for our integration tests that use this fixture which retains our current speeds without having to clear the pytest cache.

### Required reviewers
3-4 devs

### Impacted areas of the application
General components of the application that this PR will affect:

Application Initialization, Sqlalchemy, Celery, Views, Blueprints, Configurations, Pytest, Management Commands, Elasticsearch, and all other extensions
### How to test

#### Test Followers Logic
- activate your normal venv
(You can have your SQLA_CONN set to dev/stage or cfdm_test)
- `gh pr checkout 6148`
- `pytest`
- `flask run`
- run some queries
Ex: http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- change your configuration, set SQLA_FOLLOWERS to something like 'postgresql://username:@localhost:5432/cfdm_fake_test'
- `flask run`
- run some queries (should error due to the queries being sent to fake db at  SQLA_FOLLOWERS)
Ex: http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
- `pytest`
(shouldn't break unlike with current dev)
- `gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 4 'webservices.rest:create_app()'`
- test a few queries (you can keep SQLA_FOLLOWERS set to a fake db which will error, or set to cfdm_test/dev)
EX: http://127.0.0.1:8000/v1/legal/search/?q=%22federal%20funds%22


#### Re-creating the test db
- `dropdb cfdm_test`
- `createdb cfdm_test`
- `invoke create-sample-db`
- `unset SQLA_CONN`
- `unset SQLA_FOLLOWERS` (if still set from above
- `flask run`
- http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false


#### Test Downloads/Celery (locally or on dev)
LOCAL:
- Get Redis and Celery working locally using the instructions here:
https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks
- I changed the refresh_materialized task to test celery task locally
by changing the time to whatever time you're reviewing in webservices/tasks/init.py

> "refresh_materialized_views": {
>             "task": "webservices.tasks.refresh_db.refresh_materialized_views",
>             "schedule": crontab(minute=0, hour=9),
>         },

IF you do this make sure to set SLACK_ALERTS = "#test-bot" in refresh_db.py

#### Downloads on DEV:
- Run a query in any table [on dev](https://app.circleci.com/pipelines/github/fecgov/openFEC/3346/workflows/2a3d5056-d2b6-4923-9a01-07e676a7dba5/jobs/6239) and export
sample:
https://dev.fec.gov/data/disbursements/?data_type=processed&committee_id=C00010868&two_year_transaction_period=2026&min_date=01%2F01%2F2025&max_date=12%2F31%2F2026

#### Test Elasticsearch in DEV:
- rebuild push to dev [here](https://app.circleci.com/pipelines/github/fecgov/openFEC/3346/workflows/2a3d5056-d2b6-4923-9a01-07e676a7dba5/jobs/6239)
- test management commands [wiki](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-management-instruction)
previous test [here](https://logs.fr.cloud.gov/app/dashboards?security_tenant=fec-beta-fec#/view/App-Overview?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3Anow-15m%2Cto%3Anow%29%29)

#### Test Management Commands locally:
- set SLACK_HOOK
(pull from dev)
- change line 422 in manage.py:
post_to_slack(message, "#test-bot")
- `python cli.py slack_message test`

- `python cli.py delete_index ao_index`
- `python cli.py create_index ao_index`
- `python cli.py load_advisory_opinions 2024-15`

- `python cli.py display_mapping`

#### Further Testing: 
Update an env variable using the wiki [here](https://github.com/fecgov/openFEC/wiki/Add,-Update,-or-Remove-Environment-Variables-using-Task)
Pushed to stage [here](https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=push-app-fact-stage)