### PR TITLE
6555- add docid filter

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -449,6 +449,7 @@ rulemaking_search = {
     'doc_category_id': fields.List(IStr(
         validate=validate.OneOf(['', '1', '2', '3', '4', '5', '6', '7', '8'])),
                                 metadata={'description': docs.DOC_CATEGORY_DESC}),
+    'doc_id': fields.Int(required=False, metadata={'description': docs.RM_DOC_ID}),
     'min_federal_registry_publish_date': Date(metadata={'description': docs.RM_MIN_FEDERAL_REGISTRY_DATE}),
     'max_federal_registry_publish_date': Date(metadata={'description': docs.RM_MAX_FEDERAL_REGISTRY_DATE}),
     'min_hearing_date': Date(metadata={'description': docs.RM_MIN_HEARING_DATE}),

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -2530,6 +2530,11 @@ Use `-` before a parameter name to sort in descending order.
 ex: `-rm_no` or `-is_open_for_comment`
 '''
 
+RM_DOC_ID = '''
+Filter rulemakings by a specific document ID (`doc_id`).
+Returns only rulemakings that contain a document matching the given ID.
+'''
+
 RM_IS_KEY_DOCUMENT = '''
 When set to true, only rulemakings with at least one key document are returned
 '''

--- a/webservices/resources/rulemaking.py
+++ b/webservices/resources/rulemaking.py
@@ -525,6 +525,24 @@ def get_all_query_params(query, **kwargs):
         vote_dates_range["format"] = ACCEPTED_DATE_FORMATS
         must_clauses.append(Q("range", vote_dates=vote_dates_range))
 
+    doc_id = kwargs.get("doc_id")
+    if doc_id is not None:
+        doc_id_query = Q(
+            "bool",
+            should=[
+                Q("nested", path="documents",
+                  query=Q("term", **{"documents.doc_id": doc_id})),
+                Q("nested", path="documents.level_2_labels.level_2_docs",
+                  query=Q("term", **{"documents.level_2_labels.level_2_docs.doc_id": doc_id})),
+                Q("nested", path="no_tier_documents",
+                  query=Q("term", **{"no_tier_documents.doc_id": doc_id})),
+                Q("has_child", type="level_2_doc",
+                  query=Q("term", doc_id=doc_id)),
+            ],
+            minimum_should_match=1
+        )
+        must_clauses.append(doc_id_query)
+
     # Use the .keyword subfield for wildcard matching exact full filename strings.
     # Use wildcard query with *{filename}* so partial matches are possible.
     filename = kwargs.get("filename")
@@ -545,10 +563,30 @@ def get_all_query_params(query, **kwargs):
             inner_hits={}
         )
 
+        # Query for no_tier_documents.filename.keyword
+        no_tier_filename_query = Q(
+            "nested",
+            path="no_tier_documents",
+            query=Q("wildcard", **{"no_tier_documents.filename.keyword": f"*{filename}*"}),
+            inner_hits={}
+        )
+
+        # Query for child docs (large rulemakings)
+        child_filename_query = Q(
+            "has_child",
+            type="level_2_doc",
+            query=Q("wildcard", **{"filename.keyword": f"*{filename}*"})
+        )
+
         must_clauses.append(
             Q(
                 "bool",
-                should=[doc_filename_query, level_2_docs_filename_query],
+                should=[
+                    doc_filename_query,
+                    level_2_docs_filename_query,
+                    no_tier_filename_query,
+                    child_filename_query,
+                ],
                 minimum_should_match=1
             )
         )


### PR DESCRIPTION
## Summary (required)

- Resolves #6555

Add docid filter to rulemaking, fixes filename filter to search no tier and large rulemakings 

### Required reviewers

1-2 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- rulemaking endpoint 

## How to test
This PR is on dev [here](https://app.circleci.com/pipelines/github/fecgov/openFEC/4133)
doc_id filter:
Regular doc path:
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?doc_id=420899
Large rm:
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?doc_id=396666
No tier: 
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?doc_id=22006

Added fix to filename:
Large RM:
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?filename=Comment%20from%20Asian%20Americans%20Advancing%20Justice,%20Color%20of%20Change,%20and%20National%20Hispanic%20Media%20Coalition

No tier:
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?filename=Draft%20Final%20Rules%20and%20Explanation%20and%20Justification%20on%20Collection%20of%20Administrative%20Debts%20and%20Collection