### PR TITLE
Upgrade marshmallow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apispec==4.0.0
+apispec==6.8.2
 certifi==2024.7.4
 cfenv==0.5.2
 defusedxml==0.6.0
@@ -31,8 +31,8 @@ werkzeug==3.0.6
 # Marshalling
 flask-apispec==0.11.4
 git+https://github.com/fecgov/marshmallow-pagination@upgrade-sqlalchemy-v2
-marshmallow==3.0.0
-marshmallow-sqlalchemy==0.29.0
+marshmallow==3.26.0
+marshmallow-sqlalchemy==1.4.2
 
 # Data export
 smart_open==1.8.0

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,16 +1,16 @@
 import unittest
-from apispec import utils, exceptions
 
 import webservices.rest
 import webservices.schemas  # noqa: needed to generate full spec
 from webservices.spec import spec, format_docstring
+from openapi_spec_validator import validate_spec
 
 
 class TestSwagger(unittest.TestCase):
     def test_swagger_valid(self):
         try:
-            utils.validate_spec(spec)
-        except exceptions.OpenAPIError as error:
+            validate_spec(spec.to_dict())
+        except Exception as error:
             self.fail(str(error))
 
     def test_format_docstring(self):

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -21,8 +21,8 @@ def _validate_natural(value):
 Natural = functools.partial(fields.Int, validate=_validate_natural)
 
 per_page = Natural(
-    missing=20,
-    description='The number of results returned per page. Defaults to 20.',
+    load_default=20,
+    metadata={'description': 'The number of results returned per page. Defaults to 20.'},
 )
 
 
@@ -186,10 +186,10 @@ class TwoYearTransactionPeriod(fields.Int):
             )
 
 
-election_full = fields.Bool(missing=True, description=docs.ELECTION_FULL)
+election_full = fields.Bool(load_default=True, metadata={'description': docs.ELECTION_FULL})
 
 paging = {
-    'page': Natural(missing=1, description='For paginating through results, starting at page 1'),
+    'page': Natural(load_default=1, metadata={'description': 'For paginating through results, starting at page 1'}),
     'per_page': per_page,
 }
 
@@ -280,26 +280,26 @@ def make_sort_args(
 
     args = {
         'sort': fields.Str(
-            missing=default,
+            load_default=default,
             validate=validator,
-            description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
+            metadata={'description': 'Provide a field to sort by. Use `-` for descending order.\n{}'.format(
                 additional_description
-            ),
+            )},
         ),
         'sort_hide_null': fields.Bool(
-            missing=default_hide_null,
-            description='Hide null values on sorted column(s).'
+            load_default=default_hide_null,
+            metadata={'description': 'Hide null values on sorted column(s).'}
         ),
         'sort_null_only': fields.Bool(
-            missing=default_nulls_only,
-            description='Toggle that filters out all rows having sort column that is non-null'
+            load_default=default_nulls_only,
+            metadata={'description': 'Toggle that filters out all rows having sort column that is non-null'}
         ),
 
     }
     if show_nulls_last_arg:
         args['sort_nulls_last'] = fields.Bool(
-            missing=default_sort_nulls_last,
-            description='Toggle that sorts null values last'
+            load_default=default_sort_nulls_last,
+            metadata={'description': 'Toggle that sorts null values last'}
         )
     return args
 
@@ -310,9 +310,10 @@ def make_multi_sort_args(default=None, validator=None, default_hide_null=False, 
     args = make_sort_args(default, validator, default_hide_null, default_nulls_only,
                           default_sort_nulls_last, show_nulls_last_arg, additional_description)
 
-    args['sort'] = fields.List(fields.Str, missing=default, validate=validator, required=False, allow_none=True,
-                               description='Provide a field to sort by. Use `-` for descending order.\n{}'.format(
-                                additional_description))
+    args['sort'] = fields.List(
+        fields.Str, load_default=default, validate=validator, required=False, allow_none=True,
+        metadata={'description': 'Provide a field to sort by. Use `-` for descending order.\n{}'.format(
+                                additional_description)})
     return args
 
 
@@ -320,8 +321,8 @@ def make_seek_args(field=fields.Int, description=None):
     return {
         'per_page': per_page,
         'last_index': field(
-            missing=None,
-            description=description or 'Index of last result from previous page',
+            load_default=None,
+            metadata={'description': description or 'Index of last result from previous page'},
         ),
     }
 
@@ -340,135 +341,138 @@ disbursment_purpose_list = ['ADMINISTRATIVE',
                             'TRAVEL']
 
 names = {
-    'q': fields.List(Keyword, required=True, description='Name (candidate or committee) to search for'),
+    'q': fields.List(Keyword, required=True, metadata={'description': 'Name (candidate or committee) to search for'}),
 }
 
 
 # for endpoint: /legal/search/ (resources/legal.py/UniversalSearch)
 legal_universal_search = {
-    'q': fields.Str(required=False, description=docs.TEXT_SEARCH),
-    'from_hit': fields.Int(required=False, description=docs.FROM_HIT),
-    'hits_returned': fields.Int(required=False, description=docs.HITS_RETURNED),
+    'q': fields.Str(required=False, metadata={'description': docs.TEXT_SEARCH}),
+    'from_hit': fields.Int(required=False, metadata={'description': docs.FROM_HIT}),
+    'hits_returned': fields.Int(required=False, metadata={'description': docs.HITS_RETURNED}),
     'type': fields.Str(
             validate=validate.OneOf(['', 'admin_fines', 'adrs', 'advisory_opinions',
                                      'murs', 'statutes']),
-            description=docs.LEGAL_DOC_TYPE),
+            metadata={'description': docs.LEGAL_DOC_TYPE}),
 
-    'ao_no': fields.List(IStr, required=False, description=docs.AO_NUMBER),
-    'ao_year': fields.Int(required=False, description=docs.AO_YEAR),
-    'ao_name': fields.List(IStr, required=False, description=docs.AO_NAME),
-    'ao_min_issue_date': Date(description=docs.AO_MIN_ISSUE_DATE),
-    'ao_max_issue_date': Date(description=docs.AO_MAX_ISSUE_DATE),
-    'ao_min_request_date': Date(description=docs.AO_MIN_REQUEST_DATE),
-    'ao_max_request_date': Date(description=docs.AO_MAX_REQUEST_DATE),
-    'ao_min_document_date': Date(description=docs.AO_MIN_DOCUMENT_DATE),
-    'ao_max_document_date': Date(description=docs.AO_MAX_DOCUMENT_DATE),
+    'ao_no': fields.List(IStr, required=False, metadata={'description': docs.AO_NUMBER}),
+    'ao_year': fields.Int(required=False, metadata={'description': docs.AO_YEAR}),
+    'ao_name': fields.List(IStr, required=False, metadata={'description': docs.AO_NAME}),
+    'ao_min_issue_date': Date(metadata={'description': docs.AO_MIN_ISSUE_DATE}),
+    'ao_max_issue_date': Date(metadata={'description': docs.AO_MAX_ISSUE_DATE}),
+    'ao_min_request_date': Date(metadata={'description': docs.AO_MIN_REQUEST_DATE}),
+    'ao_max_request_date': Date(metadata={'description': docs.AO_MAX_REQUEST_DATE}),
+    'ao_min_document_date': Date(metadata={'description': docs.AO_MIN_DOCUMENT_DATE}),
+    'ao_max_document_date': Date(metadata={'description': docs.AO_MAX_DOCUMENT_DATE}),
     'ao_doc_category_id': fields.List(
         IStr(validate=validate.OneOf(['', 'F', 'V', 'D', 'R', 'W', 'C', 'S'])),
-        description=docs.AO_DOC_CATEGORY_ID),
-    'ao_is_pending': fields.Bool(description=docs.AO_IS_PENDING),
-    'ao_status': fields.Str(description=docs.AO_STATUS),
-    'ao_requestor': fields.Str(description=docs.AO_REQUESTOR),
+        metadata={'description': docs.AO_DOC_CATEGORY_ID}),
+    'ao_is_pending': fields.Bool(metadata={'description': docs.AO_IS_PENDING}),
+    'ao_status': fields.Str(metadata={'description': docs.AO_STATUS}),
+    'ao_requestor': fields.Str(metadata={'description': docs.AO_REQUESTOR}),
     'ao_requestor_type': fields.List(IStr(
         validate=validate.OneOf(['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
                                 '12', '13', '14', '15', '16'])),
-                                description=docs.AO_REQUESTOR_TYPE),
-    'ao_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
-    'ao_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
-    'ao_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
-    'ao_commenter': fields.Str(description=docs.AO_COMMENTER),
-    'ao_representative': fields.Str(description=docs.AO_REPRESENTATIVE),
-    'case_no': fields.List(IStr, required=False, description=docs.CASE_NO),
-    'case_respondents': IStr(required=False, description=docs.CASE_RESPONDENTS),
-    'case_election_cycles': fields.Int(required=False, description=docs.CASE_ELECTION_CYCLES),
-    'case_min_open_date': Date(required=False, description=docs.CASE_MIN_OPEN_DATE),
+                                metadata={'description': docs.AO_REQUESTOR_TYPE}),
+    'ao_regulatory_citation': fields.List(IStr, required=False, metadata={'description': docs.REGULATORY_CITATION}),
+    'ao_statutory_citation': fields.List(IStr, required=False, metadata={'description': docs.STATUTORY_CITATION}),
+    'ao_citation_require_all': fields.Bool(metadata={'description': docs.CITATION_REQUIRE_ALL}),
+    'ao_commenter': fields.Str(metadata={'description': docs.AO_COMMENTER}),
+    'ao_representative': fields.Str(metadata={'description': docs.AO_REPRESENTATIVE}),
+    'case_no': fields.List(IStr, required=False, metadata={'description': docs.CASE_NO}),
+    'case_respondents': IStr(required=False, metadata={'description': docs.CASE_RESPONDENTS}),
+    'case_election_cycles': fields.Int(required=False, metadata={'description': docs.CASE_ELECTION_CYCLES}),
+    'case_min_open_date': Date(required=False, metadata={'description': docs.CASE_MIN_OPEN_DATE}),
     'primary_subject_id': fields.List(IStr(
         validate=validate.OneOf(
             ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
                 '12', '13', '14', '15', '16', '17', '18', '19', '20'])),
-            description=docs.PRIMARY_SUBJECT_DESCRIPTION),
+            metadata={'description': docs.PRIMARY_SUBJECT_DESCRIPTION}),
     'secondary_subject_id': fields.List(IStr(
         validate=validate.OneOf(
             ['', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
                 '12', '13', '14', '15', '16', '17', '18'])),
-            description=docs.SECONDARY_SUBJECT_DESCRIPTION),
-    'case_max_open_date': Date(required=False, description=docs.CASE_MAX_OPEN_DATE),
-    'case_min_close_date': Date(required=False, description=docs.CASE_MIN_CLOSE_DATE),
-    'case_max_close_date': Date(required=False, description=docs.CASE_MAX_CLOSE_DATE),
-    'case_min_document_date': Date(required=False, description=docs.CASE_MIN_DOCUMENT_DATE),
-    'case_max_document_date': Date(required=False, description=docs.CASE_MAX_DOCUMENT_DATE),
-    'case_regulatory_citation': fields.List(IStr, required=False, description=docs.REGULATORY_CITATION),
-    'case_statutory_citation': fields.List(IStr, required=False, description=docs.STATUTORY_CITATION),
-    'case_citation_require_all': fields.Bool(description=docs.CITATION_REQUIRE_ALL),
-    'q_exclude': IStr(required=False, description=docs.Q_EXCLUDE),
+            metadata={'description': docs.SECONDARY_SUBJECT_DESCRIPTION}),
+    'case_max_open_date': Date(required=False, metadata={'description': docs.CASE_MAX_OPEN_DATE}),
+    'case_min_close_date': Date(required=False, metadata={'description': docs.CASE_MIN_CLOSE_DATE}),
+    'case_max_close_date': Date(required=False, metadata={'description': docs.CASE_MAX_CLOSE_DATE}),
+    'case_min_document_date': Date(required=False, metadata={'description': docs.CASE_MIN_DOCUMENT_DATE}),
+    'case_max_document_date': Date(required=False, metadata={'description': docs.CASE_MAX_DOCUMENT_DATE}),
+    'case_regulatory_citation': fields.List(IStr, required=False, metadata={'description': docs.REGULATORY_CITATION}),
+    'case_statutory_citation': fields.List(IStr, required=False, metadata={'description': docs.STATUTORY_CITATION}),
+    'case_citation_require_all': fields.Bool(metadata={'description': docs.CITATION_REQUIRE_ALL}),
+    'q_exclude': IStr(required=False, metadata={'description': docs.Q_EXCLUDE}),
     'case_doc_category_id': fields.List(IStr(
         validate=validate.OneOf(
             ['', '1', '2', '3', '4', '5', '6', '1001', '1002', '1003', '1004', '1005', '1006', '2001'])),
-        description=docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION),
+        metadata={'description': docs.CASE_DOCUMENT_CATEGORY_DESCRIPTION}),
 
     'mur_type': fields.Str(
-        required=False, validate=validate.OneOf(['', 'archived', 'current']), description=docs.MUR_TYPE),
+        required=False, validate=validate.OneOf(['', 'archived', 'current']), metadata={'description': docs.MUR_TYPE}),
     'mur_disposition_category_id': fields.List(IStr(
         validate=validate.OneOf([
             '', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
             '11', '12', '13', '14', '15', '16', '17', '18'])),
-        description=docs.MUR_DISPOSITION_CATEGORY_DESCRIPTION
+        metadata={'description': docs.MUR_DISPOSITION_CATEGORY_DESCRIPTION}
     ),
 
