### PR TITLE
6155- add filename filter and tests to legal search

### DIFF
--- a/tests/integration/test_advisory_opinions.py
+++ b/tests/integration/test_advisory_opinions.py
@@ -185,6 +185,7 @@ class TestLoadAdvisoryOpinions(BaseTestCase):
             "description": "Some Description",
             "date": datetime.datetime(2017, 2, 9, 0, 0),
             "url": "/files/legal/aos/{0}/{1}".format(ao_no, filename.replace(' ', '-')),
+            "filename": filename[:-4]
         }
         expected_ao = {
             "no": ao_no,

--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -104,6 +104,15 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
 
         self.check_incorrect_values({"ao_doc_category_id": "P"}, True)
 
+    def test_filename_filter(self):
+        filename = "AO_2014-19_(ActBlue)_Final_(1.15.15)"
+        self.check_doc_filters({"filename": filename}, "filename", filename)
+
+        filename = "202412R_1"
+        self.check_doc_filters({"filename": filename}, "filename", filename)
+
+        self.check_incorrect_values({"filename": "somefilename.pdf"}, False)
+
     def test_ao_sort(self):
         sort = "-ao_no"
         response = self._results_ao(api.url_for(UniversalSearch, sort=sort))

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -286,12 +286,14 @@ def legal_doc_data(*args, **kwargs):
                             "category": "Final Opinion",
                             "description": "Closeout Letter",
                             "url": "files/legal/aos/100/111.pdf",
+                            "filename": "111",
                         },
                         {
                             "document_id": 222,
                             "category": "Draft Documents",
                             "description": "Vote",
                             "url": "files/legal/aos/100/222.pdf",
+                            "filename": "222",
                         }
                     ]
                 },
@@ -318,12 +320,15 @@ class TestLegalDoc(unittest.TestCase):
                         "category": "Final Opinion",
                         "description": "Closeout Letter",
                         "url": "files/legal/aos/100/111.pdf",
+                        "filename": "111",
                     },
                     {
                         "document_id": 222,
                         "category": "Draft Documents",
                         "description": "Vote",
                         "url": "files/legal/aos/100/222.pdf",
+                        "filename": "222",
+
                     }
                 ]
             }]

