### PR TITLE
add soft and hard time limits to downloads, add task_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ target/
 
 # Celery artifacts
 celerybeat-schedule
-
+dump.rdb
 # Credientials
 *.env.json
 
@@ -73,6 +73,7 @@ static/swagger-ui/js
 # Pycharm
 .idea
 .vscode/launch.json
+*.vscode/settings.json
 
 # token file
 token.txt

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import hashlib
+import json
 import unittest.mock as mock
 
 import pytest
@@ -67,6 +68,30 @@ class TestDownloadTask(ApiBaseTest):
             },
             ExpiresIn=resource.URL_EXPIRY,
         )
+
+    @mock.patch('webservices.tasks.download.task_utils.delete_redis_value')
+    @mock.patch('webservices.tasks.download.task_utils.set_redis_value')
+    @mock.patch('webservices.tasks.download.make_bundle')
+    @mock.patch('webservices.tasks.download.call_resource')
+    def test_export_query_writes_failure_on_exception(self, call_resource,
+                                                      make_bundle, set_redis_value, delete_redis_value):
+        make_bundle.side_effect = Exception('S3 error')
+        tasks.export_query('/v1/candidates/', base64.b64encode(b'office=H').decode())
+        assert set_redis_value.called
+        key = set_redis_value.call_args[0][0]
+        assert key.startswith('download-failed:')
+        assert set_redis_value.call_args[0][1] is True
+        assert delete_redis_value.called
+
+    @mock.patch('webservices.tasks.download.task_utils.delete_redis_value')
+    @mock.patch('webservices.tasks.download.task_utils.set_redis_value')
+    @mock.patch('webservices.tasks.download.make_bundle')
+    @mock.patch('webservices.tasks.download.call_resource')
+    def test_export_query_no_failure_redis_on_success(self, call_resource,
+                                                      make_bundle, set_redis_value, delete_redis_value):
+        tasks.export_query('/v1/candidates/', base64.b64encode(b'office=H').decode())
+        assert not set_redis_value.called
+        assert not delete_redis_value.called
 
     @mock.patch('webservices.tasks.download.make_bundle')
     def test_views(self, make_bundle):
@@ -139,20 +164,73 @@ class TestDownloadTask(ApiBaseTest):
 
 
 class TestDownloadResource(ApiBaseTest):
+    @mock.patch('webservices.resources.download.task_utils.set_redis_value')
     @mock.patch('webservices.resources.download.get_cached_file')
     @mock.patch('webservices.resources.download.download.export_query')
-    def test_download(self, export, get_cached):
+    def test_download(self, export, get_cached, set_redis_value):
         get_cached.return_value = None
+        export.delay.return_value = mock.Mock(id='test-task-id')
         res = self.client.post(
             api.url_for(resource.DownloadView, path='candidates', office='S', q='joh', sort='receipts')
         )
-        assert res.get_json() == {'status': 'queued'}
+        assert res.get_json() == {'status': 'queued', 'task_id': 'test-task-id'}
         get_cached.assert_called_once_with(
             '/v1/candidates/', b'office=S&q=joh&sort=receipts', filename=None
         )
         export.delay.assert_called_once_with(
             '/v1/candidates/', base64.b64encode(b'office=S&q=joh&sort=receipts').decode('UTF-8')
         )