-    'af_name': fields.List(IStr, required=False, description=docs.AF_NAME),
-    'af_committee_id': Committee_ID(required=False, description=docs.AF_COMMITTEE_ID),
-    'af_report_year': IStr(required=False, description=docs.AF_REPORT_YEAR),
-    'af_min_rtb_date': Date(required=False, description=docs.AF_MIN_RTB_DATE),
-    'af_max_rtb_date': Date(required=False, description=docs.AF_MAX_RTB_DATE),
-    'af_rtb_fine_amount': fields.Int(required=False, description=docs.AF_RTB_FINE_AMOUNT),
-    'af_min_fd_date': Date(required=False, description=docs.AF_MIN_FD_DATE),
-    'af_max_fd_date': Date(required=False, description=docs.AF_MAX_FD_DATE),
-    'af_fd_fine_amount': fields.Int(required=False, description=docs.AF_FD_FINE_AMOUNT),
-    'sort': IStr(required=False, description=docs.SORT),
-    'case_min_penalty_amount': fields.Str(required=False, description=docs.CASE_MIN_PENALTY_AMOUNT),
-    'case_max_penalty_amount': fields.Str(required=False, description=docs.CASE_MAX_PENALTY_AMOUNT),
-    'q_proximity': fields.List(fields.Str, description=docs.Q_PROXIMITY),
-    'max_gaps': fields.Int(required=False, description=docs.MAX_GAPS),
-    'proximity_preserve_order': fields.Bool(required=False, description=docs.PROXIMITY_PRESERVE_ORDER),
-    'proximity_filter': fields.Str(validate=validate.OneOf(["after", "before"]), description=docs.PROXIMITY_FILTER),
-    'proximity_filter_term': fields.Str(required=False, description=docs.PROXIMITY_FILTER_TERM),
-    'filename': fields.Str(required=False, description=docs.FILENAME),
+    'af_name': fields.List(IStr, required=False, metadata={'description': docs.AF_NAME}),
+    'af_committee_id': Committee_ID(required=False, metadata={'description': docs.AF_COMMITTEE_ID}),
+    'af_report_year': IStr(required=False, metadata={'description': docs.AF_REPORT_YEAR}),
+    'af_min_rtb_date': Date(required=False, metadata={'description': docs.AF_MIN_RTB_DATE}),
+    'af_max_rtb_date': Date(required=False, metadata={'description': docs.AF_MAX_RTB_DATE}),
+    'af_rtb_fine_amount': fields.Int(required=False, metadata={'description': docs.AF_RTB_FINE_AMOUNT}),
+    'af_min_fd_date': Date(required=False, metadata={'description': docs.AF_MIN_FD_DATE}),
+    'af_max_fd_date': Date(required=False, metadata={'description': docs.AF_MAX_FD_DATE}),
+    'af_fd_fine_amount': fields.Int(required=False, metadata={'description': docs.AF_FD_FINE_AMOUNT}),
+    'sort': IStr(required=False, metadata={'description': docs.SORT}),
+    'case_min_penalty_amount': fields.Str(required=False, metadata={'description': docs.CASE_MIN_PENALTY_AMOUNT}),
+    'case_max_penalty_amount': fields.Str(required=False, metadata={'description': docs.CASE_MAX_PENALTY_AMOUNT}),
+    'q_proximity': fields.List(fields.Str, metadata={'description': docs.Q_PROXIMITY}),
+    'max_gaps': fields.Int(required=False, metadata={'description': docs.MAX_GAPS}),
+    'proximity_preserve_order': fields.Bool(required=False, metadata={'description': docs.PROXIMITY_PRESERVE_ORDER}),
+    'proximity_filter': fields.Str(validate=validate.OneOf(["after", "before"]),
+                                   metadata={'description': docs.PROXIMITY_FILTER}),
+    'proximity_filter_term': fields.Str(required=False, metadata={'description': docs.PROXIMITY_FILTER_TERM}),
+    'filename': fields.Str(required=False, metadata={'description': docs.FILENAME}),
 }
 
 citation = {
     'doc_type': fields.Str(
                 required=False, validate=validate.OneOf(['', 'adrs', 'advisory_opinions', 'murs']),
-                description=docs.CITATION_DOC_TYPE
+                metadata={'description': docs.CITATION_DOC_TYPE}
             )
 }
 
 candidate_detail = {
-    'cycle': fields.List(fields.Int, description=docs.CANDIDATE_CYCLE),
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
-    'state': fields.List(IStr, description=docs.STATE),
-    'party': fields.List(IStr, description=docs.PARTY),
-    'year': fields.Str(attribute='year', description=docs.YEAR),
-    'district': fields.List(District, description=docs.DISTRICT),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.CANDIDATE_CYCLE}),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.ELECTION_YEAR}),
+    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])),
+                          metadata={'description': docs.OFFICE}),
+    'state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'year': fields.Str(attribute='year', metadata={'description': docs.YEAR}),
+    'district': fields.List(District, metadata={'description': docs.DISTRICT}),
     'candidate_status': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'F', 'N', 'P'])),
-        description=docs.CANDIDATE_STATUS,
+        metadata={'description': docs.CANDIDATE_STATUS},
     ),
     'incumbent_challenge': fields.List(
         IStr(validate=validate.OneOf(['', 'I', 'C', 'O'])),
-        description=docs.INCUMBENT_CHALLENGE,
+        metadata={'description': docs.INCUMBENT_CHALLENGE},
     ),
-    'federal_funds_flag': fields.Bool(description=docs.FEDERAL_FUNDS_FLAG),
-    'has_raised_funds': fields.Bool(description=docs.HAS_RAISED_FUNDS),
-    'name': fields.List(fields.Str, description='Name (candidate or committee) to search for. Alias for \'q\'.'),
+    'federal_funds_flag': fields.Bool(metadata={'description': docs.FEDERAL_FUNDS_FLAG}),
+    'has_raised_funds': fields.Bool(metadata={'description': docs.HAS_RAISED_FUNDS}),
+    'name': fields.List(fields.Str,
+                        metadata={'description': 'Name (candidate or committee) to search for. Alias for \'q\'.'}),
 }
 
 candidate_list = {
-    'q': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'min_first_file_date': Date(description=docs.CANDIDATE_MIN_FIRST_FILE_DATE),
-    'max_first_file_date': Date(description=docs.CANDIDATE_MAX_FIRST_FILE_DATE),
-    'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
+    'q': fields.List(Keyword, metadata={'description': docs.CANDIDATE_NAME}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'min_first_file_date': Date(metadata={'description': docs.CANDIDATE_MIN_FIRST_FILE_DATE}),
+    'max_first_file_date': Date(metadata={'description': docs.CANDIDATE_MAX_FIRST_FILE_DATE}),
+    'is_active_candidate': fields.Bool(metadata={'description': docs.ACTIVE_CANDIDATE}),
 }
 
 candidate_history = {
@@ -476,44 +480,44 @@ candidate_history = {
 }
 
 committee = {
-    'year': fields.List(fields.Int, description=docs.COMMITTEE_YEAR),
-    'cycle': fields.List(fields.Int, description=docs.COMMITTEE_CYCLE),
+    'year': fields.List(fields.Int, metadata={'description': docs.COMMITTEE_YEAR}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.COMMITTEE_CYCLE}),
     'filing_frequency': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'M', 'N', 'Q', 'T', 'W', '-A', '-T'])),
-        description=docs.FILING_FREQUENCY,
+        metadata={'description': docs.FILING_FREQUENCY},
     ),
     'designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
     'organization_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+        metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
 }
 
 committee_list = {
-    'q': fields.List(Keyword, description=docs.COMMITTEE_NAME),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'state': fields.List(IStr, description=docs.STATE_GENERIC),
-    'party': fields.List(IStr, description=docs.PARTY),
-    'min_first_file_date': Date(description=docs.MIN_FIRST_FILE_DATE),
-    'max_first_file_date': Date(description=docs.MAX_FIRST_FILE_DATE),
-    'min_last_file_date': Date(description=docs.MIN_LAST_FILE_DATE),
-    'max_last_file_date': Date(description=docs.MAX_LAST_FILE_DATE),
-    'min_first_f1_date': Date(description=docs.MIN_FIRST_F1_DATE),
-    'max_first_f1_date': Date(description=docs.MAX_FIRST_F1_DATE),
-    'min_last_f1_date': Date(description=docs.MIN_LAST_F1_DATE),
-    'max_last_f1_date': Date(description=docs.MAX_LAST_F1_DATE),
-    'treasurer_name': fields.List(Keyword, description=docs.TREASURER_NAME),
-    'sponsor_candidate_id': fields.List(Candidate_ID, description=docs.SPONSOR_CANDIDATE_ID),
+    'q': fields.List(Keyword, metadata={'description': docs.COMMITTEE_NAME}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'state': fields.List(IStr, metadata={'description': docs.STATE_GENERIC}),
+    'party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'min_first_file_date': Date(metadata={'description': docs.MIN_FIRST_FILE_DATE}),
+    'max_first_file_date': Date(metadata={'description': docs.MAX_FIRST_FILE_DATE}),
+    'min_last_file_date': Date(metadata={'description': docs.MIN_LAST_FILE_DATE}),
+    'max_last_file_date': Date(metadata={'description': docs.MAX_LAST_FILE_DATE}),
+    'min_first_f1_date': Date(metadata={'description': docs.MIN_FIRST_F1_DATE}),
+    'max_first_f1_date': Date(metadata={'description': docs.MAX_FIRST_F1_DATE}),
+    'min_last_f1_date': Date(metadata={'description': docs.MIN_LAST_F1_DATE}),
+    'max_last_f1_date': Date(metadata={'description': docs.MAX_LAST_F1_DATE}),
+    'treasurer_name': fields.List(Keyword, metadata={'description': docs.TREASURER_NAME}),
+    'sponsor_candidate_id': fields.List(Candidate_ID, metadata={'description': docs.SPONSOR_CANDIDATE_ID}),
 }
 
 
@@ -521,432 +525,436 @@ committee_history = {
     'election_full': election_full,
     'designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
 }
 
 # used for endpoint:`/filings/`
 # under tag: filing
 filings = {
-    'committee_type': fields.Str(description=docs.COMMITTEE_TYPE),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'is_amended': fields.Bool(description=docs.IS_AMENDED),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT),
-    'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
-    'request_type': fields.List(IStr, description=docs.REQUEST_TYPE),
-    'document_type': fields.List(IStr, description=docs.DOC_TYPE),
-    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'min_receipt_date': Date(description=docs.MIN_RECEIPT_DATE),
-    'max_receipt_date': Date(description=docs.MAX_RECEIPT_DATE),
-    'form_type': fields.List(IStr, description=docs.FORM_TYPE),
-    'state': fields.List(IStr, description=docs.STATE),
-    'district': fields.List(IStr, description=docs.DISTRICT),
-    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
-    'party': fields.List(IStr, description=docs.PARTY),
+    'committee_type': fields.Str(metadata={'description': docs.COMMITTEE_TYPE}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'is_amended': fields.Bool(metadata={'description': docs.IS_AMENDED}),
+    'most_recent': fields.Bool(metadata={'description': docs.MOST_RECENT}),
+    'report_type': fields.List(IStr, metadata={'description': docs.REPORT_TYPE}),
+    'request_type': fields.List(IStr, metadata={'description': docs.REQUEST_TYPE}),
+    'document_type': fields.List(IStr, metadata={'description': docs.DOC_TYPE}),
+    'beginning_image_number': fields.List(ImageNumber, metadata={'description': docs.BEGINNING_IMAGE_NUMBER}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'min_receipt_date': Date(metadata={'description': docs.MIN_RECEIPT_DATE}),
+    'max_receipt_date': Date(metadata={'description': docs.MAX_RECEIPT_DATE}),
+    'form_type': fields.List(IStr, metadata={'description': docs.FORM_TYPE}),
+    'state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'district': fields.List(IStr, metadata={'description': docs.DISTRICT}),
+    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])),
+                          metadata={'description': docs.OFFICE}),
+    'party': fields.List(IStr, metadata={'description': docs.PARTY}),
     'filer_type': fields.Str(
         validate=validate.OneOf(['e-file', 'paper']),
-        description=docs.MEANS_FILED,
+        metadata={'description': docs.MEANS_FILED},
     ),
