### PR TITLE
add functionality to sort advisory opinions by issue_date

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -124,6 +124,17 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         # logging.info(response)
         self.assertEqual(response[0]["ao_no"], "2014-19")
 
+        # Test sorting by issue_date in descending order
+        sort = "-issue_date"
+        response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
+        # logging.info(response)
+        self.assertEqual(response[0]["issue_date"], "2024-09-19")
+
+        sort = "issue_date"
+        response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
+        # logging.info(response)
+        self.assertEqual(response[0]["issue_date"], "2015-01-15")
+
     def test_q_filters(self):
         q = "fourth"
         response = self._results_ao(api.url_for(UniversalSearch, q=q))

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -646,16 +646,19 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     # Only pass query string to document list below
     query = generic_query_builder(None, type_, from_hit, hits_returned, **kwargs)
 
-    # so far only be able to sort by 'ao_no', default sort is descending order.
-    # descending order: 'sort=-ao_no'; ascending order; sort=ao_no
+    # Sort AO's by 'ao_no' or 'issue_date'. Default sort order is desc.
+    # example desc order: 'sort=-ao_no'; asc order; sort=ao_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=-ao_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=ao_no
 
-    if kwargs.get("sort"):
-        if kwargs.get("sort").upper() == "AO_NO":
-            query = query.sort({"ao_no": {"order": "asc"}})
-        else:
-            query = query.sort({"ao_no": {"order": "desc"}})
+    sort_field = kwargs.get("sort")
+    if sort_field:
+        sort_order = "desc" if sort_field in ["ao_no", "issue_date"] else "asc"
+
+        if sort_field.upper() == "AO_NO":
+            query = query.sort({"ao_no": {"order": sort_order}})
+        elif sort_field.upper() == "ISSUE_DATE":
+            query = query.sort({"issue_date": {"order": sort_order}})
 
     should_query = [
         get_ao_document_query(q, **kwargs),


### PR DESCRIPTION
## Summary (required)

- Resolves #6167 

Add logic to sort advisory opinions by `issue_date` parameter 

### Required reviewers

2 or more developers

## Impacted areas of the application

- legal/search api endpoint
- ao datatables in cms


## How to test

- run `git checkout feature/6167-add-ao-sort-by-issue-date`
- run `pytest`
- run `python cli.py delete_index ao_index` (delete existing index from local elasticsearch service)
- run `python cli.py create_index ao_index` (create new ao_index on local elasticsearch service)
- **Note: switch SQLA_CONN to point to Stage database. Dev data is not clean.**
- run `python cli.py load_advisory_opinions` (load few advisory_opinion documents from 2025-05 to 2023-12)
- run `flask run` (start server)
- test urls to sort by ao_no and issue_date for advisory_opinion document type

- ### test the following urls when `ao_status=final` parameter is set:
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_doc_category_id=&ao_status=final&sort=-issue_date
       (list begins with, ao_no = 2024-15, issue_date = null; Some AO's may not have an issue_date. Check the issue_date further down the list to ensure that sorting by issue_date works when a value is set)
       - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_doc_category_id=&ao_status=final&sort=issue_date
       (list begins with, ao_no = 2023-12, issue_date = 2024-01-05)
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_doc_category_id=&ao_status=final&sort=ao_no
       (list begins with, ao_no = 2023-12)
       - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_doc_category_id=&ao_status=final&sort=-ao_no
       (list begins with, ao_no = 2024-15)


- ### test the following urls:
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&sort=-issue_date (list begins with for issue_date = null, ao_no = 2025-05; Some AO's may not have an issue_date. Check the issue_date further down the list to ensure that sorting by issue_date works when a value is set)
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&sort=issue_date (list begins with, issue_date = 2024-01-05, ao_no = 2023-12)
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&sort=-ao_no (list begins with, ao_no = 2025-05)
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&sort=ao_no (list begins with, ao_no = 2023-12)

