### PR TITLE
Upgrade to sqlalchemy v1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ elasticsearch-dsl==7.3.0
 Flask==2.2.5
 Flask-Cors==5.0.0
 Flask-RESTful==0.3.9
-Flask-SQLAlchemy==2.5.1
+Flask-SQLAlchemy==3.0.0
 gevent==24.11.1
 gunicorn==23.0.0
 GitPython==3.1.41
@@ -23,7 +23,7 @@ python-dotenv>=0.20.0 # Sets variable defaults in .flaskenv file
 requests==2.32.3
 requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
-SQLAlchemy==1.3.19
+SQLAlchemy==1.4.54
 ujson==5.4.0 # decoding CSP violation reported
 vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==7.0.0
@@ -31,9 +31,9 @@ werkzeug==3.0.6
 
 # Marshalling
 flask-apispec==0.11.4
-git+https://github.com/fecgov/marshmallow-pagination@master
+git+https://github.com/fecgov/marshmallow-pagination@upgrade-sqlalchemy-v1.4
 marshmallow==3.0.0
-marshmallow-sqlalchemy==0.23.1
+marshmallow-sqlalchemy==0.29.0
 
 # Data export
 smart_open==1.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,3 @@ addopts=--cov webservices --cov-report term-missing
 testpaths=tests
 filterwarnings =
     ignore:.*propagate_exceptions:DeprecationWarning:flask_restful:
-    ignore:.*_app_ctx_stack:DeprecationWarning:flask_sqlalchemy:

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,12 +35,14 @@ def _reset_schema(db):
             conn.execute('drop schema if exists staging cascade;')
             conn.execute('drop schema if exists fecapp cascade;')
             conn.execute('drop schema if exists real_efile cascade;')
+            conn.execute('drop schema if exists test_efile cascade;')
             conn.execute('drop schema if exists auditsearch cascade;')
             conn.execute('create schema public;')
             conn.execute('create schema disclosure;')
             conn.execute('create schema staging;')
             conn.execute('create schema fecapp;')
             conn.execute('create schema real_efile;')
+            conn.execute('create schema test_efile;')
             conn.execute('create schema auditsearch;')
 
 
@@ -91,14 +93,7 @@ class ApiBaseTest(BaseTestCase):
             )
 
         with db.engine.connect() as connection:
-            db.metadata.create_all(
-                bind=connection,
-                tables=[
-                    each.__table__
-                    for each in db.Model._decl_class_registry.values()
-                    if hasattr(each, '__table__')
-                ]
-            )
+            db.metadata.create_all(bind=connection,)
 
     def setUp(self):
         super(ApiBaseTest, self).setUp()

--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -2,6 +2,8 @@ import datetime
 
 from unittest import mock
 
+import sqlalchemy as sa
+
 from tests import factories
 from tests.common import ApiBaseTest
 
@@ -17,7 +19,7 @@ class TestCounts(ApiBaseTest):
         factories.EFilingsFactory(file_number=123)
         db.session.flush()
 
-        query = db.session.query(models.ScheduleEEfile)
+        query = sa.select(models.ScheduleEEfile)
         # Estimated rows = 6000000
         get_query_plan_mock.return_value = [
             (
@@ -46,7 +48,7 @@ class TestCounts(ApiBaseTest):
                 two_year_transaction_period=2016,
             ),
         ]
