### PR TITLE
upgrade webargs v8.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==2.0.41
 ujson==5.4.0 # decoding CSP violation reported
-webargs==7.0.0
+webargs==8.7.1
 werkzeug==3.0.6
 
 # Marshalling


### PR DESCRIPTION
## Summary (required)

- Resolves #6280 

This PR upgrades webargs to the latest version to remove a pytest warning. It is also a blocker for upgrading to future python versions. According to the [documentation](https://webargs.readthedocs.io/en/latest/upgrading.html), none of the breaking changes impact our code.

 
### Required reviewers 1 developer


## Impacted areas of the application

General components of the application that this PR will affect:

- API endpoints 

## How to test

- checkout this branch
- start new virtualenv
- `pip install -r requirements.txt`
- `pytest`
- `flask run`
- test endpoints