### PR TITLE
upgrade flyway v11.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/11.4.0/flyway-commandline-11.4.0-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-11.4.0:$PATH' >> $BASH_ENV
+            curl -s https://repo.maven.apache.org/maven2/org/flywaydb/flyway-commandline/11.6.0/flyway-commandline-11.6.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-11.6.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Elastic Search 7.x (instructions [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/_installation.html))
-   - Flyway 11.4.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
+   - Flyway 11.6.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
-     - After downloading, create a .toml file in the following location: `flyway-11.4.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
+     - After downloading, create a .toml file in the following location: `flyway-11.6.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
 
        ```
        [environments.local]

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "11.4.0"
-    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "11.4.0") {
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "11.6.0"
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "11.6.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-11.4.0.jar:app/gradle/lib/flyway-core-11.4.0.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-11.6.0.jar:app/gradle/lib/flyway-core-11.6.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

Upgrading flyway to v11.6.0  to resolves snyk vulnerability. There are no breaking changes with this new version: https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine

- Resolves #https://github.com/fecgov/openFEC/issues/6159

### Required reviewers

1 Developer

## Impacted areas of the application

- DB migrations

## How to test

1. checkout this branch 
2. start your virtualenv 
3. Update flyway run:  `brew upgrade flyway`
4. Confirm flyway version 11.6.0: `flyway -v` 
5. run `dropdb cfdm_test`
6. run `createdb cfdm_test`
7. run `invoke create-sample-db`
8. run `pytest`
9. run `snyk test --file=data/flyway/build.gradle`  (snyk no longer flags flyway as vulnerable pkg )