### PR TITLE
[WIP] 6169-upgrade psycopg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ kombu==5.5.3 # Starting from celery 5.x release, the minimum required version is
 networkx==2.6.2
 prance[osv]==0.22.11.4.0
 pre-commit==2.21.0 #client-side hook triggered by operations like git commit
-psycopg2-binary==2.9.1
+psycopg[binary]==3.2.9
 python-dateutil==2.8.1
 python-dotenv>=0.20.0 # Sets variable defaults in .flaskenv file
 requests==2.32.4


### PR DESCRIPTION
## Summary (required)

- Resolves #6169 

Upgrades our db driver to psycopg 3

### Required reviewers

2-3 devs

## Impacted areas of the application

- DB connections, downloads


## How to test

- `gh pr checkout 6275`
- `pyenv virtualenv 3.11.9 psycopg`
- `pyenv activate psycopg`
-  `pip install -r requirements.txt`
-  `pip install -r requirements-dev.txt`
- `npm i && npm run build`
If you have psycopg2 installed locally either uninstall or add psycopg to your connection strings (example below)
export SQLA_CONN='postgresql+psycopg://username:@localhost:5432/cfdm_test'
- `pytest`
-  `flask run`
-  http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false

Test download locally:
#### Test Downloads/Celery (locally or on dev)
LOCAL:
- Get Redis and Celery working locally using the instructions here:
https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks
- Download (I tested from the receipts table)

#### Downloads on DEV:
- Run a query in any table [on dev]() and export
sample:
https://dev.fec.gov/data/disbursements/?data_type=processed&committee_id=C00010868&two_year_transaction_period=2026&min_date=01%2F01%2F2025&max_date=12%2F31%2F2026
