### PR TITLE
[MERGE WITH GITFLOW] Hotfix/add time limit downloads

### DIFF
--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -9,6 +9,7 @@ from flask_apispec.utils import resolve_annotations
 from postgres_copy import query_entities, format_flags
 from smart_open import open
 from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
 from webservices.tasks.celery import FlaskQueueOnce
 from sqlalchemy.dialects import postgresql
 from webservices.env import env
@@ -194,7 +195,12 @@ def convert_lists_to_tuples(params, overlap_prefixes):
     return params
 
 
-@shared_task(base=FlaskQueueOnce, once={"graceful": True})
+@shared_task(
+    base=FlaskQueueOnce,
+    once={"graceful": True},
+    soft_time_limit=480,
+    time_limit=600,
+)
 def export_query(path, qs):
     qs = base64.b64decode(qs)
 
@@ -204,6 +210,8 @@ def export_query(path, qs):
         logger.info("Download resource: {0}".format(qs))
         make_bundle(resource)
         logger.info("Bundled: {0}".format(qs))
+    except SoftTimeLimitExceeded:
+        logger.exception("Download soft time limit exceeded (8 min): {0}".format(qs))
     except Exception:
         logger.exception("Download failed: {0}".format(qs))
 


### PR DESCRIPTION
## Summary (required)

This hotfix adds a soft limit of 8 mins and a hard limit of 10 mins to our downloads task to prevent long running downloads from running indefinitely. 

(Include a summary of proposed changes and connect issue below)

### Required reviewers 1 dev 

(Include who is required to review prior to merge. For example: One designer and two front end developer reviews are required prior to merge)

## Impacted areas of the application

General components of the application that this PR will affect:

- download task 


## How to test

-

