### PR TITLE
Add missing org types

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -524,7 +524,7 @@ committee = {
         metadata={'description': docs.DESIGNATION},
     ),
     'organization_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'committee_type': fields.List(
@@ -634,7 +634,7 @@ form1efilings = {
     'max_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
     'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
     'organization_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},
     ),
 }
@@ -727,7 +727,7 @@ totals_by_entity_type = {
     # sponsor_candidate_id Only for 'pac' and 'pac-party'
     'sponsor_candidate_id': fields.List(Candidate_ID, metadata={'description': docs.SPONSOR_CANDIDATE_ID}),
     'organization_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'min_first_f1_date': Date(metadata={'description': docs.MIN_FIRST_F1_DATE}),
@@ -830,7 +830,7 @@ schedule_a = {
         metadata={'description': docs.COMMITTEE_TYPE},
     ),
     'recipient_committee_org_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'recipient_committee_designation': fields.List(
@@ -926,7 +926,7 @@ schedule_b = {
         metadata={'description': docs.DESIGNATION},
     ),
     'spender_committee_org_type': fields.List(
-        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W'])),
+        IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},
     ),
     'spender_committee_type': fields.List(

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -382,6 +382,8 @@ ORGANIZATION_TYPE = 'The one-letter code for the kind for organization:\n\
         - T trade association\n\
         - V cooperative\n\
         - W corporation without capital stock\n\
+        - H host committee\n\
+        - I inaugural committee\n\
 '
 COMMITTEE_TYPE = 'The one-letter type code of the organization:\n\
         - C communication cost\n\


### PR DESCRIPTION
## Summary (required)

- Resolves #6320 

This PR adds two missing org types to all of our organization_type filters.

### Required reviewers 1 dev 


## Impacted areas of the application

General components of the application that this PR will affect:

- all org type filters

## How to test

- checkout this branch 
- start virtualenv 
- `pytest`
- `flask run`
- test org type filters 

Sample URLs:
http://127.0.0.1:5000/v1/committees/?organization_type=H

http://127.0.0.1:5000/v1/committees/?organization_type=I

http://127.0.0.1:5000/v1/totals/pac/?organization_type=H

http://127.0.0.1:5000/v1/schedules/schedule_a/?two_year_transaction_period=2020&recipient_committee_org_type=H&per_page=20&sort=-contribution_receipt_date&sort_hide_null=false&sort_null_only=false

