### PR TITLE
6487-upgrade deps for snyk

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 git+https://github.com/18F/rdbms-subsetter
 
 # Testing
-pdbpp==0.9.1
+pdbpp==0.11.7
 click==8.1.3
 
 # requirements.txt generation (pip-compile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ requests==2.32.4
 requests-aws4auth==1.0
 sqlalchemy-postgres-copy==0.3.0
 SQLAlchemy==2.0.41
-ujson==5.4.0 # decoding CSP violation reported
+ujson==5.11.0
 urllib3==2.6.3
 webargs==8.7.1
 werkzeug==3.1.5


### PR DESCRIPTION
## Summary (required)

- Resolves #6487 

Upgrades deps to fix compatibility issues with latest Snyk cloud config

### Required reviewers

1 dev

## How to test
`pyenv virtualenv 3.11.9 new`
`penv activate new`
`pip install -r requirements.txt`
`pip install -r requirements-dev.txt`

I tested and paired with @pkfec to show that this worked via a forked version of this repo. We can retry import after this is merged to dev