-    'file_number': fields.List(fields.Int, description=docs.FILE_NUMBER),
-    'primary_general_indicator': fields.List(IStr, description=docs.PRIMARY_GENERAL_INDICTOR),
+    'file_number': fields.List(fields.Int, metadata={'description': docs.FILE_NUMBER}),
+    'primary_general_indicator': fields.List(IStr, metadata={'description': docs.PRIMARY_GENERAL_INDICTOR}),
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
-        description=docs.AMENDMENT_INDICATOR),
-    'form_category': fields.List(IStr, description=docs.FORM_CATEGORY),
-    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
+        metadata={'description': docs.AMENDMENT_INDICATOR}),
+    'form_category': fields.List(IStr, metadata={'description': docs.FORM_CATEGORY}),
+    'q_filer': fields.List(Keyword, metadata={'description': docs.FILER_NAME_TEXT}),
 }
 
 efilings = {
-    'file_number': fields.List(fields.Int, description=docs.FILE_NUMBER),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    'min_receipt_date': Date(description=docs.MIN_RECEIPT_DATE),
-    'max_receipt_date': Date(description=docs.MAX_RECEIPT_DATE),
-    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
-    'form_type': fields.List(IStr, description=docs.FORM_TYPE_EFILING),
+    'file_number': fields.List(fields.Int, metadata={'description': docs.FILE_NUMBER}),
+    'committee_id': fields.List(IStr, metadata={'description': docs.COMMITTEE_ID}),
+    'min_receipt_date': Date(metadata={'description': docs.MIN_RECEIPT_DATE}),
+    'max_receipt_date': Date(metadata={'description': docs.MAX_RECEIPT_DATE}),
+    'q_filer': fields.List(Keyword, metadata={'description': docs.FILER_NAME_TEXT}),
+    'form_type': fields.List(IStr, metadata={'description': docs.FORM_TYPE_EFILING}),
 }
 
 form2efilings = {
-    'file_number': fields.List(fields.Int, description=docs.FILE_NUMBER),
-    'committee_id': fields.List(IStr, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(IStr, description=docs.CANDIDATE_ID),
-    'election_state': fields.List(IStr, description=docs.ELECTION_STATE),
+    'file_number': fields.List(fields.Int, metadata={'description': docs.FILE_NUMBER}),
+    'committee_id': fields.List(IStr, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(IStr, metadata={'description': docs.CANDIDATE_ID}),
+    'election_state': fields.List(IStr, metadata={'description': docs.ELECTION_STATE}),
     'candidate_office': fields.List(fields.Str(
         validate=validate.OneOf(['', 'H', 'S', 'P'])),
-        description=docs.OFFICE),
-    'candidate_district': fields.List(IStr, description=docs.ELECTION_DISTRICT),
-    'candidate_party': fields.List(IStr, description=docs.PARTY),
-    'image_number': fields.List(IStr, description=docs.IMAGE_NUMBER),
-    'min_load_timestamp': Date(description=docs.LOAD_DATE),
-    'max_load_timestamp': Date(description=docs.LOAD_DATE),
+        metadata={'description': docs.OFFICE}),
+    'candidate_district': fields.List(IStr, metadata={'description': docs.ELECTION_DISTRICT}),
+    'candidate_party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'image_number': fields.List(IStr, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
+    'max_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
 }
 
 form1efilings = {
-    'file_number': fields.List(FileNumber, description=docs.FILE_NUMBER),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'election_state': fields.List(IStr, description=docs.ELECTION_STATE),
+    'file_number': fields.List(FileNumber, metadata={'description': docs.FILE_NUMBER}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'election_state': fields.List(IStr, metadata={'description': docs.ELECTION_STATE}),
     'candidate_office': fields.List(fields.Str(
         validate=validate.OneOf(['', 'H', 'S', 'P'])),
-        description=docs.OFFICE),
-    'candidate_district': fields.List(IStr, description=docs.ELECTION_DISTRICT),
-    'candidate_party': fields.List(IStr, description=docs.PARTY),
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_load_timestamp': Date(description=docs.LOAD_DATE),
-    'max_load_timestamp': Date(description=docs.LOAD_DATE),
-    'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
+        metadata={'description': docs.OFFICE}),
+    'candidate_district': fields.List(IStr, metadata={'description': docs.ELECTION_DISTRICT}),
+    'candidate_party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
+    'max_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
+    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
     'organization_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+        metadata={'description': docs.ORGANIZATION_TYPE},
     ),
 }
 
 reports = {
-    'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
-    'is_amended': fields.Bool(description=docs.IS_AMENDED),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT),
+    'year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'beginning_image_number': fields.List(ImageNumber, metadata={'description': docs.BEGINNING_IMAGE_NUMBER}),
+    'report_type': fields.List(fields.Str, metadata={'description': docs.BASE_REPORT_TYPE_W_EXCLUDE}),
+    'is_amended': fields.Bool(metadata={'description': docs.IS_AMENDED}),
+    'most_recent': fields.Bool(metadata={'description': docs.MOST_RECENT}),
     'filer_type': fields.Str(
         validate=validate.OneOf(['e-file', 'paper']),
-        description=docs.MEANS_FILED,
+        metadata={'description': docs.MEANS_FILED},
     ),
-    'min_disbursements_amount': Currency(description=docs.MIN_FILTER),
-    'max_disbursements_amount': Currency(description=docs.MAX_FILTER),
-    'min_receipts_amount': Currency(description=docs.MIN_FILTER),
-    'max_receipts_amount': Currency(description=docs.MAX_FILTER),
-    'max_receipt_date': Date(description=docs.MAX_REPORT_RECEIPT_DATE),
-    'min_receipt_date': Date(description=docs.MIN_REPORT_RECEIPT_DATE),
-    'min_cash_on_hand_end_period_amount': Currency(description=docs.MIN_FILTER),
-    'max_cash_on_hand_end_period_amount': Currency(description=docs.MAX_FILTER),
-    'min_debts_owed_amount': Currency(description=docs.MIN_FILTER),
-    'max_debts_owed_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_independent_expenditures': Currency(description=docs.MIN_FILTER),
-    'max_independent_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_party_coordinated_expenditures': Currency(description=docs.MIN_FILTER),
-    'max_party_coordinated_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_total_contributions': Currency(description=docs.MIN_FILTER),
-    'max_total_contributions': Currency(description=docs.MAX_FILTER),
-    'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
+    'min_disbursements_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_disbursements_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_receipts_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_receipts_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'max_receipt_date': Date(metadata={'description': docs.MAX_REPORT_RECEIPT_DATE}),
+    'min_receipt_date': Date(metadata={'description': docs.MIN_REPORT_RECEIPT_DATE}),
+    'min_cash_on_hand_end_period_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_cash_on_hand_end_period_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_debts_owed_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_debts_owed_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_independent_expenditures': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_independent_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_party_coordinated_expenditures': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_party_coordinated_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_total_contributions': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_total_contributions': Currency(metadata={'description': docs.MAX_FILTER}),
+    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
     # AUTHORIZING CANDIDATE
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
     'amendment_indicator': fields.List(
         IStr(validate=validate.OneOf(['', 'N', 'A', 'T', 'C', 'M', 'S'])),
-        description=docs.AMENDMENT_INDICATOR),
-    'q_filer': fields.List(Keyword, description=docs.FILER_NAME_TEXT),
-    'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
+        metadata={'description': docs.AMENDMENT_INDICATOR}),
+    'q_filer': fields.List(Keyword, metadata={'description': docs.FILER_NAME_TEXT}),
+    'q_spender': fields.List(Keyword, metadata={'description': docs.SPENDER_NAME_TEXT}),
 }
 
 committee_reports = {
-    'year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_type': fields.List(fields.Str, description=docs.BASE_REPORT_TYPE_W_EXCLUDE),
-    'is_amended': fields.Bool(description=docs.IS_AMENDED),
-    'min_disbursements_amount': Currency(description=docs.MIN_FILTER),
-    'max_disbursements_amount': Currency(description=docs.MAX_FILTER),
-    'min_receipts_amount': Currency(description=docs.MIN_FILTER),
-    'max_receipts_amount': Currency(description=docs.MAX_FILTER),
-    'min_cash_on_hand_end_period_amount': Currency(description=docs.MIN_FILTER),
-    'max_cash_on_hand_end_period_amount': Currency(description=docs.MAX_FILTER),
-    'min_debts_owed_amount': Currency(description=docs.MIN_FILTER),
-    'max_debts_owed_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_independent_expenditures': Currency(description=docs.MIN_FILTER),
-    'max_independent_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_party_coordinated_expenditures': Currency(description=docs.MIN_FILTER),
-    'max_party_coordinated_expenditures': Currency(description=docs.MAX_FILTER),
-    'min_total_contributions': Currency(description=docs.MIN_FILTER),
-    'max_total_contributions': Currency(description=docs.MAX_FILTER),
-    'type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE)
+    'year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'beginning_image_number': fields.List(ImageNumber, metadata={'description': docs.BEGINNING_IMAGE_NUMBER}),
+    'report_type': fields.List(fields.Str, metadata={'description': docs.BASE_REPORT_TYPE_W_EXCLUDE}),
+    'is_amended': fields.Bool(metadata={'description': docs.IS_AMENDED}),
+    'min_disbursements_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_disbursements_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_receipts_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_receipts_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_cash_on_hand_end_period_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_cash_on_hand_end_period_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_debts_owed_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_debts_owed_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_independent_expenditures': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_independent_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_party_coordinated_expenditures': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_party_coordinated_expenditures': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_total_contributions': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_total_contributions': Currency(metadata={'description': docs.MAX_FILTER}),
+    'type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE})
 }
 
 committee_totals = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
 }
 
 totals_by_entity_type = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'committee_designation': fields.List(fields.Str, description=docs.DESIGNATION),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
-    'committee_state': fields.List(IStr, description=docs.STATE_GENERIC),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'committee_designation': fields.List(fields.Str, metadata={'description': docs.DESIGNATION}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
+    'committee_state': fields.List(IStr, metadata={'description': docs.STATE_GENERIC}),
     'filing_frequency': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'M', 'N', 'Q', 'T', 'W', '-A', '-T'])),
-        description=docs.FILING_FREQUENCY,
+        metadata={'description': docs.FILING_FREQUENCY},
     ),
-    'treasurer_name': fields.List(Keyword, description=docs.TREASURER_NAME),
-    'min_disbursements': Currency(description=docs.MIN_FILTER),
-    'max_disbursements': Currency(description=docs.MAX_FILTER),
-    'min_receipts': Currency(description=docs.MIN_FILTER),
-    'max_receipts': Currency(description=docs.MAX_FILTER),
-    'min_last_cash_on_hand_end_period': Currency(description=docs.MIN_FILTER),
-    'max_last_cash_on_hand_end_period': Currency(description=docs.MAX_FILTER),
-    'min_last_debts_owed_by_committee': Currency(description=docs.MIN_FILTER),
-    'max_last_debts_owed_by_committee': Currency(description=docs.MAX_FILTER),
+    'treasurer_name': fields.List(Keyword, metadata={'description': docs.TREASURER_NAME}),
+    'min_disbursements': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_disbursements': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_receipts': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_receipts': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_last_cash_on_hand_end_period': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_last_cash_on_hand_end_period': Currency(metadata={'description': docs.MAX_FILTER}),
+    'min_last_debts_owed_by_committee': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_last_debts_owed_by_committee': Currency(metadata={'description': docs.MAX_FILTER}),
 
     # sponsor_candidate_id Only for 'pac' and 'pac-party'
-    'sponsor_candidate_id': fields.List(Candidate_ID, description=docs.SPONSOR_CANDIDATE_ID),
+    'sponsor_candidate_id': fields.List(Candidate_ID, metadata={'description': docs.SPONSOR_CANDIDATE_ID}),
     'organization_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+        metadata={'description': docs.ORGANIZATION_TYPE},
     ),
