### PR TITLE
[Hotfix] upgrade to opensearch 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
           POSTGRES_DB: cfdm_unit_test
 
       # Opensearch
-      - image: opensearchproject/opensearch:1.3.19
+      - image: opensearchproject/opensearch:2.11.1
         environment:
           cluster.name: opensearch
-          plugins.security.disabled: true
+          DISABLE_SECURITY_PLUGIN: "true"
           OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
           discovery.type: single-node
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Mac OSX tutorial](https://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
-   - Opensearch 1.3 (instructions [here](https://docs.opensearch.org/1.3/install-and-configure/install-opensearch/index/))
+   - Opensearch 2.11 (instructions [here](https://docs.opensearch.org/2.11/install-and-configure/install-opensearch/index/))
    - Flyway 11.20.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
      - After downloading, create a .toml file in the following location: `flyway-11.20.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
@@ -223,13 +223,15 @@ Follow these steps every time you want to work on this project locally.
    ```
 
 2. If you are using the legal search portion of the site, you will need OpenSearch running.
-   Navigate to the installation folder (eg., `opensearch-1.3.x`) and run:
+   Navigate to the installation folder (eg., `opensearch-2.11.x`) and run:
 
    ```
    cd bin
    ./opensearch \
      -E plugins.security.disabled=true
    ```
+
+   NOTE: You can also disable security in your opensearch.yml file in your local opensearch
 
 3. Start the web server:
 
@@ -650,7 +652,7 @@ The materialized views are manually refreshed when something needs to be removed
 
 ### Managing Opensearch
 
-Reference Wiki [Opensearch 1.3.x management instruction](https://github.com/fecgov/openFEC/wiki/Opensearch-1.3.x-management-instruction)
+Reference Wiki [Opensearch 2.11.x management instruction](https://github.com/fecgov/openFEC/wiki/Opensearch-2.11.x-management-instruction)
 
 There are some management commands to manage (display, create, delete, restore...) repository, index and snapshot on Opensearch.
 More information is available by invoking each of these commands with a `--help` option. These commands can be run as [cf tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html) on `cloud.gov`, e.g.,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ apispec==6.8.2
 certifi==2024.7.4
 cfenv==0.5.2
 defusedxml==0.6.0
-opensearch-py==1.1.0
-opensearch-dsl==1.0.0
+opensearch-py==2.8.0
 Flask==3.1.0
 Flask-Cors==6.0.0
 Flask-RESTful==0.3.9
@@ -25,6 +24,7 @@ requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==2.0.41
 ujson==5.4.0 # decoding CSP violation reported
+urllib3==2.6.3
 webargs==8.7.1
 werkzeug==3.1.4
 

--- a/webservices/legal/constants.py
+++ b/webservices/legal/constants.py
@@ -45,7 +45,7 @@ ANALYZER_SETTING = {
 }
 
 OS_SERVICE_INSTANCE_NAME = "fec-api-opensearch"
-# TODO (clucas) update constants for v2
+# AWS service name remains 'es' even for OpenSearch 2.x
 AWS_ES_SERVICE = "es"
 REGION = "us-gov-west-1"
 PORT = 443

--- a/webservices/legal/legal_docs/advisory_opinions.py
+++ b/webservices/legal/legal_docs/advisory_opinions.py
@@ -145,7 +145,7 @@ def load_advisory_opinions(from_ao_no=None):
                 if ao is not None:
                     if ao.get("published_flg"):
                         logger.info(" Loading AO number: %s", ao["no"])
-                        opensearch_client.index(AO_ALIAS, ao, id=ao["no"])
+                        opensearch_client.index(index=AO_ALIAS, body=ao, id=ao["no"])
                         ao_count += 1
                 # ==for local dubug use: remove the big "documents" section to display the object "ao" data.
                         debug_ao_data = ao
@@ -455,7 +455,7 @@ def get_citations(ao_names):
             "citation_type": "regulation",
             "doc_type": "advisory_opinions",
         }
-        opensearch_client.index(AO_ALIAS, entry, id=entry["citation_text"])
+        opensearch_client.index(index=AO_ALIAS, body=entry, id=entry["citation_text"])
 
     for citation in all_statutory_citations:
         entry = {
@@ -464,7 +464,7 @@ def get_citations(ao_names):
             "citation_type": "statute",
             "doc_type": "advisory_opinions",
         }
-        opensearch_client.index(AO_ALIAS, entry, id=entry["citation_text"])
+        opensearch_client.index(index=AO_ALIAS, body=entry, id=entry["citation_text"])
     logger.info(" AO Citations loaded.")
     return citations
 

--- a/webservices/legal/legal_docs/archived_murs.py
+++ b/webservices/legal/legal_docs/archived_murs.py
@@ -1,5 +1,5 @@
 from sqlalchemy.sql import text
-from opensearch_dsl import Search
+from opensearchpy import Search
 import logging
 import re
 from webservices.common.models import db
@@ -141,10 +141,10 @@ def load_archived_murs(mur_no=None):
         for mur in get_murs(mur_no):
             if mur is not None:
                 try:
-                    logger.info("Loading archived MUR No: {0}".format(mur["no"]))
-                    opensearch_client.index(ARCH_MUR_ALIAS, mur, id=mur["doc_id"])
+                    logger.info("Loading archived MUR No: %s", mur["no"])
+                    opensearch_client.index(index=ARCH_MUR_ALIAS, body=mur, id=mur["doc_id"])
                     mur_count += 1
-                    logger.info("{0} Archived Mur(s) loaded".format(mur_count))
+                    logger.info("%s Archived Mur(s) loaded", mur_count)
                 except Exception as err:
                     logger.error(
                         "An error occurred while uploading archived mur:\nmur no={0} \nerr={1}".format(
@@ -309,7 +309,7 @@ def get_documents(mur_id):
 def extract_pdf_text(mur_no=None):
     """
     1)Reads "text" and "documents" object data for Archived MURs from Opensearch,
-    under index: ARCH_MUR_INDEX and type of `murs`
+    under index: ARCH_MUR_INDEX
     2)Assembles a JSON document corresponding to the archived murs,
     3)Insert the JSON document into Postgres database table: mur_arch.documents
     4)Run this command carefully, backup mur_arch.documents table first
@@ -335,7 +335,6 @@ def extract_pdf_text(mur_no=None):
             ])
             .extra(size=each_fetch_size, from_=from_no)
             .index(ARCH_MUR_ALIAS)
-            .doc_type("murs")
             .sort("no")
             .execute()
         )

--- a/webservices/legal/legal_docs/current_cases.py
+++ b/webservices/legal/legal_docs/current_cases.py
@@ -353,7 +353,7 @@ def load_cases(case_type, case_no=None):
                 if case is not None:
                     if case.get("published_flg"):
                         logger.info("Loading {0}: {1}".format(case_type, case["no"]))
-                        opensearch_client.index(CASE_ALIAS, case, id=case["doc_id"])
+                        opensearch_client.index(index=CASE_ALIAS, body=case, id=case["doc_id"])
                         case_count += 1
                         logger.info("{0} {1}(s) loaded".format(case_count, case_type))
                     else:

--- a/webservices/legal/legal_docs/statutes.py
+++ b/webservices/legal/legal_docs/statutes.py
@@ -70,7 +70,7 @@ def get_title_52_statutes():
                         "sort1": 52,
                         "sort2": int(section_no),
                     }
-                    opensearch_client.index(AO_ALIAS, doc, id=doc["doc_id"])
+                    opensearch_client.index(index=AO_ALIAS, body=doc, id=doc["doc_id"])
                     section_count += 1
     return section_count
 
@@ -113,7 +113,7 @@ def get_title_26_statutes():
                         "sort2": int(section_no),
                     }
                     try:
-                        opensearch_client.index(AO_ALIAS, doc, id=doc["doc_id"])
+                        opensearch_client.index(index=AO_ALIAS, body=doc, id=doc["doc_id"])
                         section_count += 1
                     except Exception as e:
                         logger.error("Failed to index statute %s: %s", doc["doc_id"], str(e))

--- a/webservices/legal/rulemaking_docs/rulemaking.py
+++ b/webservices/legal/rulemaking_docs/rulemaking.py
@@ -194,7 +194,7 @@ def load_rulemaking(specific_rm_no=None):
         for rm in get_rulemaking(specific_rm_no):
             if rm is not None:
                 logger.info(" Loading rm_no: {0}, rm_id: {1} ".format(rm["rm_no"], rm["rm_id"]))
-                opensearch_client.index(constants.RM_ALIAS, rm, id=rm["rm_id"])
+                opensearch_client.index(index=constants.RM_ALIAS, body=rm, id=rm["rm_id"])
                 rm_count += 1
 
         logger.info(" Total %d rulemaking loaded.", rm_count)

--- a/webservices/legal/utils_opensearch.py
+++ b/webservices/legal/utils_opensearch.py
@@ -74,7 +74,7 @@ def upload_citations(statutory_citations, regulatory_citations, index, doc_type,
                 "citation_type": "statute",
                 "doc_type": doc_type,
             }
-            opensearch_client.index(index, entry, id=doc_type + "_" + citation)
+            opensearch_client.index(index=index, body=entry, id=f"{doc_type}_{citation}")
 
         for citation in regulatory_citations:
             entry = {
@@ -83,9 +83,9 @@ def upload_citations(statutory_citations, regulatory_citations, index, doc_type,
                 "citation_type": "regulation",
                 "doc_type": doc_type,
             }
-            opensearch_client.index(index, entry, id=doc_type + "_" + citation)
+            opensearch_client.index(index=index, body=entry, id=f"{doc_type}_{citation}")
     except Exception:
-        logger.error("An error occurred while uploading {} citations".format(doc_type))
+        logger.error(f"An error occurred while uploading {doc_type} citations")
 
 
 def check_filter_exists(kwargs, filter):
@@ -473,7 +473,7 @@ def configure_snapshot_repository(repo_name=None):
                 "access_key": credentials["access_key_id"],
                 "secret_key": credentials["secret_access_key"],
                 "base_path": constants.S3_BACKUP_DIRECTORY,
-                "role_arn": env.get_credential("OS_SNAPSHOT_ROLE_ARN"),
+                "role_arn": env.get_credential("OS2_SNAPSHOT_ROLE_ARN"),
             },
         }
         opensearch_client.snapshot.create_repository(

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -1,6 +1,6 @@
 import re
 
-from opensearch_dsl import Search, Q
+from opensearchpy import Search, Q
 from flask import abort
 from flask_apispec import doc
 from webservices import docs

--- a/webservices/resources/rulemaking.py
+++ b/webservices/resources/rulemaking.py
@@ -1,4 +1,4 @@
-from opensearch_dsl import Search, Q
+from opensearchpy import Search, Q
 from flask_apispec import doc
 from webservices import docs
 from webservices import args


### PR DESCRIPTION
## Summary (required)

- Resolves #6462

This PR upgrades us to opensearch 2.11. This is as far as we can go because we are limited by cloud.gov service options. 

### Required reviewers

2-3 reviewers

## Impacted areas of the application

General components of the application that this PR will affect:

- legal search and tasks


## How to test
- pull this branch 
- create and activate a new pyenv then run req files

```
pyenv virtualenv 3.11.9 open2
pyenv activate open2
pip install -r requirements.txt
pip install -r requirements-dev.txt
npm i && npm run build
```

- open a seperate tab
- install opensearch
navigate to wherever you want it, I created a folder then ran: 
MAC chip:
```
curl -L -O https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.1/opensearch-2.11.1-linux-arm64.tar.gz
tar -zxf opensearch-2.11.1-linux-arm64.tar.gz
cd opensearch-2.11.1
cd bin
```
INTEL chips: 
```
curl -L -O https://artifacts.opensearch.org/releases/bundle/opensearch/2.11.1/opensearch-2.11.1-linux-x64.tar.gz
tar -zxf opensearch-2.11.1-linux-x64.tar.gz
cd opensearch-2.11.1
cd bin
```
When running opensearch locally you need to run this command: 
```
./opensearch \
  -E plugins.security.disabled=true
```
OR you can navigate to the opensearch.yml file in your local copy of opensearch (in the config folder) add this line:
plugins.security.disabled: true

then you can just run ./opensearch 

_NOTE: You may get an error if your java version isn't compatible. I would recommend using JDK 17. How you do this will depend on if you're using brew for java. I had to update mine in brew and add this to my .zshrc:
export JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home_

go back to your openfec tab
`pytest`
test opensearch commands locally:
```
python cli.py create_index case_index
python cli.py create_index ao_index
python cli.py create_index arch_mur_index
python cli.py create_index rm_index
python cli.py display_index_alias
```

Try loading a few of each:
```
python cli.py initialize_legal_data case_index
python cli.py initialize_legal_data ao_index
python cli.py initialize_legal_data arch_mur_index
python cli.py initialize_legal_data rm_index

```
Load statutes and regs:
```
python cli.py load_statutes
python cli.py load_regulations
```

Test individual load: 
```
python cli.py load_current_murs 8003
python cli.py load_adrs 008
python cli.py load_admin_fines 3314
python cli.py load_archived_murs 400
```

Start the server, run some queries:
http://127.0.0.1:5000/v1/legal/search/?q=many
http://127.0.0.1:5000/v1/legal/search/?ao_is_pending=false

Use management commands [WIKI](https://github.com/fecgov/openFEC/wiki/Opensearch-2.11.x-management-instructions) to test in a space.

Here's the branch to rebuild on dev: 
https://app.circleci.com/pipelines/github/fecgov/openFEC/3986/workflows/40d8d15e-deb6-4b5e-ab15-e1f7b66821eb/jobs/7017