--- a/tests/test_legal_data.py
+++ b/tests/test_legal_data.py
@@ -1626,7 +1626,8 @@ first_ao = {
           "description": "Vote",
           "document_id": 88638,
           "text": "Random document text for first ao document",
-          "url": "/files/legal/aos/2024-12/202412V_1.pdf"
+          "url": "/files/legal/aos/2024-12/202412V_1.pdf",
+          "filename": "202412V_1",
         },
         {
           "ao_doc_category_id": "C",
@@ -1635,7 +1636,8 @@ first_ao = {
           "description": "Comment on Draft AO 2024-12, Agenda Document Nos. 24-38-A and 24-38-B, by Shaun McCutcheon",
           "document_id": 88639,
           "text": "Random document text for the second ao document",
-          "url": "/files/legal/aos/2024-12/202412C_3.pdf"
+          "url": "/files/legal/aos/2024-12/202412C_3.pdf",
+          "filename": "202412C_3",
         },
         {
           "ao_doc_category_id": "R",
@@ -1644,7 +1646,8 @@ first_ao = {
           "description": "Request by Shaun McCutcheon (Comments due on August 19, 2024)",
           "document_id": 88640,
           "text": "Random document text for the third ao document",
-          "url": "/files/legal/aos/2024-12/202412R_1.pdf"
+          "url": "/files/legal/aos/2024-12/202412R_1.pdf",
+          "filename": "202412R_1",
         },
         {
           "ao_doc_category_id": "C",
@@ -1653,7 +1656,9 @@ first_ao = {
           "description": "Comment on AOR 2024-12 by League of Women Voters of Maine, RepresentUS, and Fair Vote",
           "document_id": 88641,
           "text": "Random document text for the fourth ao document",
-          "url": "/files/legal/aos/2024-12/202412C_1.pdf"
+          "url": "/files/legal/aos/2024-12/202412C_1.pdf",
+          "filename": "202412C_1",
+
         },
         {
           "ao_doc_category_id": "F",
@@ -1662,7 +1667,9 @@ first_ao = {
           "description": "AO 2024-12",
           "document_id": 88637,
           "text": "Random document text for the fifth ao document",
-          "url": "/files/legal/aos/2024-12/2024-12.pdf"
+          "url": "/files/legal/aos/2024-12/2024-12.pdf",
+          "filename": "2024-12",
+
         },
         {
           "ao_doc_category_id": "C",
@@ -1671,7 +1678,8 @@ first_ao = {
           "description": "Comment on AOR 2024-12 by Campaign Legal Center",
           "document_id": 88642,
           "text": "Random document text for the sixth ao document",
-          "url": "/files/legal/aos/2024-12/202412C_2.pdf"
+          "url": "/files/legal/aos/2024-12/202412C_2.pdf",
+          "filename": "202412C_2",
         },
         {
           "ao_doc_category_id": "D",
@@ -1680,7 +1688,9 @@ first_ao = {
           "description": "Draft AO, Agenda Document No. 24-38-A (Comments due on September 18, 2024 by 12:00pm ET)",
           "document_id": 88643,
           "text": "Random document text for the seventh ao document",
-          "url": "/files/legal/aos/2024-12/202412.pdf"
+          "url": "/files/legal/aos/2024-12/202412.pdf",
+          "filename": "202412",
+
         },
         {
           "ao_doc_category_id": "D",
@@ -1689,7 +1699,8 @@ first_ao = {
           "description": "Draft AO, Agenda Document No. 24-38-B (Comments due on September 18, 2024 by 12:00pm ET)",
           "document_id": 88644,
           "text": "Random document text for the eighth ao document",
-          "url": "/files/legal/aos/2024-12/202412_1.pdf"
+          "url": "/files/legal/aos/2024-12/202412_1.pdf",
+          "filename": "202412_1",
         }
       ],
       "entities": [
@@ -1811,7 +1822,8 @@ second_ao = {
           "description": "Request by ActBlue",
           "document_id": 80835,
           "text": "Document text for the first ao document",
-          "url": "/files/legal/aos/2014-19/1308389.pdf"
+          "url": "/files/legal/aos/2014-19/1308389.pdf",
+          "filename": "1308389",
         },
         {
           "ao_doc_category_id": "D",
@@ -1820,7 +1832,8 @@ second_ao = {
           "description": "Draft AO, Agenda Document No. 15-03-A",
           "document_id": 80836,
           "text": "Document text for the second ao document",
-          "url": "/files/legal/aos/2014-19/201419.pdf"
+          "url": "/files/legal/aos/2014-19/201419.pdf",
+          "filename": "201419",
         },
         {
           "ao_doc_category_id": "V",
@@ -1829,7 +1842,8 @@ second_ao = {
           "description": "Vote",
           "document_id": 80837,
           "text": "Document text for the third ao document",
-          "url": "/files/legal/aos/2014-19/1310405.pdf"
+          "url": "/files/legal/aos/2014-19/1310405.pdf",
+          "filename": "1310405",
         },
         {
           "ao_doc_category_id": "F",
@@ -1838,7 +1852,8 @@ second_ao = {
           "description": "2014-19",
           "document_id": 80838,
           "text": "Proximity document text for the fourth ao document",
-          "url": "/files/legal/aos/2014-19/AO_2014-19_(ActBlue)_Final_(1.15.15).pdf"
+          "url": "/files/legal/aos/2014-19/AO_2014-19_(ActBlue)_Final_(1.15.15).pdf",
+          "filename": "AO_2014-19_(ActBlue)_Final_(1.15.15)",
         }
       ],
       "entities": [

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -428,8 +428,9 @@ legal_universal_search = {
     'case_max_penalty_amount': fields.Str(required=False, description=docs.CASE_MAX_PENALTY_AMOUNT),
     'q_proximity': fields.List(fields.Str, description=docs.Q_PROXIMITY),
     'max_gaps': fields.Int(required=False, description=docs.MAX_GAPS),
-    "proximity_filter": fields.Str(validate=validate.OneOf(["after", "before"]), description=docs.PROXIMITY_FILTER),
+    'proximity_filter': fields.Str(validate=validate.OneOf(["after", "before"]), description=docs.PROXIMITY_FILTER),
     'proximity_filter_term': fields.Str(required=False, description=docs.PROXIMITY_FILTER_TERM),
+    'filename': fields.Str(required=False, description=docs.FILENAME),
 }
 
 citation = {

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2403,6 +2403,11 @@ Specifies the term to which the `proximity_filter` option applies to and defines
 `q_proximity` phrase
 '''
 
+FILENAME = '''
+Search documents by file name
+'''
+
+
 # ======== legal end =========
 
 

--- a/webservices/legal_docs/advisory_opinions.py
+++ b/webservices/legal_docs/advisory_opinions.py
@@ -283,6 +283,8 @@ def get_documents(ao_id, bucket):
                     row["ao_no"], row["filename"].replace(" ", "-")
                 )
                 document["url"] = "/files/" + pdf_key
+                filename = row["filename"][:-4]
+                document["filename"] = filename
                 logger.debug("S3: Uploading {}".format(pdf_key))
                 documents.append(document)
 

--- a/webservices/legal_docs/archived_murs.py
+++ b/webservices/legal_docs/archived_murs.py
@@ -180,7 +180,6 @@ def get_single_mur(mur_no):
                 "doc_id": "mur_{0}".format(row["mur_no"]),
                 "no": row["mur_no"],
                 "case_serial": row["mur_id"],
-                "url": "/legal/matter-under-review/{0}/".format(row["mur_no"]),
                 "mur_type": "archived",
                 "mur_name": row["mur_name"],
                 "open_date": row["open_date"],
@@ -299,7 +298,8 @@ def get_documents(mur_id):
                 "document_id": int(row["document_id"] or 1),
                 "length": int(row["length"] or 0),
                 "text": row["pdf_text"],
-                "url": (row["url"] or "/files/legal/murs/{0}.pdf".format(mur_id))
+                "url": (row["url"] or "/files/legal/murs/{0}.pdf".format(mur_id)),
+                "filename": row["mur_no"]
             })
     return documents
 

--- a/webservices/legal_docs/current_cases.py
+++ b/webservices/legal_docs/current_cases.py
@@ -867,6 +867,8 @@ def get_documents(case_id, bucket):
                     get_es_type(row["case_type"]), row["case_no"], row["filename"].replace(" ", "-")
                 )
                 document["url"] = "/files/" + pdf_key
+                filename = row["filename"][:-4]
+                document["filename"] = filename
                 documents.append(document)
 
                 # bucket is None on local, don't need upload pdf to s3

--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -67,6 +67,7 @@ CASE_DOCUMENT_MAPPING = {
         },
         "document_date": {"type": "date", "format": "dateOptionalTime"},
         "url": {"type": "text"},
+        "filename": {"type": "text"},
         "doc_order_id": {"type": "integer"},
     },
 }
@@ -346,6 +347,7 @@ AO_MAPPING = {
                 },
                 "date": {"type": "date", "format": "dateOptionalTime"},
                 "url": {"type": "text", "index": False},
+                "filename": {"type": "text"},
             },
         },
         "requestor_names": {"type": "text"},
@@ -379,6 +381,7 @@ ARCH_MUR_DOCUMENT_MAPPING = {
             "term_vector": "with_positions_offsets",
         },
         "url": {"type": "text", "index": False},
+        "filename": {"type": "text"}
     },
 }
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -194,6 +194,12 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
         else:
             query = query.highlight("documents.text", "documents.description")
 
+    if kwargs.get("filename"):
+        must_clauses = []
+        must_clauses.append(Q("nested", path="documents",
+                            query=Q("match", documents__filename=kwargs.get("filename"))))
+        query = query.query("bool", must=must_clauses)
+
     if kwargs.get("q_exclude"):
         must_not = []
         must_not.append(


### PR DESCRIPTION
## Summary (required)

- Resolves #6155 

Adds filename field and filter

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- Legal search 

## How to test

You will need to reload your documents
- Checkout branch
- `pytest`
- `python cli.py delete_index ao_index`
- `python cli.py delete_index case_index`
- `python cli.py delete_index arch_mur_index`
- `python cli.py create_index case_index`
- `python cli.py create_index ao_index`
- `python cli.py create_index arch_mur_index`
Load some of each document type (I wait for ~5 to be loaded of each)
- `python cli.py load_adrs`
- `python cli.py load_advisory_opinions`
- `python cli.py load_current_murs`
- `python cli.py load_statutes`
- `python cli.py load_archived_murs`

- `flask run`
- http://127.0.0.1:5000/v1/legal/search/?filename=4777_01
- http://127.0.0.1:5000/v1/legal/search/?filename=1203_04
- http://127.0.0.1:5000/v1/legal/search/?filename=202504R_1
- http://127.0.0.1:5000/v1/legal/search/?filename=8353_03
- http://127.0.0.1:5000/v1/legal/search/?filename=4842