-    'min_first_f1_date': Date(description=docs.MIN_FIRST_F1_DATE),
-    'max_first_f1_date': Date(description=docs.MAX_FIRST_F1_DATE),
+    'min_first_f1_date': Date(metadata={'description': docs.MIN_FIRST_F1_DATE}),
+    'max_first_f1_date': Date(metadata={'description': docs.MAX_FIRST_F1_DATE}),
 }
 
 candidate_totals_detail = {
     # no default value for election_full
-    'election_full': fields.Bool(description=docs.ELECTION_FULL),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'election_full': fields.Bool(metadata={'description': docs.ELECTION_FULL}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
 }
 
 # ====tag:dates -- endpoints [start]========
 calendar_dates = {
-    'calendar_category_id': fields.List(fields.Int, description=docs.CATEGORY),
-    'description': fields.List(Keyword, description=docs.CAL_DESCRIPTION),
-    'summary': fields.List(Keyword, description=docs.SUMMARY),
-    'min_start_date': FullDate(description=docs.MIN_START_DATE),
-    'min_end_date': FullDate(description=docs.MIN_END_DATE),
-    'max_start_date': FullDate(description=docs.MAX_START_DATE),
-    'max_end_date': FullDate(description=docs.MAX_END_DATE),
-    'event_id': fields.Int(description=docs.EVENT_ID),
+    'calendar_category_id': fields.List(fields.Int, metadata={'description': docs.CATEGORY}),
+    'description': fields.List(Keyword, metadata={'description': docs.CAL_DESCRIPTION}),
+    'summary': fields.List(Keyword, metadata={'description': docs.SUMMARY}),
+    'min_start_date': FullDate(metadata={'description': docs.MIN_START_DATE}),
+    'min_end_date': FullDate(metadata={'description': docs.MIN_END_DATE}),
+    'max_start_date': FullDate(metadata={'description': docs.MAX_START_DATE}),
+    'max_end_date': FullDate(metadata={'description': docs.MAX_END_DATE}),
+    'event_id': fields.Int(metadata={'description': docs.EVENT_ID}),
 }
 
 election_dates = {
-    'election_state': fields.List(fields.Str, description=docs.ELECTION_STATE),
-    'election_district': fields.List(fields.Str, description=docs.ELECTION_DISTRICT),
-    'election_party': fields.List(fields.Str, description=docs.ELECTION_PARTY),
-    'office_sought': fields.List(fields.Str(validate=validate.OneOf(['H', 'S', 'P'])), description=docs.OFFICE_SOUGHT),
-    'min_election_date': Date(description=docs.MIN_ELECTION_DATE),
-    'max_election_date': Date(description=docs.MAX_ELECTION_DATE),
-    'election_type_id': fields.List(fields.Str, description=docs.ELECTION_TYPE_ID),
-    'min_create_date': Date(description=docs.MIN_CREATE_DATE),
-    'max_create_date': Date(description=docs.MAX_CREATE_DATE),
-    'min_update_date': Date(description=docs.MIN_UPDATE_DATE),
-    'max_update_date': Date(description=docs.MAX_UPDATE_DATE),
-    'election_year': fields.List(fields.Str, description=docs.ELECTION_YEAR),
-    'min_primary_general_date': Date(description=docs.MIN_PRIMARY_GENERAL_DATE),
-    'max_primary_general_date': Date(description=docs.MAX_PRIMARY_GENERAL_DATE),
+    'election_state': fields.List(fields.Str, metadata={'description': docs.ELECTION_STATE}),
+    'election_district': fields.List(fields.Str, metadata={'description': docs.ELECTION_DISTRICT}),
+    'election_party': fields.List(fields.Str, metadata={'description': docs.ELECTION_PARTY}),
+    'office_sought': fields.List(fields.Str(validate=validate.OneOf(['H', 'S', 'P'])),
+                                 metadata={'description': docs.OFFICE_SOUGHT}),
+    'min_election_date': Date(metadata={'description': docs.MIN_ELECTION_DATE}),
+    'max_election_date': Date(metadata={'description': docs.MAX_ELECTION_DATE}),
+    'election_type_id': fields.List(fields.Str, metadata={'description': docs.ELECTION_TYPE_ID}),
+    'min_create_date': Date(metadata={'description': docs.MIN_CREATE_DATE}),
+    'max_create_date': Date(metadata={'description': docs.MAX_CREATE_DATE}),
+    'min_update_date': Date(metadata={'description': docs.MIN_UPDATE_DATE}),
+    'max_update_date': Date(metadata={'description': docs.MAX_UPDATE_DATE}),
+    'election_year': fields.List(fields.Str, metadata={'description': docs.ELECTION_YEAR}),
+    'min_primary_general_date': Date(metadata={'description': docs.MIN_PRIMARY_GENERAL_DATE}),
+    'max_primary_general_date': Date(metadata={'description': docs.MAX_PRIMARY_GENERAL_DATE}),
 }
 
 reporting_dates = {
-    'min_due_date': Date(description=docs.MIN_DUE_DATE),
-    'max_due_date': Date(description=docs.MAX_DUE_DATE),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
-    'min_create_date': Date(description=docs.MIN_CREATE_DATE),
-    'max_create_date': Date(description=docs.MAX_CREATE_DATE),
-    'min_update_date': Date(description=docs.MIN_UPDATE_DATE),
-    'max_update_date': Date(description=docs.MAX_UPDATE_DATE),
+    'min_due_date': Date(metadata={'description': docs.MIN_DUE_DATE}),
+    'max_due_date': Date(metadata={'description': docs.MAX_DUE_DATE}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'report_type': fields.List(fields.Str, metadata={'description': docs.REPORT_TYPE}),
+    'min_create_date': Date(metadata={'description': docs.MIN_CREATE_DATE}),
+    'max_create_date': Date(metadata={'description': docs.MAX_CREATE_DATE}),
+    'min_update_date': Date(metadata={'description': docs.MIN_UPDATE_DATE}),
+    'max_update_date': Date(metadata={'description': docs.MAX_UPDATE_DATE}),
 }
 # ====tag:dates -- endpoints [end]========
 
 itemized = {
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
-    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
-    'min_amount': Currency(description='Filter for all amounts greater than a value.'),
-    'max_amount': Currency(description='Filter for all amounts less than a value.'),
-    'min_date': Date(description='Minimum date'),
-    'max_date': Date(description='Maximum date'),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_image_number': ImageNumber(metadata={'description': docs.MIN_IMAGE_NUMBER}),
+    'max_image_number': ImageNumber(metadata={'description': docs.MAX_IMAGE_NUMBER}),
+    'min_amount': Currency(metadata={'description': 'Filter for all amounts greater than a value.'}),
+    'max_amount': Currency(metadata={'description': 'Filter for all amounts less than a value.'}),
+    'min_date': Date(metadata={'description': 'Minimum date'}),
+    'max_date': Date(metadata={'description': 'Maximum date'}),
 }
 
 schedule_a = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
-    'contributor_name': fields.List(Keyword, description=docs.CONTRIBUTOR_NAME),
-    'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
-    'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'contributor_zip': fields.List(IStr, description=docs.CONTRIBUTOR_ZIP),
-    'contributor_employer': fields.List(Keyword, description=docs.CONTRIBUTOR_EMPLOYER),
-    'contributor_occupation': fields.List(Keyword, description=docs.CONTRIBUTOR_OCCUPATION),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'contributor_id': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_ID}),
+    'contributor_name': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_NAME}),
+    'contributor_city': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_CITY}),
+    'contributor_state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
+    'contributor_zip': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_ZIP}),
+    'contributor_employer': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_EMPLOYER}),
+    'contributor_occupation': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_OCCUPATION}),
     'last_contribution_receipt_date': Date(
-        missing=None,
-        description='When sorting by `contribution_receipt_date`, this is populated with the \
+        load_default=None,
+        metadata={'description': 'When sorting by `contribution_receipt_date`, this is populated with the \
         `contribution_receipt_date` of the last result. However, you will need to pass the index \
-        of that last result to `last_index` to get the next page.'
+        of that last result to `last_index` to get the next page.'}
     ),
     'last_contribution_receipt_amount': fields.Float(
-        missing=None,
-        description='When sorting by `contribution_receipt_amount`, this is populated with the \
+        load_default=None,
+        metadata={'description': 'When sorting by `contribution_receipt_amount`, this is populated with the \
         `contribution_receipt_amount` of the last result. However, you will need to pass the index \
-        of that last result to `last_index` to get the next page.'
+        of that last result to `last_index` to get the next page.'}
     ),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
-    'is_individual': fields.Bool(missing=None, description=docs.IS_INDIVIDUAL),
+    'line_number': fields.Str(metadata={'description': docs.LINE_NUMBER}),
+    'is_individual': fields.Bool(load_default=None, metadata={'description': docs.IS_INDIVIDUAL}),
     'contributor_type': fields.List(
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
-        description='Filters individual or committee contributions based on line number'
+        metadata={'description': 'Filters individual or committee contributions based on line number'}
     ),
     'two_year_transaction_period': fields.List(
         TwoYearTransactionPeriod,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+        metadata={'description': docs.TWO_YEAR_TRANSACTION_PERIOD},
     ),
     'recipient_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'recipient_committee_org_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+        metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'recipient_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
-    'min_load_date': Date(description=docs.MIN_LOAD_DATE),
-    'max_load_date': Date(description=docs.MAX_LOAD_DATE),
+    'min_load_date': Date(metadata={'description': docs.MIN_LOAD_DATE}),
+    'max_load_date': Date(metadata={'description': docs.MAX_LOAD_DATE}),
 }
 
 schedule_a_e_file = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    # 'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
-    'contributor_name': fields.List(Keyword, description=docs.CONTRIBUTOR_NAME),
-    'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
-    'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'contributor_employer': fields.List(Keyword, description=docs.CONTRIBUTOR_EMPLOYER),
-    'contributor_occupation': fields.List(Keyword, description=docs.CONTRIBUTOR_OCCUPATION)
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    # 'contributor_id': fields.List(IStr, 'description': docs.CONTRIBUTOR_ID),
+    'contributor_name': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_NAME}),
+    'contributor_city': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_CITY}),
+    'contributor_state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
+    'contributor_employer': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_EMPLOYER}),
+    'contributor_occupation': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_OCCUPATION})
 }
 
 schedule_a_by_size = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])),
+                        metadata={'description': docs.SIZE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_a_by_state = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'hide_null': fields.Bool(missing=False, description=docs.MISSING_STATE),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'hide_null': fields.Bool(load_default=False, metadata={'description': docs.MISSING_STATE}),
 }
 
 schedule_a_by_zip = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'zip': fields.List(fields.Str, description=docs.CONTRIBUTOR_ZIP),
-    'state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'zip': fields.List(fields.Str, metadata={'description': docs.CONTRIBUTOR_ZIP}),
+    'state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_a_by_employer = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'employer': fields.List(Keyword, description=docs.EMPLOYER),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'employer': fields.List(Keyword, metadata={'description': docs.EMPLOYER}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_a_by_occupation = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'occupation': fields.List(Keyword, description=docs.OCCUPATION),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'occupation': fields.List(Keyword, metadata={'description': docs.OCCUPATION}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_a_by_contributor = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'contributor_id': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_ID}),
 }
 
 schedule_b_by_purpose = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
     'purpose': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
-                           description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+                           metadata={'description': docs.DISBURSEMENT_PURPOSE_CATEGORY}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_b_by_recipient = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'recipient_name': fields.List(Keyword, metadata={'description': docs.RECIPIENT_NAME}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_b_by_recipient_id = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'recipient_id': fields.List(IStr, description=docs.RECIPIENT_ID),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'recipient_id': fields.List(IStr, metadata={'description': docs.RECIPIENT_ID}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 schedule_b = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'disbursement_description': fields.List(Keyword, metadata={'description': docs.DISBURSEMENT_DESCRIPTION}),
     'disbursement_purpose_category': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
-                                                 description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
-    'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
-    'last_disbursement_date': Date(missing=None, description=docs.LAST_DISBURSEMENT_DATE),
-    'line_number': fields.Str(description=docs.LINE_NUMBER),
-    'recipient_city': fields.List(IStr, description=docs.RECIPIENT_CITY),
-    'recipient_committee_id': fields.List(Committee_ID, description=docs.RECIPIENT_COMMITTEE_ID),
-    'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
-    'recipient_state': fields.List(IStr, description=docs.RECIPIENT_STATE),
+                                                 metadata={'description': docs.DISBURSEMENT_PURPOSE_CATEGORY}),
+    'last_disbursement_amount': fields.Float(load_default=None,
+                                             metadata={'description': docs.LAST_DISBURSEMENT_AMOUNT}),
+    'last_disbursement_date': Date(load_default=None, metadata={'description': docs.LAST_DISBURSEMENT_DATE}),
+    'line_number': fields.Str(metadata={'description': docs.LINE_NUMBER}),
+    'recipient_city': fields.List(IStr, metadata={'description': docs.RECIPIENT_CITY}),
+    'recipient_committee_id': fields.List(Committee_ID, metadata={'description': docs.RECIPIENT_COMMITTEE_ID}),
+    'recipient_name': fields.List(Keyword, metadata={'description': docs.RECIPIENT_NAME}),
+    'recipient_state': fields.List(IStr, metadata={'description': docs.RECIPIENT_STATE}),
     'spender_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
     'spender_committee_org_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
-        description=docs.ORGANIZATION_TYPE,
+        metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'two_year_transaction_period': fields.List(
         TwoYearTransactionPeriod,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+        metadata={'description': docs.TWO_YEAR_TRANSACTION_PERIOD},
     ),
 }
 
 schedule_b_efile = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    # 'recipient_committee_id': fields.List(IStr, description='The FEC identifier should be represented here
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    # 'recipient_committee_id': fields.List(IStr, 'description': 'The FEC identifier should be represented here
     # if the contributor is registered with the FEC.'),
