### PR TITLE
add slow reindex

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -136,6 +136,12 @@ def initialize_legal_data_cli(index_name):
     load_utils.initialize_legal_data(index_name)
 
 
+@cli.command('slow_reload_zero_downtime')
+@click.argument('index_name', default=None, required=False)
+def slow_reload_zero_downtime_cli(index_name):
+    load_utils.slow_reload_zero_downtime(index_name)
+
+
 @cli.command('update_mapping_and_reload_legal_data')
 @click.argument('index_name', default=None, required=False)
 def update_mapping_and_reload_legal_data_cli(index_name):

--- a/webservices/legal/rulemaking_docs/rulemaking.py
+++ b/webservices/legal/rulemaking_docs/rulemaking.py
@@ -406,7 +406,7 @@ def load_large_rulemaking(specific_rm_no):
         doc.pop('text', None)
 
     # Index parent rulemaking
-    opensearch_client.index(index=constants.RM_ALIAS, body=rm_parent, id=rm["rm_id"])
+    opensearch_client.index(index=constants.RM_ALIAS, body=rm_parent, id=rm["rm_id"], routing=rm["rm_id"])
 
     logger.info("Indexing %d level-2 documents separately for rm_no: %s", len(level_2_docs_to_index), rm["rm_no"])
     # Index level-2 docs separately with parent-child relationship

--- a/webservices/legal/utils_load.py
+++ b/webservices/legal/utils_load.py
@@ -1,7 +1,10 @@
 import webservices.legal.constants as constants
 import logging
 
