### PR TITLE
6225-Fix ao_no sorting bug

### DIFF
--- a/tests/test_legal/test_ao_endpoint.py
+++ b/tests/test_legal/test_ao_endpoint.py
@@ -51,7 +51,7 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
     def test_ao_filters(self):
         filters = [
             [{"ao_no": "2014-19"}, "no", False, False],
-            [{"ao_no": ["2014-22", "2024-12"]}, "no", True, False],
+            [{"ao_no": ["2014-22", "2024-12",]}, "no", True, False],
             [{"ao_name": "McCutcheon"}, "name", False, False],
             [{"ao_name": ["Fake Name", "ActBlue"]}, "name", True, False],
             [{"ao_is_pending": True}, "is_pending", False, True],
@@ -126,12 +126,24 @@ class TestAODocsElasticsearch(ElasticSearchBaseTest):
         sort = "-ao_no"
         response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
         # logging.info(response)
+        # sort by ao_year and ao_serial for correct numerical desc ordering.
+        # Ex: 1980-100, 1980-11, 1980-10
         self.assertEqual(response[0]["ao_no"], "2024-12")
+        self.assertEqual(response[1]["ao_no"], "2014-19")
+        self.assertEqual(response[2]["ao_no"], "1980-100")
+        self.assertEqual(response[3]["ao_no"], "1980-11")
+        self.assertEqual(response[4]["ao_no"], "1980-10")
 
         sort = "ao_no"
         response = self._results_ao(api.url_for(UniversalSearch, sort=sort))
         # logging.info(response)
-        self.assertEqual(response[0]["ao_no"], "2014-19")
+        # sort by ao_year and ao_serial for correct numerical asc ordering.
+        # Ex: 1980-10, 1980-11, 1980-100
+        self.assertEqual(response[0]["ao_no"], "1980-10")
+        self.assertEqual(response[1]["ao_no"], "1980-11")
+        self.assertEqual(response[2]["ao_no"], "1980-100")
+        self.assertEqual(response[3]["ao_no"], "2014-19")
+        self.assertEqual(response[4]["ao_no"], "2024-12")
 
         # Test sorting by issue_date in descending order
         sort = "-issue_date"

--- a/tests/test_legal/test_case_endpoint.py
+++ b/tests/test_legal/test_case_endpoint.py
@@ -248,7 +248,7 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
         # logging.info(response)
 
         self.assertEqual(response["total_admin_fines"], 0)
-        self.assertEqual(response["total_all"], 10)
+        self.assertEqual(response["total_all"], 13)
 
     def test_q_proximity_filters(self):
         # for archived and current murs, advisory_opinions, adrs, and afs

--- a/tests/test_legal/test_legal_data.py
+++ b/tests/test_legal/test_legal_data.py
@@ -1933,6 +1933,208 @@ second_ao = {
       "type": "advisory_opinions"
 }
 
+third_ao = {
+      "ao_citations": [
+        {
+          "name": "Farrell",
+          "no": "2004-20"
+        },
+      ],
+      "ao_no": "1980-10",
+      "ao_serial": 10,
+      "ao_year": 1980,
+      "aos_cited_by": [],
+      "commenter_names": ["Francis Beaver"],
+      "doc_id": "advisory_opinions_1980-10",
+      "documents": [
+        {
+          "ao_doc_category_id": "V",
+          "category": "Votes",
+          "date": "2024-09-19T00:00:00",
+          "description": "Vote",
+          "document_id": 1111,
+          "text": "Random document text for first ao document",
+          "url": "/files/legal/aos/2024-12/202412V_1.pdf",
+          "filename": "202412V_1",
+        },
+      ],
+      "entities": [
+        {
+          "name": "Mr. Shaun McCutcheon",
+          "role": "Requestor",
+          "type": "Individual"
+        },
+      ],
+      "is_pending": False,
+      "issue_date": "2024-09-19",
+      "name": "McCutcheon",
+      "no": "2018-10",
+      "regulatory_citations": [
+        {
+          "part": 100,
+          "section": 2,
+          "title": 11
+        },
+      ],
+      "representative_names": [
+        "Chalmers, Adams, Backer & Kaufman, LLC",
+        ""
+      ],
+      "request_date": "2024-07-23",
+      "requestor_names": [
+        "Jane Doe",
+        "Jack Brown"
+      ],
+      "requestor_types": [
+        "Individual"
+      ],
+      "status": "Final",
+      "statutory_citations": [
+        {
+          "section": "30101",
+          "title": 52
+        },
+      ],
+      "summary": """Whether for purposes of contribution limits the first round of a ranked choice voting election
+      constitutes a general election, and each subsequent round, if any, is a distinct runoff election.""",
+      "type": "advisory_opinions"
+}
+
+fourth_ao = {
+      "ao_citations": [
+        {
+          "name": "Farrell",
+          "no": "2004-20"
+        },
+      ],
+      "ao_no": "1980-100",
+      "ao_serial": 100,
+      "ao_year": 1980,
+      "aos_cited_by": [],
+      "commenter_names": ["Francis Beaver"],
+      "doc_id": "advisory_opinions_1980-100",
+      "documents": [
+        {
+          "ao_doc_category_id": "V",
+          "category": "Votes",
+          "date": "2024-09-19T00:00:00",
+          "description": "Vote",
+          "document_id": 88638,
+          "text": "Random document text for first ao document",
+          "url": "/files/legal/aos/2024-12/202412V_1.pdf",
+          "filename": "202412V_1",
+        },
+      ],
+      "entities": [
+        {
+          "name": "Mr. Shaun McCutcheon",
+          "role": "Requestor",
+          "type": "Individual"
+        },
+      ],
+      "is_pending": False,
+      "issue_date": "2024-09-19",
+      "name": "McCutcheon",
+      "no": "1980-100",
+      "regulatory_citations": [
+        {
+          "part": 100,
+          "section": 2,
+          "title": 11
+        },
+      ],
+      "representative_names": [
+        "Chalmers, Adams, Backer & Kaufman, LLC",
+        ""
+      ],
+      "request_date": "2024-07-23",
+      "requestor_names": [
+        "Jane Doe",
+        "Jack Brown"
+      ],
+      "requestor_types": [
+        "Individual"
+      ],
+      "status": "Final",
+      "statutory_citations": [
+        {
+          "section": "30101",
+          "title": 52
+        },
+      ],
+      "summary": """Whether for purposes of contribution limits the first round of a ranked choice voting election
+      constitutes a general election, and each subsequent round, if any, is a distinct runoff election.""",
+      "type": "advisory_opinions"
+}
+
+fifth_ao = {
+      "ao_citations": [
+        {
+          "name": "Farrell",
+          "no": "2004-20"
+        },
+      ],
+      "ao_no": "1980-11",
+      "ao_serial": 11,
+      "ao_year": 1980,
+      "aos_cited_by": [],
+      "commenter_names": ["Francis Beaver"],
+      "doc_id": "advisory_opinions_1980-11",
+      "documents": [
+        {
+          "ao_doc_category_id": "V",
+          "category": "Votes",
+          "date": "2024-09-19T00:00:00",
+          "description": "Vote",
+          "document_id": 88638,
+          "text": "Random document text for first ao document",
+          "url": "/files/legal/aos/2024-12/202412V_1.pdf",
+          "filename": "202412V_1",
+        },
+      ],
+      "entities": [
+        {
+          "name": "Mr. Shaun McCutcheon",
+          "role": "Requestor",
+          "type": "Individual"
+        },
+      ],
+      "is_pending": False,
+      "issue_date": "2024-09-19",
+      "name": "McCutcheon",
+      "no": "1980-11",
+      "regulatory_citations": [
+        {
+          "part": 100,
+          "section": 2,
+          "title": 11
+        },
+      ],
+      "representative_names": [
+        "Chalmers, Adams, Backer & Kaufman, LLC",
+        ""
+      ],
+      "request_date": "2024-07-23",
+      "requestor_names": [
+        "Jane Doe",
+        "Jack Brown"
+      ],
+      "requestor_types": [
+        "Individual"
+      ],
+      "status": "Final",
+      "statutory_citations": [
+        {
+          "section": "30101",
+          "title": 52
+        },
+      ],
+      "summary": """Whether for purposes of contribution limits the first round of a ranked choice voting election
+      constitutes a general election, and each subsequent round, if any, is a distinct runoff election.""",
+      "type": "advisory_opinions"
+}
+
+
 first_citation = {
       "citation_text": "2 U.S.C. §31021",
       "citation_type": "statute",
@@ -1968,7 +2170,7 @@ document_dictionary = {
     "adrs": [first_adr, second_adr],
     "admin_fines": [first_admin_fine, second_admin_fine],
     "statutes": [first_statute, second_statute],
-    "advisory_opinions": [first_ao, second_ao],
+    "advisory_opinions": [first_ao, second_ao, third_ao, fourth_ao, fifth_ao],
     "ao_citations": [second_citation, fourth_citation],
     "mur_citations": [first_citation, third_citation]
 }

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -654,7 +654,9 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     query = generic_query_builder(None, type_, from_hit, hits_returned, **kwargs)
 
     # Sort AO's by 'ao_no' or 'issue_date'. Default sort order is desc.
-    # example desc order: 'sort=-ao_no'; asc order; sort=ao_no
+    # Example desc order: 'sort=-ao_no'; asc order; sort=ao_no
+    # Sorting by 'ao_no' will be replaced to sort by 'ao_year' and 'ao_serial'
+    # for correct numerical ordering.
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=-ao_no
     # https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=advisory_opinions&sort=ao_no
     sort_field = kwargs.get("sort")
@@ -666,7 +668,7 @@ def ao_query_builder(q, type_, from_hit, hits_returned, **kwargs):
             sort_order = "asc"
 
         if sort_field.upper() == "AO_NO":
-            query = query.sort({"ao_no": {"order": sort_order}})
+            query = query.sort({"ao_year": {"order": sort_order}}, {"ao_serial": {"order": sort_order}})
         elif sort_field.upper() == "ISSUE_DATE":
             query = query.sort({"issue_date": {"order": sort_order}})
 


### PR DESCRIPTION
## Summary (required)
This PR will fix the sort by **ao_no** with correct numerical ordering.

- Resolves #6225 

### Required reviewers

1 dev

## Impacted areas of the application
legal/search/ endpoint

## How to test
- checkout branch
- `pytest`
- Test on local, you need upload all AO: 1975 docs, 
   you can modify legal_docs/advisory_opinions.py line 42, remove **desc**:
   --- ORDER BY ao_parsed.ao_year, ao_parsed.ao_serial
    some commands:
    `python cli.py create_index ao_index`
    `python cli.py load_advisory_opinions`
    Test url to check correct AO sort order : 
http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&sort=ao_no&from_hit=6&hits_returned=100

Compare with wrong order in prod:
https://api.open.fec.gov/v1/legal/search/?type=advisory_opinions&sort=ao_no&from_hit=2&hits_returned=100&api_key=DEMO_KEY

- or deploy in dev or stage, check AO sorting order.
https://api-stage.open.fec.gov/v1/legal/search/?type=advisory_opinions&sort=ao_no&from_hit=2&hits_returned=100&api_key=DEMO_KEY

wrong AO order like this: 1975-10, 1975-100, 1975-101,..1975-109, 1975-11
<img width="400" alt="wrong_order" src="https://github.com/user-attachments/assets/2ff0807e-9d8c-41aa-95d1-2053b68baecc" />

correct AO order should be 1975-10, 1975-11,1975-12.....1975-100, 1975-101,..1975-109
<img width="400" alt="correct_order" src="https://github.com/user-attachments/assets/701e1b66-2bea-40fd-b2a0-79d221546fe1" />
