### PR TITLE
Add celery task to load rulemakings to es service

### DIFF
--- a/webservices/legal/rulemaking_docs/rulemaking.py
+++ b/webservices/legal/rulemaking_docs/rulemaking.py
@@ -1,7 +1,11 @@
 import logging
+import json
 import webservices.legal.constants as constants
 from webservices.common.models import db
-from webservices.legal.utils_es import create_es_client
+from webservices.legal.utils_es import (
+    create_es_client,
+    DateTimeEncoder
+)
 from webservices.tasks.utils import get_bucket
 from sqlalchemy import text
 logger = logging.getLogger(__name__)
@@ -12,7 +16,8 @@ logger = logging.getLogger(__name__)
 ALL_RMS = """
 SELECT
 rm_number,
-rm_id
+rm_id,
+published_flg
 FROM fosers.rulemaking_vw
 ORDER BY rm_year DESC, rm_serial DESC
 """
@@ -32,7 +37,8 @@ rm_number,
 rm_serial,
 rm_year,
 sync_status,
-title
+title,
+published_flg
 FROM fosers.rulemaking_vw
 WHERE rm_number = :rm
 """
@@ -184,20 +190,35 @@ ORDER BY hearing_date DESC
 """
 
 
-# Load specific one rm_no command: `python cli.py load_rulemaking 2021-01`
+# Load a single rulemaking with rm_no command: `python cli.py load_rulemaking 2021-01`
 # Load all rulemakings command: `python cli.py load_rulemaking`
 def load_rulemaking(specific_rm_no=None):
     es_client = create_es_client()
     rm_count = 0
     if es_client.indices.exists(index=constants.RM_ALIAS):
-        logger.info(" Index alias '{0}' exists, start loading rulemaking...".format(constants.RM_ALIAS))
+        logger.debug(" Index alias '{0}' exists, start loading rulemakings...".format(constants.RM_ALIAS))
         for rm in get_rulemaking(specific_rm_no):
             if rm is not None:
-                logger.info(" Loading rm_no: {0}, rm_id: {1} ".format(rm["rm_no"], rm["rm_id"]))
-                es_client.index(constants.RM_ALIAS, rm, id=rm["rm_id"])
-                rm_count += 1
-
-        logger.info(" Total %d rulemaking loaded.", rm_count)
+                if rm.get("published_flg"):
+                    logger.info(" Loading rm_no: {0}, rm_id: {1} ".format(rm["rm_no"], rm["rm_id"]))
+                    es_client.index(constants.RM_ALIAS, rm, id=rm["rm_id"])
+                    rm_count += 1
+                    logger.info("Sucessfully loaded rulemaking rm_no: {0}, rm_id: {1} ".format(
+                        rm["rm_no"], rm["rm_id"]))
+                else:
+                    try:
+                        logger.info("Found an unpublished rulemaking - deleting {0}: {1} from ES".format(
+                            rm["rm_no"], rm["rm_id"]))
+                        es_client.delete(index=constants.RM_ALIAS, id=rm["rm_id"])
+                        logger.info("Successfully deleted {} {} from ES".format(rm["rm_no"], rm["rm_id"]))
+                    except Exception as err:
+                        logger.error("An error occurred while deleting an unpublished rulemaking.{0} {1} {2}".format(
+                            rm["rm_no"], rm["rm_id"], err))
+            # ==for local debug use: remove the big "documents" section to display the object "rulemakings" data
+            debug_rm_data = rm
+            del debug_rm_data["documents"]
+            logger.debug("rm_data count=" + str(rm_count))
+            logger.debug("debug_rm_data =" + json.dumps(debug_rm_data, indent=3, cls=DateTimeEncoder))
     else:
         logger.error(" The index alias '{0}' is not found, cannot load rulemaking".format(constants.RM_ALIAS))
 
@@ -231,6 +252,7 @@ def get_single_rulemaking(rm_number, bucket):
             "last_updated": row["last_updated"],
             "key_documents": get_key_documents(rm_no, rm_id, bucket),
             "no_tier_documents": get_no_tier_documents(rm_no, rm_id, bucket),
+            "published_flg": row["published_flg"],
             "rm_id": rm_id,
             "rm_name": row["rm_name"],
             "rm_no": row["rm_no"],
@@ -302,7 +324,7 @@ def get_documents(rm_no, rm_id, bucket):
                 documents.append(document)
 
                 try:
-                    # The bucket is None locally, so there is no need to upload the PDF to S3
+                    # The bucket is None when running locally, so there’s no need to upload the PDF to S3.
                     if bucket:
                         logger.debug("S3: Uploading {}".format(pdf_key))
                         bucket.put_object(

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -21,6 +21,15 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
             "schedule": crontab(minute="*/5", hour="10-23"),
         },
+
+        # Task 1C: refresh_most_recent_rulemakings(conn):
+        # When found modified case(s)(MUR/AF/ADR) within 10 hours and 5 minutes,
+        #   if published_flg = true, upload the rulemaking(s) to elasticsearch service.
+        #   if published_flg = false, delete the rulemaking(s) from elasticsearch service.
+        "refresh_rulemakings": {
+            "task": "webservices.tasks.legal_docs.refresh_most_recent_rulemakings",
+            "schedule": crontab(minute="*/1", hour="10-23"),
+        },
         # Task 2: This task is launched at 9pm(EST) everyday except Sunday.
         # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
         # 2) For each modified AO, find the earliest AO referenced by the modified AO
