### PR TITLE
Create task and endpoint to monitor celery

### DIFF
--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,88 @@
+import json
+import redis
+
+from tests.common import ApiBaseTest
+from unittest.mock import patch, MagicMock
+from webservices.api_setup import api
+from webservices.resources.monitoring import celery_check
+from webservices.tasks.service_status_checks import heartbeat
+from webservices.tasks.utils import set_redis_value, get_redis_value
+
+
+class TestMonitoring(ApiBaseTest):
+
+    def test_celery_status_up(self):
+        mock_value = {"celery-is-running": True}
+
+        with patch("webservices.resources.monitoring.get_redis_value", return_value=mock_value):
+
+            response = self.app.get(api.url_for(celery_check))
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data["status"] == "ok"
+
+    def test_celery_status_down(self):
+        with patch("webservices.resources.monitoring.get_redis_value", return_value={}):
+            response = self.app.get(api.url_for(celery_check))
+            assert response.status_code == 503
+            data = json.loads(response.data)
+            assert data["status"] == "down"
+            assert "No Celery workers responding" in data["message"]
+
+    def test_celery_check_redis_down(self):
+        with patch("webservices.resources.monitoring.get_redis_value", side_effect=redis.ConnectionError):
+            response = self.app.get(api.url_for(celery_check))
+            assert response.status_code == 503
+            assert response.json["status"] == "down"
+            assert "Redis connection error" in response.json["message"]
+
+    @patch("webservices.tasks.service_status_checks.set_redis_value")
+    def test_heartbeat_sets_redis_value(self, mock_set):
+        heartbeat()
+        mock_set.assert_called_once_with(
+            "CELERY_STATUS",
+            {"celery-is-running": True},
+            age=40
+        )
+
+    @patch("webservices.tasks.utils.get_redis_instance")
+    def test_set_redis_value(self, mock_get_redis_instance):
+        mock_redis = MagicMock()
+        mock_get_redis_instance.return_value = mock_redis
+
+        set_redis_value("FOO", {"bar": "baz"}, age=600)
+
+        mock_redis.set.assert_called_once_with("FOO", json.dumps({"bar": "baz"}), ex=600)
+
+    @patch("webservices.tasks.utils.get_redis_instance")
+    def test_get_redis_value_found(self, mock_get_redis_instance):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps({"bar": "baz"})
+        mock_get_redis_instance.return_value = mock_redis
+
+        result = get_redis_value("FOO")
+
+        mock_redis.get.assert_called_once_with("FOO")
+        assert result == {"bar": "baz"}
+
+    @patch("webservices.tasks.utils.get_redis_instance")
+    def test_get_redis_value_not_found(self, mock_get_redis_instance):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mock_get_redis_instance.return_value = mock_redis
+
+        result = get_redis_value("FOO", fallback={"bar": "default"})
+
+        mock_redis.get.assert_called_once_with("FOO")
+        assert result == {"bar": "default"}
+
+    @patch("webservices.tasks.utils.get_redis_instance")
+    def test_get_redis_value_empty(self, mock_get_redis_instance):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = ""
+        mock_get_redis_instance.return_value = mock_redis
+
+        result = get_redis_value("FOO", fallback={"bar": "default"})
+
+        mock_redis.get.assert_called_once_with("FOO")
+        assert result == {"bar": "default"}

--- a/webservices/api_setup.py
+++ b/webservices/api_setup.py
@@ -28,6 +28,7 @@ from webservices.resources import audit
 from webservices.resources import operations_log
 from webservices.resources import presidential
 from webservices.resources import spending_by_others
+from webservices.resources import monitoring
 from webservices.env import env
 
 
