### PR TITLE
6194-upgrade kombu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ gunicorn==23.0.0
 GitPython==3.1.41
 icalendar==4.0.2
 invoke==2.2.0
-kombu==5.2.4 # Starting from celery 5.x release, the minimum required version is Kombu 5.x
+kombu==5.5.3 # Starting from celery 5.x release, the minimum required version is Kombu 5.x
 networkx==2.6.2
 prance[osv]==0.22.11.4.0
 pre-commit==2.21.0 #client-side hook triggered by operations like git commit
@@ -25,7 +25,6 @@ requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==1.3.19
 ujson==5.4.0 # decoding CSP violation reported
-vine==5.0.0 # previosly pinned to 1.3.0 to fix amqp dependency, which is a dependency of kombu
 webargs==7.0.0
 werkzeug==3.0.6
 

--- a/webservices/tasks/celery.py
+++ b/webservices/tasks/celery.py
@@ -27,7 +27,7 @@ def celery_init_app(app: Flask) -> Celery:
         ),
         beat_schedule=schedule,
         broker_connection_timeout=30,  # in seconds
-        broker_connection_max_retries=0,  # for unlimited retries
+        broker_connection_max_retries=None,  # for unlimited retries
         task_acks_late=False
     )
     celery_app.conf.ONCE = {


### PR DESCRIPTION
## Summary (required)

- Resolves #6194 

Fixes max broker_connection_max_retries to match documentation [here](https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries) and upgrades kombu to lts. In upgrading kombu, we should unpin vine (a kombu dependency).  

I tried recreating an issue where redis was disconnected locally and found that our celery-worker gets stuck in the mingle process after being disconnected from redis. I think this is what happened with our recent outages. 

Here's some helpful threads on this issue:
[celery worker](https://github.com/celery/celery/pull/8796)
[kombu](https://github.com/celery/kombu/pull/2007)

PR about max_retries
[broker_connection_max_retries](https://github.com/celery/celery/pull/8626) 

### Required reviewers

2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- celery

## How to test

Using dev, set up redis and celery locally using[ the wiki ](https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks)
- stop redis long enough for celery-worker to get past this error:
```
[: ERROR/MainProcess] consumer: Cannot connect to redis://localhost:6379/0: Error 61 connecting to localhost:6379. Connection refused..
Trying again in 10.00 seconds... (5/None)
```
- restart redis-server by running `redis-server`
- look at your celery-worker terminal, it should have stopped at: 
```
[INFO/MainProcess] mingle: searching for neighbors
 INFO/MainProcess] mingle: all alone
```
- keep it open for 20 sec to confirm it won't reconnect

Now pull this branch and recreate your venv:
- pyenv virtualenv 3.11.9 venv
- pyenv activate venv
- pip install -r requirements.txt
- pip install -r requirements-dev.txt
- npm i && npm run build

Using this PR, set up redis and celery locally using[ the wiki ](https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks)
- stop redis long enough for celery-worker to get past this error:
```
[: ERROR/MainProcess] consumer: Cannot connect to redis://localhost:6379/0: Error 61 connecting to localhost:6379. Connection refused..
Trying again in 10.00 seconds... (5/None)
```
- restart redis-server by running `redis-server`
- look at your celery-worker terminal, you need to give it at least 20 seconds, but it should start processing tasks and should have progressed past the mingle process which is used to sync workers

I ran several tests like this by starting and restarting the flask server, celery-beat, celery-worker, after redis to see what would get "stuck." Also, might be helpful to try running celery-worker --without-mingle which was the recommended solution before kombu was fixed. This also worked for me. 