### PR TITLE
Add sql and code profiling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ujson==5.4.0 # decoding CSP violation reported
 urllib3==2.6.3
 webargs==8.7.1
 werkzeug==3.1.5
-yappi==1.6.10
+yappi==1.7.3
 
 # Marshalling
 flask-apispec==0.11.4

--- a/webservices/profiling.py
+++ b/webservices/profiling.py
@@ -6,6 +6,56 @@ import io
 import contextlib
 import yappi
 
+
+"""
+===========================
+SQL + CODE PROFILING
+===========================
+
+This module provides two types of profiling:
+
+1) SQLAlchemy
+2) Full Python function profiling using Yappi 
+
+--------------------------------------------------
+1) HOW TO ENABLE SQL QUERY PROFILING
+--------------------------------------------------
+
+To activate sqlalchemy query timing, you need to import this module
+during application startup in create_app()
+
+
+    def create_app():
+        app = Flask(__name__)
+        db.init_app(app)
+
+        # Enable SQL profiling
+        import webservices.profiling # noqa
+
+        .
+        .
+        .
+        return app
+
+--------------------------------------------------
+2) HOW TO USE THE YAPPI CONTEXT MANAGER
+--------------------------------------------------
+
+The `profiled()` context manager enables python code
+profiling for wrapped blocks of code. 
+
+To use wrap any slow code with profiled().
+
+Usage example:
+
+    from webservices.profiling import profiled
+
+    def get():
+        with profiled():
+            run_expensive_code()
+
+"""
+
 logging.basicConfig()
 logger = logging.getLogger("sql_profiling")
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary (required)

- Resolves #6301 

This PR adds  SQL and code profiling tools that can be use during development and debugging.

The SQL profiling tool logs all sql statements and how long they take to execute and gives us visibility into slow sql. Sqlalchemy also provides [guidance](https://docs.sqlalchemy.org/en/21/faq/performance.html#how-can-i-profile-a-sqlalchemy-powered-application) on how to find and fix issues with slow queries using these profiling tools. 

The code profiling is greenlet aware and shows us exactly which parts of our code take the longest to run. 


### Required reviewers 2 devs 


## How to test

- pull this branch 
- create and activate a virtual environment 
- `pip install -r requirements.txt`
- `pytest`
- `flask run`
- Run any query (there should be no unexpected logging statements in your terminal)
-  Follow the instructions in the code on how to enable the profiling tools or use this [branch](https://github.com/fecgov/openFEC/tree/test-profiling-dev) 
   - in `webservices.common.views.py` add the following import statement `from webservices.profiling import profiled`
   - In the `ItemizedResource` wrap the code under the `get` method with `with profiled():`
- Run any itemized endpoint (there should now be logging statements) 
