### PR TITLE
Fix nested rulemaking filters

### DIFF
--- a/tests/test_legal/test_rm_endpoint.py
+++ b/tests/test_legal/test_rm_endpoint.py
@@ -310,6 +310,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
                                                 proximity_preserve_order=True,
                                                 max_gaps=max_gaps))
         self.assertEqual(len(response), 1)
+        self.assertNotEqual(len(response[0]["source"]), 0)
         self.assertEqual(response[0]["rm_no"], "2022-06")
 
         q_prox_lvl_two = ["fourth lvl 2", "Second RM"]
@@ -321,6 +322,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
                                                 max_gaps=max_gaps))
         self.assertEqual(len(response), 1)
         self.assertEqual(response[0]["rm_no"], "2024-08")
+        self.assertNotEqual(len(response[0]["source"]), 0)
 
         q_prox_description = "RM lvl 2"
         proximity_filter = "before"
@@ -341,7 +343,7 @@ class TestRuleMakingDocsElasticsearch(ElasticSearchBaseTest):
         q = "\"REG 2024-10 Civil Monetary\""
         q_proximity = ["First RM", "first lvl 2"]
         max_gaps = 3
-        doc_category_id = 7
+        doc_category_id = 3
         is_key_document = False
         entity_name = "Fake"
         entity_role = 2


### PR DESCRIPTION
## Summary (required)

- Resolves #6437 & 6450

This PR adds the source column, which indicates which document matches a proximity search, and fixes all of the nested filters. A rulemaking should only be a result when the nested filters match on the same nested document. This behavior matches our other legal searches.

Note: q matches in description need to be handled differently in the code 
### Required reviewers 2 devs


## Impacted areas of the application

General components of the application that this PR will affect:

- rulemaking search



## How to test

- checkout this branch 
- start virtual env 
- start elasticsearch 
- load these specific rulemakings:  
 `python cli.py load_rulemaking 2023-04`
`python cli.py load_rulemaking 2013-02`
`python cli.py load_rulemaking 2013-04`
`python cli.py load_rulemaking 2013-05`
`python cli.py load_rulemaking 2021-01`
- `flask run`

Sample URLs: 

## Q: 

### Description: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202023-04%22 
(2023-04)

### Lvl 1: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22Inflation%20Adjustment%20Act%22 
(2013-02)


### Lvl2: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22
(2013-04) 


## doc_category_id:

### On lvl 2 only : 
http://127.0.0.1:5000/v1/rulemaking/search/?doc_category_id=2 
(2021-01)

### On all levels: 
http://127.0.0.1:5000/v1/rulemaking/search/?doc_category_id=4

### Two category IDs: 
http://127.0.0.1:5000/v1/rulemaking/search/?doc_category_id=2&doc_category_id=4


## Proximity:

### Lvl 1: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10 (2013-02)

### Lvl2: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=Draft Final Rules and Explanation&q_proximity=Administrative Fines Program&max_gaps=20 
(2013-05)


## Proximity + doc_category_id:

http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=Draft%20Final%20Rules%20and%20Explanation&q_proximity=Administrative%20Fines%20Program&max_gaps=20&doc_category_id=3
(2013-05)

### Wrong proximity: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=Draft%20Final%20Rules%20and%20Explanationaaaaa&q_proximity=Administrative%20Fines%20Program&max_gaps=20&doc_category_id=7

### Wrong doc category id: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=Draft Final Rules and Explanation&q_proximity=Administrative Fines Program&max_gaps=20&doc_category_id=2

## Q + proximity:

http://127.0.0.1:5000/v1/rulemaking/search/?q=%22Inflation%20Adjustment%20Act%22&q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10
(2013-02)

### Wrong q: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22abcd%22&q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10

### Wrong proximity:
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22Inflation%20Adjustment%20Act%22&q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=1


## Q in description + doc category ID:
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202023-04%22&doc_category_id=4 
(2023-04)

### Wrong doc_category_id:
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202023-04%22&doc_category_id=2


## Q in description + proximity: 

http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10&q=%22REG%202013-02%22
(2013-02)

### Wrong q: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=raw%20civil%20penalty&q_proximity=penalty%20cap&max_gaps=10&q=%22REG%202013-0u2%22

### Wrong proximity: 
http://127.0.0.1:5000/v1/rulemaking/search/?q_proximity=raw%20csivil%20penalty&q_proximity=penalty%20cap&max_gaps=10&q=%22REG%202013-02%22


### Q + doc_category_id:
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22%20&doc_category_id=1 (2013-04)

### Wrong q: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202023-04abcd%22&doc_category_id=4


### Wrong category id: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202023-04%22&doc_category_id=8

## Q + doc_category_id + proximity:

http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=1
(2013-04)

### Wrong q: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22aaaWITHDRAWAL%20AND%20RESUBMISSION%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=1

### Wrong doc_category_id: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=2

### Wrong max gap: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22WITHDRAWAL%20AND%20RESUBMISSION%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=1&doc_category_id=1

## Q in description + doc_category_id + proximity: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202013-04%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=1 
(2013-04)

### Wrong q: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202013-0r4%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=1

### Wrong doc_category_id: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202013-04%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissioners%20Goodman&max_gaps=3&doc_category_id=5

### Wrong proximity: 
http://127.0.0.1:5000/v1/rulemaking/search/?q=%22REG%202013-04%22&q_proximity=Weintraub%20voting%20affirmatively&q_proximity=Commissiosdners%20Goodman&max_gaps=3&doc_category_id=1
