### PR TITLE
6384--Feature/upgrade redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ smart_open==1.8.0
 # Task queue
 celery==5.2.2 # if celery version is updated, need to verify compatibility with kombu and ensure correct version of kombu is pinned above
 celery-once==3.0.0
-redis==6.2
+redis==6.2.0
 
 # testing and build in circle
 coverage==7.0.3


### PR DESCRIPTION
## Summary (required)

- Resolves #6384
Upgrades redis to remain consistent with out elasticache redis version

### Required reviewers

1 dev

## Impacted areas of the application

- Celery tasks

## How to test
Either
Rebuild stage branch here, check to see in the logs there's no errors and tasks are running successfully: 
-https://app.circleci.com/pipelines/github/fecgov/openFEC/3877/workflows/68f583c8-269a-4540-b445-4467673f5f57/jobs/6883 

Test locally:
- rerun `pip install -r requirements.txt` or uninstall current version of redis and reinstall redis==6.2.0
- test task locally using wiki https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks

stage and dev have been upgraded to 6.2, you can check this by running cf env api in those spaces (prod will be updated early next week) 