### PR TITLE
Change ao_commenter, ao_requestor and ao_representative to use simple query string search type

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -724,13 +724,16 @@ def apply_ao_specific_query_params(query, **kwargs):
         must_clauses.append(Q("match", status=kwargs.get("ao_status")))
 
     if kwargs.get("ao_requestor"):
-        must_clauses.append(Q("match", requestor_names=kwargs.get("ao_requestor")))
+        must_clauses.append(Q("simple_query_string",
+                            query=kwargs.get("ao_requestor"), fields=["requestor_names"]))
 
     if kwargs.get("ao_commenter"):
-        must_clauses.append(Q("match", commenter_names=kwargs.get("ao_commenter")))
+        must_clauses.append(Q("simple_query_string",
+                            query=kwargs.get("ao_commenter"), fields=["commenter_names"]))
 
     if kwargs.get("ao_representative"):
-        must_clauses.append(Q("match", representative_names=kwargs.get("ao_representative")))
+        must_clauses.append(Q("simple_query_string",
+                            query=kwargs.get("ao_representative"), fields=["representative_names"]))
 
     citation_queries = []
     if kwargs.get("ao_regulatory_citation"):


### PR DESCRIPTION
## Summary 

Update ao_commenter, ao_requestor and ao_representative filter parameters from match to use simple query string search type. This update will ensure that both exact match and partial match results are returned.

- Resolves #6146 


### Required reviewers
2 or more 

## Impacted areas of the application

legal/search endpoint ao filter parameters, ao_commenter, ao_requestor and ao_representative


## How to test
- Feel free to deploy a test branch to Dev space and test this PR with a broader data set

### OR

- To set up the local Elasticsearch service, please follow this wiki [here](https://github.com/fecgov/openFEC/wiki/Elasticsearch-7.x.0-setup-and-test-locally#1-install-elasticsearch-7x0-locally-both-740-and-760-work-well)
- git checkout feature/6146-ao-commenter-representative-requestor-sqs
- run `pytest`
- run `python cli.py create_index ao_index` (create ao_index on local es service)
- run `python cli.py create_index case_index` (create case_index, without this you may see errors in the logs)
- run `python cli.py load_advisory_opinions 2024-01` (Total 19 advisory opinions will load)
- run `flask run`
- test below urls: 

**ao_requestor:**

- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor=` (Returns all 19 AO's)
-  `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Rep"` (Returns 3 results)
-  `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Rep."` (Returns 3 results)
-   `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Mikie"` (Returns AO#2025-01)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Independence Blue Cross LLC Political Action Committee"` (Returns AO#2024-04 )
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Party of"` (Returns 1 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_requestor="Party of"` (on develop branch, returns 3 results)


**ao_commenter:**
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter=` (Returns all 19 AO's)
-  `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter="Mr. Michael Bayes Esq."` (Returns AO#2024-13)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter="Mr. M~"` (No results) 
Note: with match query (on develop branch), ^^ still returns few results. 
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter="campaign legal center"` (Returns 4 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter="campaign center"` (on develop branch, returns 5 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_commenter="campaign center"` (Returns 0 results)

**ao_representative:**
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_representative=` (Returns all 19 AO's)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_representative="Elias Law Group"`(Returns 5 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_representative="Law"` (Returns 5 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_representative="Mr.Jonathan A."` (Returns 4 results)
- `http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&ao_representative="Mr.Jonathan A."` (on develop branch, Returns 8 results)