-        query = db.session.query(models.ScheduleA)
+        query = sa.select(models.ScheduleA)
         # Estimated rows == 200
         get_query_plan_mock.return_value = [
             ('Seq Scan on fec_fitem_sched_a  (cost=0.00..10.60 rows=200 width=1289)',)
@@ -57,7 +59,7 @@ class TestCounts(ApiBaseTest):
         self.assertEqual(estimate, False)
 
     def test_use_estimated_counts_over_threshold(self, get_query_plan_mock):
-        query = db.session.query(models.ScheduleA)
+        query = sa.select(models.ScheduleA)
         # Estimated rows == 2000000
         get_query_plan_mock.return_value = [
             (
@@ -72,7 +74,7 @@ class TestCounts(ApiBaseTest):
 
     # test boundary conditions (n-1)
     def test_threshold_boundary_minus_1(self, get_query_plan_mock):
-        query = db.session.query(models.ScheduleA)
+        query = sa.select(models.ScheduleA)
         resource = sched_a.ScheduleAView()
         get_query_plan_mock.return_value = [
             (
@@ -85,7 +87,7 @@ class TestCounts(ApiBaseTest):
 
     # test boundary conditions (n)
     def test_threshold_boundary(self, get_query_plan_mock):
-        query = db.session.query(models.ScheduleA)
+        query = sa.select(models.ScheduleA)
         resource = sched_a.ScheduleAView()
         get_query_plan_mock.return_value = [
             (
@@ -98,7 +100,7 @@ class TestCounts(ApiBaseTest):
 
     # test boundary conditions (n+1)
     def test_threshold_boundary_plus_1(self, get_query_plan_mock):
-        query = db.session.query(models.ScheduleA)
+        query = sa.select(models.ScheduleA)
         resource = sched_a.ScheduleAView()
         get_query_plan_mock.return_value = [
             (

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -46,35 +46,35 @@ class TestFilterMatch(ApiBaseTest):
     def test_filter_match(self):
         # Filter for a single integer value
         query_dates = filters.filter_match(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'event_id': 123},
             CalendarDatesView.filter_match_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(each for each in self.dates if each.event_id == 123),
         )
 
         # Filter for a single string value
         query_reports = filters.filter_match(
-            models.CommitteeReportsHouseSenate.query,
+            sa.select(models.CommitteeReportsHouseSenate),
             {'filer_type': 'e-file'},
             self.filter_match_fields,
         )
         self.assertEqual(
-            set(query_reports.all()),
+            set(models.db.session.execute(query_reports).scalars().all()),
             set(each for each in self.reports if each.means_filed == 'e-file'),
         )
 
     def test_filter_match_exclude(self):
         # Exclude a single integer value
         query_dates = filters.filter_match(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'event_id': -321},
             CalendarDatesView.filter_match_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(
                 each
                 for each in self.dates
@@ -84,12 +84,12 @@ class TestFilterMatch(ApiBaseTest):
 
         # Exclude a single string value
         query_reports = filters.filter_match(
-            models.CommitteeReportsHouseSenate.query,
+            sa.select(models.CommitteeReportsHouseSenate),
             {'filer_type': '-paper'},
             self.filter_match_fields,
         )
         self.assertEqual(
-            set(query_reports.all()),
+            set(models.db.session.execute(query_reports).scalars().all()),
             set(each for each in self.reports if each.means_filed != 'paper'),
         )
 
@@ -128,46 +128,46 @@ class TestFilterMulti(ApiBaseTest):
     def test_filter_multi(self):
         # Filter for multiple integer values
         query_dates = filters.filter_multi(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'calendar_category_id': [1, 3]},
             CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(each for each in self.dates if each.calendar_category_id in [1, 3]),
         )
 
         # Filter for multiple string values
         query_committees = filters.filter_multi(
-            models.Committee.query,
+            sa.select(models.Committee),
             {'designation': ['P', 'U']},
             CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_committees.all()),
+            set(models.db.session.execute(query_committees).unique().scalars().all()),
             set(each for each in self.committees if each.designation in ['P', 'U']),
         )
 
     def test_filter_multi_exclude(self):
         # Exclude multiple integer values
         query_dates = filters.filter_multi(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'calendar_category_id': [-1, -3]},
             CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(each for each in self.dates if each.calendar_category_id not in [1, 3]),
         )
 
         # Exclude multiple string values
         query_committees = filters.filter_multi(
-            models.Committee.query,
+            sa.select(models.Committee),
             {'designation': ['-P', '-U']},
             CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_committees.all()),
+            set(models.db.session.execute(query_committees).unique().scalars().all()),
             set(
                 each
                 for each in self.committees
@@ -178,12 +178,12 @@ class TestFilterMulti(ApiBaseTest):
     def test_filter_multi_combo(self):
         # Exclude/include multiple integer values
         query_dates = filters.filter_multi(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'calendar_category_id': [-1, 3]},
             CalendarDatesView.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(
                 each
                 for each in self.dates
@@ -194,12 +194,12 @@ class TestFilterMulti(ApiBaseTest):
 
         # Exclude/include multiple string values
         query_committees = filters.filter_multi(
-            models.Committee.query,
+            sa.select(models.Committee),
             {'designation': ['-P', 'U']},
             CommitteeList.filter_multi_fields,
         )
         self.assertEqual(
-            set(query_committees.all()),
+            set(models.db.session.execute(query_committees).unique().scalars().all()),
             set(
                 each
                 for each in self.committees
@@ -240,44 +240,44 @@ class TestFilterOther(ApiBaseTest):
 
     def test_filter_contributor_type_individual(self):
         query = filters.filter_contributor_type(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             models.ScheduleA.entity_type,
             {'contributor_type': ['individual']},
         )
         self.assertEqual(
-            set(query.all()),
+            set(models.db.session.execute(query).unique().scalars().all()),
             set(each for each in self.receipts if each.entity_type == 'IND'),
         )
 
     def test_filter_contributor_type_committee(self):
         query = filters.filter_contributor_type(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             models.ScheduleA.entity_type,
             {'contributor_type': ['committee']},
         )
         self.assertEqual(
-            set(query.all()),
+            set(models.db.session.execute(query).unique().scalars().all()),
             set(each for each in self.receipts if each.entity_type != 'IND'),
         )
 
     def test_filter_contributor_type_none(self):
         query = filters.filter_contributor_type(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             models.ScheduleA.entity_type,
             {'contributor_type': ['individual', 'committee']},
         )
-        self.assertEqual(set(query.all()), set(self.receipts))
+        self.assertEqual(set(models.db.session.execute(query).unique().scalars().all()), set(self.receipts))
 
     # Note: filter_fulltext is tested in test_itemized
 
     def test_filter_fulltext_exclude(self):
         query_dates = filters.filter_fulltext(
-            models.CalendarDate.query,
+            sa.select(models.CalendarDate),
             {'summary': ['Report', '-IE']},
             CalendarDatesView.filter_fulltext_fields,
         )
         self.assertEqual(
-            set(query_dates.all()),
+            set(models.db.session.execute(query_dates).scalars().all()),
             set(
                 each
                 for each in self.dates
@@ -297,23 +297,23 @@ class TestFilterOverlap(ApiBaseTest):
     def test_filter_overlap(self):
         """Test the filter that compares whether two arrays have elements in common."""
         query_committees = filters.filter_overlap(
-            models.Committee.query,
+            sa.select(models.Committee),
             {'sponsor_candidate_id': ['H001']},
             CommitteeList.filter_overlap_fields,
         )
         self.assertEqual(
-            set(query_committees.all()),
+            set(models.db.session.execute(query_committees).unique().scalars().all()),
             set(each for each in self.committees if each.sponsor_candidate_ids == ['H001']),
         )
 
     def test_filter_overlap_exclude(self):
         query_committees = filters.filter_overlap(
-            models.Committee.query,
+            sa.select(models.Committee),
             {'sponsor_candidate_id': ['-H001']},
             CommitteeList.filter_overlap_fields,
         )
         self.assertEqual(
-            set(query_committees.all()),
+            set(models.db.session.execute(query_committees).unique().scalars().all()),
             set(each for each in self.committees if each.sponsor_candidate_ids == ['S001']),
         )
 
@@ -345,12 +345,12 @@ class TestFilterFulltext_NA(ApiBaseTest):
 
     def test_filter_fulltext_NA_include(self):
         query_receipts = filters.filter_fulltext_NA(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             {'contributor_employer': ['amzaon.com',]},
             ScheduleAView.filter_fulltext_fields_NA,
         )
         self.assertEqual(
-            set(query_receipts.all()),
+            set(models.db.session.execute(query_receipts).unique().scalars().all()),
             set(
                 each
                 for each in self.receipts
@@ -360,12 +360,12 @@ class TestFilterFulltext_NA(ApiBaseTest):
 
     def test_filter_fulltext_NA_include_NA(self):
         query_receipts = filters.filter_fulltext_NA(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             {'contributor_employer': ['N/A',]},
             ScheduleAView.filter_fulltext_fields_NA,
         )
         self.assertEqual(
-            set(query_receipts.all()),
+            set(models.db.session.execute(query_receipts).unique().scalars().all()),
             set(
                 each
                 for each in self.receipts
@@ -385,12 +385,12 @@ class TestFilterFulltext_NA(ApiBaseTest):
 
     def test_filter_fulltext_NA_exclude(self):
         query_receipts = filters.filter_fulltext_NA(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             {'contributor_employer': ['-amazon',]},
             ScheduleAView.filter_fulltext_fields_NA,
         )
         self.assertEqual(
-            set(query_receipts.all()),
+            set(models.db.session.execute(query_receipts).unique().scalars().all()),
             set(
                 each
                 for each in self.receipts
@@ -400,12 +400,12 @@ class TestFilterFulltext_NA(ApiBaseTest):
 
     def test_filter_fulltext_NA_exclude_NA(self):
         query_receipts = filters.filter_fulltext_NA(
-            models.ScheduleA.query,
+            sa.select(models.ScheduleA),
             {'contributor_employer': ['-N/A',]},
             ScheduleAView.filter_fulltext_fields_NA,
         )
         self.assertEqual(
-            set(query_receipts.all()),
+            set(models.db.session.execute(query_receipts).unique().scalars().all()),
             set(
                 each
                 for each in self.receipts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import sqlalchemy as sa
 
 from unittest import TestCase
 from flask import request
@@ -24,9 +25,9 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(district='02'),
         ]
         query, columns = sorting.sort(
-            models.Candidate.query, 'district', model=models.Candidate
+            sa.select(models.Candidate), 'district', model=models.Candidate
         )
-        self.assertEqual(query.all(), candidates)
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), candidates)
 
     def test_single_column_reverse(self):
         candidates = [
@@ -34,9 +35,9 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(district='02'),
         ]
         query, columns = sorting.sort(
-            models.Candidate.query, '-district', model=models.Candidate
+            sa.select(models.Candidate), '-district', model=models.Candidate
         )
-        self.assertEqual(query.all(), candidates[::-1])
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), candidates[::-1])
 
     def test_multi_column(self):
         audit = [
@@ -91,9 +92,9 @@ class TestSort(ApiBaseTest):
             ),
         ]
         query, columns = sorting.multi_sort(
-            models.AuditCase.query, ['cycle', 'committee_name', ], model=models.AuditCase
+            sa.select(models.AuditCase), ['cycle', 'committee_name', ], model=models.AuditCase
         )
-        self.assertEqual(query.all(), audit)
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), audit)
 
     def test_multi_column_reverse_first_column(self):
         audit = [
@@ -148,11 +149,11 @@ class TestSort(ApiBaseTest):
             ),
         ]
         query, columns = sorting.multi_sort(
-            models.AuditCase.query,
+            sa.select(models.AuditCase),
             ['-cycle', 'committee_name', ],
             model=models.AuditCase,
         )
-        self.assertEqual(query.all(), audit[::-1])
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), audit[::-1])
 
     def test_hide_null(self):
         candidates = [
@@ -161,13 +162,13 @@ class TestSort(ApiBaseTest):
             factories.CandidateFactory(),
         ]
         query, columns = sorting.sort(
-            models.Candidate.query, 'district', model=models.Candidate
+            sa.select(models.Candidate), 'district', model=models.Candidate
         )
-        self.assertEqual(query.all(), candidates)
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), candidates)
         query, columns = sorting.sort(
-            models.Candidate.query, 'district', model=models.Candidate, hide_null=True
+            sa.select(models.Candidate), 'district', model=models.Candidate, hide_null=True
         )
-        self.assertEqual(query.all(), candidates[:2])
+        self.assertEqual(db.session.execute(query).unique().scalars().all(), candidates[:2])
 
     def test_hide_null_candidate_totals(self):
         candidates = [
@@ -210,15 +211,18 @@ class TestSort(ApiBaseTest):
         query, columns = sorting.sort(
             tcv.build_query(election_full=False), 'disbursements', model=None
         )
-        self.assertEqual(len(query.all()), len(candidates))
+        results = db.session.execute(query).all()
+        self.assertEqual(len(results), len(candidates))
         query, columns = sorting.sort(
             tcv.build_query(election_full=False),
             'disbursements',
             model=None,
             hide_null=True,
         )
-        self.assertEqual(len(query.all()), len(candidates) - 1)
-        self.assertTrue(candidates[1].candidate_id in query.all()[0])
+        results = db.session.execute(query).all()
+
+        self.assertEqual(len(results), len(candidates) - 1)
+        self.assertTrue(candidates[1].candidate_id in results[0])
 
     def test_hide_null_election(self):
         candidates = [
@@ -289,21 +293,21 @@ class TestSort(ApiBaseTest):
             'total_disbursements',
             model=None,
         )
-
-        # print(str(query.statement.compile(dialect=postgresql.dialect())))
-        self.assertEqual(len(query.all()), len(candidates))
+        results = db.session.execute(query).all()
+        self.assertEqual(len(results), len(candidates))
         query, columns = sorting.sort(
             electionView.build_query(office='senate', cycle=2016, state='MO'),
             'total_disbursements',
             model=None,
             hide_null=True,
         )
+        results = db.session.execute(query).all()
         # Taking this assert statement out because I believe, at least how the FEC interprets null (i.e. none) primary
         # committees for a candidate is that they have in fact raised/spent 0.0 dollars, this can be shown as true
         # using the Alabama special election as an example
         # self.assertEqual(len(query.all()), len(candidates) - 1)
-        self.assertTrue(candidates[1].candidate_id in query.all()[0])
-        self.assertEqual(query.all()[0].total_disbursements, 0.0)
+        self.assertTrue(candidates[1].candidate_id in results[0])
+        self.assertEqual(results[0].total_disbursements, 0.0)
 
 
 class TestArgs(TestCase):

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -7,9 +7,9 @@ ANALYZE borrowed from https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes/
 import re
 
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.expression import Executable, ClauseElement, _literal_as_text
+from sqlalchemy.sql.expression import Executable, ClauseElement
 from webservices.common import models
-
+from sqlalchemy import select, func
 
 count_pattern = re.compile(r'rows=(\d+)')
 
@@ -22,7 +22,7 @@ def is_estimated_count(resource, query):
     """
     if resource.use_pk_for_count and resource.model:
         primary_key = resource.model.__mapper__.primary_key[0]
-        query = query.with_entities(primary_key)
+        query = query.with_only_columns(primary_key)
     if resource.use_estimated_counts:
         estimated_count = get_estimated_count(query)
         if estimated_count > resource.estimated_count_threshold:
@@ -43,7 +43,7 @@ def get_count(resource, query):
         estimated_count = get_estimated_count(query)
         return estimated_count, is_estimate
     # Use exact counts for `use_estimated_counts == False` and small result sets
-    exact_count = query.count()
+    exact_count = models.db.session.scalar(select(func.count()).select_from(query.subquery()))
     return exact_count, is_estimate
 
 
@@ -54,7 +54,7 @@ def get_estimated_count(query):
 
 
 def get_query_plan(query):
-    return models.db.session.execute(explain(query)).fetchall()
+    return models.db.session.execute(explain(select("*").select_from(query.subquery()))).fetchall()
 
 
 def extract_analyze_count(rows):
@@ -65,8 +65,10 @@ def extract_analyze_count(rows):
 
 
 class explain(Executable, ClauseElement):
+    inherit_cache = False
+
     def __init__(self, stmt, analyze=False):
-        self.statement = _literal_as_text(stmt)
+        self.statement = stmt
         self.analyze = analyze
         # helps with INSERT statements
         self.inline = getattr(stmt, 'inline', None)

--- a/webservices/common/models/audit.py
+++ b/webservices/common/models/audit.py
@@ -62,7 +62,8 @@ class AuditCaseCategoryRelation(db.Model):
             foreign(AuditCaseCategoryRelation.primary_category_id) == AuditCaseSubCategory.primary_category_id
        )''',
         uselist=True,
-        lazy='joined'
+        lazy='joined',
+        viewonly=True
     )
 
 
@@ -92,7 +93,8 @@ class AuditCase(db.Model):
             foreign(AuditCaseCategoryRelation.audit_case_id) == AuditCase.audit_case_id
         )''',
         uselist=True,
-        lazy='joined'
+        lazy='joined',
+        viewonly=True
     )
 
 

--- a/webservices/common/models/base.py
+++ b/webservices/common/models/base.py
@@ -2,11 +2,11 @@ import random
 import celery
 from sqlalchemy import orm
 from flask_sqlalchemy import SQLAlchemy as SQLAlchemyBase
-from flask_sqlalchemy import SignallingSession
+from flask_sqlalchemy import session
 from flask import current_app
 
 
-class RoutingSession(SignallingSession):
+class RoutingSession(session.Session):
     """Route requests to database leader or follower as appropriate.
 
     Based on http://techspot.zzzeek.org/2012/01/11/django-style-database-routers-in-sqlalchemy/

--- a/webservices/common/models/candidates.py
+++ b/webservices/common/models/candidates.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from webservices import docs
 
 from .base import db, BaseModel
+from webservices.common.models.links import CandidateCommitteeLink
 
 
 class CandidateSearch(BaseModel):
@@ -65,6 +66,7 @@ class BaseCandidate(BaseModel):
             primaryjoin=sa.orm.foreign(CandidateFlags.candidate_id)
             == self.candidate_id,
             uselist=False,
+            viewonly=True,
         )
 
 
@@ -86,15 +88,15 @@ class Candidate(BaseConcreteCandidate):
     # Customize join to restrict to principal committees
     principal_committees = db.relationship(
         "Committee",
-        secondary="ofec_cand_cmte_linkage_mv",
+        secondary=CandidateCommitteeLink.__table__,
         secondaryjoin="""and_(
-            Committee.committee_id == ofec_cand_cmte_linkage_mv.c.cmte_id,
-            ofec_cand_cmte_linkage_mv.c.cmte_dsgn == 'P',
+            Committee.committee_id == CandidateCommitteeLink.committee_id,
+            CandidateCommitteeLink.committee_designation == 'P',
         )""",
         order_by=(
-            "desc(ofec_cand_cmte_linkage_mv.c.cand_election_yr),"
+            "desc(CandidateCommitteeLink.fec_election_year),"
             "desc(Committee.last_file_date),"
-        ),
+        )
     )
 
 

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -576,7 +576,8 @@ class BaseF3PFiling(TreasurerMixin, BaseFiling):
             )''',
         foreign_keys=file_number,
         uselist=True,
-        lazy='subquery',
+        lazy='selectin',
+
     )
 
     amendment = db.relationship(
@@ -586,6 +587,7 @@ class BaseF3PFiling(TreasurerMixin, BaseFiling):
                             )''',
         foreign_keys=file_number,
         lazy='joined',
+        viewonly=True
     )
 
     @declared_attr
@@ -594,7 +596,7 @@ class BaseF3PFiling(TreasurerMixin, BaseFiling):
             ReportType,
             primaryjoin="and_(BaseF3PFiling.report_type==ReportType.report_type)",
             foreign_keys=self.report_type,
-            lazy='subquery',
+            lazy='selectin',
         )
 
 
@@ -648,7 +650,8 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
             )''',
         foreign_keys=file_number,
         uselist=True,
-        lazy='subquery',
+        lazy='selectin',
+        viewonly=True
     )
 
     @declared_attr
@@ -657,7 +660,7 @@ class BaseF3Filing(TreasurerMixin, BaseFiling):
             ReportType,
             primaryjoin="and_(BaseF3Filing.report_type==ReportType.report_type)",
             foreign_keys=self.report_type,
-            lazy='subquery',
+            lazy='selectin',
         )
 
 
@@ -680,7 +683,7 @@ class BaseF3XFiling(BaseFiling):
             )''',
         foreign_keys=file_number,
         uselist=True,
-        lazy='subquery',
+        lazy='selectin',
     )
 
     amendment = db.relationship(
@@ -690,6 +693,7 @@ class BaseF3XFiling(BaseFiling):
                                 )''',
         foreign_keys=file_number,
         lazy='joined',
+        viewonly=True
     )
 
     @declared_attr
@@ -698,5 +702,5 @@ class BaseF3XFiling(BaseFiling):
             ReportType,
             primaryjoin="and_(BaseF3XFiling.report_type==ReportType.report_type)",
             foreign_keys=self.report_type,
-            lazy='subquery',
+            lazy='selectin',
         )

--- a/webservices/common/util.py
+++ b/webservices/common/util.py
@@ -34,15 +34,3 @@ def output_json(data, code, headers=None):
     resp.mimetype = 'application/json'
     resp.headers.extend(headers or {})
     return resp
-
-
-def get_class_by_tablename(tablename):
-    """Return class reference mapped to table.
-
-    :param tablename: String with name of table.
-    :return: Class reference or None.
-    """
-    from webservices.common.models import db
-    for c in db.Model._decl_class_registry.values():
-        if hasattr(c, '_sa_class_manager') and c._sa_class_manager.mapper.persist_selectable == tablename:
-            return c

--- a/webservices/filters.py
+++ b/webservices/filters.py
@@ -89,14 +89,14 @@ def filter_fulltext(query, kwargs, fields):
                     sa.not_(column.match(utils.parse_fulltext(value)))
                     for value in exclude_list
                 ]
-                query = query.filter(sa.and_(*filters))
+                query = query.filter(sa.and_(*filters)) if len(filters) > 1 else query.filter(*filters)
             if include_list:
                 filters = []
                 for value in include_list:
                     filters.append(column.match(utils.parse_fulltext(value)))
                     if value.upper() == 'NULL':
                         filters.append(column.is_(None))
-                query = query.filter(sa.or_(*filters))
+                query = query.filter(sa.or_(*filters)) if len(filters) > 1 else query.filter(*filters)
     return query
 
 
@@ -113,7 +113,7 @@ def filter_fulltext_NA(query, kwargs, fields):
                         query = query.filter(original_column != 'N/A')
                     else:
                         filters.append(sa.not_(column.match(utils.parse_fulltext(value))))
-                query = query.filter(sa.and_(*filters))
+                query = query.filter(sa.and_(*filters)) if len(filters) > 1 else query.filter(*filters)
             if include_list:
                 filters = []
                 for value in include_list:
@@ -123,7 +123,7 @@ def filter_fulltext_NA(query, kwargs, fields):
                         filters.append(column.match(utils.parse_fulltext(value)))
                         if value.upper() == 'NULL':
                             filters.append(column.is_(None))
-                query = query.filter(sa.or_(*filters))
+                query = query.filter(sa.or_(*filters)) if len(filters) > 1 else query.filter(*filters)
     return query
 
 
@@ -137,13 +137,13 @@ def filter_multi_start_with(query, kwargs, fields):
                     sa.not_(column.startswith(value))
                     for value in exclude_list
                 ]
-                query = query.filter(sa.and_(*filters))
+                query = query.filter(sa.and_(*filters)) if len(filters) > 1 else query.filter(*filters)
             if include_list:
                 filters = [
                     column.startswith(value)
                     for value in include_list
                 ]
-                query = query.filter(sa.or_(*filters))
+                query = query.filter(sa.or_(*filters)) if len(filters) > 1 else query.filter(*filters)
     return query
 
 

--- a/webservices/resources/audit.py
+++ b/webservices/resources/audit.py
@@ -58,7 +58,7 @@ class AuditCategoryView(ApiResource):
     model = models.AuditCategory
     schema = schemas.AuditCategorySchema
     page_schema = schemas.AuditCategoryPageSchema
-
+    contains_joined_load = True
     filter_multi_fields = [
         ('primary_category_id', model.primary_category_id),
         ('tier', model.tier),
@@ -96,7 +96,7 @@ class AuditCaseView(ApiResource):
     model = models.AuditCase
     schema = schemas.AuditCaseSchema
     page_schema = schemas.AuditCasePageSchema
-
+    contains_joined_load = True
     filter_multi_fields = [
         ('audit_case_id', model.audit_case_id),
         ('cycle', model.cycle),
@@ -173,11 +173,12 @@ class AuditCandidateNameSearch(utils.Resource):
     @use_kwargs(args.names)
     @marshal_with(schemas.AuditCandidateSearchListSchema())
     def get(self, **kwargs):
-        query = filters.filter_fulltext(models.AuditCandidateSearch.query, kwargs, self.filter_fulltext_fields)
+        query = sa.select(models.AuditCandidateSearch.id, models.AuditCandidateSearch.name)
+        query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
             sa.desc(models.AuditCandidateSearch.id)
         ).limit(20)
-        return {'results': query.all()}
+        return {'results': models.db.session.execute(query).all()}
 
 
 # used for endpoint:`/names/audit_committees/`
@@ -197,8 +198,9 @@ class AuditCommitteeNameSearch(utils.Resource):
     @use_kwargs(args.names)
     @marshal_with(schemas.AuditCommitteeSearchListSchema())
     def get(self, **kwargs):
-        query = filters.filter_fulltext(models.AuditCommitteeSearch.query, kwargs, self.filter_fulltext_fields)
+        query = sa.select(models.AuditCommitteeSearch.id, models.AuditCommitteeSearch.name)
+        query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
             sa.desc(models.AuditCommitteeSearch.id)
         ).limit(20)
-        return {'results': query.all()}
+        return {'results': models.db.session.execute(query).all()}

--- a/webservices/resources/candidate_aggregates.py
+++ b/webservices/resources/candidate_aggregates.py
@@ -12,8 +12,7 @@ from webservices.common import models
 from webservices.common.models import (
     CandidateCommitteeLink,
     ScheduleABySize,
-    ScheduleAByState,
-    db,
+    ScheduleAByState
 )
 
 
@@ -31,16 +30,14 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
     Aggregated data are calculated per fec_cycle only, no odd year
 
     """
-    rows = (
-        db.session.query(
+    rows = sa.select(
             CandidateCommitteeLink.candidate_id.label('candidate_id'),
             CandidateCommitteeLink.committee_id.label('committee_id'),
             CandidateCommitteeLink.fec_election_year.label('fec_election_year'),
             CandidateCommitteeLink.election_yr_to_be_included.label(
                 'election_yr_to_be_included'
             ),
-        )
-        .filter(
+        ).filter(
             (
                 CandidateCommitteeLink.fec_election_year.in_(kwargs['cycle'])
                 if not kwargs.get('election_full')
@@ -50,10 +47,7 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
             ),
             CandidateCommitteeLink.candidate_id.in_(kwargs['candidate_id']),
             CandidateCommitteeLink.committee_designation.in_(['P', 'A']),
-        )
-        .distinct()
-        .subquery()
-    )
+        ).distinct().subquery()
 
     cycle_column = (
         rows.c.election_yr_to_be_included
@@ -61,17 +55,14 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
         else rows.c.fec_election_year
     ).label('cycle')
 
-    aggregates = (
-        db.session.query(rows.c.candidate_id, cycle_column, *label_columns)
-        .join(
+    aggregates = sa.select(rows.c.candidate_id, cycle_column, *label_columns).join(
             aggregate_model,
             sa.and_(
                 rows.c.committee_id == aggregate_model.committee_id,
                 rows.c.fec_election_year == aggregate_model.cycle,
             ),
-        )
-        .group_by(rows.c.candidate_id, cycle_column, *group_columns)
-    )
+        ).group_by(rows.c.candidate_id, cycle_column, *group_columns)
+
     return rows, aggregates
 
 
@@ -85,6 +76,7 @@ def candidate_aggregate(aggregate_model, label_columns, group_columns, kwargs):
 class ScheduleABySizeCandidateView(NoCapResource):
     schema = schemas.ScheduleABySizeCandidateSchema
     page_schema = schemas.ScheduleABySizeCandidatePageSchema()
+    contains_individual_columns = True
     sort_option = [
             'total',
             'size',
@@ -130,6 +122,7 @@ class ScheduleABySizeCandidateView(NoCapResource):
 class ScheduleAByStateCandidateView(NoCapResource):
     schema = schemas.ScheduleAByStateCandidateSchema
     page_schema = schemas.ScheduleAByStateCandidatePageSchema()
+    contains_individual_columns = True
     sort_option = [
             'total',
             'count',
@@ -175,6 +168,7 @@ class ScheduleAByStateCandidateView(NoCapResource):
 class ScheduleAByStateCandidateTotalsView(NoCapResource):
     schema = schemas.ScheduleAByStateCandidateSchema
     page_schema = schemas.ScheduleAByStateCandidatePageSchema()
+    contains_individual_columns = True
     sort_option = [
             'total',
             'count',
@@ -206,7 +200,7 @@ class ScheduleAByStateCandidateTotalsView(NoCapResource):
             kwargs,
         )
         q = query.subquery()
-        query = db.session.query(
+        query = sa.select(
             sa.func.sum(q.c.total).label('total'),
             sa.func.sum(q.c.count).label('count'),
             q.c.candidate_id.label('candidate_id'),
@@ -227,7 +221,7 @@ class TotalsCandidateView(ApiResource):
 
     schema = schemas.CandidateHistoryTotalSchema
     page_schema = schemas.CandidateHistoryTotalPageSchema
-
+    contains_individual_columns = True
     sort_options = [
         'election_year',
         'name',
@@ -289,7 +283,7 @@ class TotalsCandidateView(ApiResource):
     def build_query(self, **kwargs):
         history = models.CandidateHistoryWithFuture
         query = (
-            db.session.query(history.__table__, models.CandidateTotal.__table__)
+            sa.select(history.__table__, models.CandidateTotal.__table__)
             .join(
                 models.CandidateTotal,
                 sa.and_(
@@ -347,6 +341,7 @@ class CandidateTotalAggregateView(ApiResource):
 
     schema = schemas.CandidateTotalAggregateSchema
     page_schema = schemas.CandidateTotalAggregatePageSchema
+    contains_individual_columns = True
 
     @property
     def args(self):
@@ -361,7 +356,7 @@ class CandidateTotalAggregateView(ApiResource):
     def build_query(self, **kwargs):
         total = models.CandidateTotal
 
-        query = db.session.query(
+        query = sa.select(
             total.election_year.label("election_year"),
             sa.func.sum(total.receipts).label(
                 "total_receipts"),

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -43,6 +43,7 @@ class CandidateList(ApiResource):
     filter_range_fields = filter_range_fields(models.Candidate)
     filter_fulltext_fields = [('q', models.CandidateSearch.fulltxt)]
     aliases = {'receipts': models.CandidateSearch.receipts}
+    contains_joined_load = True
 
     query_options = [
         sa.orm.joinedload(models.Candidate.flags),
@@ -96,6 +97,9 @@ class CandidateList(ApiResource):
                 candidate_detail.candidate_id == models.CandidateSearch.id,
             ).distinct()
 
+            if kwargs.get("sort") in {"receipts", "-receipts"}:
+                query = query.add_columns(models.CandidateSearch.receipts)
+
         if kwargs.get('cycle'):
             query = query.filter(candidate_detail.cycles.overlap(kwargs['cycle']))
         if kwargs.get('election_year'):
@@ -147,9 +151,11 @@ class CandidateSearch(CandidateList):
 
     schema = schemas.CandidateSearchSchema
     page_schema = schemas.CandidateSearchPageSchema
+    contains_joined_load = True
+
     query_options = [
         sa.orm.joinedload(models.Candidate.flags),
-        sa.orm.subqueryload(models.Candidate.principal_committees),
+        sa.orm.selectinload(models.Candidate.principal_committees),
     ]
 
 
@@ -172,6 +178,7 @@ class CandidateView(ApiResource):
     schema = schemas.CandidateDetailSchema
     page_schema = schemas.CandidateDetailPageSchema
     filter_multi_fields = filter_multi_fields(models.CandidateDetail)
+    contains_joined_load = True
 
     query_options = [
         sa.orm.joinedload(models.CandidateDetail.flags),
@@ -250,6 +257,7 @@ class CandidateHistoryView(ApiResource):
     model = models.CandidateHistory
     schema = schemas.CandidateHistorySchema
     page_schema = schemas.CandidateHistoryPageSchema
+    contains_joined_load = True
 
     query_options = [
         sa.orm.joinedload(models.CandidateHistory.flags),

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -90,7 +90,9 @@ class CalendarDatesExport(CalendarDatesView):
         schema_type, renderer, mimetype = self.renderers[kwargs['renderer']]
         schema = schema_type(many=True)
         return Response(
-            renderer(schema.dump(query), schema),
+            renderer(
+                schema.dump(
+                    models.db.session.execute(query).scalars().all()), schema),
             mimetype=mimetype,
         )
 
@@ -149,6 +151,7 @@ class ReportingDatesView(ApiResource):
     model = models.ReportDate
     schema = schemas.ReportingDatesSchema
     page_schema = schemas.ReportingDatesPageSchema
+    contains_joined_load = True
 
     @property
     def args(self):

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -69,11 +69,11 @@ class ElectionsListView(utils.Resource):
     @marshal_with(schemas.ElectionsListPageSchema())
     def get(self, **kwargs):
         query = self._get_elections(kwargs)
-        return utils.fetch_page(query, kwargs, is_count_exact=True, model=ElectionsList, multi=True)
+        return utils.fetch_page(query, kwargs, models.db.session, is_count_exact=True, model=ElectionsList, multi=True)
 
     def _get_elections(self, kwargs):
         """Get elections from ElectionsList model."""
-        query = db.session.query(ElectionsList)
+        query = sa.select(ElectionsList)
         if kwargs.get('office'):
             values = [each[0].upper() for each in kwargs['office']]
             query = query.filter(ElectionsList.office.in_(values))
@@ -99,7 +99,7 @@ class ElectionsListView(utils.Resource):
     def _filter_zip(self, query, kwargs):
         """Filter query by zip codes."""
         districts = (
-            db.session.query(ZipsDistricts)
+            sa.select(ZipsDistricts)
             .filter(
                 cast(ZipsDistricts.zip_code, Integer).in_(kwargs['zip']),
                 ZipsDistricts.active == 'Y',
@@ -149,6 +149,7 @@ class ElectionView(ApiResource):
         return utils.fetch_page(
             query,
             kwargs,
+            models.db.session,
             is_count_exact=self.is_count_exact,
             count=count,
             model=self.model,
@@ -157,6 +158,7 @@ class ElectionView(ApiResource):
             index_column=self.index_column,
             cap=0,
             multi=multi,
+            contains_individual_columns=True
         )
 
     def build_query(self, **kwargs):
@@ -168,7 +170,7 @@ class ElectionView(ApiResource):
         candAggregates = self._get_candAggregates(aggregates).subquery()
 
         final_query = (
-            db.session.query(
+            sa.select(
                 candAggregates, BaseConcreteCommittee.name.label('candidate_pcc_name')
             )
             .outerjoin(
@@ -181,7 +183,8 @@ class ElectionView(ApiResource):
 
     def _get_basicPairs(self, totals_model, kwargs):
         # get basic data for election totals
-        basicPairs = CandidateHistory.query.with_entities(
+        query = sa.select(CandidateHistory)
+        basicPairs = query.with_only_columns(
             CandidateHistory.candidate_id,
             CandidateHistory.name,
             CandidateHistory.party_full,
@@ -246,7 +249,7 @@ class ElectionView(ApiResource):
             ],
         }
 
-        pairs = db.session.query(
+        pairs = sa.select(
             basicPairs.c.candidate_id,
             basicPairs.c.name,
             basicPairs.c.party_full,
@@ -269,7 +272,7 @@ class ElectionView(ApiResource):
 
     def _get_aggregates(self, pairs):
         # sum up values per candidate_id/candidate_election_year/cmte_id
-        aggregates = db.session.query(
+        aggregates = sa.select(
             pairs.c.candidate_id,
             pairs.c.candidate_election_year,
             pairs.c.committee_id,
@@ -295,7 +298,7 @@ class ElectionView(ApiResource):
 
     def _get_candAggregates(self, aggregates):
         # sum up values per candidate_id/candidate_election_year
-        candAggregates = db.session.query(
+        candAggregates = sa.select(
             aggregates.c.candidate_id,
             aggregates.c.candidate_election_year,
             sa.func.max(aggregates.c.candidate_name).label('candidate_name'),
@@ -333,20 +336,19 @@ class ElectionSummary(utils.Resource):
         utils.check_election_arguments(kwargs)
         aggregates = self._get_aggregates(kwargs).subquery()
         expenditures = self._get_expenditures(kwargs).subquery()
-        return (
-            db.session.query(
-                aggregates.c.count,
-                aggregates.c.receipts,
-                aggregates.c.disbursements,
-                expenditures.c.independent_expenditures,
-            )
-            .first()
-            ._asdict()
+
+        query = sa.select(
+            aggregates.c.count,
+            aggregates.c.receipts,
+            aggregates.c.disbursements,
+            expenditures.c.independent_expenditures,
         )
+
+        return (db.session.execute(query).first()._asdict())
 
     def _get_aggregates(self, kwargs):
         totals_model = office_totals_map[kwargs['office']]
-        aggregates = CandidateHistory.query.with_entities(
+        aggregates = sa.select(
             sa.func.count(sa.distinct(CandidateHistory.candidate_id)).label('count'),
             sa.func.sum(totals_model.receipts).label('receipts'),
             sa.func.sum(totals_model.disbursements).label('disbursements'),
@@ -357,7 +359,7 @@ class ElectionSummary(utils.Resource):
 
     def _get_expenditures(self, kwargs):
         expenditures = (
-            db.session.query(
+            sa.select(
                 sa.func.sum(ScheduleEByCandidate.total).label(
                     'independent_expenditures'
                 ),

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -125,6 +125,7 @@ class EFilingsView(ApiResource):
     model = models.EFilings
     schema = schemas.EFilingsSchema
     page_schema = schemas.EFilingsPageSchema
+    contains_joined_load = True
 
     filter_multi_fields = [
         ("file_number", models.EFilings.file_number),

--- a/webservices/resources/sched_h4.py
+++ b/webservices/resources/sched_h4.py
@@ -75,6 +75,10 @@ class ScheduleH4View(ItemizedResource):
         'disbursement_purpose',
     ]
 
+    query_options = [
+        sa.orm.joinedload(models.ScheduleH4.committee),
+    ]
+
     @property
     def args(self):
         return utils.extend(
@@ -87,7 +91,6 @@ class ScheduleH4View(ItemizedResource):
 
     def build_query(self, **kwargs):
         query = super(ScheduleH4View, self).build_query(**kwargs)
-        query = query.options(sa.orm.joinedload(models.ScheduleH4.committee))
         if kwargs.get('sub_id'):
             query = query.filter_by(sub_id=int(kwargs.get('sub_id')))
         utils.check_form_line_number(kwargs)

--- a/webservices/resources/search.py
+++ b/webservices/resources/search.py
@@ -27,11 +27,14 @@ class CandidateNameSearch(utils.Resource):
     @use_kwargs(args.names)
     @marshal_with(schemas.CandidateSearchListSchema())
     def get(self, **kwargs):
-        query = filters.filter_fulltext(models.CandidateSearch.query, kwargs, self.filter_fulltext_fields)
+        query = sa.select(models.CandidateSearch.id,
+                          models.CandidateSearch.name,
+                          models.CandidateSearch.office_sought)
+        query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
             sa.desc(models.CandidateSearch.total_activity)
         ).limit(20)
-        return {'results': query.all()}
+        return {'results': models.db.session.execute(query).all()}
 
 
 # search committee full text name
@@ -52,8 +55,11 @@ class CommitteeNameSearch(utils.Resource):
     @use_kwargs(args.names)
     @marshal_with(schemas.CommitteeSearchListSchema())
     def get(self, **kwargs):
-        query = filters.filter_fulltext(models.CommitteeSearch.query, kwargs, self.filter_fulltext_fields)
+        query = sa.select(models.CommitteeSearch.id,
+                          models.CommitteeSearch.name,
+                          models.CommitteeSearch.is_active)
+        query = filters.filter_fulltext(query, kwargs, self.filter_fulltext_fields)
         query = query.order_by(
             sa.desc(models.CommitteeSearch.total_activity)
         ).limit(20)
-        return {'results': query.all()}
+        return {'results': models.db.session.execute(query).all()}

--- a/webservices/resources/spending_by_others.py
+++ b/webservices/resources/spending_by_others.py
@@ -10,7 +10,6 @@ from webservices.common.models import (
     ElectioneeringByCandidate,
     ScheduleEByCandidate,
     CommunicationCostByCandidate,
-    db,
 )
 
 
@@ -20,7 +19,7 @@ def get_candidate_list(kwargs):
 
     """
     candidate = (
-        db.session.query(
+        sa.select(
             CandidateHistory.candidate_id.label('candidate_id'),
             CandidateHistory.two_year_period.label('two_year_period'),
             CandidateHistory.candidate_election_year.label('candidate_election_year'),
@@ -47,7 +46,7 @@ def get_candidate_list(kwargs):
 
 # used for '/electioneering/totals/by_candidate/'
 # under tag: electioneering
-# Ex:http://127.0.0.1:5000/v1/electioneering/totals/by_candidate/?sort=-cycle&election_full=true
+# Ex: http://127.0.0.1:5000/v1/electioneering/totals/by_candidate/?sort=-cycle&election_full=true
 @doc(
     tags=['electioneering'], description=docs.ELECTIONEERING_TOTAL_BY_CANDIDATE,
 )
@@ -55,6 +54,7 @@ class ECTotalsByCandidateView(ApiResource):
 
     schema = schemas.ECTotalsByCandidateSchema
     page_schema = schemas.ECTotalsByCandidatePageSchema
+    contains_individual_columns = True
     sort_option = [
             'cycle',
             'candidate_id',
@@ -76,7 +76,7 @@ class ECTotalsByCandidateView(ApiResource):
         cycle_column, candidate = get_candidate_list(kwargs)
 
         query = (
-            db.session.query(
+            sa.select(
                 ElectioneeringByCandidate.candidate_id,
                 cycle_column,
                 sa.func.sum(ElectioneeringByCandidate.total).label('total'),
@@ -109,7 +109,7 @@ class IETotalsByCandidateView(ApiResource):
 
     schema = schemas.IETotalsByCandidateSchema
     page_schema = schemas.IETotalsByCandidatePageSchema
-
+    contains_individual_columns = True
     sort_option = [
             'cycle',
             'candidate_id',
@@ -131,7 +131,7 @@ class IETotalsByCandidateView(ApiResource):
         cycle_column, candidate = get_candidate_list(kwargs)
 
         query = (
-            db.session.query(
+            sa.select(
                 ScheduleEByCandidate.candidate_id,
                 ScheduleEByCandidate.support_oppose_indicator,
                 cycle_column,
@@ -170,7 +170,7 @@ class CCTotalsByCandidateView(ApiResource):
 
     schema = schemas.CCTotalsByCandidateSchema
     page_schema = schemas.CCTotalsByCandidatePageSchema
-
+    contains_individual_columns = True
     sort_option = [
             'cycle',
             'candidate_id',
@@ -192,7 +192,7 @@ class CCTotalsByCandidateView(ApiResource):
         cycle_column, candidate = get_candidate_list(kwargs)
 
         query = (
-            db.session.query(
+            sa.select(
                 CommunicationCostByCandidate.candidate_id,
                 CommunicationCostByCandidate.support_oppose_indicator,
                 cycle_column,

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -77,7 +77,8 @@ class TotalsByEntityTypeView(ApiResource):
         query, totals_class, totals_schema = self.build_query(
             committee_id=committee_id, entity_type=entity_type, **kwargs
         )
-        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
+        page = utils.fetch_page(query, kwargs, models.db.session, is_count_exact=True, model=totals_class,
+                                contains_joined_load=True)
         return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, entity_type=None, **kwargs):
@@ -85,7 +86,7 @@ class TotalsByEntityTypeView(ApiResource):
             committee_type_map.get(entity_type),
             default_schemas,
         )
-        query = totals_class.query
+        query = sa.select(totals_class)
 
         # Committee ID needs to be handled separately because it's not in kwargs
         if committee_id is not None:
@@ -231,7 +232,8 @@ class TotalsCommitteeView(ApiResource):
         query, totals_class, totals_schema = self.build_query(
             committee_id=committee_id.upper(), committee_type=committee_type, **kwargs
         )
-        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
+        page = utils.fetch_page(query, kwargs, models.db.session, is_count_exact=True, model=totals_class,
+                                contains_joined_load=True)
         return totals_schema().dump(page)
 
     def build_query(self, committee_id=None, committee_type=None, **kwargs):
@@ -241,7 +243,8 @@ class TotalsCommitteeView(ApiResource):
             ),
             default_schemas,
         )
-        query = totals_class.query
+        query = sa.select(totals_class)
+
         if committee_id is not None:
             query = query.filter(totals_class.committee_id == committee_id)
         if kwargs.get('cycle'):
@@ -252,11 +255,12 @@ class TotalsCommitteeView(ApiResource):
     def _resolve_committee_type(self, committee_id=None, committee_type=None, **kwargs):
         if committee_id is not None:
             utils.check_committee_id(committee_id)
-            query = models.CommitteeHistory.query.filter_by(committee_id=committee_id)
+            query = sa.select(models.CommitteeHistory)
+            query = query.filter_by(committee_id=committee_id)
             if kwargs.get('cycle'):
                 query = query.filter(models.CommitteeHistory.cycle.in_(kwargs['cycle']))
             query = query.order_by(sa.desc(models.CommitteeHistory.cycle))
-            committee = query.first_or_404()
+            committee = models.db.first_or_404(query)
             return committee.committee_type
 
 
@@ -281,7 +285,7 @@ class CandidateTotalsDetailView(utils.Resource):
             validator = args.IndexValidator(totals_class)
             validator(kwargs['sort'])
 
-        page = utils.fetch_page(query, kwargs, is_count_exact=True, model=totals_class)
+        page = utils.fetch_page(query, kwargs, models.db.session, is_count_exact=True, model=totals_class)
         return totals_schema().dump(page)
 
     def build_query(self, candidate_id=None, **kwargs):
@@ -291,7 +295,7 @@ class CandidateTotalsDetailView(utils.Resource):
             totals_schema = schemas.CandidateTotalsDetailPresidentialPageSchema
         else:
             totals_schema = schemas.CandidateTotalsDetailHouseSenatePageSchema
-        query = totals_class.query
+        query = sa.select(totals_class)
         query = query.filter(totals_class.candidate_id == candidate_id.upper())
 
         if kwargs.get('election_full') is None:

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -2,13 +2,15 @@ import base64
 import hashlib
 import logging
 import datetime
+import re
 
 from webargs import flaskparser
 from flask_apispec.utils import resolve_annotations
-from postgres_copy import query_entities, copy_to
+from postgres_copy import query_entities, format_flags
 from celery_once import QueueOnce
 from smart_open import smart_open
 from celery import shared_task
+from sqlalchemy.dialects import postgresql
 
 from webservices import utils
 from webservices.common import counts
@@ -97,9 +99,9 @@ def query_with_labels(query, schema, sort_columns=False):
         entities.sort(key=lambda x: x.name)
 
     if joins:
-        query = query.join(*joins).with_entities(*entities)
+        query = query.join(*joins).with_only_columns(*entities)
     else:
-        query = query.with_entities(*entities)
+        query = query.with_only_columns(*entities)
 
     return query
 
@@ -138,6 +140,42 @@ def make_bundle(resource):
             format="csv",
             header=True
         )
+
+
+# modified for sqlalchemy 2.0 style taken from sqlalchemy-postgres-copy package by Joshua Carp
+# https://github.com/jmcarp/sqlalchemy-postgres-copy
+def copy_to(source, dest, engine, **flags):
+    dialect = postgresql.dialect()
+    compiled = source.compile(dialect=dialect)
+
+    sql = compiled.string
+    params = compiled.params
+    conn = engine.raw_connection()
+
+    if "POSTCOMPILE" in sql:
+        sql = rebind_postcompile(sql)
+        params = convert_lists_to_tuples(params)
+
+    try:
+        with conn.cursor() as cursor:
+            query = cursor.mogrify(sql, params).decode()
+            formatted_flags = f"({format_flags(flags)})" if flags else ""
+            copy_sql = f"COPY ({query}) TO STDOUT {formatted_flags}"
+            cursor.copy_expert(copy_sql, dest)
+    finally:
+        conn.close()
+
+
+def rebind_postcompile(sql):
+    pattern = r"\(__\[POSTCOMPILE_([a-zA-Z0-9_]+)\]\)"
+    return re.sub(pattern, r"%(\1)s", sql)
+
+
+def convert_lists_to_tuples(params):
+    for key, val in params.items():
+        if isinstance(val, list):
+            params[key] = tuple(val)
+    return params
 
 
 @shared_task(base=QueueOnce, once={"graceful": True})


### PR DESCRIPTION
## Summary (required)

- Resolves #6157

This PR upgrades Sqlalchemy to version 1.4. [Here](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#what-s-new-in-sqlalchemy-1-4) is the documentation for full list of changes.

Link to load testing: https://docs.google.com/spreadsheets/d/1tBjbcAbl1EEINOJ0qoqIVH9EoSkJ69uqgAobKmjek7Q/edit?gid=2044726843#gid=2044726843

### Required reviewers 3-4 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

- all endpoints 
- downloads


## Related PRs

Related PRs against other branches:

| branch           | PR       |
| ---------------- | -------- |
| marshmallow-pagination  | [link](https://github.com/fecgov/marshmallow-pagination/pull/20/files) |

## How to test

locally:
- checkout this branch
- activate new virtualenv 
- `pip install -r requirements.txt`
- `pytest`
- `flask run`
- test endpoints, filters, pagination, counts, sorting 

dev:
- deploy this test [branch](test-sqlalchemy-dev) 
- test downloads 

Changes

Here is a link to the documentation for Sqlalchemy 1.4: https://docs.sqlalchemy.org/en/14/

And a list of other changes made:



Change | Description
-- | --
Direct access of _decl_class_registry is removed | Use the new `_class_registry` registry class instead of directly accessing _decl_class_registry.
Direct access of _literal_as_text is removed | Use the text() function instead of directly accessing _literal_as_text.
SQLAlchemy now detects overlapping or conflicting relationships between models | Conflicting relationships may cause issues with INSERT, UPDATE, or DELETE operations. Use viewonly=True when only performing SELECT queries.
Direct access of _entities is removed | Use query.column_descriptions() instead of directly accessing _entities.
Need to pass in session to execute queries in Marshmallow pagination | Pass in the session explicitly to execute queries when using Marshmallow pagination.
Query is being deprecated in favor of Select() | Transition from using Query to Select() for future compatibility.
Direct count() method is removed | https://github.com/sqlalchemy/sqlalchemy/issues/5908
Eager queries with joinedload may contain duplicates | To remove duplicate entries, ensure that eager queries with joinedload use unique().
Direct access of _limit is removed |
Direct access of _offset is removed |
Changes in implementing explain query | https://github.com/sqlalchemy/sqlalchemy/wiki/Query-Plan-SQL-construct
Fix warning by adding view only relationship parameter when data is only being queried from the database (no inserts, updates, or deletes) | https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#persistence-related-cascade-operations-disallowed-with-viewonly-true 
SIgnalling session renamed to session |  https://flask-sqlalchemy.readthedocs.io/en/stable/api/
Replace subqueryload with selectinload | https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#subquery-eager-loading
Changes in implementing union queries | https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#selecting-orm-entities-from-unions
`in_` filters are now late compiled, need to compile manually for downloads | https://docs.sqlalchemy.org/en/20/faq/sqlexpressions.html#rendering-postcompile-parameters-as-bound-parameters
  