@@ -196,5 +197,7 @@ api.add_resource(presidential.PresidentialSummaryView, '/presidential/financial_
 api.add_resource(presidential.PresidentialBySizeView, '/presidential/contributions/by_size/')
 api.add_resource(presidential.PresidentialByStateView, '/presidential/contributions/by_state/')
 api.add_resource(presidential.PresidentialCoverageView, '/presidential/coverage_end_date/')
+api.add_resource(monitoring.celery_check, '/monitoring/celery_check/')
+
 if SHOW_TEST_F1:
     api.add_resource(filings.TestF1EFilingsView, '/efile/test-form1/')

--- a/webservices/resources/monitoring.py
+++ b/webservices/resources/monitoring.py
@@ -1,0 +1,21 @@
+import redis
+
+from flask import jsonify
+from webservices.utils import Resource
+from webservices.tasks.utils import get_redis_value
+
+
+class celery_check(Resource):
+
+    def get(self):
+        try:
+
+            celery_status = get_redis_value("CELERY_STATUS", {})
+
+            if celery_status.get("celery-is-running"):
+                return jsonify(status='ok', message='Celery workers are processing tasks'), 200
+            else:
+                return jsonify(status='down', message='No Celery workers responding'), 503
+
+        except redis.ConnectionError:
+            return jsonify(status='down', message='Redis connection error'), 503

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -62,6 +62,7 @@ from webservices.env import env
 from webservices.tasks.celery import celery_init_app
 from webservices.tasks.response_exception import ResponseException
 from webservices.tasks.error_code import ErrorCode
+from webservices.tasks.utils import redis_url
 from webservices.api_setup import api, v1
 from celery import signals
 
@@ -148,24 +149,10 @@ def create_app(test_config=None):
     api.init_app(app)
     NPlusOne(app)
 
-    def redis_url():
-        """
-        Retrieve the URL needed to connect to a Redis instance, depending on environment.
-        When running in a cloud.gov environment, retrieve the uri credential for the 'aws-elasticache-redis' service.
-        """
-        # Is the app running in a cloud.gov environment
-        if env.space is not None:
-            redis_env = env.get_service(label="aws-elasticache-redis")
-            redis_url = redis_env.credentials.get("uri")
-
-            return redis_url
-
-        return env.get_credential("FEC_REDIS_URL", "redis://localhost:6379/0")
-
     app.config.from_mapping(
         CELERY=dict(
             broker_url=redis_url(),
-            result_backend=None,  # may need to set
+            result_backend=redis_url(),
             task_ignore_result=True,  # may need to unset
         ),
     )

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -62,20 +62,10 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.legal_docs.delete_es_backup_monthly",
             "schedule": crontab(minute=0, hour=5, day_of_month=1),
         },
+        # Task 8: This task is launched every 30 seconds
+        # Checks that redis, celery-beat, and celery-worker are running
+        "essential-services-status-check": {
+            "task": "webservices.tasks.service_status_checks.heartbeat",
+            "schedule": 30.0,
+        },
     }
-
-
-def redis_url():
-    """
-    Retrieve the URL needed to connect to a Redis instance, depending on environment.
-    When running in a cloud.gov environment, retrieve the uri credential for the 'aws-elasticache-redis' service.
-    """
-
-    # Is the app running in a cloud.gov environment
-    if env.space is not None:
-        redis_env = env.get_service(label="aws-elasticache-redis")
-        redis_url = redis_env.credentials.get("uri")
-
-        return redis_url
-
-    return env.get_credential("FEC_REDIS_URL", "redis://localhost:6379/0")

--- a/webservices/tasks/celery.py
+++ b/webservices/tasks/celery.py
@@ -1,7 +1,8 @@
 import ssl
 from celery import Celery, Task
 from flask import Flask
-from webservices.tasks import redis_url, schedule
+from webservices.tasks import schedule
+from webservices.tasks.utils import redis_url
 
 
 def celery_init_app(app: Flask) -> Celery:
@@ -24,6 +25,7 @@ def celery_init_app(app: Flask) -> Celery:
             "webservices.tasks.refresh_db",
             "webservices.tasks.download",
             "webservices.tasks.legal_docs",
+            "webservices.tasks.service_status_checks",
         ),
         beat_schedule=schedule,
         broker_connection_timeout=30,  # in seconds

--- a/webservices/tasks/service_status_checks.py
+++ b/webservices/tasks/service_status_checks.py
@@ -1,0 +1,12 @@
+from webservices.tasks.utils import set_redis_value
+from webservices.env import env
+from celery_once import QueueOnce
+from celery import shared_task
+
+SYSTEM_STATUS_CACHE_AGE = env.get_credential("SYSTEM_STATUS_CACHE_AGE") or 40
+
+
+@shared_task(once={"graceful": True}, base=QueueOnce, ignore_result=False)
+def heartbeat():
+    # if this task is running, that means that redis, celery-beat, and celery-worker are up
+    set_redis_value("CELERY_STATUS", {"celery-is-running": True}, age=SYSTEM_STATUS_CACHE_AGE)


### PR DESCRIPTION
## Summary (required)

- Resolves #6191

This PR creates an endpoint to monitor the status of `celery-beat`, `celery-worker`, and `redis`. This method was borrowed from [fecfile](https://github.com/fecgov/fecfile-web-api/pull/1292/files). Once merged I will create the pingdom check! 

### Required reviewers 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

- tasks 
- celery 


## How to test

On dev 
- Deploy this [branch](https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-celery-dev) and test the endpoint: https://fec-dev-api.app.cloud.gov/v1/monitoring/celery_check/. 

locally: 

Terminal One:
- checkout this branch 
- start your virtual environment 
- `pytest`
- `flask run` (keep running)
- comment out `broker_use_ssl`, `redis_backend_use_ssl`, and + `?ssl=true `
Terminal Two: 
- start redis `redis-server`

Terminal Three:
- start virtual environment
- start celery worker `celery -A webservices.tasks.make_celery worker --loglevel=INFO`

Terminal Four:
- start virtual environment 
- start celery beat `celery -A webservices.tasks.make_celery beat --loglevel=INFO`

- Go to http://127.0.0.1:5000/v1/monitoring/celery_check/ once task successfully completes

- Turn off any component (celery-beat, celery-worker, redis) and confirm that status is down after approximately 40 seconds 

