### PR TITLE
Add check result exist function in endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ yappi==1.7.3
 
 # Marshalling
 flask-apispec==0.11.4
-git+https://github.com/fecgov/marshmallow-pagination@master
+git+https://github.com/fecgov/marshmallow-pagination@check_result_exist
 marshmallow==3.26.2
 marshmallow-sqlalchemy==1.4.2
 

--- a/webservices/common/counts.py
+++ b/webservices/common/counts.py
@@ -14,17 +14,41 @@ from sqlalchemy import select, func
 count_pattern = re.compile(r'rows=(\d+)')
 
 
+def check_result_exist(resource, query):
+    """
+    use_pk_for_count = true for schedule_a, schedule_b and schedule_e.
+    """
+    is_result_exist = False
+    if resource.use_pk_for_count and resource.model:
+        primary_key = resource.model.__mapper__.primary_key[0]
+        query = query.with_only_columns(primary_key)
+
+    is_result_exist = models.db.session.execute(select(query.exists())).scalar()
+    return is_result_exist
+
+
 def is_estimated_count(resource, query):
     """
-    determine prior to counting if count will be an estimate (avoids calling
+    1)Determine prior to counting if count will be an estimate (avoids calling
     get_counts and using the `is_estimate` return value which may cause
     exact counting (when False)
+
+    2)use_estimated_counts is always false for ScheduleEEfileView
+
+    3)is_count_exact is always true for
+    ElectionsListView(endpoint:'/elections/search/')
+    ReportsView('/reports/<string:entity_type>/')
+    CommitteeReportsView('/committee/<string:committee_id>/reports/')
+    TotalsByEntityTypeView('/totals/<string:entity_type>/')
+    TotalsCommitteeView('/committee/<string:committee_id>/totals/')
+    CandidateTotalsDetailView('/candidate/<string:candidate_id>/totals/')
     """
+
     if resource.use_pk_for_count and resource.model:
         primary_key = resource.model.__mapper__.primary_key[0]
         query = query.with_only_columns(primary_key)
     if resource.use_estimated_counts:
-        estimated_count = get_estimated_count(query)
+        estimated_count, _ = get_estimated_count(resource, query)
         if estimated_count > resource.estimated_count_threshold:
             resource.is_count_exact = False
             return True
@@ -32,25 +56,34 @@ def is_estimated_count(resource, query):
     return False
 
 
+def get_exact_count(resource, query):
+    exact_count = models.db.session.scalar(select(func.count()).select_from(query.subquery()))
+    resource.is_count_exact = True
+    return exact_count, resource.is_count_exact
+
+
 def get_count(resource, query):
     """
     Calculate either the estimated count or exact count.
     Indicate whether the count is an estimate.
     Optionally only select the primary key column in the query
+    used by download.py
     """
     is_estimate = is_estimated_count(resource, query)
+
     if is_estimate:
-        estimated_count = get_estimated_count(query)
+        estimated_count, _ = get_estimated_count(resource, query)
         return estimated_count, is_estimate
-    # Use exact counts for `use_estimated_counts == False` and small result sets
+        # # Use exact counts for `use_estimated_counts == False` and small result sets
     exact_count = models.db.session.scalar(select(func.count()).select_from(query.subquery()))
     return exact_count, is_estimate
 
 
-def get_estimated_count(query):
+def get_estimated_count(resource, query):
     rows = get_query_plan(query)
     estimated_count = extract_analyze_count(rows)
-    return estimated_count
+    resource.is_estimate = True
+    return estimated_count, resource.is_estimate
 
 
 def get_query_plan(query):

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -7,6 +7,7 @@ from webservices.common import counts
 from webservices.utils import use_kwargs
 from webservices.common import models
 import sqlalchemy as sa
+from webservices.env import env
 
 
 class ApiResource(utils.Resource):
@@ -39,8 +40,22 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        if counts.check_result_exist(self, query):
-            # result exist
+        if env.get_credential("CHECK_RESULT_EXIST_REGULAR_API", False) in utils.VALID_TRUE_VALUES:
+            # Call check_result_exist to check whether the result exists
+            if counts.check_result_exist(self, query):
+                # result exist
+                is_estimate = counts.is_estimated_count(self, query)
+                if not is_estimate:
+                    # is exact count
+                    count = None
+                else:
+                    # get estimated count
+                    count, _ = counts.get_estimated_count(self, query)
+            else:
+                # result not exist, set count = 0
+                count = 0
+        else:
+            # Don't Call check_result_exist function
             is_estimate = counts.is_estimated_count(self, query)
             if not is_estimate:
                 # is exact count
