### PR TITLE
upgrade werkzeug to fix snyk vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cfenv==0.5.2
 defusedxml==0.6.0
 elasticsearch==7.10.1
 elasticsearch-dsl==7.4.1
-Flask==2.2.5
+Flask==3.1.0
 Flask-Cors==6.0.0
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.1.1
@@ -26,7 +26,7 @@ sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==2.0.41
 ujson==5.4.0 # decoding CSP violation reported
 webargs==8.7.1
-werkzeug==3.0.6
+werkzeug==3.1.4
 
 # Marshalling
 flask-apispec==0.11.4


### PR DESCRIPTION
## Summary 

Upgrade werkzeug to fix snyk vulnerability. flask pulls the latest version of werkzeug v3.1.3  With this new version of werkzeug, pytests are failing with an error saying module 'werkzeug' has no attribute '__version__'. 
Upgrade flask to fix the pytest errors shown in the screenshot below

<img width="1293" height="395" alt="Screenshot 2025-12-17 at 7 20 27 PM" src="https://github.com/user-attachments/assets/bf13775b-fdfb-4a84-afb8-002b9700cd9f" />





### Resolves #6427 

### Required reviewers

1-2 backend developers


## Screenshots

**Before:**
<img width="1086" height="106" alt="Screenshot 2025-12-17 at 6 38 13 PM" src="https://github.com/user-attachments/assets/cec68390-bfe0-411b-8da2-46e5c1b968f0" />


## How to test
- `git checkout develop`
- `git pull`
- `pyenv activate <virtualenv>`
- `snyk test --file=requirements.txt --package-manager=pip` (werkzeug is flagged as a vulnerable package as show in the screenshot above)
- `git checkout feature/6427-upgrade-werkzeug`
- `pyenv virtualenv <new virtualenv name>`
- `pyenv activate <new virtualenv name>`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `snyk test --file=requirements.txt --package-manager=pip`
- `pytest`
- `flask run` (API app runs OK, no errors in the logs)
