### PR TITLE
Remove webtest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,3 @@ nplusone==0.8.0
 pytest==8.0.2
 pytest-cov==4.1.0
 setuptools==78.1.1
-webtest==2.0.34

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,6 @@ import subprocess
 import unittest
 
 from flask import current_app
-from webtest import TestApp
 
 from webservices.rest import create_app, db
 from webservices import __API_VERSION__
@@ -58,7 +57,7 @@ class BaseTestCase(unittest.TestCase):
             BaseTestCase.application = create_app(test_config='testing')
             BaseTestCase._application = True
         cls.app = cls.application.test_client()
-        cls.client = TestApp(cls.application)
+        cls.client = cls.application.test_client()
         cls.app_context = cls.application.app_context()
         cls.app_context.push()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,7 @@ class TestBaseTestCase(BaseTestCase):
 
     def test_client_is_available(self):
         response = self.client.get("/")
-        self.assertEqual(response.status_int, 301, "Test client request failed")
+        self.assertEqual(response.status_code, 301)
 
     def test_home_page(self):
         response = self.client.get('/developers/')

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -143,10 +143,10 @@ class TestDownloadResource(ApiBaseTest):
     @mock.patch('webservices.resources.download.download.export_query')
     def test_download(self, export, get_cached):
         get_cached.return_value = None
-        res = self.client.post_json(
+        res = self.client.post(
             api.url_for(resource.DownloadView, path='candidates', office='S', q='joh', sort='receipts')
         )
-        assert res.json == {'status': 'queued'}
+        assert res.get_json() == {'status': 'queued'}
         get_cached.assert_called_once_with(
             '/v1/candidates/', b'office=S&q=joh&sort=receipts', filename=None
         )
@@ -158,15 +158,15 @@ class TestDownloadResource(ApiBaseTest):
     @mock.patch('webservices.resources.download.download.export_query')
     def test_download_cached(self, export, get_cached):
         get_cached.return_value = '/download'
-        res = self.client.post_json(
+        res = self.client.post(
             api.url_for(resource.DownloadView, path='candidates', office='S')
         )
-        assert res.json == {'status': 'complete', 'url': '/download'}
+        assert res.get_json() == {'status': 'complete', 'url': '/download'}
         assert not export.delay.called
 
     def test_download_forbidden(self):
         with pytest.raises(ApiError):
-            self.client.post_json(
+            self.client.post(
                 api.url_for(
                     resource.DownloadView,
                     path='elections/search',
@@ -183,7 +183,7 @@ class TestDownloadResource(ApiBaseTest):
         get_cached.return_value = None
         [factories.CandidateFactory() for _ in range(5)]
         db.session.commit()
-        res = self.client.post_json(
+        res = self.client.post(
             api.url_for(resource.DownloadView, path='/candidates', expect_errors=True)
         )
         assert res.status_code == 308


### PR DESCRIPTION
## Summary (required)

- Resolves #6283 

This PR removes webtest package and uses the Flask test client instead. Webtest will break when upgrading to future python releases.

### Required reviewers 1 dev

(Include who is required to review prior to merge. For example: One designer and two front end developer reviews are required prior to merge)

## Impacted areas of the application

General components of the application that this PR will affect:

- tests

## How to test

- checkout this branch 
- create and activate new virtualenv 
- `pip install -r requirements.txt`
- `pytest`
