### PR TITLE
upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-webpack-plugin": "^4.0.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "mini-css-extract-plugin": "^2.7.6",
         "prettier": "^3.1.0",
         "react-hot-loader": "^4.1.0",
@@ -6907,9 +6907,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -14810,9 +14810,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-react": "^7.33.2",
     "mini-css-extract-plugin": "^2.7.6",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "prettier": "^3.1.0",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^3.3.3",


### PR DESCRIPTION
## Summary (required)

upgrade lodash to v4.17.23 to fix snyk vulnerability. 

- Resolves # https://github.com/fecgov/openFEC/issues/6486


### Required reviewers

1-2 developers

## Screenshots

**Before**

<img width="844" height="135" alt="Screenshot 2026-02-26 at 6 53 42 PM" src="https://github.com/user-attachments/assets/a31b88d8-0947-44cc-9abe-75372561c506" />



## How to test
- run : `git checkout develop`
- run: `pyenv activate <your python virutal env>`
- run: snyk test --file=package.json (snyk flags lodash as vulnerable)
- run: `git checkout feature/6486-fix-snyk-prototype-pollution`
- run: `rm -rf node_modules`
- run: `npm i`
- run: `npm run build`
- run: snyk test --file=package.json (snyk no longer flags lodash as vulnerable)
- run: `flask run` (& test api)