@@ -48,9 +63,6 @@ class ApiResource(utils.Resource):
             else:
                 # get estimated count
                 count, _ = counts.get_estimated_count(self, query)
-        else:
-            # result not exist, set count = 0
-            count = 0
 
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
@@ -89,10 +101,23 @@ class ItemizedResource(ApiResource):
         """Get itemized resources.
         """
         self.validate_kwargs(kwargs)
-
         query = self.build_query(**kwargs)
-        if counts.check_result_exist(self, query):
-            # result exist
+        if env.get_credential("CHECK_RESULT_EXIST_ITEMIZED_API", False) in utils.VALID_TRUE_VALUES:
+            # Call check_result_exist to check whether the result exists
+            if counts.check_result_exist(self, query):
+                # result exist
+                is_estimate = counts.is_estimated_count(self, query)
+                if not is_estimate:
+                    # is exact count
+                    count = None
+                else:
+                    # get estimated count
+                    count, _ = counts.get_estimated_count(self, query)
+            else:
+                # result not exist, set count = 0
+                count = 0
+        else:
+            # Don't Call check_result_exist function
             is_estimate = counts.is_estimated_count(self, query)
             if not is_estimate:
                 # is exact count
@@ -100,10 +125,6 @@ class ItemizedResource(ApiResource):
             else:
                 # get estimated count
                 count, _ = counts.get_estimated_count(self, query)
