### PR TITLE
[MERGE WITH GITFLOW]Filings endpoint, update document type T's description in docs.py

### DIFF
--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -98,7 +98,6 @@ class Filings(FecFileNumberMixin, CsvMixin, db.Model):
             self.report_year,
             self.report_type_full,
             self.document_type_full,
-            self.document_type,
             self.form_type,
         )
 
@@ -161,7 +160,6 @@ class EFilings(FecFileNumberMixin, AmendmentChainMixin, CsvMixin, FecMixin, db.M
             self.coverage_end_date.year,
             clean_report_type(self.report.report_type_full),
             None,
-            self.document_type,
             self.form_type,
         )
 

--- a/webservices/common/models/reports.py
+++ b/webservices/common/models/reports.py
@@ -262,7 +262,6 @@ class CommitteeReports(FecFileNumberMixin, PdfMixin, CsvMixin, BaseModel):
             clean_report_type(str(self.report_type_full)),
             None,
             None,
-            None,
         )
 
 
@@ -540,7 +539,6 @@ class BaseFiling(FecFileNumberMixin, AmendmentChainMixin, PdfMixin, FecMixin, db
             self.coverage_end_date.year,
             clean_report_type(self.report.report_type_full),
             None,
-            self.document_type,
             None,
         )
 

--- a/webservices/docs.py
+++ b/webservices/docs.py
@@ -1279,7 +1279,7 @@ The type of document for documents other than reports:\n\
     - B Acknowledgment of Receipt of Debt Settlement Statement\n\
     - C RFAI: Debt Settlement First Notice\n\
     - D Commission Debt Settlement Review\n\
-    - E Commission Response TO Debt Settlement Request\n\
+    - E Commission Response To Debt Settlement Request\n\
     - F Administrative Termination\n\
     - G Debt Settlement Plan Amendment\n\
     - H Disavowal Notice\n\
@@ -1290,13 +1290,13 @@ The type of document for documents other than reports:\n\
     - M Filing Frequency Change Notice\n\
     - N Paper Amendment to Electronic Report\n\
     - O Acknowledgment of Filing Frequency Change\n\
-    - S RFAI: Debt Settlement Second\n\
-    - T Miscellaneous Report TO FEC\n\
-    - V Repeat Violation Notice (441A OR 441B)\n\
     - P Notice of Paper Filing\n\
-    - R F3L Filing Frequency Change Notice\n\
     - Q Acknowledgment of F3L Filing Frequency Change\n\
+    - R F3L Filing Frequency Change Notice\n\
+    - S RFAI: Debt Settlement Second\n\
+    - T Miscellaneous Submission To FEC\n\
     - U Unregistered Committee Notice\n\
+    - V Repeat Violation Notice (441A OR 441B)\n\
     - W C-1/Loan Agreement\n\
     - X Loan Forgiveness\n\
 '''

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -404,17 +404,11 @@ related_efile_summary = functools.partial(
 
 
 def document_description(
-    report_year, report_type=None, document_type_full=None, document_type=None, form_type=None
+    report_year, report_type=None, document_type_full=None, form_type=None
 ):
 
     if report_type:
         clean = re.sub(r"\{[^)]*\}", "", report_type)
-    elif document_type == "W":
-        clean = "C-1/Loan Agreement"
-    elif document_type == "X":
-        clean = "Loan Forgiveness"
-    elif document_type == "A":
-        clean = "Debt Settlement Plan"
     elif document_type_full:
         clean = document_type_full
     elif form_type and form_type in decoders.form_types:


### PR DESCRIPTION
## Summary 

1. In filings endpoint, update `document_type=T` variable description to `Miscellaneous submission To FEC`
2. In swagger, rearrange `document_type` variable descriptions in alphabetical order
3. Clean up the API code that has references to `document_type=W` and `document_type=X` and move these two entries to postgres `expand_document` function (refer to pr#https://github.com/fecgov/openFEC/pull/6613)
4. `document_type_full` variable is always populated with the proper document description for a given `document_type`

**Filings endpoint swagger docs before:**

<img width="1187" height="747" alt="Screenshot 2026-06-03 at 4 52 24 PM" src="https://github.com/user-attachments/assets/a163cc26-ea55-4d71-a934-9cfea8b61b86" />


**Filings endpoint swagger docs after:**

<img width="1169" height="737" alt="Screenshot 2026-06-03 at 4 54 09 PM" src="https://github.com/user-attachments/assets/2ab02b95-5701-4c65-a3f1-26c7c65a5c52" />

- Resolves #6611 

### Required reviewers

2 or more developers

## Impacted areas of the application
swagger docs, filings endpoint

## How to test

- run: `git checkout feature/update-filings-endpoint-doc-description`
- run:  `pytest`
- run: `flask run`
Test filings endpoint, verify the `document_type_full` is NOT NULL and shows value in feature branch

**Prod/ Filings endpoint with `document_type=T`:**
https://api.open.fec.gov/v1/filings/?page=1&per_page=20&document_type=T&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

**Local/Filings endpoint with `document_type=T`:**
http://localhost:5000/v1/filings/?page=1&per_page=20&document_type=T&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false


**Prod/ Filings endpoint with `document_type=W`:**
https://api.open.fec.gov/v1/filings/?page=1&per_page=20&document_type=W&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

**Local/Filings endpoint with `document_type=W`:**
http://localhost:5000/v1/filings/?page=1&per_page=20&document_type=W&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false


**Prod/ Filings endpoint with `document_type=X`:**
https://api.open.fec.gov/v1/filings/?page=1&per_page=20&document_type=X&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false&api_key=DEMO_KEY

**Local/Filings endpoint with `document_type=X`:**
http://localhost:5000/v1/filings/?page=1&per_page=20&document_type=X&sort=-receipt_date&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false