### PR TITLE
Migration file to modify the expand_document function to include W, X document types

### DIFF
--- a/data/migrations/V0321__update_function_expand_document.sql
+++ b/data/migrations/V0321__update_function_expand_document.sql
@@ -1,0 +1,49 @@
+/* This migration file is related to issues #6523,6612 and #6611,  
+This will update the original version V0240__modify_function_expand_document.sql
+
+*/
+-- FUNCTION: public.expand_document(text)
+
+-- DROP FUNCTION public.expand_document(text);
+
+CREATE OR REPLACE FUNCTION public.expand_document(acronym text)
+    RETURNS text
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+    begin
+        return case acronym
+            when '2' then '24-Hour Contribution Notice'
+            when '4' then '48-Hour Contribution Notice'
+            when 'A' then 'Debt Settlement Plan'
+            when 'B' then 'Acknowledgment of Receipt of Debt Settlement Statement'
+            when 'C' then 'RFAI: Debt Settlement First Notice'
+            when 'D' then 'Commission Debt Settlement Review'
+            when 'E' then 'Commission Response to Debt Settlement Request'
+            when 'F' then 'Administrative Termination'
+            when 'G' then 'Debt Settlement Plan Amendment'
+            when 'H' then 'Disavowal Notice'
+            when 'I' then 'Disavowal Response'
+            when 'J' then 'Conduit Report'
+            when 'K' then 'Termination Approval'
+            when 'L' then 'Repeat Non-Filer Notice'
+            when 'M' then 'Filing Frequency Change Notice'
+            when 'N' then 'Paper Amendment to Electronic Report'
+            when 'O' then 'Acknowledgment of Filing Frequency Change'
+            when 'P' then 'Notice of Paper Filing'
+            when 'Q' then 'Acknowledgment of F3L Filing Frequency Change'
+            when 'R' then 'F3L Filing Frequency Change Notice'
+            when 'S' then 'RFAI: Debt Settlement Second'
+            when 'T' then 'Miscellaneous Submission to FEC'
+            when 'U' then 'Unregistered Committee Notice'
+            when 'V' then 'Repeat Violation Notice (441A OR 441B)'
+            when 'W' then 'C-1/Loan Agreement'
+            when 'X' then 'Loan Forgiveness'
+            else null
+        end;
+    end
+$BODY$;
+
+ALTER FUNCTION public.expand_document(text)
+    OWNER TO fec;


### PR DESCRIPTION
### Summary

Postgres contains a function named **_expand_document_** that maintains the mapping of document types to their corresponding descriptions. This function is used by **_ofec_filings_all_mv_** to populate the _**document_type_full**_ field.

The entries listed in postgres function are the same found in FECP `staging.ref_to_from_ind` and `staging.ref_text_cd` reference tables. These reference table are the source of truth for campaign finance data in FECP and are NOT available in postgres. Updating the Postgres function manually to include these entries to ensure the changes in postgres are in sync with the changes made in FECP. This would help keep the document type descriptions consistent across these two system (Both FECP and POSTGRES).


Keeping postgre _expand_document_ function as the single source of truth would ensure that any updates are automatically reflected across all dependent components and avoid maintaining the same information in multiple places.


### Resolves # #6523, #6612 and #6611

### Reviewers required
1 developer

### How to test
- run: git checkout feature/update-document-description-in-postgres-function
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run: `flyway migrate`
- run: `pytest`

