### PR TITLE
Add q_exclude filter for rulemakings

### DIFF
--- a/tests/test_legal/test_rm_endpoint.py
+++ b/tests/test_legal/test_rm_endpoint.py
@@ -282,6 +282,22 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
 
         self.check_incorrect_values({"q": "IncorrectValue"}, False)
 
+    def test_q_exclude_filter(self):
+        q_exclude_one = "level1test"
+        response = self._results_rm(api.url_for(RulemakingSearch, q_exclude=q_exclude_one))
+        self.assertEqual(len(response), 3)
+        self.assertEqual(response[0]["rm_no"], "2024-08")
+        self.assertEqual(response[1]["rm_no"], "2024-04")
+        self.assertEqual(response[2]["rm_no"], "2022-06")
+
+        # q_exclude_two = "Second RM, first doc, sixthteenth lvl 2"
+        q_exclude_two = "sixthteenth"
+        response = self._results_rm(api.url_for(RulemakingSearch, q_exclude=q_exclude_two))
+        self.assertEqual(len(response), 3)
+        self.assertEqual(response[0]["rm_no"], "2024-10")
+        self.assertEqual(response[1]["rm_no"], "2024-04")
+        self.assertEqual(response[2]["rm_no"], "2022-06")
+
     def test_q_prox_filter(self):
         q_prox_lvl_one = ["Fourth RM", "lvl1"]
         max_gaps = 2

--- a/webservices/args.py
+++ b/webservices/args.py
@@ -440,6 +440,7 @@ legal_universal_search = {
 # rulemaking endpoint: /rulemaking/search (resources/rulemaking.py/Rulemakingsearch)
 rulemaking_search = {
     'q': fields.Str(required=False, metadata={'description': docs.TEXT_SEARCH}),
+    'q_exclude': IStr(required=False, metadata={'description': docs.Q_EXCLUDE}),
     'from_hit': fields.Int(required=False, metadata={'description': docs.FROM_HIT}),
     'hits_returned': fields.Int(required=False, metadata={'description': docs.HITS_RETURNED_RM}),
     'rm_no': fields.List(IStr, required=False, metadata={'description': docs.RM_NUMBER}),


### PR DESCRIPTION
## Summary (required)

- Resolves #6359 

Add `q_exclude` to the args to allow filter by the `q_exclude` parameter from the `rulemaking/search` API endpoint.

### Required reviewers

2 developers

## Impacted areas of the application

- `rulemaking/search` endpoint

## Screenshots
<img width="1404" height="542" alt="Screenshot 2025-12-10 at 9 01 05 PM" src="https://github.com/user-attachments/assets/c4c4723c-be9e-438c-87d3-a8acbdc8e322" />


## How to test

- git checkout feature/6359-rulemaking-q-exclude
- pytest
- load few rulemakings:
- python cli.py load_rulemaking 2013-05
- python cli.py load_rulemaking 2013-04
- python cli.py load_rulemaking 2013-02
 - flask run
 **Test q-exclude variable:**
 - http://localhost:5000/v1/rulemaking/search/?q_exclude=Commission (ZERO results. This common word exists in all 3 rulemakings)
 - http://localhost:5000/v1/rulemaking/search/?q_exclude=contributions : 2013-05 is returned.
  (2013-04  and 2013-02 rulemaking documents contain this word)
- http://localhost:5000/v1/rulemaking/search/?q_exclude=%22encompass%20violations%22: 2013-04 and 2013-02 is returned. (2013-05 rulemaking documents contain this word)

PDF's are available on Dev S3 [here](https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index2.html?prefix=legal/rulemakings/)

