### PR TITLE
fix celery_check endpoint

### DIFF
--- a/webservices/resources/monitoring.py
+++ b/webservices/resources/monitoring.py
@@ -7,7 +7,7 @@ from webservices.tasks.utils import get_redis_value
 
 class celery_check(Resource):
 
-    def get(self):
+    def get(self, **kwargs):
         try:
 
             celery_status = get_redis_value("CELERY_STATUS", {})


### PR DESCRIPTION
## Summary (required)

- Resolves #6249

This PR fixes our celery_check endpoint in prod. 

### Required reviewers - 1 developer

## Impacted areas of the application

General components of the application that this PR will affect:

- celery_check endpoint

## How to test

- go to: https://api.open.fec.gov/v1/monitoring/celery_check/?api_key=DEMO_KEY
- see the following error message in logs: 

```
TypeError: celery_check.get() got an unexpected keyword argument 'api_key'
08:03:14.403: [APP/PROC/WEB.6] During handling of the above exception, another exception occurred:
08:03:14.403: [APP/PROC/WEB.6] Traceback (most recent call last):
```
