### PR TITLE
Enforce word order within q_proximity and proximity_filter_term

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -316,20 +316,20 @@ def get_proximity_query(**kwargs):
     if kwargs.get("proximity_filter") and kwargs.get("proximity_filter_term"):
         contains_filter = True
         filter = "before" if kwargs.get("proximity_filter") == "after" else "after"
-        filters = {filter: {'match': {'query': kwargs.get("proximity_filter_term")}}}
+        filters = {filter: {'match': {'query': kwargs.get("proximity_filter_term"), "max_gaps": 0, "ordered": True}}}
 
     if len(q_proximity) == 1:
         if contains_filter:
             intervals_inner_query = Q('intervals', documents__text={
-                'match':  {'query': q_proximity[0], 'max_gaps': max_gaps, "filter": filters}
+                'match':  {'query': q_proximity[0], 'max_gaps': max_gaps, "filter": filters, "ordered": True}
                 })
         else:
             intervals_inner_query = Q('intervals', documents__text={
-                'match':  {'query': q_proximity[0], 'max_gaps': max_gaps}
+                'match':  {'query': q_proximity[0], 'max_gaps': max_gaps, "ordered": True}
                 })
     else:
         for q in q_proximity:
-            dict_item = {"match": {"query": q, "max_gaps": 0, }}
+            dict_item = {"match": {"query": q, "max_gaps": 0, "ordered": True}}
             intervals_list.append(dict_item)
 
         if contains_filter:


### PR DESCRIPTION
## Summary (required)

- Resolves #6147

This PR enforces the word order within `q_proximity` and within `proximity_filter_term`. It also enforces a default `max_gap` of 0 within `proximity_filter_term`. 

### Required reviewers 2 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

- legal proximity search 


## How to test

- checkout this branch
- start elasticsearch `./elasticsearch`
- `pytest`
- create case index: `python cli.py create_index case_index`
- create ao index: `python cli.py create_index ao_index`
- load sample data for ao, mur, af, and adrs: `python cli.py load_current_murs` `python cli.py load_admin_fines` `python cli.py load_advisory_opinions` `python cli.py load_adrs`
- `flask run`
- see test URLs below 

Test URLs reference the following documents: MUR 8282, AO 2024-10

MUR 8282

Correct Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=signed%20conciliation&q_proximity=Michigan%20Republican&max_gaps=2

Incorrect Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=conciliation%20signed&q_proximity=Michigan%20Republican&max_gaps=2

Correct Order proximity_filter_term:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Memorandum%20to%20the%20Commission%20&q_proximity=Jennifer%20Standerfer&max_gaps=10&proximity_filter=before&proximity_filter_term=signed%20conciliation

Incorrect Order proximity_filter_term:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Memorandum%20to%20the%20Commission%20&q_proximity=Jennifer%20Standerfer&max_gaps=10&proximity_filter=before&proximity_filter_term=conciliation%20signed%20%20

Incorrect max_gap for proximity_filter_term (greater than zero): 
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Memorandum%20to%20the%20Commission%20&q_proximity=Jennifer%20Standerfer&max_gaps=10&proximity_filter=before&proximity_filter_term=signed%20agreement


AO 2024-10

Correct Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6

Incorrect Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=concludes%20The%20Commission&max_gaps=6

Correct Order proximity_filter_term:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6&proximity_filter=after&proximity_filter_term=exists%20irrespective

Incorrect Order proximity_filter_term:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6&proximity_filter=after&proximity_filter_term=irrespective%20exists

Incorrect max_gap for proximity_filter_term (greater than zero): 
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6&proximity_filter=after&proximity_filter_term=expense%20exists

Correct max_gap for proximity_filter_term: 
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6&proximity_filter=after&proximity_filter_term=expense%20that%20exists

Correct Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20draft&max_gaps=1

Incorrect Order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=draft%20Congressman&max_gaps=1

