### PR TITLE
Add a celery task to publish/unpublish rulemakings

### DIFF
--- a/webservices/legal/constants.py
+++ b/webservices/legal/constants.py
@@ -44,6 +44,9 @@ ANALYZER_SETTING = {
     "highlight.max_analyzed_offset": 60000000,
 }
 
+SLACK_BOTS = "#bots"
+SLACK_ALERTS = "#alerts"
+
 OS_SERVICE_INSTANCE_NAME = "fec-api-opensearch"
 # TODO (clucas) update constants for v2
 AWS_ES_SERVICE = "es"

--- a/webservices/legal/rulemaking_docs/rulemaking.py
+++ b/webservices/legal/rulemaking_docs/rulemaking.py
@@ -1,7 +1,12 @@
 import logging
+import json
 import webservices.legal.constants as constants
 from webservices.common.models import db
-from webservices.legal.utils_opensearch import create_opensearch_client
+from webservices.legal.utils_opensearch import (
+    create_opensearch_client,
+    DateTimeEncoder
+)
+
 from webservices.tasks.utils import get_bucket
 from sqlalchemy import text
 logger = logging.getLogger(__name__)
@@ -12,7 +17,9 @@ logger = logging.getLogger(__name__)
 ALL_RMS = """
 SELECT
 rm_number,
-rm_id
+rm_id,
+pg_date,
+published_flg
 FROM fosers.rulemaking_vw
 ORDER BY rm_year DESC, rm_serial DESC
 """
@@ -32,7 +39,9 @@ rm_number,
 rm_serial,
 rm_year,
 sync_status,
-title
+title,
+pg_date,
+published_flg
 FROM fosers.rulemaking_vw
 WHERE rm_number = :rm
 """
@@ -184,22 +193,38 @@ ORDER BY hearing_date DESC
 """
 
 
-# Load specific one rm_no command: `python cli.py load_rulemaking 2021-01`
+# Load a single rulemaking with rm_no, command: `python cli.py load_rulemaking 2021-01`
 # Load all rulemakings command: `python cli.py load_rulemaking`
 def load_rulemaking(specific_rm_no=None):
     opensearch_client = create_opensearch_client()
     rm_count = 0
+    # slack_message = ""
     if opensearch_client.indices.exists(index=constants.RM_ALIAS):
-        logger.info(" Index alias '{0}' exists, start loading rulemaking...".format(constants.RM_ALIAS))
+        logger.debug(" Index alias '{0}' exists, start loading rulemaking...".format(constants.RM_ALIAS))
         for rm in get_rulemaking(specific_rm_no):
             if rm is not None:
-                logger.info(" Loading rm_no: {0}, rm_id: {1} ".format(rm["rm_no"], rm["rm_id"]))
-                opensearch_client.index(constants.RM_ALIAS, rm, id=rm["rm_id"])
-                rm_count += 1
-
-        logger.info(" Total %d rulemaking loaded.", rm_count)
+                if rm.get("published_flg"):
+                    logger.info("Loading rm_no: %s, rm_id: %s", rm["rm_no"], rm["rm_id"])
+                    opensearch_client.index(constants.RM_ALIAS, rm, id=rm["rm_id"])
+                    rm_count += 1
+                    logger.info("Successfully loaded rulemaking rm_no: %s, rm_id: %s", rm["rm_no"], rm["rm_id"])
+                else:
+                    try:
+                        logger.info("Found an unpublished rulemaking - deleting %s: %s from opensearch service",
+                                    rm["rm_no"], rm["rm_id"])
+                        opensearch_client.delete(index=constants.RM_ALIAS, id=rm["rm_id"])
+                        logger.info("Successfully deleted rulemaking rm_no: %s, rm_id: %s from opensearch service",
+                                    rm["rm_no"], rm["rm_id"])
+                    except Exception as err:
+                        logger.error("An error occurred while deleting an unpublished rulemaking: %s %s %s",
+                                     rm["rm_no"], rm["rm_id"], err)
+            # ==for local debug use: remove the big "documents" section to display the object "rulemakings" data
+            debug_rm_data = rm
+            del debug_rm_data["documents"]
+            logger.debug("rm_data count=" + str(rm_count))
+            logger.debug("debug_rm_data =" + json.dumps(debug_rm_data, indent=3, cls=DateTimeEncoder))
     else:
-        logger.error(" The index alias '{0}' is not found, cannot load rulemaking".format(constants.RM_ALIAS))
+        logger.error("The index alias '%s' was not found; cannot load rulemaking", constants.RM_ALIAS)
 
 
 def get_rulemaking(specific_rm_no):
@@ -231,6 +256,7 @@ def get_single_rulemaking(rm_number, bucket):
             "last_updated": row["last_updated"],
             "key_documents": get_key_documents(rm_no, rm_id, bucket),
             "no_tier_documents": get_no_tier_documents(rm_no, rm_id, bucket),
+            "published_flg": row["published_flg"],
             "rm_id": rm_id,
             "rm_name": row["rm_name"],
             "rm_no": row["rm_no"],