+        set_redis_value.assert_called_once_with('download-queued:test-task-id', True, age=7200)
+
+    @mock.patch('webservices.resources.download.task_utils.set_redis_value')
+    @mock.patch('webservices.resources.download.get_cached_file')
+    @mock.patch('webservices.resources.download.download.export_query')
+    @mock.patch('webservices.resources.download.task_utils.get_redis_value')
+    def test_download_with_task_id_no_failure_not_queued(self, get_redis_value, export, get_cached, set_redis_value):
+        # task_id is stale — neither failed nor queued in Redis — so a new task is queued
+        get_cached.return_value = None
+        get_redis_value.return_value = None
+        export.delay.return_value = mock.Mock(id='new-task-id')
+        res = self.client.post(
+            api.url_for(resource.DownloadView, path='candidates', office='S'),
+            data=json.dumps({'task_id': 'old-task-id'}),
+            content_type='application/json',
+        )
+        assert res.get_json() == {'status': 'queued', 'task_id': 'new-task-id'}
+        get_redis_value.assert_any_call('download-failed:old-task-id')
+        get_redis_value.assert_any_call('download-queued:old-task-id')
+        assert export.delay.called
+
+    @mock.patch('webservices.resources.download.get_cached_file')
+    @mock.patch('webservices.resources.download.download.export_query')
+    @mock.patch('webservices.resources.download.task_utils.get_redis_value')
+    def test_download_with_task_id_still_queued(self, get_redis_value, export, get_cached):
+        # task_id is valid and still running — return same task_id without queuing new task
+        get_cached.return_value = None
+        get_redis_value.side_effect = lambda key: key == 'download-queued:running-task-id'
+        res = self.client.post(
+            api.url_for(resource.DownloadView, path='candidates', office='S'),
+            data=json.dumps({'task_id': 'running-task-id'}),
+            content_type='application/json',
+        )
+        assert res.get_json() == {'status': 'queued', 'task_id': 'running-task-id'}
+        assert not export.delay.called
+
+    @mock.patch('webservices.resources.download.get_cached_file')
+    @mock.patch('webservices.resources.download.download.export_query')
+    @mock.patch('webservices.resources.download.delete_redis_value')
+    @mock.patch('webservices.resources.download.task_utils.get_redis_value')
+    def test_download_with_task_id_failed(self, get_redis_value, delete_redis_value, export, get_cached):
+        get_cached.return_value = None
+        get_redis_value.return_value = True
+        res = self.client.post(
+            api.url_for(resource.DownloadView, path='candidates', office='S'),
+            data=json.dumps({'task_id': 'failed-task-id'}),
+            content_type='application/json',
+        )
+        assert res.status_code == 500
+        delete_redis_value.assert_called_once_with('download-failed:failed-task-id')
+        assert not export.delay.called
 
     @mock.patch('webservices.resources.download.get_cached_file')
     @mock.patch('webservices.resources.download.download.export_query')

--- a/webservices/resources/download.py
+++ b/webservices/resources/download.py
@@ -11,6 +11,7 @@ from flask import request
 from webservices import utils
 from webservices import exceptions
 from webservices.tasks import download
+from webservices.tasks.utils import delete_redis_value
 from webservices.tasks import utils as task_utils
 from webservices.utils import use_kwargs_original
 from flask import current_app
@@ -23,28 +24,45 @@ URL_EXPIRY = 7 * 24 * 60 * 60
 
 class DownloadView(utils.Resource):
 
-    @use_kwargs_original({'filename': fields.Str(load_default=None)})
-    def post(self, path, filename=None, **kwargs):
+    @use_kwargs_original({'filename': fields.Str(load_default=None),
+                          'task_id': fields.Str(load_default=None)}, location='json')
+    def post(self, path, filename=None, task_id=None, **kwargs):
         parts = request.path.split('/')
         parts.remove('download')
         path = '/'.join(parts)
+
         cached_file = get_cached_file(path, request.query_string, filename=filename)
         if cached_file:
+            if task_id and task_utils.get_redis_value('download-queued:{}'.format(task_id)):
+                delete_redis_value('download-queued:{}'.format(task_id))
+
             return {
                 'status': 'complete',
                 'url': cached_file,
             }
+
+        if task_id:
+            if task_utils.get_redis_value('download-failed:{}'.format(task_id)):
+                delete_redis_value('download-failed:{}'.format(task_id))
+                raise exceptions.ApiError('Download failed', status_code=http.client.INTERNAL_SERVER_ERROR)
+            if task_utils.get_redis_value('download-queued:{}'.format(task_id)):
+                return {'status': 'queued', 'task_id': task_id}
+
         resource = download.call_resource(current_app, path, request.query_string.decode('UTF-8'))
+
         if resource['count'] > MAX_RECORDS:
             raise exceptions.ApiError(
                 'Cannot request downloads with more than {} records'.format(MAX_RECORDS),
                 status_code=http.client.FORBIDDEN,
             )
-        download.export_query.delay(
+
+        task_id = download.export_query.delay(
             path,
             base64.b64encode(request.query_string).decode('UTF-8')
-        )
-        return {'status': 'queued'}
+        ).id
+        task_utils.set_redis_value('download-queued:{}'.format(task_id), True, age=7200)
+
+        return {'status': 'queued', 'task_id': task_id}
 
 
 def get_cached_file(path, qs, filename=None):

