### PR TITLE
Add source field for rulemaking proximity search

### DIFF
--- a/tests/test_legal/test_rm_endpoint.py
+++ b/tests/test_legal/test_rm_endpoint.py
@@ -309,6 +309,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
                                                 q_proximity=q_prox_lvl_one,
                                                 proximity_preserve_order=True,
                                                 max_gaps=max_gaps))
+        self.assertNotEqual(len(response[0]["source"]), 0)
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["rm_no"], "2022-06")
 
@@ -320,6 +321,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
                                                 proximity_preserve_order=False,
                                                 max_gaps=max_gaps))
         self.assertEqual(len(response), 1)
+        self.assertNotEqual(len(response[0]["source"]), 0)
         self.assertEqual(response[0]["rm_no"], "2024-08")
 
         q_prox_description = "RM lvl 2"
@@ -333,6 +335,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
                                                 proximity_filter_term=proximity_filter_term,
                                                 max_gaps=max_gaps))
         self.assertEqual(len(response), 1)
+        self.assertNotEqual(len(response[0]["source"]), 0)
         self.assertEqual(response[0]["rm_no"], "2024-10")
 
         self.check_incorrect_values({"q_proximity": "Incorrect value", "max_gaps": 1}, False)


### PR DESCRIPTION
## Summary (required)

- Resolves #6437

This ticket add the source column to the rulemaking results. This field will be used by front end to determine exactly which nested documents are a match for the proximity search.

### Required reviewers 2 devs

(Include who is required to review prior to merge. For example: One designer and two front end developer reviews are required prior to merge)

## Impacted areas of the application

General components of the application that this PR will affect:

- rulemaking search 



## How to test

- checkout this branch 
- activate virtualenv 
- start elasticsearch 
- load these specific rulemakings:
`python cli.py load_rulemaking 2013-02`
`python cli.py load_rulemaking 2013-04`
`python cli.py load_rulemaking 2013-05`
- `pytest`
- `flask run`
- Test rulemaking proximity 

URLs:

Lvl 1: http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10 (2013-02)

Lvl2: http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=Draft Final Rules and Explanation&q_proximity=Administrative Fines Program&max_gaps=20 (2013-05)

test all nested filters together: http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=1 (2013-04)