### PR TITLE
Feature/6341 consolidate dismiss disposition categories

### DIFF
--- a/tests/test_legal/test_case_endpoint.py
+++ b/tests/test_legal/test_case_endpoint.py
@@ -529,6 +529,13 @@ class TestCaseDocsElasticsearch(ElasticSearchBaseTest):
             )
             for mur in response["murs"]
         )
+
+        category = 4
+        response = self._results_mur(api.url_for(UniversalSearch, mur_disposition_category_id=category))
+        # logging.info(response)
+
+        assert len(response["murs"]) == 1
+
         self.check_incorrect_values({"mur_disposition_category_id": "49"}, "total_murs", True)
 
 # ---------------------- End MUR  filters ------------------------------------------------

--- a/tests/test_legal/test_legal_data.py
+++ b/tests/test_legal/test_legal_data.py
@@ -362,7 +362,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Shearer, Alaina"
         },
@@ -376,7 +376,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Hubay, Scott M."
         },
@@ -396,7 +396,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Frost-Brooks, Patricia"
         },
@@ -410,7 +410,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Alaina Shearer for Congress"
         },
@@ -424,7 +424,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Gem City Rise PAC (f/k/a Friends of Desiree Tims)"
         },
@@ -450,7 +450,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Tims, Desiree"
         },
@@ -470,7 +470,7 @@ second_test_mur = {
             }
           ],
           "disposition": "No RTB",