-from webservices.legal.utils_opensearch import create_index, switch_alias, restore_from_swapping_index, INDEX_DICT
+from webservices.legal.utils_opensearch import (
+    create_index, switch_alias, restore_from_swapping_index,
+    INDEX_DICT, create_opensearch_client, delete_index,
+)
 
 from webservices.legal.legal_docs.current_cases import (
     load_current_murs,
@@ -79,10 +82,109 @@ def initialize_legal_data(index_name=None):
     """
     index_name = index_name or constants.CASE_INDEX
     if index_name in INDEX_DICT.keys():
+        swap_index = INDEX_DICT.get(index_name)[3]
+        delete_index(swap_index)
         create_index(index_name)
         reload_all_data_by_index(index_name)
     else:
         logger.error(" Invalid index '{0}', unable to initialize this index.".format(index_name))
+
+
+def slow_reload_zero_downtime(index_name=None):
+    """
+    Reload all legal data into a fresh index, then switch aliases once complete (no downtime).
+    Alternates between XXXX_INDEX and XXXX_SWAP_INDEX on each run by checking which physical
+    index search_alias currently points to. Safe to re-run after failure: deletes any stale
+    incomplete new index before starting.
+
+    Steps:
+    1. Check search_alias to find the current live index; the other becomes the new target
+    2. Delete the new target index if it exists (cleanup from a prior failed run)
+    3. Create the new target index with correct mapping (no aliases yet)
+    4. Move XXXX_ALIAS to new index so loaders write there; SEARCH_ALIAS stays on old index
+    5. Load all legal data into new index
+    6. Atomically move both aliases to new index (only after load completes)
+    7. Delete old index
+
+    How to call task command:
+    a) cf run-task api --command "python cli.py slow_reload_zero_downtime case_index" -m 4G
+    --name slow_reload_zero_downtime_case
+    b) cf run-task api --command "python cli.py slow_reload_zero_downtime ao_index" -m 4G
+    --name slow_reload_zero_downtime_ao
+    c) cf run-task api --command "python cli.py slow_reload_zero_downtime arch_mur_index" -m 4G
+    --name slow_reload_zero_downtime_arch_mur
+    d) cf run-task api --command "python cli.py slow_reload_zero_downtime rm_index" -m 4G
+    --name slow_reload_zero_downtime_rm
+    """
+    index_name = index_name or constants.CASE_INDEX
+    if index_name not in INDEX_DICT.keys():
+        logger.error(" Invalid index '{0}', unable to reload.".format(index_name))
+        return
+
+    swap_index = INDEX_DICT.get(index_name)[3]
+    xxxx_alias = INDEX_DICT.get(index_name)[1]
+    search_alias = INDEX_DICT.get(index_name)[2]
+
+    opensearch_client = create_opensearch_client()
+
+    # 1) Find the current live index via xxxx_alias (unique per index), determine the new target
+    try:
+        aliases = opensearch_client.indices.get_alias(name=xxxx_alias)
+        old_index = list(aliases.keys())[0]
+        logger.info(" Alias '{0}' currently points to '{1}'.".format(xxxx_alias, old_index))
+        new_index = swap_index if old_index == index_name else index_name
+    except Exception:
+        # Alias doesn't exist yet (first run or broken state), default to swap_index
+        logger.warning(" Alias '{0}' not found, defaulting to first run.".format(xxxx_alias))
+        old_index = None
+        new_index = swap_index
+
+    # 2) Delete new_index if it exists (stale from a prior failed run)
+    if opensearch_client.indices.exists(index=new_index):
+        opensearch_client.indices.delete(index=new_index)
+        logger.info(" Deleted stale index '{0}'.".format(new_index))
+
+    # 3) Create new index with correct mapping, no aliases yet
+    _create_index_without_aliases(new_index, INDEX_DICT.get(index_name)[0], opensearch_client)
+
+    # 4) Move xxxx_alias to new_index so loaders write there; search_alias stays on old_index
+    actions = [{"add": {"index": new_index, "alias": xxxx_alias}}]
+    if old_index and opensearch_client.indices.exists(index=old_index):
+        actions.append({"remove": {"index": old_index, "alias": xxxx_alias}})
+    opensearch_client.indices.update_aliases(body={"actions": actions})
+    logger.info(" Pointed write alias '{0}' at '{1}' for loading.".format(xxxx_alias, new_index))
+
+    # 5) Load all data into new_index via xxxx_alias
+    reload_all_data_by_index(index_name)
+    logger.info(" Load complete. Switching aliases to '{0}'.".format(new_index))
+
+    # 6) Move both aliases to new_index now that load is complete
+    actions = [{"add": {"index": new_index, "alias": search_alias}}]
+    if old_index and opensearch_client.indices.exists(index=old_index):
+        actions += [
+            {"remove": {"index": old_index, "alias": search_alias}},
+            {"remove": {"index": old_index, "alias": xxxx_alias}},
+        ]
+    opensearch_client.indices.update_aliases(body={"actions": actions})
+    logger.info(" Aliases '{0}' and '{1}' now point to '{2}'.".format(
+        xxxx_alias, search_alias, new_index))
+
+    # 7) Delete old_index now that new_index is live
+    if old_index and opensearch_client.indices.exists(index=old_index):
+        opensearch_client.indices.delete(old_index)
+        logger.info(" Deleted old index '{0}'.".format(old_index))
+
+    logger.info(" slow_reload_zero_downtime on '{0}' completed successfully.".format(index_name))
+
+
+def _create_index_without_aliases(index_name, mapping, opensearch_client):
+    body = {
+        "settings": constants.ANALYZER_SETTING,
+        "mappings": mapping,
+    }
+    logger.info(" Creating index '{0}'...".format(index_name))
+    opensearch_client.indices.create(index=index_name, body=body)
+    logger.info(" Created index '{0}'.".format(index_name))
 
 
 def update_mapping_and_reload_legal_data(index_name=None):

--- a/webservices/legal/utils_opensearch.py
+++ b/webservices/legal/utils_opensearch.py
@@ -549,10 +549,24 @@ def create_opensearch_snapshot(index_name):
     if index_name in INDEX_DICT.keys():
         repo_name = INDEX_DICT.get(index_name)[4]
         prefix_snapshot = INDEX_DICT.get(index_name)[5]
-        index_name_list = [index_name]
+        xxxx_alias = INDEX_DICT.get(index_name)[1]
         opensearch_client = create_opensearch_client()
+
+        # Choose the index via the write alias, since
+        # slow_reload_zero_downtime may have left index XXXX_SWAP_INDEX
+        try:
+            aliases = opensearch_client.indices.get_alias(name=xxxx_alias)
+            physical_index = list(aliases.keys())[0]
+            logger.info(" Alias '{0}' resolved to physical index '{1}' for snapshot.".format(
+                xxxx_alias, physical_index))
+        except Exception:
+            logger.warning(
+                " Could not resolve alias '{0}', falling back to '{1}'.".format(
+                    xxxx_alias, index_name))
+            physical_index = index_name
+
         body = {
-            "indices": index_name_list,
+            "indices": [physical_index],
         }
         configure_snapshot_repository(repo_name)
         snapshot_name = "{0}_{1}".format(


### PR DESCRIPTION
## Summary (required)

- Resolves #6475 

Adds slow zero downtime option for reindexing large document

### Required reviewers

2-3 devs


## How to test

Rebuild this on dev:
https://app.circleci.com/pipelines/github/fecgov/openFEC/4215/workflows/1d8ad081-4bc3-4713-a380-c19b27a8e0d7/jobs/7301

Run this task on dev:
cf run-task api --command "python cli.py display_index_alias" -m 2G --name display_index_alias 

cf tasks api
Run slow reload of each legal type, make sure that the task is finished before running the next task
cf run-task api --command "python cli.py slow_reload_zero_downtime case_index" -m 4G --name slow_reload_zero_downtime_case

cf run-task api --command "python cli.py slow_reload_zero_downtime ao_index" -m 4G --name initialize_legal_data_ao

cf run-task api --command "python cli.py slow_reload_zero_downtime arch_mur_index" -m 4G --name initialize_legal_data_arch_mur

cf run-task api --command "python cli.py slow_reload_zero_downtime rm_index" -m 4G --name init_rm_data

cf run-task api --command "python cli.py display_index_alias" -m 2G --name display_index_alias 

Take a snapshot, run an intialize...
https://github.com/fecgov/openFEC/wiki/Opensearch-2.11.x-management-instructions

