### PR TITLE
upgrade flyway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.8.1/flyway-commandline-12.8.1-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-12.8.1:$PATH' >> $BASH_ENV
+            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.9.0/flyway-commandline-12.9.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-12.9.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Opensearch 2.11 (instructions [here](https://docs.opensearch.org/2.11/install-and-configure/install-opensearch/index/))
-   - Flyway 12.8.1 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
+   - Flyway 12.9.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
-     - After downloading, create a .toml file in the following location: `flyway-12.8.1/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
+     - After downloading, create a .toml file in the following location: `flyway-12.9.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
 
        ```
        [environments.local]

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -5,8 +5,31 @@ repositories {
     mavenCentral()
 }
 
+configurations.all {
+    resolutionStrategy.force "io.netty:netty-handler:4.1.135.Final"
+    resolutionStrategy.force "io.netty:netty-handler-proxy:4.1.135.Final"
+    resolutionStrategy.force "io.netty:netty-codec-dns:4.1.135.Final"
+    resolutionStrategy.force "io.netty:netty-codec-http:4.1.135.Final"
+    resolutionStrategy.force "io.netty:netty-codec-http2:4.1.135.Final"
+    resolutionStrategy.force "io.netty:netty-resolver-dns:4.1.135.Final"
+    resolutionStrategy.force "io.projectreactor.netty:reactor-netty-http:1.2.18"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:2.21.2"
+    resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:5.3.5"
+    resolutionStrategy.force "com.nimbusds:nimbus-jose-jwt:10.0.2"
+}
+
 dependencies {
     implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: ""
+    implementation "io.netty:netty-handler:4.1.135.Final"
+    implementation "io.netty:netty-handler-proxy:4.1.135.Final"
+    implementation "io.netty:netty-codec-dns:4.1.135.Final"
+    implementation "io.netty:netty-codec-http:4.1.135.Final"
+    implementation "io.netty:netty-codec-http2:4.1.135.Final"
+    implementation "io.netty:netty-resolver-dns:4.1.135.Final"
+    implementation "io.projectreactor.netty:reactor-netty-http:1.2.18"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.21.2"
+    implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.3.5"
+    implementation "com.nimbusds:nimbus-jose-jwt:10.0.2"
     implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.9.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: ""
-    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.8.1") {
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.9.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-12.8.1.jar:app/gradle/lib/flyway-core-12.8.1.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-12.9.0.jar:app/gradle/lib/flyway-core-12.9.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #6629 

Upgrades Snyk to remediate critical security vulnerability. Flyway just released this version and it should go out before the 26th

### Required reviewers

2 devs

## Impacted areas of the application

- migrations


## How to test

- activate your virtualenv 
- checkout this branch
- run: `brew upgrade flyway`
- run: `flyway -v` (confirm flyway version 12.9.0)
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run:` pytest`


I added the transitive dependency pins to my forked copy and you can review the snyk scan here:
https://app.snyk.io/org/cnlucas/project/227dce0f-cf85-42dd-989f-8804420c91a1?action=retest&success=true&result=RETESTED