@@ -302,7 +328,7 @@ def get_documents(rm_no, rm_id, bucket):
                 documents.append(document)
 
                 try:
-                    # The bucket is None locally, so there is no need to upload the PDF to S3
+                    # The bucket is None when running locally, so there’s no need to upload the PDF to S3
                     if bucket:
                         logger.debug("S3: Uploading {}".format(pdf_key))
                         bucket.put_object(

--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -21,6 +21,14 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.legal_docs.refresh_most_recent_legal_doc",
             "schedule": crontab(minute="*/5", hour="10-23"),
         },
+        # Task 1C: refresh_most_recent_rulemakings(conn):
+        # When found modified rulemaking(s) within 10 hours and 5 minutes
+        #   if published_flg = true, upload the rulemaking(s) to elasticsearch service.
+        #   if published_flg = false, delete the rulemaking(s) from elasticsearch service.
+        "refresh_most_recent_rulemakings": {
+            "task": "webservices.tasks.legal_docs.refresh_most_recent_rulemakings",
+            "schedule": crontab(minute="*/1", hour="10-23"),
+        },
         # Task 2: This task is launched at 9pm(EST) everyday except Sunday.
         # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
         # 2) For each modified AO, find the earliest AO referenced by the modified AO
@@ -67,5 +75,12 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
         "essential-services-status-check": {
             "task": "webservices.tasks.service_status_checks.heartbeat",
             "schedule": 30.0,
+        },
+        # Task 9: This task is launched at 19:55pm(EST) everyday.
+        # Check for rulemakings modified in the previous 24-hour window (7:55 PM–7:55 PM EST)
+        # and send their detailed information to Slack.
+        "send_alert_rulemakings": {
+            "task": "webservices.tasks.legal_docs.send_alert_daily_modified_rulemakings",
+            "schedule": crontab(minute=55, hour=23),
         },
     }

--- a/webservices/tasks/legal_docs.py
+++ b/webservices/tasks/legal_docs.py
@@ -8,12 +8,14 @@ from celery import shared_task
 from webservices import utils
 from webservices.legal.legal_docs.advisory_opinions import load_advisory_opinions
 from webservices.legal.legal_docs.current_cases import load_cases
+from webservices.legal.rulemaking_docs.rulemaking import load_rulemaking
 from webservices.legal.utils_opensearch import create_opensearch_snapshot, display_snapshot_detail, delete_snapshot
 from webservices.legal.constants import (  # noqa
     CASE_INDEX,
     AO_INDEX,
     AO_REPO,
     CASE_REPO,
+    SLACK_BOTS
 )
 
 from webservices.common.models import db
@@ -36,6 +38,13 @@ RECENTLY_MODIFIED_CASES = """
     ORDER BY case_serial;
 """
 
+RECENTLY_MODIFIED_RULEMAKINGS = """
+    SELECT /* celery_rulemakings_5 */ rm_no, pg_date, published_flg
+    FROM fosers.rulemaking_vw
+    WHERE pg_date >= NOW() - '10 hours + 5 minutes'::INTERVAL
+    ORDER BY rm_year desc, rm_serial desc;
+"""
+
 # For daily_reload_all_aos_when_change(): in past 24 hours(9pm-9pm EST)
 DAILY_MODIFIED_AOS = """
     SELECT ao_no, pg_date
@@ -52,7 +61,13 @@ DAILY_MODIFIED_CASES_SEND_ALERT = """
     ORDER BY case_serial;
 """
 
-SLACK_BOTS = "#bots"
+# for send_alert_daily_modified_rulemakings():  during 19:55pm-19:55pm(EST) (24 hours)
+DAILY_MODIFIED_RULEMAKINGS_SEND_ALERT = """
+    SELECT rm_no, pg_date, published_flg
+    FROM fosers.rulemaking_vw
+    WHERE pg_date >= NOW() - '24 hour'::INTERVAL
+    ORDER BY rm_serial;
+"""
 
 
 @shared_task(once={"graceful": True}, base=QueueOnce)
@@ -121,6 +136,36 @@ def refresh_most_recent_cases(conn):
 
 
 @shared_task(once={"graceful": True}, base=QueueOnce)
+def refresh_most_recent_rulemakings():
+    """
+        # When found modified rulemakings within 8 hours,
+        #   if published_flg = true, reload rulemaking(s) to opensearch service.
+        #   if published_flg = false, delete the rulemaking(s) to opensearch service.
+    """
+    with db.engine.begin() as conn:
+        logger.info(" Checking for recently modified rulemakings...")
+        rs = conn.execute(text(RECENTLY_MODIFIED_RULEMAKINGS)).mappings()
+        row_count = 0
+        load_count = 0
+        deleted_rulemakings_count = 0
+        for row in rs:
+            row_count += 1
+            logger.info(" Rulemaking %s was recently modified on %s", row["rm_no"], row["pg_date"])
+            load_rulemaking(row["rm_no"])
+            if row["published_flg"]:
+                load_count += 1
+                logger.info(" A total of %d rulemaking(s) have been successfully loaded to opensearch service.",
+                            load_count)
+            else:
+                deleted_rulemakings_count += 1
+                logger.info(" A total of %d rulemaking(s) successfully unpublished from opensearch service.",
+                            deleted_rulemakings_count)
+
+        if row_count <= 0:
+            logger.info(" No rulemakings have been modified recently.")
+
+
+@shared_task(once={"graceful": True}, base=QueueOnce)
 def daily_reload_all_aos_when_change():
     """
         # 1) Identify the daily modified AO(s) in past 24 hours(9pm-9pm EST)
