### PR TITLE
[MERGE WITH GITFLOW] Hotfix/fix candidate committee download

### DIFF
--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -65,7 +65,7 @@ def extract_analyze_count(rows):
 
 
 class explain(Executable, ClauseElement):
-    inherit_cache = True
+    inherit_cache = False
 
     def __init__(self, stmt, analyze=False):
         self.statement = stmt

--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -75,6 +75,8 @@ class CandidateList(ApiResource):
             kwargs['q'] = kwargs['name']
 
         query = super().build_query(**kwargs)
+        query._array_cast_keys = set()
+
         candidate_detail = models.Candidate
 
         if 'has_raised_funds' in kwargs:
@@ -102,10 +104,12 @@ class CandidateList(ApiResource):
 
         if kwargs.get('cycle'):
             query = query.filter(candidate_detail.cycles.overlap(kwargs['cycle']))
+            query._array_cast_keys.add('cycles_')
         if kwargs.get('election_year'):
             query = query.filter(
                 candidate_detail.election_years.overlap(kwargs['election_year'])
             )
+            query._array_cast_keys.add('election_years_')
         if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):
             # load active candidates only if True
             if kwargs.get('election_year'):
@@ -119,6 +123,8 @@ class CandidateList(ApiResource):
                         candidate_detail.inactive_election_years.is_(None),
                     )
                 )
+                query._array_cast_keys.add('inactive_election_years_')
+
             else:
                 query = query.filter(
                     candidate_detail.candidate_inactive.is_(False)
@@ -131,6 +137,7 @@ class CandidateList(ApiResource):
                         kwargs['election_year']
                     )
                 )
+                query._array_cast_keys.add('inactive_election_years_')
             else:
                 query = query.filter(
                     candidate_detail.candidate_inactive == True  # noqa
@@ -196,6 +203,7 @@ class CandidateView(ApiResource):
 
     def build_query(self, candidate_id=None, committee_id=None, **kwargs):
         query = super().build_query(**kwargs)
+        query._array_cast_keys = set()
 
         if candidate_id is not None:
             candidate_id = candidate_id.upper()
@@ -214,10 +222,12 @@ class CandidateView(ApiResource):
 
         if kwargs.get('cycle'):
             query = query.filter(models.CandidateDetail.cycles.overlap(kwargs['cycle']))
+            query._array_cast_keys.add('cycles_')
         if kwargs.get('election_year'):
             query = query.filter(
                 models.Candidate.election_years.overlap(kwargs['election_year'])
             )
+            query._array_cast_keys.add('election_years_')
         if 'has_raised_funds' in kwargs:
             query = query.filter(
                 models.Candidate.flags.has(

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -92,11 +92,13 @@ class CommitteeList(ApiResource):
                 )
 
         query = super().build_query(**kwargs)
+        query._array_cast_keys = set()
+        query._array_cast_keys.add('sponsor_candidate_ids')
         if kwargs.get("candidate_id"):
             query = query.filter(
                 models.Committee.candidate_ids.overlap(kwargs["candidate_id"])
             )
-
+            query._array_cast_keys.add('candidate_ids_')
         if kwargs.get("q"):
             query = query.join(
                 models.CommitteeSearch,
@@ -111,6 +113,7 @@ class CommitteeList(ApiResource):
 
         if kwargs.get("cycle"):
             query = query.filter(models.Committee.cycles.overlap(kwargs["cycle"]))
+            query._array_cast_keys.add('cycles_')
 
         return query
 
@@ -156,6 +159,7 @@ class CommitteeView(ApiResource):
 
     def build_query(self, committee_id=None, candidate_id=None, **kwargs):
         query = super().build_query(**kwargs)
+        query._array_cast_keys = set()
 
         if committee_id is not None:
             committee_id = committee_id.upper()
@@ -176,6 +180,7 @@ class CommitteeView(ApiResource):
 
         if kwargs.get("cycle"):
             query = query.filter(models.CommitteeDetail.cycles.overlap(kwargs["cycle"]))
+            query._array_cast_keys.add('cycles_')
 
         return query
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -160,7 +160,8 @@ class ReportsView(views.ApiResource):
             reports_type_map.get(entity_type), default_schemas,
         )
         query = sa.select(reports_class)
-
+        query._array_cast_keys = set()
+        query._array_cast_keys.add('candidate_ids_')
         filter_multi_fields = [
             ('amendment_indicator', models.CommitteeReports.amendment_indicator),
             ('report_type', reports_class.report_type),

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -87,7 +87,8 @@ class TotalsByEntityTypeView(ApiResource):
             default_schemas,
         )
         query = sa.select(totals_class)
-
+        query._array_cast_keys = set()
+        query._array_cast_keys.add('sponsor_candidate_ids_')
         # Committee ID needs to be handled separately because it's not in kwargs
         if committee_id is not None:
             query = query.filter(totals_class.committee_id.in_(committee_id))


### PR DESCRIPTION
## Summary (required)

This hotfix fixes an issue with candidate and committee table downloads when there are multiple cycles or election years chosen combined with a filter that utilizes `in_`. 

### Required reviewers 3 developers

## Impacted areas of the application

General components of the application that this PR will affect:

- downloads

## How to test

- test downloads on stage: https://stage.fec.gov/

Test URLs: 
https://stage.fec.gov/data/committees/?cycle=2010&cycle=2018&cycle=2024&party=DEM
https://stage.fec.gov/data/candidates/?election_year=2018&election_year=2025&election_year=2027&election_year=2028&is_active_candidate=true&has_raised_funds=true&party=DEM
