### PR TITLE
Fix multiple level_1 rows in rm document_vw when upload to Opensearch

### DIFF
--- a/webservices/legal/constants.py
+++ b/webservices/legal/constants.py
@@ -58,13 +58,14 @@ REPO_BASE_PATHS = {
     ARCH_MUR_REPO: f"{S3_BACKUP_DIRECTORY}/arch_mur_repo",
 }
 
-# ========= For legal document end ==========
 
+# ========= For legal document end ==========
 DOCS_PATH = "docs"
 RULEMAKING_PATH = "rulemaking"
 RULEMAKING_TYPE = "rulemakings"
 DISMISSED_ALL = "4"
 DISMISSED_CATEGORIES = {"3", "5", "6", "7", "8"}
+
 
 # =========Start rulemaking Constants==========
 RM_INDEX = "rm_index"
@@ -76,7 +77,7 @@ RM_SEARCH_ALIAS = "rm_search_alias"
 RM_PDF_S3_PATH = "legal/rulemakings/"
 RM_URL_PATH = "/files/"
 
-# doc_category_id(int):doc_category_label(string)
+# Get doc_category_label by passing doc_category_id(int)
 DOC_CATEGORY_MAP = {
     1: "Open Meeting",
     2: "Hearing",
@@ -88,8 +89,7 @@ DOC_CATEGORY_MAP = {
     8: "Press &amp; Public Guidance",
 }
 
-
-# level_1(int):level_1_label(string)
+# Get level_1_label by passing level_1 using the following mapping.
 LEVEL_1_MAP = {
     1: "Final Rules",
     2: "NPRM",
@@ -114,6 +114,7 @@ LEVEL_1_MAP = {
     21: "Termination of Rulemaking",
 }
 
+# Get the priority by passing level_1, where 0 represents the highest priority.
 TIER_PRECEDENCE = {
     15: 0,  # Notice of Disposition (highest priority)
     5: 1,   # Advance NPRM
@@ -129,6 +130,7 @@ TIER_PRECEDENCE = {
     10: 11,  # Explanation and Justification
 }
 
+# Get the level_2_label by passing level_1 and level_2 using the following mapping.
 LEVEL_1_2_MAP = {
     1: {
         0: "Final Rules",
@@ -239,7 +241,7 @@ LEVEL_1_2_MAP = {
     },
 }
 
-
+# Get doc_type label by passing doc_type_id using the following mapping.
 DOC_TYPE_MAP = {
     0:  "NO TIER ENTRY Sers Code :0",
     1:  "NO TIER ENTRY Sers Code :1",
@@ -570,4 +572,4 @@ ENTITY_ROLE_TYPES = {
 }
 
 ENTITY_ROLE_TYPE_VALID_VALUES = ['1', '2', '3', '4', '5']
-# ========= For rulemaking end ==========
+# ========= End rulemaking Constants ==========

--- a/webservices/legal/rulemaking_docs/rulemaking.py
+++ b/webservices/legal/rulemaking_docs/rulemaking.py
@@ -79,7 +79,7 @@ FROM fosers.documents_vw
 WHERE rm_id = :rm
 AND level_1 = :level_1
 AND level_2 = 0
-ORDER BY doc_date DESC
+ORDER BY doc_date,doc_id
 """
 
 NO_TIER_DOCUMENTS = """
@@ -99,7 +99,6 @@ FROM fosers.documents_vw
 WHERE rm_id = :rm
 AND level_1 is NULL
 ORDER BY doc_date DESC, doc_id DESC
-
 """
 
 LEVEL_2_ID_LIST = """
@@ -108,7 +107,6 @@ DISTINCT level_2
 FROM fosers.documents_vw
 WHERE rm_id = :rm
 AND level_1 = :level
-AND level_2 > 0
 """
 
 LEVEL_2_DOCS = """
@@ -509,8 +507,13 @@ def get_documents(rm_no, rm_id, bucket):
             rows = rs.fetchall()
             row_count = len(rows)
             if row_count >= 1:
-                # The level_1 document exists in the documents table (level_2 = 0). Only the first row is used
-                # due to duplicate rows.
+                # Case 1: When row_count == 1, there is a single document row
+                #         in documents_vw with a level_1 value and level_2 = 0.
+                # Case 2: When row_count > 1, multiple document rows in documents_vw
+                #         with the same level_1 value and level_2 = 0,
+                #         only the first row is displayed as the level_1 document;
+                #         all remaining rows are displayed as level_2 documents.
+                # Ex: 1994-02, rm_id=74241, level_1=8, level_2=0
                 row = rows[0]
                 document = {
                     "doc_admin_close_date": row["admin_close_date"],
@@ -567,7 +570,8 @@ def get_documents(rm_no, rm_id, bucket):
                         pass
 
             else:
-                # level_1 has label Only. The level_1 document not exists in the documents table (level_2 = 0).
+                # If no level_1 document record exists in documents_vw for the specified level_1 value and level_2 = 0,
+                # only the level_1 label will be displayed. Ex:1997-03,rm_id=4391,level_1=1
                 document = {
                     "doc_category_id": None,
                     "is_comment_eligible": False,
@@ -621,15 +625,30 @@ def get_doc_date(doc):
 
 def get_level_2_labels(rm_no, rm_id, level_1, bucket):
     level_2_labels = []
+    document = {}
     with db.engine.begin() as conn:
         rs = conn.execute(text(LEVEL_2_ID_LIST), {"rm": rm_id, "level": level_1}).mappings()
         for row in rs:
-            document = {
-                "level_2": row["level_2"],
-                "level_2_label": (constants.LEVEL_1_2_MAP.get(level_1).get(row["level_2"])),
-                "level_2_docs": get_level_2_docs(rm_no, rm_id, level_1, row["level_2"], bucket),
-            }
-            level_2_labels.append(document)
+            if row["level_2"] == 0:
+                with db.engine.begin() as conn2:
+                    rs = conn2.execute(text(LEVEL_2_DOCS), {"rm": rm_id, "level_1": level_1, "level_2": 0}).mappings()
+                    rows = rs.fetchall()
+                    row_count = len(rows)
+                    if row_count > 1:
+                        document = {
+                            "level_2": row["level_2"],
+                            "level_2_label": (constants.LEVEL_1_2_MAP.get(level_1).get(row["level_2"])),
+                            "level_2_docs": get_level_2_docs(rm_no, rm_id, level_1, 0, bucket),
+                        }
+            else:
+                document = {
+                    "level_2": row["level_2"],
+                    "level_2_label": (constants.LEVEL_1_2_MAP.get(level_1).get(row["level_2"])),
+                    "level_2_docs": get_level_2_docs(rm_no, rm_id, level_1, row["level_2"], bucket),
+                }
+
+            if document:
+                level_2_labels.append(document)
         return level_2_labels
 
 
@@ -637,7 +656,16 @@ def get_level_2_docs(rm_no, rm_id, level_1, level_2, bucket):
     level_2_documents = []
     with db.engine.begin() as conn:
         rs = conn.execute(text(LEVEL_2_DOCS), {"rm": rm_id, "level_1": level_1, "level_2": level_2}).mappings()
-        for row in rs:
+        rows = rs.fetchall()
+        row_count = len(rows)
+        if row_count >= 1 and level_2 == 0:
+            # When row_count > 1, multiple document rows in documents_vw with the same level_1 value and level_2 = 0.
+            # The first row is displayed as the level_1 document,
+            # while all remaining rows are displayed as level_2 documents.
+            # Therefore, retrieve all items from the rows list except the first one as the level_2 documents.
+            # Ex: 1994-02, rm_id=74241, level_1=8, level_2=0
+            rows = rows[1:]
+        for row in rows:
             document = {
                 "doc_admin_close_date": row["admin_close_date"],
                 "doc_comment_close_date": row["comment_close_date"],
@@ -738,6 +766,9 @@ def get_key_documents(rm_no, rm_id, bucket):
 
 
 def get_no_tier_documents(rm_no, rm_id, bucket):
+    # Some documents in the document table have level_1 = null and level_2 = null.
+    # These documents will be added to a separate dictionary array: no_tier_documents[].
+    # Ex: 2004-06, rm_id=90767
     no_tier_documents = []
     with db.engine.begin() as conn:
         rs = conn.execute(text(NO_TIER_DOCUMENTS), {"rm": rm_id}).mappings()


### PR DESCRIPTION
## Summary (required)
Some rulemakings have multiple rows in documents_vw with the same level_1 value and level_2 = 0. During the OpenSearch upload, only the first row is indexed, causing all remaining rows to be omitted. Ex: 1994-02, rm_id=74241
This PR fixes the issue. When multiple rows exist in documents_vw for the same level_1 value with level_2 = 0, the first row is treated as the level_1 document, and the remaining rows are treated as level_2 documents.

- Resolves #6637 

(Include a summary of proposed changes and connect issue below)

### Required reviewers

1-3 devs

## Impacted areas of the application
rulemakings feature


## How to test
- checkout branch
- pytest
- in local
`python cli.py create_index rm_index`
`python cli.py load_rulemaking 1994-02`
`python cli.py load_rulemaking 1994-03`
Check missing level_1 doc should inside level_2_docs
- in dev
All rulemaking data has been reloaded into the OpenSearch in dev. Please compare the web page to verify that all previously missing documents are now displayed.

https://www.fec.gov/legal/rulemakings/1994-02/
https://dev.fec.gov/legal/rulemakings/1994-02/

https://www.fec.gov/legal/rulemakings/1994-03/
https://dev.fec.gov/legal/rulemakings/1994-03/

rm: 1994-02, rm_id=74241
<img width="390" height="500" alt="dev_1994-02" src="https://github.com/user-attachments/assets/497e7f4b-a6de-45b8-b44b-332bff5b5a84" />


rm: 1994-03, rm_id=74229
<img width="400" height="500" alt="dev_1994-03" src="https://github.com/user-attachments/assets/8cb213c7-2ed7-4ac0-ba5c-a1dc691495e9" />



