### PR TITLE
6179-add legal/docs to swagger

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -10,7 +10,7 @@ class TestSwagger(unittest.TestCase):
     def test_swagger_valid(self):
         try:
             utils.validate_spec(spec)
-        except exceptions.SwaggerError as error:
+        except exceptions.OpenAPIError as error:
             self.fail(str(error))
 
     def test_format_docstring(self):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2077,7 +2077,7 @@ The maximum value of `hits_returned` is 200.\n\
 '''
 
 LEGAL_DOC_SEARCH = '''
-Search legal documents by type and No
+Search legal documents by type and number
 '''
 
 LEGAL_DOC_NO = '''
@@ -2085,7 +2085,7 @@ Document number to fetch
 '''
 
 LEGAL_DOC_TYPE = '''
-Choose a legal document type
+Choose a legal document type: advisory_opinions, murs, admin_fines, statutes, or adrs
 '''
 
 TEXT_SEARCH = '''

--- a/webservices/legal_docs/responses.py
+++ b/webservices/legal_docs/responses.py
@@ -157,6 +157,115 @@ MUR_SCHEMA["items"]["properties"]["mur_type"] = {
         "archived"
     ]
 }
+LEGAL_DOC_RESPONSE = {
+  "default": {
+    "description": "Legal single document search results",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "docs": {"type": "array"},
+                "case_serial": {"type": "integer"},
+                "challenge_outcome": {"type": "string"},
+                "challenge_receipt_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "civil_penalty_due_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "civil_penalty_payment_status": {"type": "string"},
+                "commission_votes": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "vote_date": {
+                                                        "type": "string",
+                                                        "format": "date"
+                                                    },
+                                                    "action": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                "committee_id": {"type": "string"},
+                "dispositions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "disposition_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                                    "disposition_description": {"type": "string"},
+                                    "penalty": {"type": "number"},
+                                    },
+                            }
+                        },
+                "doc_id": {"type": "string"},
+                "documents": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                        "properties": {
+                                            "document_id": {
+                                                    "type": "integer"
+                                                    },
+                                            "date": {
+                                                    "type": "string",
+                                                    "format": "date"
+                                                    },
+                                            "description": {
+                                                    "type": "string"
+                                                    },
+                                            "category": {
+                                                    "type": "string"
+                                                    },
+                                            "url": {
+                                                    "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                "final_determination_amount": {"type": "number"},
+                "final_determination_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "name": {"type": "string"},
+                "no": {"type": "integer"},
+                "payment_amount": {"type": "number"},
+                "petition_court_decision_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "petition_court_filing_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "published_flg": {"type": "boolean"},
+                "reason_to_believe_action_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "reason_to_believe_fine_amount": {"type": "number"},
+                "report_type": {"type": "string"},
+                "report_year": {"type": "integer"},
+                "treasury_referral_amount": {"type": "number"},
+                "treasury_referral_date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                "type": {"type": "string"},
+                "url": {"type": "string"}
+                }
+            }
+        }
+    }
+
 LEGAL_SEARCH_RESPONSE = {
     "default": {
         "description": "Legal search results",

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -110,8 +110,8 @@ class GetLegalDocument(Resource):
         )
 
         results = {"docs": [hit.to_dict() for hit in es_results]}
-        return results if results["docs"] else abort(404)
         # logger.debug("GetLegalDocument() results =" + json.dumps(results, indent=3, cls=DateTimeEncoder))
+        return results if results["docs"] else abort(404)
 
 
 # endpoint path: /legal/search/

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -271,6 +271,7 @@ def create_app(test_config=None):
     apidoc.register(audit.AuditCommitteeNameSearch, blueprint='v1')
     apidoc.register(operations_log.OperationsLogView, blueprint='v1')
     apidoc.register(legal.UniversalSearch, blueprint='v1')
+    apidoc.register(legal.GetLegalDocument, blueprint='v1')
     apidoc.register(candidate_aggregates.CandidateTotalAggregateView, blueprint='v1')
     apidoc.register(spending_by_others.ECTotalsByCandidateView, blueprint='v1')
     apidoc.register(spending_by_others.IETotalsByCandidateView, blueprint='v1')


### PR DESCRIPTION
## Summary (required)

- Resolves #6179

Add legal/docs endpoint to swagger, fix swagger validation test

### Required reviewers

1-2 dev

## Impacted areas of the application

General components of the application that this PR will affect:

- swagger docs legal endpoint

## Screenshots
![Screenshot 2025-04-18 at 2 53 25 PM](https://github.com/user-attachments/assets/d3adfd22-fde9-46f6-82de-4779521f9258)

## How to test
- pytest
- test swagger docs:
http://127.0.0.1:5000
- http://127.0.0.1:5000/v1/legal/docs/statutes/9001/
- http://127.0.0.1:5000/v1/legal/docs/advisory_opinions/2025-05/
- http://127.0.0.1:5000/v1/legal/docs/murs/8353/
- http://127.0.0.1:5000/v1/legal/docs/adrs/1203/
- http://127.0.0.1:5000/v1/legal/docs/admin_fines/4777/
-
- Test 404:
http://127.0.0.1:5000/v1/legal/docs/statutes/test
http://127.0.0.1:5000/v1/legal/docs/statutes/test
