### PR TITLE
6453 add pool_pre_ping

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -119,18 +119,20 @@ def create_app(test_config=None):
         'webservices.tasks.download.export_query',]
     app.config['PROPAGATE_EXCEPTIONS'] = True
     query_cache_size = int(env.get_credential('QUERY_CACHE_SIZE', '100'))
+    pool_pre_ping = bool(env.get_credential('POOL_PRE_PING_BOOL', 'False'))
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
             'query_cache_size': query_cache_size,
             'max_overflow': 50,
             'pool_size': 50,
             'pool_timeout': 120,
+            'pool_pre_ping': pool_pre_ping,
         }
 
     def create_sqlalchemy_followers(env_var_name: str, default_value: str = '') -> list:
         followers = utils.split_env_var(env.get_credential(env_var_name, default_value))
         return [sa.create_engine(follower.strip(), query_cache_size=query_cache_size,
-                                 pool_size=50, max_overflow=50,
-                                 pool_timeout=120) for follower in followers if follower.strip()
+                                 pool_size=50, max_overflow=50, pool_timeout=120,
+                                 pool_pre_ping=pool_pre_ping) for follower in followers if follower.strip()
                 ]
     # app.config['SQLALCHEMY_ECHO'] = True
 


### PR DESCRIPTION
## Summary (required)

- Resolves #6453

Adds pre-ping as a boolean to our engine config

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- sqlalchemy and flasksqlalchemy engine connection pools



## How to test

This is a tricky one to replicate the error since it's only happening in production which is why I'm adding as an env variable, so we can switch back if necessary. I deployed to dev and monitored CPU, memory, and logs and didn't have any issues. You can rebuild on dev this branch:

- https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-pre-ping-dev