--- a/webservices/tasks/celery.py
+++ b/webservices/tasks/celery.py
@@ -31,7 +31,7 @@ def celery_init_app(app: Flask) -> Celery:
             "ssl_cert_reqs": ssl.CERT_NONE,
         },
         redis_backend_use_ssl={
-            "ssl_cert_reqs": ssl.CERT_NONE,
+             "ssl_cert_reqs": ssl.CERT_NONE,
         },
         imports=(
             "webservices.tasks.refresh_db",

--- a/webservices/tasks/download.py
+++ b/webservices/tasks/download.py
@@ -9,6 +9,7 @@ from flask_apispec.utils import resolve_annotations
 from postgres_copy import query_entities, format_flags
 from smart_open import open
 from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
 from webservices.tasks.celery import FlaskQueueOnce
 from sqlalchemy.dialects import postgresql
 from webservices.env import env
@@ -194,8 +195,15 @@ def convert_lists_to_tuples(params, overlap_prefixes):
     return params
 
 
-@shared_task(base=FlaskQueueOnce, once={"graceful": True})
-def export_query(path, qs):
+@shared_task(
+    bind=True,
+    base=FlaskQueueOnce,
+    once={"graceful": True},
+    soft_time_limit=480,
+    time_limit=600,
+)
+def export_query(self, path, qs):
+    task_id = self.request.id
     qs = base64.b64decode(qs)
 
     try:
@@ -204,8 +212,15 @@ def export_query(path, qs):
         logger.info("Download resource: {0}".format(qs))
         make_bundle(resource)
         logger.info("Bundled: {0}".format(qs))
+    except SoftTimeLimitExceeded:
+        logger.exception("Download soft time limit exceeded (8 min): {0}".format(qs))
+        task_utils.delete_redis_value('download-queued:{}'.format(task_id))
+        task_utils.set_redis_value('download-failed:{}'.format(task_id), True, age=7200)
+        raise
     except Exception:
         logger.exception("Download failed: {0}".format(qs))
+        task_utils.delete_redis_value('download-queued:{}'.format(task_id))
+        task_utils.set_redis_value('download-failed:{}'.format(task_id), True, age=7200)
 
 
 @shared_task

--- a/webservices/tasks/utils.py
+++ b/webservices/tasks/utils.py
@@ -67,5 +67,12 @@ def get_redis_value(key, fallback=None):
     return json.loads(value) if value else fallback
 
 
+def delete_redis_value(key):
+    """
+    Delete a value from redis by key
+    """
+    get_redis_instance().delete(key)
+
+
 def get_redis_instance():
     return redis.Redis.from_url(redis_url())


### PR DESCRIPTION
## Summary (required)

- Resolves #6590

This PR adds a soft and hard time limit to the celery download task. It also uses a task_id to keep track of downloads that were killed. **This PR should not be merged until the [cms](https://github.com/fecgov/fec-cms/issues/7092) component is also ready.**  

### Required reviewers 3 devs 


## Impacted areas of the application

General components of the application that this PR will affect:

- downloads endpoint and task


## How to test

1. `git checkout test-download-task-id`
2. activate your virtualenv
4. Ensure appropriate env_vars for s3 are set, see this wiki for detailed instructions: https://github.com/fecgov/openFEC/wiki/Set-up-redis-and-celery-on-local-and-test-the-tasks
5. `flask run`
6. Open a new terminal tab
    - start redis: `redis-server`
7. Open another terminal tab
    - activate your virtualenv 
    - start celery-worker: `celery --app webservices.tasks.make_celery worker  --loglevel DEBUG --pool=prefork`
8. Open another terminal tab
    - activate your virtualenv 
    - start celery-beat: `celery --app webservices.tasks.make_celery beat --loglevel DEBUG`
9. open another terminal tab 
 - use to send post requests to test downloads endpoints 

Example:

No task_id: 
curl -X POST \
  "http://127.0.0.1:5000/v1/download/schedules/schedule_a/by_zip/?page=1&per_page=20&zip=PUT RANDOM ZIPCODE&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false" \
  -H "Content-Type: application/json" \
  -d '{}'

(api should return a task_id)

With task_id
curl -X POST \
  "http://127.0.0.1:5000/v1/download/schedules/schedule_a/by_zip/?page=1&per_page=20&zip=PUT RANDOM ZIP CODE&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false" \
  -H "Content-Type: application/json" \
  -d '{"task_id": “PUT TASK “ID HERE}’

(SHOULD RETURN ERROR)

Random task_Id (will ignore and return valid task id): 

curl -X POST \
  "http://127.0.0.1:5000/v1/download/schedules/schedule_a/by_zip/?page=1&per_page=20&zip=PUT RANDOM ZIPCODE&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false" \
  -H "Content-Type: application/json" \
  -d '{"task_id": "abcd"}'

curl -X POST \
  "http://127.0.0.1:5000/v1/download/schedules/schedule_a/by_zip/?page=1&per_page=20&zip=PUT RANDOM ZIP CODE&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false" \
  -H "Content-Type: application/json" \
  -d '{"task_id": “PUT TASK “ID HERE}’
<img width="994" height="463" alt="image" src="https://github.com/user-attachments/assets/257d6497-c346-45dc-9854-da1e44883b8f" />


Comment out `soft_time_limit` and `time_limit` from webservices.tasks.download.py and ensure downloads are returned correctly