-        else:
-            # result exist, set count = 0
-            count = 0
-
         return utils.fetch_seek_page(
             query,
             kwargs,

--- a/webservices/common/views.py
+++ b/webservices/common/views.py
@@ -39,14 +39,23 @@ class ApiResource(utils.Resource):
     @marshal_with(Ref('page_schema'))
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        is_estimate = counts.is_estimated_count(self, query)
-        if not is_estimate:
-            count = None
+        if counts.check_result_exist(self, query):
+            # result exist
+            is_estimate = counts.is_estimated_count(self, query)
+            if not is_estimate:
+                # is exact count
+                count = None
+            else:
+                # get estimated count
+                count, _ = counts.get_estimated_count(self, query)
         else:
-            count, _ = counts.get_count(self, query)
+            # result not exist, set count = 0
+            count = 0
+
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True
+
         return utils.fetch_page(
             query, kwargs, models.db.session, is_count_exact=self.is_count_exact,
             count=count, model=self.model, join_columns=self.join_columns, aliases=self.aliases,
@@ -82,18 +91,27 @@ class ItemizedResource(ApiResource):
         self.validate_kwargs(kwargs)
 
         query = self.build_query(**kwargs)
-        is_estimate = counts.is_estimated_count(self, query)
-        if not is_estimate:
-            count = None
+        if counts.check_result_exist(self, query):
+            # result exist
+            is_estimate = counts.is_estimated_count(self, query)
+            if not is_estimate:
+                # is exact count
+                count = None
+            else:
+                # get estimated count
+                count, _ = counts.get_estimated_count(self, query)
         else:
-            count, _ = counts.get_count(self, query)
-        return utils.fetch_seek_page(query,
-                                     kwargs,
-                                     self.index_column,
-                                     models.db.session,
-                                     is_count_exact=self.is_count_exact,
-                                     count=count,
-                                     cap=self.cap)
+            # result exist, set count = 0
+            count = 0
+
+        return utils.fetch_seek_page(
+            query,
+            kwargs,
+            self.index_column,
+            models.db.session,
+            is_count_exact=self.is_count_exact,
+            count=count,
+            cap=self.cap)
 
     def validate_kwargs(self, kwargs):
         """Custom keyword argument validation

--- a/webservices/resources/elections.py
+++ b/webservices/resources/elections.py
@@ -145,7 +145,7 @@ class ElectionView(ApiResource):
 
     def get(self, *args, **kwargs):
         query = self.build_query(*args, **kwargs)
-        count, _ = counts.get_count(self, query)
+        count, _ = counts.get_exact_count(self, query)
         multi = False
         if isinstance(kwargs['sort'], (list, tuple)):
             multi = True

--- a/webservices/resources/filings.py
+++ b/webservices/resources/filings.py
@@ -17,7 +17,6 @@ from webservices.common import models
     },
 )
 class BaseFilings(ApiResource):
-
     model = models.Filings
     schema = schemas.FilingsSchema
     page_schema = schemas.FilingsPageSchema
@@ -101,7 +100,6 @@ class FilingsView(BaseFilings):
 # Ex1: http://127.0.0.1:5000/v1/filings/?q_filer=san
 # Ex2: http://127.0.0.1:5000/v1/filings/?candidate_id=H8TX10094
 class FilingsList(BaseFilings):
-
     filter_multi_fields = BaseFilings.filter_multi_fields + [
         ("committee_id", models.Filings.committee_id),
         ("candidate_id", models.Filings.candidate_id),

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -132,7 +132,10 @@ def create_app(test_config=None):
                                  pool_size=50, max_overflow=50, pool_timeout=120,
                                  pool_pre_ping=pool_pre_ping) for follower in followers if follower.strip()
                 ]
+
+    # Uncomment these two lines to enable local query display
     # app.config['SQLALCHEMY_ECHO'] = True
+    # logging.getLogger("sqlalchemy.engine").propagate = False
 
     # Modify app configuration and logging level for production
     if not app.debug:

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -128,6 +128,9 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
         )
 
     def _fetch(self, last_index, sort_index=None, limit=None):
+        if self.count == 0:
+            self.is_count_exact = True
+            return []
         cursor = self.cursor
         direction = self.sort_column[1] if self.sort_column else sa.asc
         lhs, rhs = (), ()
@@ -217,9 +220,11 @@ class SeekCoalescePaginator(paginators.SeekPaginator):
 def fetch_seek_page(
     query, kwargs, index_column, session, is_count_exact=None, clear=False, count=None, cap=100
 ):
+
     paginator = fetch_seek_paginator(
         query, kwargs, index_column, session, is_count_exact=is_count_exact, clear=clear, count=count, cap=cap
     )
+
     if paginator.sort_column is not None:
         sort_index = kwargs["last_{0}".format(paginator.sort_column[2])]
         null_sort_by = paginator.sort_column[0]

--- a/webservices/utils.py
+++ b/webservices/utils.py
@@ -36,6 +36,9 @@ class Resource(six.with_metaclass(MethodResourceMeta, restful.Resource)):
     pass
 
 
+VALID_TRUE_VALUES = ("true", True, "True", 'TRUE')
+
+
 API_KEY_ARG = fields.Str(
      load_default="DEMO_KEY", metadata={'description': docs.API_KEY_DESCRIPTION},
 )


### PR DESCRIPTION
## Summary (required)
Add a new check_result_exist function to the relevant endpoints (see reference [diagram](https://docs.google.com/drawings/d/1_8xjMzzjjXjkoyXHuYYBBOZDdczD1qYIEpvFPry8RjI/edit) below).
If check_result_exist returns false, immediately return result = [] and skip any subsequent queries.
This optimization reduces unnecessary database queries, lowers memory usage, and improves overall performance.
 
- Resolves #6584 

- Note: This PR points to marshmallow-pagination@check_result_exist now. For local development, please create new virtualenvand run:
```
pip install -r requirements.txt
pip install -r requirements-dev.txt
```
Once the FEC API is stable, we should merge the check_result_exist branch into master in the marshmallow-pagination repository and update OpenFFC to point to marshmallow-pagination@master.

There are two feature flags:
1)CHECK_RESULT_EXIST_ITEMIZED_API
2)CHECK_RESULT_EXIST_REGULAR_API
This provides greater flexibility by allowing the itemized and regular endpoints to be enabled independently.

### Required reviewers
2 devs

## Impacted areas of the application
all endpoints

## Screenshots
<img width="600" height="468" alt="all_endpoints_work_flow" src="https://github.com/user-attachments/assets/0bd4ae65-b4f8-4b5a-a282-aa5ebb071a11" />

### Locust test compare dev branch and check_result_exist branch
(200 users, 20 rampup)
in dev:
<img width="600" height="606" alt="locust_dev_200user_20rampup" src="https://github.com/user-attachments/assets/b8786b27-02e4-4ef1-9ff1-1e7e40eec485" />

in check_result_eixst branch:
<img width="600" height="602" alt="locust_testbranch_200user_20rampup" src="https://github.com/user-attachments/assets/f4ea8a77-4bbe-44b7-8ae5-54720d0c8bd3" />


## How to test
- checkout branch
- create new virtralenv: 
```
pyenv virtualenv 3.11.12 api_mar31112
pyenv activate api_mar31112
```
- run:
```
pip install -r requirements.txt
pip install -r requirements-dev.txt
```

- run: `pytest`

- Uncomment these two lines(line137 and ling138) to enable local query display
app.config['SQLALCHEMY_ECHO'] = True
logging.getLogger("sqlalchemy.engine").propagate = False

- If you want to check query execute time, you can enable profiling
(add these codes to views.py:
```
line 11: from webservices.profiling import profiled
line 46:  with profiled():
line 104: with profiled():
```

- Test endpoints 
<br/><br/>
**Test Part One:** 
```
export CHECK_RESULT_EXIST_ITEMIZED_API=true
export CHECK_RESULT_EXIST_REGULAR_API=true
```
Test URLs in local, check terminal to see how many queries get executed

1)http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00016899&two_year_transaction_period=2026
(ScheduleAView) exact count
execute four queries:
(1)SELECT EXISTS query(==>is_result_exist=true), use_pk_for_count=true
(2)EXPLAIN(query):estimated_count=10542(is_count_exact=true),(<500K)
(3)SELECT count(*) AS count_1 (in marshmallow_pagination, call _count()),exact_count=2790
(4)SELECT data


2)http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00401224&two_year_transaction_period=2026
(ScheduleAView) estimated count
execute four queries:
(1)SELECT EXISTS query(==>is_result_exist=true), use_pk_for_count=true
(2)EXPLAIN(query):estimated_count=70936087(is_count_exact=false),(>500K)
(3)call get_estimated_count, run EXPLAIN(query) again, 70936087, select all columns
(4)SELECT data


3)http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00949636&two_year_transaction_period=2026
(ScheduleAView), count=0
execute one query only:
(1)SELECT EXISTS, is_result_exist=false
return [], no any query executed


4)http://127.0.0.1:5000/v1/schedules/schedule_e/efile/
(ScheduleEEfileView),always use exact_count
execute three queries:
(1)SELECT EXISTS query,is_result_exist=true
due to use_estimated_counts = False, EXPLAIN query won't run
(2)SELECT count(*) AS count_1,(in marshmallow_pagination, call _count()),exact_count=18539
(3)SELECT data


5)http://127.0.0.1:5000/v1/elections/?office=senate&cycle=2000&state=CA
(ElectionView)
(1)not call check_result_exist()
execute two queries:
(2)(is_count_exact=true)
SELECT count(*) AS count_1, (override get(): call get_exact_count())
(3)SELECT DISTINCT data...

6)http://127.0.0.1:5000/v1/committees/
CommitteeView)(), exact count
execute four queries:
(1)SELECT EXISTS query, is_result_exist=true
(2)EXPLAIN(query):estimated_count=88790(==>is_count_exact=true)
(3)SELECT count(*) AS count_1,(in marshmallow_pagination, call _count()),exact_count=88790
(4)SELECT data


7)http://127.0.0.1:5000/v1/filings/?cycle=2026&document_type=V
(FilingsList),count=0
execute one query only:
(1)SELECT EXISTS, is_result_exist=false
return [], no any query executed


9)http://127.0.0.1:5000/v1/filings/
(FilingsList),estimated count
execute four queries:
(1)SELECT EXISTS query,is_result_exist=true
(2)EXPLAIN(query):estimated_count=3617823(is_count_exact=false),(>500K)
(3)get_estimated_count, run EXPLAIN(query) again
(4)SELECT data
<img width="599" height="503" alt="result_table2" src="https://github.com/user-attachments/assets/eb587016-5399-4881-b4ac-ef2afae86e98" />



<br /><br />
**Test Part Two:** 
```
export CHECK_RESULT_EXIST_ITEMIZED_API=false
export CHECK_RESULT_EXIST_REGULAR_API=false
```
Test URLs in local, check terminal to see how many queries get executed(you can compare with endpoints in dev space

(1)http://127.0.0.1:5000/v1/schedules/schedule_b/?committee_id=C00952846&two_year_transaction_period=2026

(2)http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00016899&two_year_transaction_period=2026

(3)http://127.0.0.1:5000/v1/schedules/schedule_a/?committee_id=C00401224&two_year_transaction_period=2026

(4)http://127.0.0.1:5000/v1/filings/?cycle=2026&document_type=V

(5)http://127.0.0.1:5000/v1/committees/

(6)http://127.0.0.1:5000/v1/filings/

<img width="600" height="484" alt="result_table1" src="https://github.com/user-attachments/assets/a227a628-6f03-469f-a597-4cc481f70daa" />

