### PR TITLE
Add designated agent to committee endpoint

### DIFF
--- a/webservices/common/models/committees.py
+++ b/webservices/common/models/committees.py
@@ -44,6 +44,19 @@ class BaseCommittee(BaseModel):
     last_file_date = db.Column(db.Date, doc=docs.LAST_FILE_DATE)
     first_f1_date = db.Column(db.Date, index=True, doc=docs.FIRST_F1_DATE)
     last_f1_date = db.Column(db.Date, doc=docs.LAST_F1_DATE)
+    designated_agent_name = db.Column(db.String(100), index=True, doc=docs.DESIGNATED_AGENT_NAME)
+    designated_agent_last_name = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_LAST_NAME)
+    designated_agent_first_name = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_FIRST_NAME)
+    designated_agent_middle_name = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_MIDDLE_NAME)
+    designated_agent_prefix = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_PREFIX)
+    designated_agent_suffix = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_SUFFIX)
+    designated_agent_street1 = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_STREET1)
+    designated_agent_street2 = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_STREET2)
+    designated_agent_city = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_CITY)
+    designated_agent_state = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_STATE)
+    designated_agent_zip = db.Column(db.String(9), doc=docs.DESIGNATED_AGENT_ZIP)
+    designated_agent_title = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_TITLE)
+    designated_agent_phone_number = db.Column(db.String(50), doc=docs.DESIGNATED_AGENT_PHONE_NUMBER)
 
 
 class BaseConcreteCommittee(BaseCommittee):

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -640,6 +640,57 @@ PRIMARY_GENERAL_INDICATOR = '''
 Primary general indicator
 '''
 
+DESIGNATED_AGENT_NAME = '''
+Designated agent name
+'''
+
+DESIGNATED_AGENT_LAST_NAME = '''
+Designated agent last name
+'''
+
+DESIGNATED_AGENT_FIRST_NAME = '''
+Designated agent first name
+'''
+
+DESIGNATED_AGENT_MIDDLE_NAME = '''
+Designated agent middle name
+'''
+
+DESIGNATED_AGENT_PREFIX = '''
+Designated agent prefix
+'''
+
+DESIGNATED_AGENT_SUFFIX = '''
+Designated agent suffix
+'''
+
+DESIGNATED_AGENT_STREET1 = '''
+Designated agent street1
+'''
+
+DESIGNATED_AGENT_STREET2 = '''
+Designated agent street2
+'''
+
+DESIGNATED_AGENT_CITY = '''
+Designated agent city
+'''
+
+DESIGNATED_AGENT_STATE = '''
+Designated agent state
+'''
+
+DESIGNATED_AGENT_ZIP = '''
+Designated agent zip
+'''
+
+DESIGNATED_AGENT_TITLE = '''
+Designated agent title
+'''
+
+DESIGNATED_AGENT_PHONE_NUMBER = '''
+Designated agent phone number
+'''
 # ======== committee end ===========
 
 


### PR DESCRIPTION
## Summary (required)
Add designated agent to commitee endpoints:
/committees/
/committee/{committee_id}/
/committee/{committee_id}/history/
/committee/{committee_id}/history/{cycle}/

- Resolves #6546 

### Required reviewers
1 dev


## Impacted areas of the application
/committees/
/committee/{committee_id}/

## How to test
1)Check out branch
2)`pytest`
3)test committee endpoints to show 13 designated agent fields
4)exampl:
http://127.0.0.1:5000/v1/committees/
http://127.0.0.1:5000/v1/committee/C00684373/
http://127.0.0.1:5000/v1/committee/C00684373/history/
http://127.0.0.1:5000/v1/committee/C00684373/history/2022/

<img width="450" height="544" alt="Screenshot 2026-04-09 at 10 29 17 PM" src="https://github.com/user-attachments/assets/03e96f8c-8350-46d0-ab91-d0f07374be41" />
