### PR TITLE
Update logic to sort by issue_date

### DIFF
--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -49,8 +49,9 @@ Number of pages in the document
 '''
 
 SORT = '''
-Provide a field to sort by. Use `-` for descending order. \
-ex: `-case_no`
+Sort `cases` (MUR, ADR, and AF) by `case_no`. Sort `advisory opinions` by `ao_no` or `issue_date`.
+Use `-` before a parameter name to sort in descending order.
+ex: `-case_no` or `-ao_no`
 '''
 
 # ======== candidate start ===========

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -654,10 +654,13 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     # example desc order: 'sort=-ao_no'; asc order; sort=ao_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=-ao_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=ao_no
-
     sort_field = kwargs.get("sort")
     if sort_field:
-        sort_order = "desc" if sort_field in ["ao_no", "issue_date"] else "asc"
+        if sort_field.startswith("-"):
+            sort_order = "desc"
+            sort_field = sort_field[1:]
+        else:
+            sort_order = "asc"
 
         if sort_field.upper() == "AO_NO":
             query = query.sort({"ao_no": {"order": sort_order}})


### PR DESCRIPTION
## Summary

For advisory opinions, sort by issue_date asc works as expected. However, when sort_by issue_date desc, the results are inconsistent. This PR fixes the inconsistent results when sort by issue_date.

Update the description of SORT constant in docs.py 

- Resolves issue #6196 
- Related pr # https://github.com/fecgov/openFEC/pull/6173

### Required reviewers

2 or more developers

## Impacted areas of the application

- legal/search api endpoint



## How to test

- run `git checkout feature/6196-update-sort-issue_date`
- run `pytest`
- run `python cli.py delete_index ao_index` (delete existing index from local elasticsearch service)
- run `python cli.py create_index ao_index` (create new ao_index on local elasticsearch service)
- **Note: switch SQLA_CONN to point to Stage database. Dev data is not clean.**
- run `python cli.py load_advisory_opinions` (load few advisory_opinion documents from 2025-05 to 2022-22)
- run `flask run` (start server)
- test urls to sort by ao_no and issue_date for advisory_opinion document type

- ### test the following urls when `ao_status=final` parameter is set:
      sort=-issue_date (descending order):
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_status=final&sort=-issue_date
       (list begins with, ao_no = 2025-03, issue_date = 2025-03-27;  search for the issue_date 
        further down the list to ensure that ao's are sorted by issue_date)
    
      sort=issue_date (ascending order):
       - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_status=final&sort=issue_date
       (list begins with, ao_no = 2022-24, issue_date = 2022-12-01; search for the issue_date 
        further down the list to ensure that ao's are sorted by issue_date)
     
      sort=-ao_no (descending order):
      - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_status=final&sort=-ao_no
       (list begins with, ao_no = 2025-03)
     
       sort=ao_no (ascending order):
       - http://localhost:5000/v1/legal/search/?type=advisory_opinions&ao_status=final&sort=ao_no
       (list begins with, ao_no = 2022-22)


