### PR TITLE
Fix db cast error downloads

### DIFF
--- a/webservices/resources/candidates.py
+++ b/webservices/resources/candidates.py
@@ -75,7 +75,6 @@ class CandidateList(ApiResource):
             kwargs['q'] = kwargs['name']
 
         query = super().build_query(**kwargs)
-        query._array_cast_keys = set()
 
         candidate_detail = models.Candidate
 
@@ -104,12 +103,10 @@ class CandidateList(ApiResource):
 
         if kwargs.get('cycle'):
             query = query.filter(candidate_detail.cycles.overlap(kwargs['cycle']))
-            query._array_cast_keys.add('cycles_')
         if kwargs.get('election_year'):
             query = query.filter(
                 candidate_detail.election_years.overlap(kwargs['election_year'])
             )
-            query._array_cast_keys.add('election_years_')
         if 'is_active_candidate' in kwargs and kwargs.get('is_active_candidate'):
             # load active candidates only if True
             if kwargs.get('election_year'):
@@ -123,8 +120,6 @@ class CandidateList(ApiResource):
                         candidate_detail.inactive_election_years.is_(None),
                     )
                 )
-                query._array_cast_keys.add('inactive_election_years_')
-
             else:
                 query = query.filter(
                     candidate_detail.candidate_inactive.is_(False)
@@ -137,7 +132,6 @@ class CandidateList(ApiResource):
                         kwargs['election_year']
                     )
                 )
-                query._array_cast_keys.add('inactive_election_years_')
             else:
                 query = query.filter(
                     candidate_detail.candidate_inactive == True  # noqa
@@ -145,6 +139,7 @@ class CandidateList(ApiResource):
         else:
             # load all candidates
             pass
+        query = query.execution_options(overlap_columns=set(['inactive_election_years_', 'election_years_', 'cycles_']))
         return query
 
 
@@ -203,7 +198,6 @@ class CandidateView(ApiResource):
 
     def build_query(self, candidate_id=None, committee_id=None, **kwargs):
         query = super().build_query(**kwargs)
-        query._array_cast_keys = set()
 
         if candidate_id is not None:
             candidate_id = candidate_id.upper()
@@ -222,12 +216,10 @@ class CandidateView(ApiResource):
 
         if kwargs.get('cycle'):
             query = query.filter(models.CandidateDetail.cycles.overlap(kwargs['cycle']))
-            query._array_cast_keys.add('cycles_')
         if kwargs.get('election_year'):
             query = query.filter(
                 models.Candidate.election_years.overlap(kwargs['election_year'])
             )
-            query._array_cast_keys.add('election_years_')
         if 'has_raised_funds' in kwargs:
             query = query.filter(
                 models.Candidate.flags.has(
@@ -241,6 +233,7 @@ class CandidateView(ApiResource):
                     == kwargs['federal_funds_flag']
                 )
             )
+        query = query.execution_options(overlap_columns=set(['election_years_', 'cycles_']))
         return query
 
 

--- a/webservices/resources/committees.py
+++ b/webservices/resources/committees.py
@@ -84,6 +84,7 @@ class CommitteeList(ApiResource):
         )
 
     def build_query(self, **kwargs):
+
         if kwargs.get("sort"):
             if "q" not in kwargs and kwargs["sort"] in {"receipts", "-receipts"}:
                 raise exceptions.ApiError(
@@ -92,13 +93,10 @@ class CommitteeList(ApiResource):
                 )
 
         query = super().build_query(**kwargs)
-        query._array_cast_keys = set()
-        query._array_cast_keys.add('sponsor_candidate_ids')
         if kwargs.get("candidate_id"):
             query = query.filter(
                 models.Committee.candidate_ids.overlap(kwargs["candidate_id"])
             )
-            query._array_cast_keys.add('candidate_ids_')
         if kwargs.get("q"):
             query = query.join(
                 models.CommitteeSearch,
@@ -113,8 +111,8 @@ class CommitteeList(ApiResource):
 
         if kwargs.get("cycle"):
             query = query.filter(models.Committee.cycles.overlap(kwargs["cycle"]))
-            query._array_cast_keys.add('cycles_')
 
+        query = query.execution_options(overlap_columns=set(['cycles_', 'candidate_ids_', 'sponsor_candidate_ids_']))
         return query
 
 
@@ -159,7 +157,6 @@ class CommitteeView(ApiResource):
 
     def build_query(self, committee_id=None, candidate_id=None, **kwargs):
         query = super().build_query(**kwargs)
-        query._array_cast_keys = set()
 
         if committee_id is not None:
             committee_id = committee_id.upper()
@@ -180,8 +177,8 @@ class CommitteeView(ApiResource):
 
         if kwargs.get("cycle"):
             query = query.filter(models.CommitteeDetail.cycles.overlap(kwargs["cycle"]))
-            query._array_cast_keys.add('cycles_')
 
+        query = query.execution_options(overlap_columns=set(['cycles_']))
         return query
 
 

--- a/webservices/resources/reports.py
+++ b/webservices/resources/reports.py
@@ -160,8 +160,6 @@ class ReportsView(views.ApiResource):
             reports_type_map.get(entity_type), default_schemas,
         )
         query = sa.select(reports_class)
