### PR TITLE
[Merge before PR #6420] Add table ofec_zip_to_district

### DIFF
--- a/data/migrations/V0316__add_ofec_zip_to_district.sql
+++ b/data/migrations/V0316__add_ofec_zip_to_district.sql
@@ -1,0 +1,27 @@
+/*
+For issue # 6401, # 6402
+Add new table ofec_zip_to_district. This table holds Zip Code to Congressional District data from 2012 to 2026
+Data are imported separately from excel file 
+*/
+
+CREATE TABLE IF NOT EXISTS public.ofec_zip_to_district
+(
+    election_year integer NOT NULL,
+    zip_code character varying(5) NOT NULL,
+    state character varying(2) NOT NULL,
+    district character varying(2) NOT NULL,
+    state_full character varying(24) NOT NULL,
+    state_fips character varying(2) NOT NULL,
+    apportionment_census_geographies integer,
+    source character varying(90),
+    update_date timestamp without time zone DEFAULT now(),
+    CONSTRAINT ofec_zip_to_district_pkey PRIMARY KEY (election_year, zip_code, state, district)
+);
+
+ALTER TABLE IF EXISTS public.ofec_zip_to_district OWNER to fec;
+
+REVOKE ALL ON TABLE public.ofec_zip_to_district FROM fec_read;
+
+GRANT ALL ON TABLE public.ofec_zip_to_district TO fec;
+
+GRANT SELECT ON TABLE public.ofec_zip_to_district TO fec_read;


### PR DESCRIPTION
## Summary (required)

- Resolves #6401, 
#6402 

A new table ofec_zip_to_distirict is added to database. This table includes Zip Code and its congressional district data from 2012 to 2026.  This table will be used by zip code search.

Data is imported separately from excel file ( Dev, Stage and Prod)

### Required reviewers
1-2 dev

## How to test
1. Download feature branch
2. Run `flyway migrate`
3. Run  `pytest`