### PR TITLE
6131 switch q_exclude to SQS

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -196,9 +196,20 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 
     if kwargs.get("q_exclude"):
         must_not = []
-        must_not.append(Q("nested", path="documents", query=Q("match", documents__text=kwargs.get("q_exclude"))))
+        must_not.append(
+            Q(
+                "nested",
+                path="documents",
+                query=Q(
+                    "simple_query_string",
+                    query=kwargs.get("q_exclude"),
+                    fields=["documents.text"]
+                )
+            )
+        )
         if type_ == "statutes":
-            must_not.append(Q("match", name=kwargs.get("q_exclude")))
+            must_not.append(Q("simple_query_string",
+                            query=kwargs.get("q_exclude"), fields=["name"]))
         query = query.query("bool", must_not=must_not)
 
     # logging.warning("generic_query_builder =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))


### PR DESCRIPTION
## Summary (required)

- Resolves #6131 

This PR adds q_exclude to simple_query_string which will allow users to set fuzziness and do phrase negation

You should be able have a singular term, multiple terms, phrases, or any of the above with a fuzziness set at the end of the string for q_exclude
EX: q_exclude=Limon
`q_exclude=Limon Federa`
`q_exclude=Limon Federa~1`
`q_exclude=Limon~2`

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

-legal search exclusions for the keyword search 


## How to test
-pull this branch
-start your venv
-pytest
-python cli.py delete_index ao_index 
-python cli.py delete_index case_index 
-python cli.py delete_index arch_mur_index
-python cli.py create_index ao_index 
-python cli.py create_index case_index 
-python cli.py create_index arch_mur_index
-python cli.py load_statutes
-python cli.py load_advisory_opinions 2024-15
-python cli.py load_admin_fines 4771 
python cli.py load_admin_fines 4775
python cli.py load_admin_fines 4777
-python cli.py load_current_murs 
(I loaded until 8285)
-python cli.py load_archived_murs 
(loaded until 4784) 
-python cli.py load_adrs
(loaded until 1177) 
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federal
should be zero results
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federa
2 statutes 
-http://127.0.0.1:5000/v1/legal/search/?q=federal&q_exclude=federa~1
zero results
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians
should see AO 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unified
zero results 
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unifie
should see AO 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Libertarians&q_exclude=Unifie~1
zero results
-http://127.0.0.1:5000/v1/legal/search/?q=Mike
should see admin fine 4777 and ao 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q=Mike&q_exclude=Massachuses~2
should not see ao 2024-15
-http://127.0.0.1:5000/v1/legal/search/?q_exclude=Wied+ActBlue
should not see MURS 8324 or 8299 
-http://127.0.0.1:5000/v1/legal/search/?q_exclude=Wie%20AtBlue%20~1
should see zero murs
-http://127.0.0.1:5000/v1/legal/search/?q=%22federal%20funding%22
should see mur 4784 and AO 2025-02
-http://127.0.0.1:5000/v1/legal/search/?q_exclude=%22federal%20funding%22
should not see mur 4784  or AO 2025-02


You can also push to dev and test the FE 
