### PR TITLE
Remove unused node packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
-        "async": "^2.6.4",
-        "immutable": "^3.8.2",
         "minimist": "^1.2.6",
         "prop-types": "^15.6.2",
         "react": "^16.7.0",
@@ -33,7 +31,6 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-webpack-plugin": "^4.0.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.7.6",
         "prettier": "^3.1.0",
         "react-hot-loader": "^4.1.0",
@@ -3144,14 +3141,6 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
@@ -6187,14 +6176,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6905,11 +6886,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12083,14 +12059,6 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
@@ -14298,11 +14266,6 @@
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "dev": true
     },
-    "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="
-    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -14808,11 +14771,6 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,10 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
-    "immutable": "^3.8.2",
     "minimist": "^1.2.6",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "async": "^2.6.4",
     "swagger-ui-dist": "4.5.0"
   },
   "devDependencies": {
@@ -39,7 +37,6 @@
     "eslint-plugin-react": "^7.33.2",
     "mini-css-extract-plugin": "^2.7.6",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.21",
     "prettier": "^3.1.0",
     "react-hot-loader": "^4.1.0",
     "style-loader": "^3.3.3",


### PR DESCRIPTION
## Summary (required)

The three node packages, `async`, `immutable` and `lodash` are not used anywhere in the openFEC repository. They are being removed from package.json to eliminate unnecessary dependencies and to remediate lodash snyk vulnerability

- Resolves # https://github.com/fecgov/openFEC/issues/6486

### Required reviewers

1-2 developers

## Screenshots

**Before**

<img width="844" height="135" alt="Screenshot 2026-02-26 at 6 53 42 PM" src="https://github.com/user-attachments/assets/a31b88d8-0947-44cc-9abe-75372561c506" />



## How to test
- run : `git checkout develop`
- run: `pyenv activate <your python virutal env>`
- run: snyk test --file=package.json (snyk flags lodash as vulnerable)
- run: `git checkout feature/remove-unused-node-packages`
- run: `rm -rf node_modules`
- run: `npm i`
- run: `npm run build`
- run: snyk test --file=package.json (snyk no longer flags lodash as vulnerable)
- run: `flask run` (& test api)