-    # 'recipient_name': fields.List(fields.Str, description='Name of recipient'),
-    'disbursement_description': fields.List(Keyword, description='Description of disbursement'),
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'recipient_city': fields.List(IStr, description='City of recipient'),
-    'recipient_state': fields.List(IStr, description='State of recipient'),
+    # 'recipient_name': fields.List(fields.Str, 'description': 'Name of recipient'),
+    'disbursement_description': fields.List(Keyword, metadata={'description': 'Description of disbursement'}),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'recipient_city': fields.List(IStr, metadata={'description': 'City of recipient'}),
+    'recipient_state': fields.List(IStr, metadata={'description': 'State of recipient'}),
     'max_date': Date(
-        missing=None,
-        description='When sorting by `disbursement_date`, this is populated with the \
+        load_default=None,
+        metadata={'description': 'When sorting by `disbursement_date`, this is populated with the \
         `disbursement_date` of the last result. However, you will need to pass the index \
-        of that last result to `last_index` to get the next page.'
+        of that last result to `last_index` to get the next page.'}
     ),
     'min_date': Date(
-        missing=None,
-        description='When sorting by `disbursement_date`, this is populated with the \
+        load_default=None,
+        metadata={'description': 'When sorting by `disbursement_date`, this is populated with the \
         `disbursement_date` of the last result. However, you will need to pass the index \
-        of that last result to `last_index` to get the next page.'
+        of that last result to `last_index` to get the next page.'}
     ),
-    'min_amount': Currency(description='Filter for all amounts less than a value.'),
-    'max_amount': Currency(description='Filter for all amounts less than a value.'),
+    'min_amount': Currency(metadata={'description': 'Filter for all amounts less than a value.'}),
+    'max_amount': Currency(metadata={'description': 'Filter for all amounts less than a value.'}),
 }
 
 
 schedule_c = {
     # TODO(jmcarp) Request integer image numbers from FEC and update argument types
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
-    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
-    'min_amount': Currency(description=docs.MIN_FILTER),
-    'max_amount': Currency(description=docs.MAX_FILTER),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_name': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'loan_source_name': fields.List(Keyword, description=docs.LOAN_SOURCE),
-    'min_payment_to_date': fields.Int(description=docs.MIN_PAYMENT_DATE),
-    'max_payment_to_date': fields.Int(description=docs.MAX_PAYMENT_DATE),
-    'min_incurred_date': Date(missing=None, description=docs.MIN_INCURRED_DATE),
-    'max_incurred_date': Date(missing=None, description=docs.MAX_INCURRED_DATE),
-    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_image_number': ImageNumber(metadata={'description': docs.MIN_IMAGE_NUMBER}),
+    'max_image_number': ImageNumber(metadata={'description': docs.MAX_IMAGE_NUMBER}),
+    'min_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_name': fields.List(Keyword, metadata={'description': docs.CANDIDATE_NAME}),
+    'loan_source_name': fields.List(Keyword, metadata={'description': docs.LOAN_SOURCE}),
+    'min_payment_to_date': fields.Int(metadata={'description': docs.MIN_PAYMENT_DATE}),
+    'max_payment_to_date': fields.Int(metadata={'description': docs.MAX_PAYMENT_DATE}),
+    'min_incurred_date': Date(load_default=None, metadata={'description': docs.MIN_INCURRED_DATE}),
+    'max_incurred_date': Date(load_default=None, metadata={'description': docs.MAX_INCURRED_DATE}),
+    'form_line_number': fields.List(IStr, metadata={'description': docs.FORM_LINE_NUMBER}),
 }
 
 schedule_d = {
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
-    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_image_number': ImageNumber(metadata={'description': docs.MIN_IMAGE_NUMBER}),
+    'max_image_number': ImageNumber(metadata={'description': docs.MAX_IMAGE_NUMBER}),
     'min_payment_period': fields.Float(),
     'max_payment_period': fields.Float(),
     'min_amount_incurred': fields.Float(),
@@ -957,113 +965,113 @@ schedule_d = {
     'max_amount_outstanding_close': fields.Float(),
     'creditor_debtor_name': fields.List(Keyword),
     'nature_of_debt': fields.Str(),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'min_coverage_end_date': Date(missing=None, description=docs.MIN_COVERAGE_END_DATE),
-    'max_coverage_end_date': Date(missing=None, description=docs.MAX_COVERAGE_END_DATE),
-    'min_coverage_start_date': Date(missing=None, description=docs.MIN_COVERAGE_START_DATE),
-    'max_coverage_start_date': Date(missing=None, description=docs.MAX_COVERAGE_START_DATE),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'report_type': fields.List(fields.Str, description=docs.REPORT_TYPE),
-    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
-    'committee_type': fields.List(fields.Str, description=docs.COMMITTEE_TYPE),
-    'filing_form': fields.List(fields.Str, description=docs.FORM_TYPE),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'min_coverage_end_date': Date(load_default=None, metadata={'description': docs.MIN_COVERAGE_END_DATE}),
+    'max_coverage_end_date': Date(load_default=None, metadata={'description': docs.MAX_COVERAGE_END_DATE}),
+    'min_coverage_start_date': Date(load_default=None, metadata={'description': docs.MIN_COVERAGE_START_DATE}),
+    'max_coverage_start_date': Date(load_default=None, metadata={'description': docs.MAX_COVERAGE_START_DATE}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'report_type': fields.List(fields.Str, metadata={'description': docs.REPORT_TYPE}),
+    'form_line_number': fields.List(IStr, metadata={'description': docs.FORM_LINE_NUMBER}),
+    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
+    'filing_form': fields.List(fields.Str, metadata={'description': docs.FORM_TYPE}),
 }
 
 schedule_e_by_candidate = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
-        description=docs.OFFICE,
+        metadata={'description': docs.OFFICE},
     ),
     'support_oppose': IStr(
-        missing=None,
+        load_default=None,
         validate=validate.OneOf(['S', 'O']),
-        description=docs.SUPPORT_OPPOSE,
+        metadata={'description': docs.SUPPORT_OPPOSE},
     ),
 }
 
 schedule_f = {
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'payee_name': fields.List(Keyword, metadata={'description': docs.PAYEE_NAME}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'form_line_number': fields.List(IStr, metadata={'description': docs.FORM_LINE_NUMBER}),
 }
 
 communication_cost = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
-        description=docs.SUPPORT_OPPOSE,
+        metadata={'description': docs.SUPPORT_OPPOSE},
     ),
 }
 
 CC_aggregates = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
     'support_oppose_indicator': IStr(
-        missing=None,
+        load_default=None,
         validate=validate.OneOf(['S', 'O']),
-        description=docs.SUPPORT_OPPOSE,
+        metadata={'description': docs.SUPPORT_OPPOSE},
     ),
 }
 
 electioneering = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'min_amount': Currency(description=docs.ELECTIONEERING_MIN_AMOUNT),
-    'max_amount': Currency(description=docs.ELECTIONEERING_MAX_AMOUNT),
-    'min_date': Date(description=docs.ELECTIONEERING_MIN_DATE),
-    'max_date': Date(description=docs.ELECTIONEERING_MAX_DATE),
-    'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'min_amount': Currency(metadata={'description': docs.ELECTIONEERING_MIN_AMOUNT}),
+    'max_amount': Currency(metadata={'description': docs.ELECTIONEERING_MAX_AMOUNT}),
+    'min_date': Date(metadata={'description': docs.ELECTIONEERING_MIN_DATE}),
+    'max_date': Date(metadata={'description': docs.ELECTIONEERING_MAX_DATE}),
+    'disbursement_description': fields.List(Keyword, metadata={'description': docs.DISBURSEMENT_DESCRIPTION}),
 }
 
 electioneering_by_candidate = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
-        description=docs.OFFICE,
+        metadata={'description': docs.OFFICE},
     ),
 }
 
 # used for endpoint:`/electioneering/aggregates/`
 # under tag: electioneering
 EC_aggregates = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
 }
 
 elections_list = {
-    'state': fields.List(IStr, description=docs.STATE),
-    'district': fields.List(District, description=docs.DISTRICT),
-    'cycle': fields.List(fields.Int, description=docs.CANDIDATE_CYCLE),
-    'zip': fields.List(fields.Int, description=docs.ZIP_CODE),
+    'state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'district': fields.List(District, metadata={'description': docs.DISTRICT}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.CANDIDATE_CYCLE}),
+    'zip': fields.List(fields.Int, metadata={'description': docs.ZIP_CODE}),
     'office': fields.List(
         fields.Str(validate=validate.OneOf(['house', 'senate', 'president'])),
     ),
 }
 
 elections = {
-    'state': IStr(description=docs.STATE),
-    'district': District(description=docs.DISTRICT),
-    'cycle': fields.Int(required=True, description=docs.CANDIDATE_CYCLE),
+    'state': IStr(metadata={'description': docs.STATE}),
+    'district': District(metadata={'description': docs.DISTRICT}),
+    'cycle': fields.Int(required=True, metadata={'description': docs.CANDIDATE_CYCLE}),
     'office': fields.Str(
         required=True,
         validate=validate.OneOf(['house', 'senate', 'president']),
-        description=docs.OFFICE,
+        metadata={'description': docs.OFFICE},
     ),
     'election_full': election_full,
 }
 
 state_election_office_info = {
-    'state': IStr(required=True, description=docs.STATE_ELECTION_OFFICES_ADDRESS),
+    'state': IStr(required=True, metadata={'description': docs.STATE_ELECTION_OFFICES_ADDRESS}),
 }
 
 # used for endpoints
@@ -1073,60 +1081,61 @@ state_election_office_info = {
 # under tag: receipts
 
 schedule_a_candidate_aggregate = {
-    'candidate_id': fields.List(Candidate_ID, required=True, description=docs.CANDIDATE_ID),
-    'cycle': fields.List(fields.Int, required=True, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(Candidate_ID, required=True, metadata={'description': docs.CANDIDATE_ID}),
+    'cycle': fields.List(fields.Int, required=True, metadata={'description': docs.RECORD_CYCLE}),
     'election_full': election_full,
 }
 
 # used for '/candidates/totals/'
 # under tag: candidate
 candidate_totals = {
-    'q': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])), description=docs.OFFICE),
+    'q': fields.List(Keyword, metadata={'description': docs.CANDIDATE_NAME}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'office': fields.List(fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P'])),
+                          metadata={'description': docs.OFFICE}),
     'election_full': election_full,
-    'state': fields.List(IStr, description=docs.STATE),
-    'district': fields.List(District, description=docs.DISTRICT),
-    'party': fields.List(IStr, description='Three-letter party code'),
-    'min_receipts': Currency(description='Minimum aggregated receipts'),
-    'max_receipts': Currency(description='Maximum aggregated receipts'),
-    'min_disbursements': Currency(description='Minimum aggregated disbursements'),
-    'max_disbursements': Currency(description='Maximum aggregated disbursements'),
-    'min_cash_on_hand_end_period': Currency(description='Minimum cash on hand'),
-    'max_cash_on_hand_end_period': Currency(description='Maximum cash on hand'),
-    'min_debts_owed_by_committee': Currency(description='Minimum debt'),
-    'max_debts_owed_by_committee': Currency(description='Maximum debt'),
-    'federal_funds_flag': fields.Bool(description=docs.FEDERAL_FUNDS_FLAG),
-    'has_raised_funds': fields.Bool(description=docs.HAS_RAISED_FUNDS),
-    'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
+    'state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'district': fields.List(District, metadata={'description': docs.DISTRICT}),
+    'party': fields.List(IStr, metadata={'description': 'Three-letter party code'}),
+    'min_receipts': Currency(metadata={'description': 'Minimum aggregated receipts'}),
+    'max_receipts': Currency(metadata={'description': 'Maximum aggregated receipts'}),
+    'min_disbursements': Currency(metadata={'description': 'Minimum aggregated disbursements'}),
+    'max_disbursements': Currency(metadata={'description': 'Maximum aggregated disbursements'}),
+    'min_cash_on_hand_end_period': Currency(metadata={'description': 'Minimum cash on hand'}),
+    'max_cash_on_hand_end_period': Currency(metadata={'description': 'Maximum cash on hand'}),
+    'min_debts_owed_by_committee': Currency(metadata={'description': 'Minimum debt'}),
+    'max_debts_owed_by_committee': Currency(metadata={'description': 'Maximum debt'}),
+    'federal_funds_flag': fields.Bool(metadata={'description': docs.FEDERAL_FUNDS_FLAG}),
+    'has_raised_funds': fields.Bool(metadata={'description': docs.HAS_RAISED_FUNDS}),
+    'is_active_candidate': fields.Bool(metadata={'description': docs.ACTIVE_CANDIDATE}),
 }
 
 totals_committee_aggregate = {
-    'min_receipts': Currency(description='Minimum aggregated receipts'),
-    'max_receipts': Currency(description='Maximum aggregated receipts'),
-    'min_disbursements': Currency(description='Minimum aggregated disbursements'),
-    'max_disbursements': Currency(description='Maximum aggregated disbursements'),
+    'min_receipts': Currency(metadata={'description': 'Minimum aggregated receipts'}),
+    'max_receipts': Currency(metadata={'description': 'Maximum aggregated receipts'}),
+    'min_disbursements': Currency(metadata={'description': 'Minimum aggregated disbursements'}),
+    'max_disbursements': Currency(metadata={'description': 'Maximum aggregated disbursements'}),
 }
 
 communication_cost_by_candidate = {
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
     'office': fields.Str(
         validate=validate.OneOf(['house', 'senate', 'president']),
-        description=docs.OFFICE,
+        metadata={'description': docs.OFFICE},
     ),
     'support_oppose': IStr(
-        missing=None,
+        load_default=None,
         validate=validate.OneOf(['S', 'O']),
-        description='Support or opposition',
+        metadata={'description': 'Support or opposition'},
     ),
 }
 
 entities = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
 }
 
 # Used for endpoint `/schedules/schedule_e/`