-          "mur_disposition_category_id": 12,
+          "mur_disposition_category_id": 10,
           "penalty": None,
           "respondent": "Ohio Democratic Party"
         }

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -412,7 +412,7 @@ legal_universal_search = {
     'mur_disposition_category_id': fields.List(IStr(
         validate=validate.OneOf([
             '', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-            '11', '12', '13', '14', '15', '16', '17', '18'])),
+            '11', '12', '13', '14', '15', '16'])),
         metadata={'description': docs.MUR_DISPOSITION_CATEGORY_DESCRIPTION}
     ),
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2276,24 +2276,22 @@ Select one or more case document category id to filter by corresponding case doc
 
 MUR_DISPOSITION_CATEGORY_DESCRIPTION = '''
 Select one or more MUR disposition category id to filter by corresponding MUR disposition category:\n\
-        - 1 - Conciliation-PPC\n\
-        - 2 - Conciliation-PC\n\
-        - 3 - Dismiss and Remind\n\
-        - 4 - Dismissed\n\
+        - 1 - Conciliation: Pre Probable Cause\n\
+        - 2 - Conciliation: Probable Cause\n\
+        - 3 - Dismiss with Caution\n\
+        - 4 - Dismissed-All\n\
         - 5 - Dismissed-Low Rated\n\
         - 6 - Dismissed-Other\n\
         - 7 - Dismissed-Stale\n\
-        - 8 - Dismiss pursuant to prosecutorial discretion\n\
-        - 9 - Dismiss pursuant to prosecutorial discretion, and caution\n\
-        - 10 - Enforcement - Disposition - Dismissed Dismiss - Dismiss and Caution\n\
-        - 11 - No PCTB\n\
-        - 12 - No RTB\n\
-        - 13 - PCTB Finding\n\
-        - 14 - PC/NFA\n\
-        - 15 - RTB Finding\n\
-        - 16 - RTB/NFA\n\
-        - 17 - Take no action\n\
-        - 18 - Take No Further Action\n\
+        - 8 - Dismiss Pursuant to Prosecutorial Discretion\n\
+        - 9 - No Probable Cause to Believe\n\
+        - 10 - No Reason to Believe\n\
+        - 11 - Probable Cause to Believe Finding\n\
+        - 12 - Probable Cause to Believe Finding/No Further Action\n\
+        - 13 - Reason to Believe Finding\n\
+        - 14 - Reason to Believe Finding/No Further Action\n\
+        - 15 - Take No Action\n\
+        - 16 - Take No Further Action\n\
 '''
 
 MUR_TYPE = '''

--- a/webservices/legal/constants.py
+++ b/webservices/legal/constants.py
@@ -50,6 +50,8 @@ PORT = 443
 DOCS_PATH = "docs"
 RULEMAKING_PATH = "rulemaking"
 RULEMAKING_TYPE = "rulemakings"
+DISMISSED_ALL = "4"
+DISMISSED_CATEGORIES = {"3", "5", "6", "7", "8"}
 
 # =========Start rulemaking Constants==========
 RM_INDEX = "rm_index"

--- a/webservices/legal/legal_docs/current_cases.py
+++ b/webservices/legal/legal_docs/current_cases.py
@@ -278,7 +278,8 @@ ADR_CASE_STATUS_MAP = {
 CASE_DISPOSITION_CATEGORY = """
     SELECT category_name,
     category_id,
-    doc_type
+    doc_type,
+    display_category_name
     from fecmur.ref_case_disposition_category
     WHERE published_flg = true
     AND doc_type = :type
@@ -627,17 +628,22 @@ def get_mur_dispositions(case_id):
         logger.debug("category_list =" + json.dumps(category_list, indent=3, cls=DateTimeEncoder))
         disposition_data = []
         for row in rs:
-            category_id = get_display_case_disposition_category_id(category_list, row["event_name"], "MUR")
+            category_id, display_nm = get_display_case_disposition_category_id(category_list, row["event_name"], "MUR")
             if category_id:
+                disposition = None
                 citations = []
                 if ALL_STATUTORY_CITATIONS.get(str(case_id) + row["name"]):
                     citations += ALL_STATUTORY_CITATIONS.get(str(case_id) + row["name"])
                 if ALL_REGULATORY_CITATIONS.get(str(case_id) + row["name"]):
                     citations += ALL_REGULATORY_CITATIONS.get(str(case_id) + row["name"])
 
+                if category_id < 0:
+                    category_id = 3
+                    disposition = "Dismiss with Caution"
+
                 disposition_data.append({
                     "citations": citations,
-                    "disposition": row["event_name"],
+                    "disposition": disposition if disposition else display_nm,
                     "mur_disposition_category_id": category_id,
                     "penalty": row["final_amount"],
                     "respondent": row["name"], },
@@ -648,7 +654,9 @@ def get_mur_dispositions(case_id):
 def get_display_case_disposition_category_id(category_list, category_name, doc_type):
     for one_row in category_list:
         if one_row["category_name"] == category_name and one_row["doc_type"] == doc_type:
-            return one_row["category_id"]
+            return one_row["category_id"], one_row["display_category_name"]
+
+    return None, None
 
 
 def parse_statutory_citations(statutory_citation, case_id, entity_id, doc_type=None):

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -10,7 +10,7 @@ from webservices.utils import Resource
 from webservices.legal.utils_es import create_es_client, DateTimeEncoder, check_filter_exists
 
 from webservices.legal.constants import (  # noqa
-    SEARCH_ALIAS,
+    SEARCH_ALIAS, DISMISSED_ALL, DISMISSED_CATEGORIES
 )
 from webservices.utils import use_kwargs
 from elasticsearch import RequestError
@@ -429,8 +429,12 @@ def get_mur_disposition_query(q, **kwargs):
     combined_query = []
     category_queries = []
     if kwargs.get("mur_disposition_category_id") and (len(kwargs.get("mur_disposition_category_id")) > 0):
+        mur_disposition_list = set(kwargs.get("mur_disposition_category_id"))
 
-        for mur_disposition_category_id in kwargs.get("mur_disposition_category_id"):
+        if DISMISSED_ALL in mur_disposition_list:  # add all dismiss categories
+            mur_disposition_list.update(set(DISMISSED_CATEGORIES))
+
+        for mur_disposition_category_id in mur_disposition_list:
             if len(mur_disposition_category_id) > 0:
                 category_queries.append(
                     Q(


### PR DESCRIPTION
## Summary (required)

- Resolves #6340, #6341 

**Note: This PR should be deployed in same release as :**
- https://github.com/fecgov/fec-cms/pull/6863

This PR consolidates three disposition categories and renames and fixes the `Dismiss-All` category.  I spoke with a PM about these tickets, and they did not want to have ITSS update the underlying data at this time. I will need to coordinate with a DBA to update the data in `fecmur.ref_case_disposition_category` in stage and prod. 

Consolidated categories (Dismiss with Caution):
- Dismiss and Remind 
- Dismiss pursuant to prosecutorial discretion, and caution
- Enforcement – Disposition – Dismissed "Dismiss" – Dismiss and Caution

Dismiss-All categories: 
- Dismiss with Caution
- Dismissed-Low Rated
- Dismissed-Other
- Dismissed-Stale
- Dismiss pursuant to prosecutorial discretion


### Required reviewers 2 backend devs, 1 front end dev

## Impacted areas of the application

General components of the application that this PR will affect:

- mur legal search

## Related PRs

frontend PR: https://github.com/fecgov/fec-cms/pull/6863

## How to test

- pull this branch 
- start virtual environment 
- start elasticsearch
- `pytest`
- load some murs:  `python cli.py load_current_murs`
- load these specific murs: 
`python cli.py load_current_murs 7778`
`python cli.py load_current_murs 7749`
` python cli.py load_current_murs 7693`
- `flask run`
- http://127.0.0.1:5000/v1/legal/search/?mur_disposition_category_id=3 ( should show new dismiss with caution category) 
- http://127.0.0.1:5000/v1/legal/search/?mur_disposition_category_id=4 (should show all dismiss categories)

On Dev: 
- deploy this test branch: https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-disposition-categories

- test disposition categories:

https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&mur_type=current&mur_disposition_category_id=4

https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&mur_type=current&mur_disposition_category_id=4&mur_disposition_category_id=1

https://fec-dev-api.app.cloud.gov/v1/legal/search/?type=murs&mur_type=current&mur_disposition_category_id=3
Note: front end will not work until frontend PR is merged