### PR TITLE
Upgrade flyway v12.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.1.1/flyway-commandline-12.1.1-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-12.1.1:$PATH' >> $BASH_ENV
+            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.4.0/flyway-commandline-12.4.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-12.4.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Opensearch 2.11 (instructions [here](https://docs.opensearch.org/2.11/install-and-configure/install-opensearch/index/))
-   - Flyway 12.1.1 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
+   - Flyway 12.4.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
-     - After downloading, create a .toml file in the following location: `flyway-12.1.1/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
+     - After downloading, create a .toml file in the following location: `flyway-12.4.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
 
        ```
        [environments.local]

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: ""
-    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.1.1") {
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.4.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-12.1.1.jar:app/gradle/lib/flyway-core-12.1.1.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-12.4.0.jar:app/gradle/lib/flyway-core-12.4.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #6544 

This PR upgrades flyway to remediate a security vulnerability .


### Required reviewers

1 developer

## Impacted areas of the application

- flyway migration

## How to test

- activate your virtualenv 
- checkout this branch
- run: `brew upgrade flyway`
- run: `flyway -v` (confirm flyway version 12.4.0)
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run:` pytest`