@@ -1134,159 +1143,162 @@ entities = {
 schedule_e = {
     'candidate_office': fields.List(fields.Str(
         validate=validate.OneOf(['', 'H', 'S', 'P'])),
-        description=docs.OFFICE),
-    'candidate_party': fields.List(IStr, description=docs.PARTY),
-    'candidate_office_state': fields.List(IStr, description=docs.STATE_GENERIC),
-    'candidate_office_district': fields.List(District, description=docs.DISTRICT),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
+        metadata={'description': docs.OFFICE}),
+    'candidate_party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'candidate_office_state': fields.List(IStr, metadata={'description': docs.STATE_GENERIC}),
+    'candidate_office_district': fields.List(District, metadata={'description': docs.DISTRICT}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'filing_form': fields.List(IStr, metadata={'description': docs.FORM_TYPE}),
     'last_expenditure_date': Date(
-        missing=None,
-        description=docs.LAST_EXPENDITURE_DATE),
+        load_default=None,
+        metadata={'description': docs.LAST_EXPENDITURE_DATE}),
     'last_expenditure_amount': fields.Float(
-        missing=None,
-        description=docs.LAST_EXPENDITURE_AMOUNT),
+        load_default=None,
+        metadata={'description': docs.LAST_EXPENDITURE_AMOUNT}),
     'last_office_total_ytd': fields.Float(
-        missing=None,
-        description=docs.LAST_OFFICE_TOTAL_YTD),
-    'payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
+        load_default=None,
+        metadata={'description': docs.LAST_OFFICE_TOTAL_YTD}),
+    'payee_name': fields.List(Keyword, metadata={'description': docs.PAYEE_NAME}),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
-        description=docs.SUPPORT_OPPOSE_INDICATOR),
+        metadata={'description': docs.SUPPORT_OPPOSE_INDICATOR}),
     'last_support_oppose_indicator': fields.Str(
-        missing=None,
-        description=docs.LAST_SUPPOSE_OPPOSE_INDICATOR),
-    'is_notice': fields.List(fields.Bool, description=docs.IS_NOTICE),
-    'min_dissemination_date': Date(description=docs.DISSEMINATION_MIN_DATE),
-    'max_dissemination_date': Date(description=docs.DISSEMINATION_MAX_DATE),
-    'min_filing_date': Date(description=docs.MIN_FILED_DATE),
-    'max_filing_date': Date(description=docs.MAX_FILED_DATE),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
-    'q_spender': fields.List(Keyword, description=docs.SPENDER_NAME_TEXT),
-    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
+        load_default=None,
+        metadata={'description': docs.LAST_SUPPOSE_OPPOSE_INDICATOR}),
+    'is_notice': fields.List(fields.Bool, metadata={'description': docs.IS_NOTICE}),
+    'min_dissemination_date': Date(metadata={'description': docs.DISSEMINATION_MIN_DATE}),
+    'max_dissemination_date': Date(metadata={'description': docs.DISSEMINATION_MAX_DATE}),
+    'min_filing_date': Date(metadata={'description': docs.MIN_FILED_DATE}),
+    'max_filing_date': Date(metadata={'description': docs.MAX_FILED_DATE}),
+    'most_recent': fields.Bool(metadata={'description': docs.MOST_RECENT_IE}),
+    'q_spender': fields.List(Keyword, metadata={'description': docs.SPENDER_NAME_TEXT}),
+    'form_line_number': fields.List(IStr, metadata={'description': docs.FORM_LINE_NUMBER}),
 }
 
 # Used for endpoint `/schedules/schedule_e/efile/`
 # under tag: independent expenditures
 schedule_e_efile = {
-    'candidate_search': fields.List(Keyword, description=docs.CANDIDATE_FULL_SEARCH),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'payee_name': fields.List(fields.Str, description=docs.PAYEE_NAME),
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
+    'candidate_search': fields.List(Keyword, metadata={'description': docs.CANDIDATE_FULL_SEARCH}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'payee_name': fields.List(fields.Str, metadata={'description': docs.PAYEE_NAME}),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
     'support_oppose_indicator': fields.List(
         IStr(validate=validate.OneOf(['S', 'O'])),
-        description=docs.SUPPORT_OPPOSE_INDICATOR),
-    'min_expenditure_date': Date(description=docs.EXPENDITURE_MIN_DATE),
-    'max_expenditure_date': Date(description=docs.EXPENDITURE_MAX_DATE),
-    'min_dissemination_date': Date(description=docs.DISSEMINATION_MIN_DATE),
-    'max_dissemination_date': Date(description=docs.DISSEMINATION_MAX_DATE),
-    'min_expenditure_amount': fields.Integer(description=docs.EXPENDITURE_MIN_AMOUNT),
-    'max_expenditure_amount': fields.Integer(description=docs.EXPENDITURE_MAX_AMOUNT),
-    'spender_name': fields.List(IStr, description=docs.COMMITTEE_NAME),
-    'candidate_party': fields.List(IStr, description=docs.PARTY),
-    'candidate_office': fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P']), description=docs.OFFICE),
-    'candidate_office_state': fields.List(IStr, description=docs.STATE),
-    'candidate_office_district': fields.List(IStr, description=docs.DISTRICT),
-    'most_recent': fields.Bool(description=docs.MOST_RECENT_IE),
-    'min_filed_date': Date(description=docs.FILED_DATE),
-    'max_filed_date': Date(description=docs.FILED_DATE),
-    'filing_form': fields.List(IStr, description=docs.FORM_TYPE),
-    'is_notice': fields.Bool(description=docs.IS_NOTICE),
+        metadata={'description': docs.SUPPORT_OPPOSE_INDICATOR}),
+    'min_expenditure_date': Date(metadata={'description': docs.EXPENDITURE_MIN_DATE}),
+    'max_expenditure_date': Date(metadata={'description': docs.EXPENDITURE_MAX_DATE}),
+    'min_dissemination_date': Date(metadata={'description': docs.DISSEMINATION_MIN_DATE}),
+    'max_dissemination_date': Date(metadata={'description': docs.DISSEMINATION_MAX_DATE}),
+    'min_expenditure_amount': fields.Integer(metadata={'description': docs.EXPENDITURE_MIN_AMOUNT}),
+    'max_expenditure_amount': fields.Integer(metadata={'description': docs.EXPENDITURE_MAX_AMOUNT}),
+    'spender_name': fields.List(IStr, metadata={'description': docs.COMMITTEE_NAME}),
+    'candidate_party': fields.List(IStr, metadata={'description': docs.PARTY}),
+    'candidate_office': fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P']), metadata={'description': docs.OFFICE}),
+    'candidate_office_state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'candidate_office_district': fields.List(IStr, metadata={'description': docs.DISTRICT}),
+    'most_recent': fields.Bool(metadata={'description': docs.MOST_RECENT_IE}),
+    'min_filed_date': Date(metadata={'description': docs.FILED_DATE}),
+    'max_filed_date': Date(metadata={'description': docs.FILED_DATE}),
+    'filing_form': fields.List(IStr, metadata={'description': docs.FORM_TYPE}),
+    'is_notice': fields.Bool(metadata={'description': docs.IS_NOTICE}),
 }
 
 rad_analyst = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'analyst_id': fields.List(fields.Int(), description='ID of RAD analyst'),
-    'analyst_short_id': fields.List(fields.Int(), description='Short ID of RAD analyst'),
-    'telephone_ext': fields.List(fields.Int(), description='Telephone extension of RAD analyst'),
-    'name': fields.List(Keyword, description='Name of RAD analyst'),
-    'email': fields.List(fields.Str, description='Email of RAD analyst'),
-    'title': fields.List(Keyword, description='Title of RAD analyst'),
-    'min_assignment_update_date': Date(description='Filter results for assignment updates made after this date'),
-    'max_assignment_update_date': Date(description='Filter results for assignment updates made before this date')
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'analyst_id': fields.List(fields.Int(), metadata={'description': 'ID of RAD analyst'}),
+    'analyst_short_id': fields.List(fields.Int(), metadata={'description': 'Short ID of RAD analyst'}),
+    'telephone_ext': fields.List(fields.Int(), metadata={'description': 'Telephone extension of RAD analyst'}),
+    'name': fields.List(Keyword, metadata={'description': 'Name of RAD analyst'}),
+    'email': fields.List(fields.Str, metadata={'description': 'Email of RAD analyst'}),
+    'title': fields.List(Keyword, metadata={'description': 'Title of RAD analyst'}),
+    'min_assignment_update_date': Date(
+        metadata={'description': 'Filter results for assignment updates made after this date'}),
+    'max_assignment_update_date': Date(
+        metadata={'description': 'Filter results for assignment updates made before this date'})
 }
 
