### PR TITLE
6325- fix filename search

### DIFF
--- a/webservices/legal_docs/es_management.py
+++ b/webservices/legal_docs/es_management.py
@@ -67,7 +67,7 @@ CASE_DOCUMENT_MAPPING = {
         },
         "document_date": {"type": "date", "format": "dateOptionalTime"},
         "url": {"type": "text"},
-        "filename": {"type": "text"},
+        "filename": {"type": "keyword"},
         "doc_order_id": {"type": "integer"},
     },
 }
@@ -348,7 +348,7 @@ AO_MAPPING = {
                 },
                 "date": {"type": "date", "format": "dateOptionalTime"},
                 "url": {"type": "text", "index": False},
-                "filename": {"type": "text"},
+                "filename": {"type": "keyword"},
             },
         },
         "requestor_names": {"type": "text"},
@@ -382,7 +382,7 @@ ARCH_MUR_DOCUMENT_MAPPING = {
             "term_vector": "with_positions_offsets",
         },
         "url": {"type": "text", "index": False},
-        "filename": {"type": "text"}
+        "filename": {"type": "keyword"}
     },
 }
 

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -200,7 +200,7 @@ def generic_query_builder(q, type_, from_hit, hits_returned, **kwargs):
     if kwargs.get("filename"):
         must_clauses = []
         must_clauses.append(Q("nested", path="documents",
-                            query=Q("match", documents__filename=kwargs.get("filename"))))
+                            query=Q("term", documents__filename=kwargs.get("filename"))))
         query = query.query("bool", must=must_clauses)
 
     if kwargs.get("q_exclude"):


### PR DESCRIPTION
## Summary (required)

- Resolves #6325

We need to switch filename filter to keyword/term due to hyphens. This is the more efficient query than match_phrase. 

We need to make this change ASAP for saos decommission, but might want to do follow-up changes with the rulemakings filename search before that's available. 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- legal

## How to test

Rebuild this branch on dev, dev has already been reindexed
- https://app.circleci.com/pipelines/github/fecgov/openFEC/3720
- https://fec-dev-api.app.cloud.gov/v1/legal/search/?filename=4666
- https://fec-dev-api.app.cloud.gov/v1/legal/search/?filename=1976-06
- https://fec-dev-api.app.cloud.gov/v1/legal/search/?filename=4854_01
- https://fec-dev-api.app.cloud.gov/v1/legal/search/?filename=1199_02

You can also pull this branch and test locally, but will need to reload all indexes
https://github.com/fecgov/openFEC/wiki/ES-7.x.0-setup-and-test-locally


