### PR TITLE
update the rulemaking slack alert to be sent at 7:25pm everyday

### DIFF
--- a/webservices/tasks/__init__.py
+++ b/webservices/tasks/__init__.py
@@ -76,11 +76,11 @@ if env.app.get("space_name", "unknown-space").lower() != "feature":
             "task": "webservices.tasks.service_status_checks.heartbeat",
             "schedule": 30.0,
         },
-        # Task 9: This task is launched at 19:55pm(EST) everyday.
-        # Check for rulemakings modified in the previous 24-hour window (7:55 PM–7:55 PM EST)
+        # Task 9: This task is launched at 19:25pm(EST) everyday.
+        # Check for rulemakings modified in the previous 24-hour window (19:25 PM–19:25 PM EST)
         # and send their detailed information to Slack.
         "send_alert_rulemakings": {
             "task": "webservices.tasks.legal_docs.send_alert_daily_modified_rulemakings",
-            "schedule": crontab(minute=55, hour=23),
+            "schedule": crontab(minute=25, hour=23),
         },
     }


### PR DESCRIPTION
## Summary 

- Case and Rulemakings slack alerts are being sent at 19:55pm everday, there is a overlap of these two alerts. Change the rulemakings slack alert to send everyday from 19:55 to 19:25pm.



### Required reviewers

one developer


## Screenshots

<img width="707" height="318" alt="Screenshot 2026-01-28 at 12 37 55 PM" src="https://github.com/user-attachments/assets/fbede4d9-ff9b-4833-ad21-77316efc178b" />





## How to test

- Monitor the slack bots# for the change in the rulemaking slack alert time