-large_aggregates = {'cycle': fields.Int(required=True, description=docs.RECORD_CYCLE)}
+large_aggregates = {'cycle': fields.Int(required=True, metadata={'description': docs.RECORD_CYCLE})}
 
 schedule_a_by_state_recipient_totals = {
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'state': fields.List(IStr, description=docs.STATE_GENERIC),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'state': fields.List(IStr, metadata={'description': docs.STATE_GENERIC}),
     'committee_type': fields.List(
         IStr,
-        description=docs.COMMITTEE_TYPE_STATE_AGGREGATE_TOTALS
+        metadata={'description': docs.COMMITTEE_TYPE_STATE_AGGREGATE_TOTALS}
     ),
 }
 
 # endpoint audit-primary-category
 auditPrimaryCategory = {
-    'primary_category_id': fields.List(fields.Str(), description=docs.PRIMARY_CATEGORY_ID),
-    'primary_category_name': fields.List(fields.Str, description=docs.PRIMARY_CATEGORY_NAME),
+    'primary_category_id': fields.List(fields.Str(), metadata={'description': docs.PRIMARY_CATEGORY_ID}),
+    'primary_category_name': fields.List(fields.Str, metadata={'description': docs.PRIMARY_CATEGORY_NAME}),
 }
 
 
 # endpoint audit-category
 auditCategory = {
-    'primary_category_id': fields.List(fields.Str(), description=docs.PRIMARY_CATEGORY_ID),
-    'primary_category_name': fields.List(fields.Str, description=docs.PRIMARY_CATEGORY_NAME),
+    'primary_category_id': fields.List(fields.Str(), metadata={'description': docs.PRIMARY_CATEGORY_ID}),
+    'primary_category_name': fields.List(fields.Str, metadata={'description': docs.PRIMARY_CATEGORY_NAME}),
 }
 
 # endpoint audit-case
 auditCase = {
-    'q': fields.List(Keyword, description=docs.COMMITTEE_NAME),
-    'qq': fields.List(Keyword, description=docs.CANDIDATE_NAME),
-    'primary_category_id': fields.Str(missing='all', description=docs.PRIMARY_CATEGORY_ID),
-    'sub_category_id': fields.Str(missing='all', description=docs.SUB_CATEGORY_ID),
-    'audit_case_id': fields.List(fields.Str(), description=docs.AUDIT_CASE_ID),
-    'cycle': fields.List(fields.Int(), description=docs.CYCLE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'committee_type': fields.List(fields.Str(), description=docs.COMMITTEE_TYPE),
-    'committee_designation': fields.Str(description=docs.COMMITTEE_DESCRIPTION),
-    'audit_id': fields.List(fields.Int(), description=docs.AUDIT_ID),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
-    'min_election_cycle': fields.Int(description=docs.CYCLE),
-    'max_election_cycle': fields.Int(description=docs.CYCLE),
+    'q': fields.List(Keyword, metadata={'description': docs.COMMITTEE_NAME}),
+    'qq': fields.List(Keyword, metadata={'description': docs.CANDIDATE_NAME}),
+    'primary_category_id': fields.Str(load_default='all', metadata={'description': docs.PRIMARY_CATEGORY_ID}),
+    'sub_category_id': fields.Str(load_default='all', metadata={'description': docs.SUB_CATEGORY_ID}),
+    'audit_case_id': fields.List(fields.Str(), metadata={'description': docs.AUDIT_CASE_ID}),
+    'cycle': fields.List(fields.Int(), metadata={'description': docs.CYCLE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'committee_type': fields.List(fields.Str(), metadata={'description': docs.COMMITTEE_TYPE}),
+    'committee_designation': fields.Str(metadata={'description': docs.COMMITTEE_DESCRIPTION}),
+    'audit_id': fields.List(fields.Int(), metadata={'description': docs.AUDIT_ID}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
+    'min_election_cycle': fields.Int(metadata={'description': docs.CYCLE}),
+    'max_election_cycle': fields.Int(metadata={'description': docs.CYCLE}),
 }
 
 operations_log = {
-    'candidate_committee_id': fields.List(IStr, description=docs.CAND_CMTE_ID),
-    'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
-    'beginning_image_number': fields.List(ImageNumber, description=docs.BEGINNING_IMAGE_NUMBER),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'form_type': fields.List(IStr, description=docs.FORM_TYPE),
-    'amendment_indicator': fields.List(IStr, description=docs.AMENDMENT_INDICATOR),
-    'status_num': fields.List(fields.Str(validate=validate.OneOf(['0', '1'])), description=docs.STATUS_NUM),
-    'min_receipt_date': Date(description=docs.MIN_RECEIPT_DATE),
-    'max_receipt_date': Date(description=docs.MAX_RECEIPT_DATE),
-    'min_coverage_end_date': Date(description=docs.MIN_COVERAGE_END_DATE),
-    'max_coverage_end_date': Date(description=docs.MAX_COVERAGE_END_DATE),
-    'min_transaction_data_complete_date': Date(description=docs.MIN_TRANSACTION_DATA_COMPLETE_DATE),
-    'max_transaction_data_complete_date': Date(description=docs.MAX_TRANSACTION_DATA_COMPLETE_DATE),
+    'candidate_committee_id': fields.List(IStr, metadata={'description': docs.CAND_CMTE_ID}),
+    'report_type': fields.List(IStr, metadata={'description': docs.REPORT_TYPE}),
+    'beginning_image_number': fields.List(ImageNumber, metadata={'description': docs.BEGINNING_IMAGE_NUMBER}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'form_type': fields.List(IStr, metadata={'description': docs.FORM_TYPE}),
+    'amendment_indicator': fields.List(IStr, metadata={'description': docs.AMENDMENT_INDICATOR}),
+    'status_num': fields.List(fields.Str(validate=validate.OneOf(['0', '1'])),
+                              metadata={'description': docs.STATUS_NUM}),
+    'min_receipt_date': Date(metadata={'description': docs.MIN_RECEIPT_DATE}),
+    'max_receipt_date': Date(metadata={'description': docs.MAX_RECEIPT_DATE}),
+    'min_coverage_end_date': Date(metadata={'description': docs.MIN_COVERAGE_END_DATE}),
+    'max_coverage_end_date': Date(metadata={'description': docs.MAX_COVERAGE_END_DATE}),
+    'min_transaction_data_complete_date': Date(metadata={'description': docs.MIN_TRANSACTION_DATA_COMPLETE_DATE}),
+    'max_transaction_data_complete_date': Date(metadata={'description': docs.MAX_TRANSACTION_DATA_COMPLETE_DATE}),
 }
 
 
 # for /candidates/totals/aggregates/ (candidate_aggregates.CandidateTotalAggregateView
 candidate_total_aggregate = {
-    'election_year': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'office': fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P']), description=docs.OFFICE),
-    'is_active_candidate': fields.Bool(description=docs.ACTIVE_CANDIDATE),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'office': fields.Str(validate=validate.OneOf(['', 'H', 'S', 'P']), metadata={'description': docs.OFFICE}),
+    'is_active_candidate': fields.Bool(metadata={'description': docs.ACTIVE_CANDIDATE}),
     'election_full': election_full,
-    'min_election_cycle': fields.Int(description=docs.CYCLE),
-    'max_election_cycle': fields.Int(description=docs.CYCLE),
-    'state': fields.List(IStr, description=docs.STATE),
-    'district': fields.List(District, description=docs.DISTRICT),
-    'party': fields.Str(validate=validate.OneOf(['', 'DEM', 'REP', 'OTHER']), description=docs.PARTY),
+    'min_election_cycle': fields.Int(metadata={'description': docs.CYCLE}),
+    'max_election_cycle': fields.Int(metadata={'description': docs.CYCLE}),
+    'state': fields.List(IStr, metadata={'description': docs.STATE}),
+    'district': fields.List(District, metadata={'description': docs.DISTRICT}),
+    'party': fields.Str(validate=validate.OneOf(['', 'DEM', 'REP', 'OTHER']), metadata={'description': docs.PARTY}),
     'aggregate_by': fields.Str(
         validate=validate.OneOf(['office', 'office-state', 'office-state-district', 'office-party']),
-        description=docs.AGGREGATE_BY),
+        metadata={'description': docs.AGGREGATE_BY}),
 }
 
 totals_by_candidate_other_costs_EC = {
 
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
     'election_full': election_full
 }
 
@@ -1295,8 +1307,8 @@ totals_by_candidate_other_costs_EC = {
 # IETotalsByCandidateView in spending_by_others.py
 schedule_e_totals_by_candidate_other_costs_IE = {
 
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
     'election_full': election_full,
 }
 
@@ -1305,70 +1317,76 @@ schedule_e_totals_by_candidate_other_costs_IE = {
 # CCTotalsByCandidateView in spending_by_others.py
 totals_by_candidate_other_costs_CC = {
 
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID}),
     'election_full': election_full,
 }
 
 schedule_h4 = {
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
-    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
-    'report_year': fields.List(fields.Int, description=docs.REPORT_YEAR),
-    'report_type': fields.List(IStr, description=docs.REPORT_TYPE),
-    'activity_or_event': fields.List(IStr, descripiption=docs.ACTIVITY_OR_EVENT_ADD),
-    'q_payee_name': fields.List(Keyword, description=docs.PAYEE_NAME),
-    'payee_city': fields.List(IStr, description=docs.PAYEE_CITY),
-    'payee_zip': fields.List(fields.Str, description=docs.PAYEE_ZIP),
-    'payee_state': fields.List(IStr, description=docs.PAYEE_STATE),
-    'q_disbursement_purpose': fields.List(Keyword, description=docs.DISBURSEMENT_PURPOSE),
-    'cycle': fields.List(fields.Int, description=docs.RECORD_CYCLE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'last_payee_name': fields.List(IStr, missing=None, description=docs.LAST_PAYEE_NAME),
-    'last_disbursement_purpose': fields.List(IStr, missing=None, description=docs.LAST_DISBURSEMENT_PURPOSE),
-    'last_event_purpose_date': Date(missing=None, description=docs.LAST_EVENT_DATE),
-    'last_spender_committee_name': fields.List(IStr, missing=None, description=docs.LAST_COMMITTEE_NAME),
-    'min_date': Date(missing=None, description=docs.MIN_EVENT_DATE),
-    'max_date': Date(missing=None, description=docs.MAX_EVENT_DATE),
-    'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
-    'min_amount': Currency(description=docs.MIN_FILTER),
-    'max_amount': Currency(description=docs.MAX_FILTER),
-    'administrative_voter_drive_activity_indicator': fields.List(fields.Str, description=docs.ADMIN_VOTER_IND),
-    'fundraising_activity_indicator': fields.List(IStr, description=docs.FUND_ACT_IND),
-    'exempt_activity_indicator': fields.List(IStr, description=docs.EXEMPT_IND),
-    'direct_candidate_support_activity_indicator': fields.List(IStr, description=docs.CAND_SUPP_IND),
-    'administrative_activity_indicator': fields.List(IStr, description=docs.ADMIN_ACT_IND),
-    'general_voter_drive_activity_indicator': fields.List(IStr, description=docs.GENERAL_VOTER_IND),
-    'public_comm_indicator': fields.List(IStr, description=docs.PUBLIC_COMM_IND),
-    'spender_committee_name': fields.List(IStr, description=docs.COMMITTEE_NAME),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_image_number': ImageNumber(metadata={'description': docs.MIN_IMAGE_NUMBER}),
+    'max_image_number': ImageNumber(metadata={'description': docs.MAX_IMAGE_NUMBER}),
+    'report_year': fields.List(fields.Int, metadata={'description': docs.REPORT_YEAR}),
+    'report_type': fields.List(IStr, metadata={'description': docs.REPORT_TYPE}),
+    'activity_or_event': fields.List(IStr, metadata={'description': docs.ACTIVITY_OR_EVENT_ADD}),
+    'q_payee_name': fields.List(Keyword, metadata={'description': docs.PAYEE_NAME}),
+    'payee_city': fields.List(IStr, metadata={'description': docs.PAYEE_CITY}),
+    'payee_zip': fields.List(fields.Str, metadata={'description': docs.PAYEE_ZIP}),
+    'payee_state': fields.List(IStr, metadata={'description': docs.PAYEE_STATE}),
+    'q_disbursement_purpose': fields.List(Keyword, metadata={'description': docs.DISBURSEMENT_PURPOSE}),
+    'cycle': fields.List(fields.Int, metadata={'description': docs.RECORD_CYCLE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'last_payee_name': fields.List(IStr, load_default=None, metadata={'description': docs.LAST_PAYEE_NAME}),
+    'last_disbursement_purpose': fields.List(IStr, load_default=None,
+                                             metadata={'description': docs.LAST_DISBURSEMENT_PURPOSE}),
+    'last_event_purpose_date': Date(load_default=None, metadata={'description': docs.LAST_EVENT_DATE}),
+    'last_spender_committee_name': fields.List(IStr, load_default=None,
+                                               metadata={'description': docs.LAST_COMMITTEE_NAME}),
+    'min_date': Date(load_default=None, metadata={'description': docs.MIN_EVENT_DATE}),
+    'max_date': Date(load_default=None, metadata={'description': docs.MAX_EVENT_DATE}),
+    'last_disbursement_amount': fields.Float(load_default=None,
+                                             metadata={'description': docs.LAST_DISBURSEMENT_AMOUNT}),
+    'min_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_amount': Currency(metadata={'description': docs.MAX_FILTER}),
+    'administrative_voter_drive_activity_indicator': fields.List(fields.Str,
+                                                                 metadata={'description': docs.ADMIN_VOTER_IND}),
+    'fundraising_activity_indicator': fields.List(IStr, metadata={'description': docs.FUND_ACT_IND}),
+    'exempt_activity_indicator': fields.List(IStr, metadata={'description': docs.EXEMPT_IND}),
+    'direct_candidate_support_activity_indicator': fields.List(IStr, metadata={'description': docs.CAND_SUPP_IND}),
+    'administrative_activity_indicator': fields.List(IStr, metadata={'description': docs.ADMIN_ACT_IND}),
+    'general_voter_drive_activity_indicator': fields.List(IStr, metadata={'description': docs.GENERAL_VOTER_IND}),
+    'public_comm_indicator': fields.List(IStr, metadata={'description': docs.PUBLIC_COMM_IND}),
+    'spender_committee_name': fields.List(IStr, metadata={'description': docs.COMMITTEE_NAME}),
     'spender_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'spender_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
-    'form_line_number': fields.List(IStr, description=docs.FORM_LINE_NUMBER),
+    'form_line_number': fields.List(IStr, metadata={'description': docs.FORM_LINE_NUMBER}),
 }
 
 schedule_h4_efile = {
-    'image_number': fields.List(ImageNumber, description=docs.IMAGE_NUMBER),
-    'min_image_number': ImageNumber(description=docs.MIN_IMAGE_NUMBER),
-    'max_image_number': ImageNumber(description=docs.MAX_IMAGE_NUMBER),
-    'payee_city': fields.List(fields.Str, description=docs.PAYEE_CITY),
-    'payee_zip': fields.List(fields.Str, description=docs.PAYEE_ZIP),
-    'payee_state': fields.List(fields.Str, description=docs.PAYEE_STATE),
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'last_disbursement_purpose': fields.List(IStr, missing=None, description=docs.LAST_DISBURSEMENT_PURPOSE),
-    'last_event_purpose_date': Date(missing=None, description=docs.LAST_EVENT_DATE),
-    'min_date': Date(missing=None, description=docs.MIN_EVENT_DATE),
-    'max_date': Date(missing=None, description=docs.MAX_EVENT_DATE),
-    'last_disbursement_amount': fields.Float(missing=None, description=docs.LAST_DISBURSEMENT_AMOUNT),
-    'min_amount': Currency(description=docs.MIN_FILTER),
-    'max_amount': Currency(description=docs.MAX_FILTER),
+    'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_image_number': ImageNumber(metadata={'description': docs.MIN_IMAGE_NUMBER}),
+    'max_image_number': ImageNumber(metadata={'description': docs.MAX_IMAGE_NUMBER}),
+    'payee_city': fields.List(fields.Str, metadata={'description': docs.PAYEE_CITY}),
+    'payee_zip': fields.List(fields.Str, metadata={'description': docs.PAYEE_ZIP}),
+    'payee_state': fields.List(fields.Str, metadata={'description': docs.PAYEE_STATE}),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'last_disbursement_purpose': fields.List(IStr, load_default=None,
+                                             metadata={'description': docs.LAST_DISBURSEMENT_PURPOSE}),
+    'last_event_purpose_date': Date(load_default=None, metadata={'description': docs.LAST_EVENT_DATE}),
+    'min_date': Date(load_default=None, metadata={'description': docs.MIN_EVENT_DATE}),
+    'max_date': Date(load_default=None, metadata={'description': docs.MAX_EVENT_DATE}),
+    'last_disbursement_amount': fields.Float(load_default=None,
+                                             metadata={'description': docs.LAST_DISBURSEMENT_AMOUNT}),
+    'min_amount': Currency(metadata={'description': docs.MIN_FILTER}),
+    'max_amount': Currency(metadata={'description': docs.MAX_FILTER}),
 }
 
 # used for endpoints:
@@ -1377,134 +1395,135 @@ schedule_h4_efile = {
 #  '/presidential/coverage_end_date/'
 # under tag: presidential
 presidential = {
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID_PRESIDENTIAL),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.ELECTION_YEAR}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID_PRESIDENTIAL}),
 }
 
 # used for endpoint: '/presidential/contributions/by_candidate/'
 # under tag: presidential
 presidential_by_candidate = {
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.ELECTION_YEAR}),
+    'contributor_state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
 }
 
 # used for endpoint: '/presidential/contributions/by_size/'
 # under tag: presidential
 presidential_by_size = {
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'candidate_id': fields.List(Candidate_ID, description=docs.CANDIDATE_ID_PRESIDENTIAL),
-    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])), description=docs.SIZE),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.ELECTION_YEAR}),
+    'candidate_id': fields.List(Candidate_ID, metadata={'description': docs.CANDIDATE_ID_PRESIDENTIAL}),
+    'size': fields.List(fields.Int(validate=validate.OneOf([0, 200, 500, 1000, 2000])),
+                        metadata={'description': docs.SIZE}),
 }
 
 presidential_by_candidate = {
-    'election_year': fields.List(fields.Int, description=docs.ELECTION_YEAR),
-    'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
+    'election_year': fields.List(fields.Int, metadata={'description': docs.ELECTION_YEAR}),
+    'contributor_state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
 }
 
 Inaugural_donations_by_contributor = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'contributor_name': fields.List(IStr, description=docs.CONTRIBUTOR_NAME),
-    'cycle': fields.List(fields.Int(), description=docs.COMMITTEE_CYCLE)
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'contributor_name': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_NAME}),
+    'cycle': fields.List(fields.Int(), metadata={'description': docs.COMMITTEE_CYCLE})
 }
 
 # Used for endpoint `/national_party/schedule_a/`
 # under tag: national party accounts
 national_party_schedule_a = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
-    'contributor_id': fields.List(IStr, description=docs.CONTRIBUTOR_ID),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
+    'contributor_id': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_ID}),
     'two_year_transaction_period': fields.List(
         TwoYearTransactionPeriod,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+        metadata={'description': docs.TWO_YEAR_TRANSACTION_PERIOD},
     ),
-    'contributor_name': fields.List(Keyword, description=docs.CONTRIBUTOR_NAME),
-    'contributor_city': fields.List(IStr, description=docs.CONTRIBUTOR_CITY),
-    'contributor_state': fields.List(IStr, description=docs.CONTRIBUTOR_STATE),
-    'contributor_zip': fields.List(IStr, description=docs.CONTRIBUTOR_ZIP),
-    'contributor_occupation': fields.List(Keyword, description=docs.CONTRIBUTOR_OCCUPATION),
-    'contributor_employer': fields.List(Keyword, description=docs.CONTRIBUTOR_EMPLOYER),
-    'image_number': fields.List(IStr, description=docs.IMAGE_NUMBER),
-    'min_contribution_receipt_date': Date(description=docs.MIN_RECEIPT_DATE),
-    'max_contribution_receipt_date': Date(description=docs.MAX_RECEIPT_DATE),
-    'is_individual': fields.Bool(missing=None, description=docs.IS_INDIVIDUAL),
+    'contributor_name': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_NAME}),
+    'contributor_city': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_CITY}),
+    'contributor_state': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_STATE}),
+    'contributor_zip': fields.List(IStr, metadata={'description': docs.CONTRIBUTOR_ZIP}),
+    'contributor_occupation': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_OCCUPATION}),
+    'contributor_employer': fields.List(Keyword, metadata={'description': docs.CONTRIBUTOR_EMPLOYER}),
+    'image_number': fields.List(IStr, metadata={'description': docs.IMAGE_NUMBER}),
+    'min_contribution_receipt_date': Date(metadata={'description': docs.MIN_RECEIPT_DATE}),
+    'max_contribution_receipt_date': Date(metadata={'description': docs.MAX_RECEIPT_DATE}),
+    'is_individual': fields.Bool(load_default=None, metadata={'description': docs.IS_INDIVIDUAL}),
     'contributor_type': fields.List(
         fields.Str(validate=validate.OneOf(['individual', 'committee'])),
-        description=docs.CONTRIBUTOR_TYPE
+        metadata={'description': docs.CONTRIBUTOR_TYPE}
     ),
     'contributor_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'contributor_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
