### PR TITLE
use unique base path for each repo

### DIFF
--- a/webservices/legal/constants.py
+++ b/webservices/legal/constants.py
@@ -52,6 +52,12 @@ OS_SERVICE_INSTANCE_NAME = "fec-api-opensearch"
 AWS_ES_SERVICE = "es"
 REGION = "us-gov-west-1"
 PORT = 443
+REPO_BASE_PATHS = {
+    CASE_REPO: f"{S3_BACKUP_DIRECTORY}/case_repo",
+    AO_REPO: f"{S3_BACKUP_DIRECTORY}/ao_repo",
+    ARCH_MUR_REPO: f"{S3_BACKUP_DIRECTORY}/arch_mur_repo",
+}
+
 # ========= For legal document end ==========
 
 DOCS_PATH = "docs"

--- a/webservices/legal/utils_opensearch.py
+++ b/webservices/legal/utils_opensearch.py
@@ -465,6 +465,11 @@ def configure_snapshot_repository(repo_name=None):
         constants.S3_PRIVATE_SERVICE_INSTANCE_NAME))
 
     try:
+        base_path = constants.REPO_BASE_PATHS.get(repo_name)
+        if not base_path:
+            raise ValueError(
+                f"Unknown repository name: {repo_name}. Must be one of {list(constants.REPO_BASE_PATHS.keys())}")
+
         body = {
             "type": "s3",
             "settings": {
@@ -472,7 +477,7 @@ def configure_snapshot_repository(repo_name=None):
                 "region": credentials["region"],
                 "access_key": credentials["access_key_id"],
                 "secret_key": credentials["secret_access_key"],
-                "base_path": constants.S3_BACKUP_DIRECTORY,
+                "base_path": base_path,
                 "role_arn": env.get_credential("OS2_SNAPSHOT_ROLE_ARN"),
             },
         }


### PR DESCRIPTION
## Summary (required)

- Resolves #6459 

This PR fixes our backup failures but using a unique base path for each repo. 


### Required reviewers 1 dev 


## Impacted areas of the application

General components of the application that this PR will affect:

- snapshot creation task 

## How to test

- deploy this test branch to dev: https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-snapshots-dev Note: Backups will run every ten minutes, so please don't leave this branch on dev for an extended period of time  
- See celery-worker logs and bots channel to confirm backup was successful 
- ensure that other repo commands still work
    - `cf run-task api --command "python cli.py display_repositories" -m 2G --name display_repo`
    - `cf run-task api --command "python cli.py create_opensearch_snapshot arch_mur_index" -m 2G --name create_snapshot`
    - `cf run-task api --command "python cli.py display_snapshots case_repo" -m 2G --name display_snapshots`
