### PR TITLE
Add  derived_cmte_type to real_efile.f1

### DIFF
--- a/data/migrations/V0323__Add_Column_derived_cmte_type_to_real_efile_f1.sql
+++ b/data/migrations/V0323__Add_Column_derived_cmte_type_to_real_efile_f1.sql
@@ -1,0 +1,16 @@
+/*
+This migration file continues for #6640
+-- alter table eal_efile.f1 add column derived_cmte_type character varying(1);
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('alter table real_efile.f1 
+	ADD COLUMN derived_cmte_type varchar(1)');
+EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;
+


### PR DESCRIPTION
## Summary (required)

- Resolves #6640 

Column derived_cmte_type is added to real_efile.f1 in PG databases for future API work.

### Required reviewers
1 dev

## How to test
1. Download feature branch
2. Run `pytest`
3. Run `flyway migrate` and check for the new column in real_efile.f1 on local database
