### PR TITLE
Add proximity_preserve_order filter

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -156,18 +156,24 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["ao_no"], "2024-12")
 
-        multiple_phrases = ["fourth ao", "proximity document"]
+        multiple_phrases = ["proximity document", "fourth ao"]
         max_gaps = 3
 
         response = self._results_ao(api.url_for(UniversalSearch,
                                                 q_proximity=multiple_phrases,
                                                 proximity_filter=proximity_filter,
+                                                proximity_preserve_order=True,
                                                 proximity_filter_term=proximity_filter_term,
                                                 max_gaps=max_gaps))
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["ao_no"], "2014-19")
 
         self.check_incorrect_values({"q_proximity": search_phrase, "max_gaps": 1}, False)
+
+        self.check_incorrect_values(
+            {"q_proximity": [multiple_phrases[1], multiple_phrases[0]],
+             "proximity_preserve_order": True,
+             "max_gaps": 3, }, False)
 
     def test_citation_filters(self):
         statutory_title = 52

--- a/tests/integration/test_cases_elasticsearch.py
+++ b/tests/integration/test_cases_elasticsearch.py
@@ -267,15 +267,23 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
         self.assertEqual(response["total_admin_fines"], 0)
         self.assertEqual(response["total_adrs"], 0)
 
-        multiple_phrases = ["second adr", "sample text"]
+        multiple_phrases = ["sample text", "second adr"]
         max_gaps = 6
-        response = self._results_case(api.url_for(UniversalSearch, q_proximity=multiple_phrases, max_gaps=max_gaps))
-
+        response = self._results_case(api.url_for(UniversalSearch,
+                                                  q_proximity=multiple_phrases,
+                                                  proximity_preserve_order=True,
+                                                  max_gaps=max_gaps))
         self.assertEqual(response["total_murs"], 0)
         self.assertEqual(response["total_admin_fines"], 0)
         self.assertEqual(response["total_adrs"], 1)
 
         self.check_incorrect_values({"q_proximity": search_phrase, "max_gaps": 1},
+                                    ["total_murs", "total_admin_fines", "total_adrs"],
+                                    False)
+
+        self.check_incorrect_values({"q_proximity": [multiple_phrases[1], multiple_phrases[0]],
+                                     "proximity_preserve_order": True,
+                                     "max_gaps": 6},
                                     ["total_murs", "total_admin_fines", "total_adrs"],
                                     False)
 

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -428,6 +428,7 @@ legal_universal_search = {
     'case_max_penalty_amount': fields.Str(required=False, description=docs.CASE_MAX_PENALTY_AMOUNT),
     'q_proximity': fields.List(fields.Str, description=docs.Q_PROXIMITY),
     'max_gaps': fields.Int(required=False, description=docs.MAX_GAPS),
+    'proximity_preserve_order': fields.Bool(required=False, description=docs.PROXIMITY_PRESERVE_ORDER),
     'proximity_filter': fields.Str(validate=validate.OneOf(["after", "before"]), description=docs.PROXIMITY_FILTER),
     'proximity_filter_term': fields.Str(required=False, description=docs.PROXIMITY_FILTER_TERM),
     'filename': fields.Str(required=False, description=docs.FILENAME),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2394,6 +2394,10 @@ MAX_GAPS = '''
 The maximum number of positions allowed between terms specified in `q_proximity`
 '''
 
+PROXIMITY_PRESERVE_ORDER = '''
+When set to true, maintains the original order of phrases in `q_proximity`.
+'''
+
 PROXIMITY_FILTER = '''
 Adds additional filters to the proximity search that provides options to specify positional constraints
 '''

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -316,6 +316,7 @@ def case_query_builder(q, type_, from_hit, hits_returned, **kwargs):
 def get_proximity_query(**kwargs):
     q_proximity = kwargs.get("q_proximity")
     max_gaps = kwargs.get("max_gaps")
+    ordered = kwargs.get("proximity_preserve_order", False)
     intervals_list = []
     contains_filter = False
 
@@ -340,11 +341,14 @@ def get_proximity_query(**kwargs):
 
         if contains_filter:
             intervals_inner_query = Q('intervals', documents__text={
-                    'all_of':  {'max_gaps': max_gaps, "intervals": intervals_list, "filter": filters}
+                    'all_of':  {'max_gaps': max_gaps,
+                                "ordered": ordered,
+                                "intervals": intervals_list,
+                                "filter": filters}
                     })
         else:
             intervals_inner_query = Q('intervals', documents__text={
-                    'all_of':  {'max_gaps': max_gaps, "intervals": intervals_list}
+                    'all_of':  {'max_gaps': max_gaps, "ordered": ordered, "intervals": intervals_list}
                     })
     return intervals_inner_query
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6164 

This PR adds the `proximity_preserve_order` boolean filter that determines if order matters between multiple `q_proximity` phrases.

### Required reviewers 1 - 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

- legal proximity search 

## How to test
- checkout this branch
- start a virtualenv
- start elasticsearch `./elasticsearch`
- `pytest`
- create case index: `python cli.py create_index case_index`
- create ao index: `python cli.py create_index ao_index`
- load sample data for ao, mur, af, and adrs: `python cli.py load_current_murs` `python cli.py load_admin_fines` `python cli.py load_advisory_opinions` `python cli.py load_adrs`
- `flask run`
- see test URLs below 

Test URLs reference the following documents: MUR 8282, AO 2024-10

MUR 8282

Default false:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=signed%20conciliation&q_proximity=Michigan%20Republican&max_gaps=2

True:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=signed%20conciliation&q_proximity=Michigan%20Republican&max_gaps=2&proximity_preserve_order=True

Wrong order:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Michigan%20Republican&q_proximity=signed%20conciliation&max_gaps=2&proximity_preserve_order=True


Set wrong order to False:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Michigan%20Republican&q_proximity=signed%20conciliation&max_gaps=2&proximity_preserve_order=False



AO 2024-10

Default false:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6

True:
http://127.0.0.1:5000/v1/legal/search/?q_proximity=Congressman%20Lowenthal&q_proximity=The%20Commission%20concludes&max_gaps=6&proximity_preserve_order=True

Wrong order:
http://127.0.0.1:5000/v1/legal/search/?&q_proximity=The%20Commission%20concludes&q_proximity=Congressman%20Lowenthal&max_gaps=6&proximity_preserve_order=True

set wrong order to False:
http://127.0.0.1:5000/v1/legal/search/?&q_proximity=The%20Commission%20concludes&q_proximity=Congressman%20Lowenthal&max_gaps=6&proximity_preserve_order=False
