### PR TITLE
Add sort to AO _source documents

### DIFF
--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -402,7 +402,8 @@ def get_case_document_query(q, **kwargs):
 
     if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps") is not None:
         combined_query.append(get_proximity_query(**kwargs))
-        proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
+        proximity_inner_hits = {"_source": {
+            "excludes": ["documents.text"]}, "size": 100}
 
         if q:
             proximity_inner_hits["highlight"] = {
@@ -705,7 +706,20 @@ def get_ao_document_query(q, **kwargs):
 
     if check_filter_exists(kwargs, "q_proximity") and kwargs.get("max_gaps") is not None:
         combined_query.append(get_proximity_query(**kwargs))
-        proximity_inner_hits = {"_source": {"excludes": ["documents.text"]}, "size": 100}
+        proximity_inner_hits = {"_source": {
+            "excludes": ["documents.text"]},
+            "size": 100,
+            "sort": [{
+                "_script": {
+                    "type": "number",
+                    "script": {
+                        "lang": "painless",
+                        "source": """if (doc['documents.ao_doc_category_id'].size() == 0) return 1;
+                        return doc['documents.ao_doc_category_id'].value == 'F' ? 0 : 1;"""
+                        }, "order": "asc"
+                        }
+                        }, {"documents.ao_doc_category_id": "asc"}, {"_score": "desc"}]
+            }
 
         if q:
             proximity_inner_hits["highlight"] = {


### PR DESCRIPTION
## Summary (required)

- Resolves #6297

This PR sorts the AO source documents by category id (with final opinions first) then by relevance score. 

### Required reviewers 1 front end, 1 backend 


## Impacted areas of the application

- AO legal search

## How to test

- checkout this branch 
- start virtualenv 
- start elasticsearch
- `flask run`
- test AO proximity search and ensure source documents are sorted correctly 

Sample URLs:

http://127.0.0.1:5000/v1/legal/search/?type=advisory_opinions&q_proximity=responding&q_proximity=request&max_gaps=10000&ao_no=2024-05