@@ -67,5 +76,13 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
         "essential-services-status-check": {
             "task": "webservices.tasks.service_status_checks.heartbeat",
             "schedule": 30.0,
+        },
+        # Task 9: This task is launched at 19:55pm(EST) everyday.
+        # When found modified rulemakings in past 24 hours (19:55pm-19:55pm EST),
+        # send rulemaking detail information to Slack.
+        "send_alert_rulemakings": {
+            "task": "webservices.tasks.legal_docs.send_alert_daily_modified_rulemakings",
+            # "schedule": crontab(minute=55, hour=23),
+            "schedule": crontab(minute="*/5", hour="10-23")
         },
     }

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from webservices import utils
 from webservices.legal.legal_docs.advisory_opinions import load_advisory_opinions
 from webservices.legal.legal_docs.current_cases import load_cases
+from webservices.legal.rulemaking_docs.rulemaking import load_rulemaking
 from webservices.legal.utils_es import create_es_snapshot, display_snapshot_detail, delete_snapshot
 from webservices.legal.constants import (  # noqa
     CASE_INDEX,
@@ -36,6 +37,13 @@ RECENTLY_MODIFIED_CASES = """
     ORDER BY case_serial;
 """
 
+RECENTLY_MODIFIED_RULEMAKINGS = """
+    SELECT /* celery_rulemakings_5 */ rm_no, pg_date, published_flg
+    FROM fosers.rulemaking_vw
+    WHERE pg_date >= NOW() - '10 hours + 5 minutes'::INTERVAL
+    ORDER BY rm_year desc, rm_serial desc;
+"""
+
 # For daily_reload_all_aos_when_change(): in past 24 hours(9pm-9pm EST)
 DAILY_MODIFIED_AOS = """
     SELECT ao_no, pg_date
@@ -52,7 +60,15 @@ DAILY_MODIFIED_CASES_SEND_ALERT = """
     ORDER BY case_serial;
 """
 
-SLACK_BOTS = "#bots"
+# for send_alert_daily_modified_rulemakings():  during 19:55pm-19:55pm(EST) (24 hours)
+DAILY_MODIFIED_RULEMAKINGS_SEND_ALERT = """
+    SELECT rm_no, pg_date, published_flg
+    FROM fosers.rulemaking_vw
+    WHERE pg_date >= NOW() - '24 hour'::INTERVAL
+    ORDER BY rm_serial;
+"""
+
+SLACK_BOTS = "#test-bot"
 
 
 @shared_task(once={"graceful": True}, base=QueueOnce)
@@ -121,6 +137,36 @@ def refresh_most_recent_cases(conn):
 
 
 @shared_task(once={"graceful": True}, base=QueueOnce)
+def refresh_most_recent_rulemakings():
+    """
+        # When found modified rulemakings within 8 hours,
+        #   if published_flg = true, reload the rulemaking(s) on elasticsearch service.
+        #   if published_flg = false, delete the rulemaking(s) on elasticsearch service.
+    """
+    with db.engine.begin() as conn:
+        logger.info(" Checking for recently modified rulemakings...")
+        rs = conn.execute(text(RECENTLY_MODIFIED_RULEMAKINGS)).mappings()
+        row_count = 0
+        load_count = 0
+        deleted_rulemakings_count = 0
+        for row in rs:
+            row_count += 1
+            logger.info(" Rulemaking %s was recently modified on %s", row["rm_no"], row["pg_date"])
+            load_rulemaking(row["rm_no"])
+            if row["published_flg"]:
+                load_count += 1
+                logger.info(" A total of %d rulemaking(s) have been successfully loaded into elasticsearch service.",
+                            load_count)
+            else:
+                deleted_rulemakings_count += 1
+                logger.info(" A total of %d rulemaking(s) successfully unpublished from elasticsearch service.",
+                            deleted_rulemakings_count)
+
+        if row_count <= 0:
+            logger.info(" No rulemakings have been modified recently.")
+
+
+@shared_task(once={"graceful": True}, base=QueueOnce)
 def daily_reload_all_aos_when_change():
     """
         # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
@@ -186,6 +232,29 @@ def send_alert_daily_modified_legal_case():
                 slack_message = slack_message + "\n"
     if row_count <= 0:
         slack_message = "No daily modified case (MUR/AF/ADR) found"
+
+    if slack_message:
+        slack_message = slack_message + " in " + get_app_name()
+        utils.post_to_slack(slack_message, SLACK_BOTS)
+
+
+@shared_task(once={"graceful": True}, base=QueueOnce)
+def send_alert_daily_modified_rulemakings():
+    # When rulemakings modified during 6am-7pm EST, post rulemaking details to slack.
+    slack_message = "Rulemaking rm_no, "
+    with db.engine.begin() as conn:
+        rs = conn.execute(text(DAILY_MODIFIED_RULEMAKINGS_SEND_ALERT)).mappings()
+        row_count = 0
+        for row in rs:
+            row_count += 1
+            if row["published_flg"]:
+                slack_message = slack_message + " " + str(row["rm_no"]) + " found published at " + str(row["pg_date"])
+                slack_message = slack_message + "\n"
+            else:
+                slack_message = slack_message + " " + str(row["rm_no"]) + " found unpublished at " + str(row["pg_date"])
+                slack_message = slack_message + "\n"
+    if row_count <= 0:
+        slack_message = "No daily modified rulemakings found"
 
     if slack_message:
         slack_message = slack_message + " in " + get_app_name()


### PR DESCRIPTION
## Summary (required)

- Resolves #6436 

This PR adds two new celery cron jobs :

1. First one will publish/unpublish rulemakings from elasticsearch service. 
2. Second cron job send slack message/alert at the end of the day, with list of rulemakings that were modified during that day. 

### Required reviewers

2-3 developers

## Impacted areas of the application

- api, elasticsearch service and celery 

## How to test
- 