-        query._array_cast_keys = set()
-        query._array_cast_keys.add('candidate_ids_')
         filter_multi_fields = [
             ('amendment_indicator', models.CommitteeReports.amendment_indicator),
             ('report_type', reports_class.report_type),
@@ -195,6 +193,8 @@ class ReportsView(views.ApiResource):
         query = filters.filter_multi(query, kwargs, filter_multi_fields)
         query = filters.filter_fulltext(query, kwargs, filter_fulltext_fields)
         query = filters.filter_overlap(query, kwargs, filter_overlap_fields)
+
+        query = query.execution_options(overlap_columns=set(['candidate_ids_']))
         return query, reports_class, reports_schema
 
 

--- a/webservices/resources/totals.py
+++ b/webservices/resources/totals.py
@@ -87,8 +87,6 @@ class TotalsByEntityTypeView(ApiResource):
             default_schemas,
         )
         query = sa.select(totals_class)
-        query._array_cast_keys = set()
-        query._array_cast_keys.add('sponsor_candidate_ids_')
         # Committee ID needs to be handled separately because it's not in kwargs
         if committee_id is not None:
             query = query.filter(totals_class.committee_id.in_(committee_id))
@@ -132,6 +130,7 @@ class TotalsByEntityTypeView(ApiResource):
                 models.CommitteeTotalsPerCycle.committee_type == 'P'
             )
 
+        query = query.execution_options(overlap_columns=set(['sponsor_candidate_ids_']))
         return query, totals_class, totals_schema
 
     def get_filter_multi_fields(self, entity_type, totals_class):


### PR DESCRIPTION
## Summary (required)

- Resolves #6398 

This PR fixes the db cast error when downloading datatables that have an `overlap` filter added. `array_cast_keys` is being wiped out when adding additional filters to a query. I switched over to using `execution_options` because it is not wiped out when changes are made, and the [documentation](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options) states this field accepts arbitrary user defined variables. 

### Required reviewers 2 developers


## Impacted areas of the application

- downloads:

   -  `All candidates` datatable
        -  `cycle`
        - `election_year`
        - `inactive_election_year`
    - `All committees` datatable
        - `sponsor_candidate_id`
        - `cycle`
        - `candidate_id`
    -  `House and senate committee reports` datatable
        - `candidate_id`
    - `Presidential committee reports` datatable
        - `candidate_id`
     - `Political action and party committees` datatable
        - `sponsor_candidate_id` 

## How to test

- Push [this](https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-db-cast-error-stage) test branch to dev or stage
- test downloads:

Sample URLs:

https://stage.fec.gov/data/candidates/?has_raised_funds=true&is_active_candidate=true

https://stage.fec.gov/data/candidates/?election_year=2021&election_year=2022&election_year=2023&is_active_candidate=true&has_raised_funds=true

https://stage.fec.gov/data/candidates/?election_year=2021&election_year=2022&election_year=2023&district=02&district=07&is_active_candidate=true&has_raised_funds=true

https://stage.fec.gov/data/candidates/?election_year=2015&election_year=2017&election_year=2020&election_year=2021&election_year=2026&election_year=2029&state=AR&state=AZ&state=CA&is_active_candidate=true&has_raised_funds=true

https://stage.fec.gov/data/committees/?cycle=2014&cycle=2016&cycle=2018&cycle=2022

https://stage.fec.gov/data/committees/?cycle=2014&cycle=2016&cycle=2018&cycle=2022&party=APF&party=REP

https://stage.fec.gov/data/committees/?cycle=2014&cycle=2016&cycle=2018&cycle=2020&cycle=2022&cycle=2024&cycle=2026&sponsor_candidate_id=S8VA00214&sponsor_candidate_id=S6KS00122&sponsor_candidate_id=H0MT00033&sponsor_candidate_id=H6TX21012

https://stage.fec.gov/data/committees/?cycle=2014&cycle=2016&cycle=2018&cycle=2020&cycle=2022&cycle=2024&cycle=2026&state=KS&state=KY&state=NE&state=NH&state=NV&state=NY&state=TX&sponsor_candidate_id=S8VA00214&sponsor_candidate_id=S6KS00122&sponsor_candidate_id=H0MT00033&sponsor_candidate_id=H6TX21012

https://stage.fec.gov/data/reports/house-senate/?data_type=processed&candidate_id=S6MI00418&candidate_id=S6MI00459&candidate_id=S6MN00440&candidate_id=S6MN00465&report_type=Q3

https://stage.fec.gov/data/reports/presidential/?is_amended=false&data_type=processed&candidate_id=P60023207&candidate_id=P60023561&candidate_id=P80000722

https://stage.fec.gov/data/reports/presidential/?is_amended=false&data_type=processed&candidate_id=P60023207&candidate_id=P60023561&candidate_id=P80000722&report_type=Q1&report_type=Q2&report_type=Q3

https://stage.fec.gov/data/committees/pac-party/?cycle=2026

https://stage.fec.gov/data/committees/pac-party/?cycle=2026&sponsor_candidate_id=H6CA05195&sponsor_candidate_id=H6CA39020&sponsor_candidate_id=S2KY00012&sponsor_candidate_id=S6OH00379&sponsor_candidate_id=S6UT00063

https://stage.fec.gov/data/committees/pac-party/?cycle=2026&sponsor_candidate_id=H6CA05195&sponsor_candidate_id=H6CA39020&sponsor_candidate_id=S2KY00012&sponsor_candidate_id=S6OH00379&sponsor_candidate_id=S6UT00063&committee_state=AR&committee_state=AZ&committee_state=CA

https://stage.fec.gov/data/committees/?cycle=2010&cycle=2018&cycle=2024&party=DEM

https://stage.fec.gov/data/candidates/?election_year=2018&election_year=2025&election_year=2027&election_year=2028&is_active_candidate=true&has_raised_funds=true&party=DEM