### PR TITLE
Refactor ElectionsListView to use new ofec_zip_to_district table

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -481,8 +481,6 @@ class ZipsDistrictsFactory(BaseFactory):
     class Meta:
         model = models.ZipsDistricts
 
-    active = "Y"
-
 
 class CommunicationCostFactory(BaseFactory):
     class Meta:

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -68,10 +68,10 @@ class TestElectionSearch(ApiBaseTest):
 
     def test_search_zip(self):
         factories.ZipsDistrictsFactory(
-            district='05', zip_code='22902', state_abbrevation='VA'
+            district='05', zip_code='22902', state='VA', election_year=2012
         )
 
-        results = self._results(api.url_for(ElectionsListView, zip='22902'))
+        results = self._results(api.url_for(ElectionsListView, zip='22902', cycle=2012))
         assert len(results) == 3
         assert_dicts_subset(
             results[0], {'cycle': 2012, 'office': 'P', 'state': 'US', 'district': '00'}

--- a/webservices/common/models/elections.py
+++ b/webservices/common/models/elections.py
@@ -1,6 +1,5 @@
-from .base import db
-
 from webservices import docs
+from .base import db
 
 
 class ElectionsList(db.Model):
@@ -17,14 +16,13 @@ class ElectionsList(db.Model):
 
 
 class ZipsDistricts(db.Model):
-    __table_args__ = {'schema': 'staging'}
-    __tablename__ = 'ref_zip_to_district'
+    __tablename__ = 'ofec_zip_to_district'
 
-    zip_district_id = db.Column(db.Integer, primary_key=True)
-    district = db.Column(db.String, doc=docs.DISTRICT)
-    zip_code = db.Column(db.String)
-    state_abbrevation = db.Column(db.String)
-    active = db.Column(db.String)
+    election_year = db.Column(db.Integer, primary_key=True, doc=docs.ELECTION_YEAR)
+    zip_code = db.Column(db.String, primary_key=True)
+    state = db.Column(db.String, primary_key=True)
+    district = db.Column(db.String, primary_key=True, doc=docs.DISTRICT)
+    state_full = db.Column(db.String)
 
 
 class StateElectionOfficeInfo(db.Model):


### PR DESCRIPTION
## Summary (required)

This should be deployed in tandem with https://github.com/fecgov/fec-cms/issues/6919

Switch endpoint: /elections/search/ --ElectionsListView to new model which will use new zip-district table including historical elections back to 2012 and correct current election data.

- Resolves #6415 

### Required reviewers

1-2 devs

## Impacted areas of the application
/election/search/ endpoint


## How to test
1)Check out branch
2)`pytest`
3)Test /elections/search/ endpoint and compare with prod api
4)Sample test URLs
**Wrong return:"district": "03" in Prod, Correct return in local: "district": "02" )**
http://127.0.0.1:5000/v1/elections/search/?cycle=2026&zip=21211
https://api.open.fec.gov/v1/elections/search/?cycle=2026&zip=21211&api_key=DEMO_KEY

**other cycle, duplicate return: in Prod, "office": "P", and "office": "S",
Correct return in local**
http://127.0.0.1:5000/v1/elections/search/?cycle=2024&zip=21211
https://api.open.fec.gov/v1/elections/search/?cycle=2024&zip=21211&api_key=DEMO_KEY

** earliest correct data back to 2012 **
http://127.0.0.1:5000/v1/elections/search/?cycle=2012&zip=21211