### PR TITLE
6206 add ao_year filter

### DIFF
--- a/tests/integration/test_ao_elasticsearch.py
+++ b/tests/integration/test_ao_elasticsearch.py
@@ -14,12 +14,20 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
 
     def check_filters(self, params, field_name, multiple):
         response = self._results_ao(api.url_for(UniversalSearch, **params))
+        filter_value = list(params.values())[0]
         # logging.info(response)
+        # logging.info(params)
+
+        # Normalize the filter value to a list so we can check integers
+        if isinstance(filter_value, (list, tuple)):
+            expected_values = filter_value
+        else:
+            expected_values = [filter_value]
 
         if multiple:
-            assert all(x[field_name] in list(params.values())[0] for x in response)
+            assert all(x[field_name] in expected_values for x in response)
         else:
-            assert all(x[field_name] == list(params.values())[0] for x in response)
+            assert all(x[field_name] == expected_values[0] for x in response)
 
     def check_incorrect_values(self, params, raiseError):
         response = self.app.get(api.url_for(UniversalSearch, **params))
@@ -48,6 +56,7 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
             [{"ao_name": ["Fake Name", "ActBlue"]}, "name", True, False],
             [{"ao_is_pending": True}, "is_pending", False, True],
             [{"ao_status": "Final"}, "status", False, False],
+            [{"ao_year": 2024}, "ao_year", True, True],
         ]
 
         for filter in filters:

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -355,6 +355,7 @@ legal_universal_search = {
             description=docs.LEGAL_DOC_TYPE),
 
     'ao_no': fields.List(IStr, required=False, description=docs.AO_NUMBER),
+    'ao_year': fields.Int(required=False, description=docs.AO_YEAR),
     'ao_name': fields.List(IStr, required=False, description=docs.AO_NAME),
     'ao_min_issue_date': Date(description=docs.AO_MIN_ISSUE_DATE),
     'ao_max_issue_date': Date(description=docs.AO_MAX_ISSUE_DATE),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2102,15 +2102,15 @@ Number of results to return (max 10)
 '''
 
 AO_NUMBER = '''
-Force advisory opinion number
+Advisory opinion number
 '''
 
 AO_YEAR = '''
-Force advisory opinion year
+Advisory opinion year
 '''
 
 AO_NAME = '''
-Force advisory opinion name
+Advisory opinion name
 '''
 
 AO_MIN_ISSUE_DATE = '''

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2105,6 +2105,10 @@ AO_NUMBER = '''
 Force advisory opinion number
 '''
 
+AO_YEAR = '''
+Force advisory opinion year
+'''
+
 AO_NAME = '''
 Force advisory opinion name
 '''

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -733,6 +733,9 @@ def apply_ao_specific_query_params(query, **kwargs):
     if check_filter_exists(kwargs, "ao_no"):
         must_clauses.append(Q("terms", no=kwargs.get("ao_no")))
 
+    if kwargs.get("ao_year") is not None:
+        must_clauses.append(Q("term", ao_year=kwargs.get("ao_year")))
+
     if check_filter_exists(kwargs, "ao_name"):
         must_clauses.append(Q("match", name=" ".join(kwargs.get("ao_name"))))
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6206 

adds ao_year filter

### Required reviewers

2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- legal endpoint

## How to test

- start your venv and elasticsearch
- python cli.py load_advisory_opinions
- load multiple years advisory opinions (at least one of 2024) 
- flask run
- http://127.0.0.1:5000/v1/legal/search/?ao_year=2024
- http://127.0.0.1:5000/v1/legal/search/?ao_year=2025
