### PR TITLE
6176- upgrade gunicorn  to v.23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-Cors==5.0.0
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==2.5.1
 gevent==24.11.1
-gunicorn==22.0.0
+gunicorn==23.0.0
 GitPython==3.1.41
 icalendar==4.0.2
 invoke==2.2.0


### PR DESCRIPTION
## Summary (required)

- Resolves #6176 

Upgrades gunicorn to 23.0.0 to remediate snyk vulnerability

[Breaking Changes ](https://docs.gunicorn.org/en/latest/news.html)
    refuse requests where the uri field is empty 
    refuse requests with invalid CR/LR/NUL in heade field values 
    remove temporary --tolerate-dangerous-framing switch from 22.0
### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  gunicorn servers


## Related PRs

Related PRs against other branches:
https://github.com/fecgov/fec-cms/pull/6743

## How to test

- gh pr checkout 6187
- gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 -k gevent -w 4 'webservices.rest:create_app()'
- http://127.0.0.1:8000
- http://127.0.0.1:8000/v1/schedules/schedule_d/?page=1&per_page=20&sort=-coverage_end_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

OR

- Deploy to a space 