-    'min_contribution_receipt_amount': Currency(description=docs.MIN_RECEIPT_AMOUNT),
-    'max_contribution_receipt_amount': Currency(description=docs.MAX_RECEIPT_AMOUNT),
+    'min_contribution_receipt_amount': Currency(metadata={'description': docs.MIN_RECEIPT_AMOUNT}),
+    'max_contribution_receipt_amount': Currency(metadata={'description': docs.MAX_RECEIPT_AMOUNT}),
     'party_account_type': fields.List(
         IStr(validate=validate.OneOf(['', 'CONVENTION', 'HEADQUARTERS', 'RECOUNT'])),
-        description=docs.NATIONAL_PARTY_ACCOUNT_TYPE,
+        metadata={'description': docs.NATIONAL_PARTY_ACCOUNT_TYPE},
     ),
     'receipt_type': fields.List(
         IStr(validate=validate.OneOf([
             '30', '30E', '30F', '30G', '30J', '30K', '30T',
             '31', '31E', '31F', '31G', '31J', '31K', '31T',
             '32', '32E', '32F', '32G', '32J', '32K', '32T'])),
-        description=docs.RECEIPT_TYPE_CODES
+        metadata={'description': docs.RECEIPT_TYPE_CODES}
         ),
     }
 
 # Used for endpoint `/national_party/schedule_b/`
 # under tag: national party accounts
 national_party_schedule_b = {
-    'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+    'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
     'disbursement_type': fields.List(
         IStr(validate=validate.OneOf([
             '40', '40T', '40Y', '40Z', '41', '41T', '41Y',
             '41Z', '42', '42T', '42Y', '42Z'])),
-        description=docs.DISBURSEMENT_TYPE_CODES
+        metadata={'description': docs.DISBURSEMENT_TYPE_CODES}
         ),
-    'disbursement_description': fields.List(Keyword, description=docs.DISBURSEMENT_DESCRIPTION),
+    'disbursement_description': fields.List(Keyword, metadata={'description': docs.DISBURSEMENT_DESCRIPTION}),
     'disbursement_purpose_category': fields.List(IStr(validate=validate.OneOf(disbursment_purpose_list)),
-                                                 description=docs.DISBURSEMENT_PURPOSE_CATEGORY),
-    'image_number': fields.List(IStr, description=docs.IMAGE_NUMBER),
-    'line_number': fields.Str(description=docs.NATIONAL_PARTY_SB_LINE_NUMBER),
-    'min_disbursement_amount': Currency(description=docs.MIN_DISBURSEMENT_AMOUNT),
-    'max_disbursement_amount': Currency(description=docs.MAX_DISBURSEMENT_AMOUNT),
-    'min_disbursement_date': Date(description=docs.MIN_DISBURSEMENT_DATE),
-    'max_disbursement_date': Date(description=docs.MAX_DISBURSEMENT_DATE),
-    'recipient_city': fields.List(IStr, description=docs.RECIPIENT_CITY),
-    'recipient_committee_id': fields.List(Committee_ID, description=docs.RECIPIENT_COMMITTEE_ID),
-    'recipient_name': fields.List(Keyword, description=docs.RECIPIENT_NAME),
-    'recipient_state': fields.List(IStr, description=docs.RECIPIENT_STATE),
-    'recipient_zip': fields.List(IStr, description=docs.RECIPIENT_ZIP),
+                                                 metadata={'description': docs.DISBURSEMENT_PURPOSE_CATEGORY}),
+    'image_number': fields.List(IStr, metadata={'description': docs.IMAGE_NUMBER}),
+    'line_number': fields.Str(metadata={'description': docs.NATIONAL_PARTY_SB_LINE_NUMBER}),
+    'min_disbursement_amount': Currency(metadata={'description': docs.MIN_DISBURSEMENT_AMOUNT}),
+    'max_disbursement_amount': Currency(metadata={'description': docs.MAX_DISBURSEMENT_AMOUNT}),
+    'min_disbursement_date': Date(metadata={'description': docs.MIN_DISBURSEMENT_DATE}),
+    'max_disbursement_date': Date(metadata={'description': docs.MAX_DISBURSEMENT_DATE}),
+    'recipient_city': fields.List(IStr, metadata={'description': docs.RECIPIENT_CITY}),
+    'recipient_committee_id': fields.List(Committee_ID, metadata={'description': docs.RECIPIENT_COMMITTEE_ID}),
+    'recipient_name': fields.List(Keyword, metadata={'description': docs.RECIPIENT_NAME}),
+    'recipient_state': fields.List(IStr, metadata={'description': docs.RECIPIENT_STATE}),
+    'recipient_zip': fields.List(IStr, metadata={'description': docs.RECIPIENT_ZIP}),
     'recipient_committee_designation': fields.List(
         IStr(validate=validate.OneOf(['', 'A', 'J', 'P', 'U', 'B', 'D'])),
-        description=docs.DESIGNATION,
+        metadata={'description': docs.DESIGNATION},
     ),
     'recipient_committee_type': fields.List(
         IStr(validate=validate.OneOf([
             '', 'C', 'D', 'E', 'H', 'I', 'N', 'O', 'P', 'Q',
             'S', 'U', 'V', 'W', 'X', 'Y', 'Z'])),
-        description=docs.COMMITTEE_TYPE,
+        metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'two_year_transaction_period': fields.List(
         TwoYearTransactionPeriod,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+        metadata={'description': docs.TWO_YEAR_TRANSACTION_PERIOD},
     ),
     'party_account_type': fields.List(
         IStr(validate=validate.OneOf(['', 'CONVENTION', 'HEADQUARTERS', 'RECOUNT'])),
-        description=docs.NATIONAL_PARTY_ACCOUNT_TYPE,
+        metadata={'description': docs.NATIONAL_PARTY_ACCOUNT_TYPE},
     ),
 }
 
 # Used for endpoint `/national_party/totals/`
 # under tag: national party accounts
 national_party_totals = {
- 'committee_id': fields.List(Committee_ID, description=docs.COMMITTEE_ID),
+ 'committee_id': fields.List(Committee_ID, metadata={'description': docs.COMMITTEE_ID}),
  'two_year_transaction_period': fields.List(
         TwoYearTransactionPeriod,
-        description=docs.TWO_YEAR_TRANSACTION_PERIOD,
+        metadata={'description': docs.TWO_YEAR_TRANSACTION_PERIOD},
     ),
 }

--- a/webservices/resources/dates.py
+++ b/webservices/resources/dates.py
@@ -78,7 +78,7 @@ class CalendarDatesExport(CalendarDatesView):
     }
 
     @use_kwargs({
-        'renderer': fields.Str(missing='ics', validate=validate.OneOf(['ics', 'csv'])),
+        'renderer': fields.Str(load_default='ics', validate=validate.OneOf(['ics', 'csv'])),
     })
     def get(self, **kwargs):
         query = self.build_query(**kwargs)

--- a/webservices/resources/download.py
+++ b/webservices/resources/download.py
@@ -23,7 +23,7 @@ URL_EXPIRY = 7 * 24 * 60 * 60
 
 class DownloadView(utils.Resource):
 
-    @use_kwargs_original({'filename': fields.Str(missing=None)})
+    @use_kwargs_original({'filename': fields.Str(load_default=None)})
     def post(self, path, filename=None, **kwargs):
         parts = request.path.split('/')
         parts.remove('download')

--- a/webservices/schemas.py
+++ b/webservices/schemas.py
@@ -345,7 +345,7 @@ class CommitteeSearchSchema(BaseSearchSchema):
 class CandidateSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
         CandidateSearchBaseSchema,
-        ref='#/definitions/CandidateSearch',
+        metadata={'ref': '#/definitions/CandidateSearch'},
         many=True,
     )
 
@@ -353,7 +353,7 @@ class CandidateSearchListSchema(ApiSchema):
 class CommitteeSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
         CommitteeSearchSchema,
-        ref='#/definitions/CommitteeSearch',
+        metadata={'ref': '#/definitions/CommitteeSearch'},
         many=True,
     )
 
@@ -375,7 +375,7 @@ class AuditCommitteeSearchSchema(BaseSearchSchema):
 class AuditCandidateSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
         AuditCandidateSearchSchema,
-        ref='#/definitions/AuditCandidateSearch',
+        metadata={'ref': '#/definitions/AuditCandidateSearch'},
         many=True,
     )
 
@@ -383,7 +383,7 @@ class AuditCandidateSearchListSchema(ApiSchema):
 class AuditCommitteeSearchListSchema(ApiSchema):
     results = ma.fields.Nested(
         AuditCommitteeSearchSchema,
-        ref='#/definitions/AuditCommitteeSearch',
+        metadata={'ref': '#/definitions/AuditCommitteeSearch'},
         many=True,
     )
 
@@ -771,7 +771,7 @@ entity_fields = {
     'last_beginning_image_number': ma.fields.Str(),
     'transaction_coverage_date': ma.fields.Date(
         attribute='transaction_coverage.transaction_coverage_date',
-        default=None),
+        dump_default=None),
     'individual_contributions_percent': ma.fields.Float(),
     'party_and_other_committee_contributions_percent': ma.fields.Float(),
     'contributions_ie_and_party_expenditures_made_percent': ma.fields.Float(),
@@ -1002,7 +1002,7 @@ ScheduleASchema = make_schema(
         'committee': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'contributor': ma.fields.Nested(schemas['CommitteeHistorySchema']),
         'contribution_receipt_amount': ma.fields.Float(),
-        'contributor_aggregate_ytd': ma.fields.Float(description=docs.CONTRIBUTOR_AGGREGATE_YTD),
+        'contributor_aggregate_ytd': ma.fields.Float(metadata={'description': docs.CONTRIBUTOR_AGGREGATE_YTD}),
         'image_number': ma.fields.Str(),
         'original_sub_id': ma.fields.Str(),
         'sub_id': ma.fields.Str(),
@@ -1615,8 +1615,8 @@ class ElectionSchema(ma.Schema):
     incumbent_challenge_full = ma.fields.Str()
     party_full = ma.fields.Str()
     committee_ids = ma.fields.List(ma.fields.Str)
-    candidate_pcc_id = ma.fields.Str(description=docs.CANDIDATE_PCC_ID)
-    candidate_pcc_name = ma.fields.Str(description=docs.CANDIDATE_PCC_NAME)
+    candidate_pcc_id = ma.fields.Str(metadata={'description': docs.CANDIDATE_PCC_ID})
+    candidate_pcc_name = ma.fields.Str(metadata={'description': docs.CANDIDATE_PCC_NAME})
     total_receipts = ma.fields.Float()
     total_disbursements = ma.fields.Float()
     cash_on_hand_end_period = ma.fields.Float()
@@ -1680,7 +1680,7 @@ register_schema(RadAnalystPageSchema)
 EntityReceiptDisbursementTotalsSchema = make_schema(
     models.EntityReceiptDisbursementTotals,
     options={'exclude': ('idx', 'month', 'year')},
-    fields={'end_date': ma.fields.Date(description=docs.END_DATE_ENTITY_CHART)}
+    fields={'end_date': ma.fields.Date(metadata={'description': docs.END_DATE_ENTITY_CHART})}
 )
 EntityReceiptDisbursementTotalsPageSchema = make_page_schema(EntityReceiptDisbursementTotalsSchema)
 register_schema(EntityReceiptDisbursementTotalsSchema)

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -44,7 +44,7 @@ class Resource(six.with_metaclass(MethodResourceMeta, restful.Resource)):
 
 
 API_KEY_ARG = fields.Str(
-     missing="DEMO_KEY", description=docs.API_KEY_DESCRIPTION,
+     load_default="DEMO_KEY", metadata={'description': docs.API_KEY_DESCRIPTION},
 )
 if env.get_credential("PRODUCTION") or env.get_credential("STAGE"):
     Resource = use_kwargs({"api_key": API_KEY_ARG})(Resource)


### PR DESCRIPTION
## Summary (required)

- Resolves #6279 & #6281 

This PR upgrades `marshmallow`, `apispec`, and `marshmallow_sqlalchemy` to reduce warnings and allow us to upgrade python in the future. 

### Required reviewers 2 developers

## Impacted areas of the application

General components of the application that this PR will affect:

- swagger docs 
- all fields

## How to test

- checkout this branch
- create and activate a new virtualenv 
- `pip install -r requirements.txt`
- `pytest`
- `flask run`
- Test swagger:
http://127.0.0.1:5000/swagger/
(ensure metadata for descriptions and refs is correct)
- Run queries using frontend to ensure default values are loaded correctly
- Run some queries to ensure there's no change to schemas.


Here is the documentation for the upgrades:

marshmallow: https://marshmallow.readthedocs.io/en/latest/changelog.html
- `missing` is replaced with `load_default`
- `default` is replaced with `dump_default`
- field metadata must be passed using a explicit `metadata=` argument 

marshmallow-sqlalchemy: https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html

apispec:  https://apispec.readthedocs.io/en/latest/changelog.html
- removed `validate_spec` must now access validator directly 