@@ -186,6 +231,29 @@ def send_alert_daily_modified_legal_case():
                 slack_message = slack_message + "\n"
     if row_count <= 0:
         slack_message = "No daily modified case (MUR/AF/ADR) found"
+
+    if slack_message:
+        slack_message = slack_message + " in " + get_app_name()
+        utils.post_to_slack(slack_message, SLACK_BOTS)
+
+
+@shared_task(once={"graceful": True}, base=QueueOnce)
+def send_alert_daily_modified_rulemakings():
+    # When rulemakings modified during 6am-7pm EST, post rulemaking details to slack.
+    slack_message = ""
+    with db.engine.begin() as conn:
+        rs = conn.execute(text(DAILY_MODIFIED_RULEMAKINGS_SEND_ALERT)).mappings()
+        row_count = 0
+        for row in rs:
+            row_count += 1
+            if row["published_flg"]:
+                slack_message += 'Rulemaking %s found published at %s' % (row["rm_no"], row["pg_date"])
+                slack_message = slack_message + "\n"
+            else:
+                slack_message += 'Rulemaking %s found unpublished at %s' % (row["rm_no"], row["pg_date"])
+                slack_message = slack_message + "\n"
+    if row_count <= 0:
+        slack_message = "No daily modified rulemakings found"
 
     if slack_message:
         slack_message = slack_message + " in " + get_app_name()

--- a/webservices/tasks/refresh_db.py
+++ b/webservices/tasks/refresh_db.py
@@ -2,6 +2,7 @@
 import logging
 
 import manage
+import webservices.legal.constants as constants
 from webservices import utils
 from webservices.tasks import download
 from celery import shared_task
@@ -9,9 +10,6 @@ from webservices.tasks.utils import get_app_name
 
 
 logger = logging.getLogger(__name__)
-
-SLACK_BOTS = "#bots"
-SLACK_ALERTS = "#alerts"
 
 
 @shared_task
@@ -24,11 +22,11 @@ def refresh_materialized_views():
         manage.refresh_materialized()
         download.clear_bucket()
         slack_message = "*Success* daily update materialized views for {0} completed.".format(get_app_name())
-        utils.post_to_slack(slack_message, SLACK_BOTS)
+        utils.post_to_slack(slack_message, constants.SLACK_BOTS)
         manage.logger.info(slack_message)
     except Exception as error:
         manage.logger.exception(error)
         slack_message = "*ERROR* daily update materialized views failed for {0}.".format(get_app_name())
         slack_message = slack_message + "\n Error message: " + str(error)
-        utils.post_to_slack(slack_message, SLACK_BOTS)
-        utils.post_to_slack(slack_message, SLACK_ALERTS)
+        utils.post_to_slack(slack_message, constants.SLACK_BOTS)
+        utils.post_to_slack(slack_message, constants.SLACK_ALERTS)


### PR DESCRIPTION
## Summary (required)

This PR adds a cron job that publishes and unpublishes rulemakings in the OpenSearch service

1. **refresh_most_recent_rulemakings** runs every minute (this interval can be adjusted; it’s currently set to two minutes for testing). It checks for recently updated rulemakings, processes them, and sends a detailed message to the bots Slack channel.
2. **send_alert_daily_modified_rulemakings** runs at the end of the day and sends a summary of updated rulemakings. This task is included for testing purposes and may not be needed long term; we can revisit and remove it later.

- Resolves #6436 


### Required reviewers

2 or more developers

## Impacted areas of the application

rulemaking/search/ api 


## How to test

- Deploy [this test2](https://app.circleci.com/pipelines/github/fecgov/openFEC/3997/workflows/f88d2778-d456-430c-a0a7-8327a51ed3d2) branch to Stage space
- Rulemakings `1989-01` and `2020-05` are being used for testing. Update the pg_date, publish_flag values in rulemaster table to trigger the cron job.
- When a rulemaking is unpublished, verify worker app log. For testing, slack alerts are sent to`test-bot`channel 
-  Verify that the unpublished rulemakings no longer show on the Stage cms and api: 
        -  https://stage.fec.gov/legal/search/rulemakings/
        - https://api-stage.open.fec.gov/v1/rulemaking/search/?rm_no=1998-01&api_key=DEMO_KEY
        - https://api-stage.open.fec.gov/v1/rulemaking/search/?rm_no=2020-05&api_key=DEMO_KEY
