### PR TITLE
fix rm_mapping

### DIFF
--- a/webservices/legal/mappings/rm_mapping.py
+++ b/webservices/legal/mappings/rm_mapping.py
@@ -89,9 +89,9 @@ RM_MAPPING = {
                                 "doc_calc_comment_close_date": {"type": "date", "format": "date_optional_time"},
                                 "doc_category_id": {"type": "integer"},
                                 "doc_category_label": {"type": "keyword"},
-                                "document_date": {"type": "date", "format": "date_optional_time"},
+                                "doc_date": {"type": "date", "format": "date_optional_time"},
                                 "doc_description": {"type": "text"},
-                                "document_id": {"type": "long"},
+                                "doc_id": {"type": "long"},
                                 "doc_entities": {
                                     "properties": {
                                         "role": {"type": "keyword"},


### PR DESCRIPTION
## Summary (required)

- Resolves #6562 

Fixes an issue with the rm_mapping. Document_id and document_date should be doc_id and doc_date. This was found in the testing of the rm redirects

### Required reviewers
1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

- RM endpoint

## How to test
On develop load 2016-02 locally 
python cli.py load_rulemaking 2016-02
http://127.0.0.1:5000/v1/rulemaking/search/?doc_id=351025
(should not show up)

pull this branch
python cli.py delete_index rm_index
python cli.py create_index rm_index
python cli.py load_rulemaking 2016-02
http://127.0.0.1:5000/v1/rulemaking/search/?doc_id=351025
(should show up now)

I already reindexed dev: 
- https://fec-dev-api.app.cloud.gov/v1/rulemaking/search/?doc_id=420899
