### PR TITLE
upgrade postgres docker image to v15.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           SQLA_TEST_CONN: postgresql://postgres@0.0.0.0/cfdm_unit_test
 
       # PostgreSQL
-      - image: cimg/postgres:13.16
+      - image: cimg/postgres:15.10
         environment:
           POSTGRES_USER: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -40,7 +40,7 @@ jobs:
           # https://circleci.com/docs/2.0/postgres-config/#postgresql-circleci-configuration-example
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update -qq && sudo apt-get install -y build-essential postgresql-client
-            echo 'export PATH=/usr/lib/postgresql/13.16/bin/:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/lib/postgresql/15.10/bin/:$PATH' >> $BASH_ENV
 
       - run:
           name: Install flyway


### PR DESCRIPTION
## Summary (required)

Postgres instances on AWS were recently upgraded to v15.10.  This PR will upgrade the circleci docker image to match production Postgres version 15.10

- Resolves #6287


### Required reviewers

1 developer
## Impacted areas of the application

- circleci postgres docker image

## Screenshots

**Before:**
<img width="1354" height="622" alt="Screenshot 2025-12-04 at 8 58 53 PM" src="https://github.com/user-attachments/assets/f51e56a3-c442-4015-842a-924594b5f140" />


**After:**

<img width="1363" height="629" alt="Screenshot 2025-12-04 at 9 01 14 PM" src="https://github.com/user-attachments/assets/b6c880a4-5a9f-4a49-9b69-0bce3c047481" />

## How to test

- rerun [this](https://app.circleci.com/pipelines/github/fecgov/openFEC/3875/workflows/3d9fb6d9-e5e5-4710-bf0c-09f7c41f1114/jobs/6881) circle build

- verify the container, install system dependencies tasks on circleci now use  postgres v15.10
- pytests run OK



