### PR TITLE
add statement_timeout to follower engine

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,7 +34,7 @@ class TestBaseTestCase(BaseTestCase):
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
 
-class StatementTimeoutTest(unittest.TestCase):
+class TestStatementTimeout(unittest.TestCase):
     """Test statement_timeout configuration should only apply to reader"""
     def test_follower_engines_have_statement_timeout(self):
         with patch.dict('os.environ', {'SQLA_STATEMENT_TIMEOUT': '30000'}):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,11 @@
 from flask import current_app
 from tests.common import BaseTestCase
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+import unittest
+from unittest.mock import patch
+from webservices.rest import create_app
+from webservices.common.models import db
 
 
 class TestBaseTestCase(BaseTestCase):
@@ -27,3 +32,64 @@ class TestBaseTestCase(BaseTestCase):
         response = self.client.get('/swagger')
         assert "Access-Control-Allow-Origin" in response.headers
         assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+class StatementTimeoutTest(unittest.TestCase):
+    """Test statement_timeout configuration should only apply to reader"""
+    def test_follower_engines_have_statement_timeout(self):
+        with patch.dict('os.environ', {'SQLA_STATEMENT_TIMEOUT': '30000'}):
+            app = create_app(test_config='follower')
+            app_context = app.app_context()
+            app_context.push()
+
+            try:
+                follower_engines = app.config.get('SQLALCHEMY_FOLLOWERS', [])
+
+                # Skip test if no followers configured
+                if not follower_engines:
+                    self.skipTest("No follower engines configured")
+
+                for follower_engine in follower_engines:
+                    self.assertIsNotNone(follower_engine)
+
+                    # Execute a query to verify the timeout is set
+                    with follower_engine.connect() as conn:
+                        result = conn.execute(text("SHOW statement_timeout")).scalar()
+                        self.assertIsNotNone(result, "Follower should have statement_timeout configured")
+                        self.assertNotEqual(result, '0', "Follower statement_timeout should not be 0")
+
+            finally:
+                app_context.pop()
+
+    def test_statement_timeout_only_on_followers(self):
+        """Test that statement_timeout is NOT applied to writer"""
+        with patch.dict('os.environ', {'SQLA_STATEMENT_TIMEOUT': '60000'}):
+            app = create_app(test_config='follower')
+            app_context = app.app_context()
+            app_context.push()
+
+            try:
+                primary_engine = db.engine
+                follower_engines = app.config.get('SQLALCHEMY_FOLLOWERS', [])
+
+                if not follower_engines:
+                    self.skipTest("No follower engines configured")
+
+                # Primary should NOT have timeout
+                with primary_engine.connect() as conn:
+                    primary_timeout = conn.execute(text("SHOW statement_timeout")).scalar()
+                    self.assertEqual(primary_timeout, '0', "Primary should not have statement_timeout")
+
+                # Followers SHOULD have timeout
+                with follower_engines[0].connect() as conn:
+                    follower_timeout = conn.execute(text("SHOW statement_timeout")).scalar()
+                    self.assertEqual(follower_timeout, '1min', "Follower should have statement_timeout")
+
+                # Statement timeout receives 504
+                error = OperationalError("statement", {}, Exception("canceling statement due to statement timeout"),)
+                with app.test_request_context("/"):
+                    response = app.handle_user_exception(error)
+                    self.assertEqual(response.status_code, 504)
+
+            finally:
+                app_context.pop()

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -10,6 +10,7 @@ import os
 from marshmallow import EXCLUDE
 import ujson
 import sqlalchemy as sa
+from sqlalchemy.exc import OperationalError
 import flask_cors as cors
 from nplusone.ext.flask_sqlalchemy import NPlusOne
 
@@ -118,19 +119,21 @@ def create_app(test_config=None):
     app.config['PROPAGATE_EXCEPTIONS'] = True
     query_cache_size = int(env.get_credential('QUERY_CACHE_SIZE', '100'))
     pool_pre_ping = bool(env.get_credential('POOL_PRE_PING_BOOL', 'False'))
+    statement_timeout = int(env.get_credential('SQLA_STATEMENT_TIMEOUT', 1000))
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
             'query_cache_size': query_cache_size,
             'max_overflow': 50,
             'pool_size': 50,
             'pool_timeout': 120,
-            'pool_pre_ping': pool_pre_ping,
         }
 
     def create_sqlalchemy_followers(env_var_name: str, default_value: str = '') -> list:
         followers = utils.split_env_var(env.get_credential(env_var_name, default_value))
         return [sa.create_engine(follower.strip(), query_cache_size=query_cache_size,
                                  pool_size=50, max_overflow=50, pool_timeout=120,
-                                 pool_pre_ping=pool_pre_ping) for follower in followers if follower.strip()
+                                 pool_pre_ping=pool_pre_ping,
+                                 connect_args={"options": f"-c statement_timeout={statement_timeout}"},)
+                for follower in followers if follower.strip()
                 ]
     # app.config['SQLALCHEMY_ECHO'] = True
 
@@ -482,6 +485,13 @@ def create_app(test_config=None):
         for header, value in headers.items():
             response.headers.add(header, value)
         return response
+
+    @app.errorhandler(OperationalError)
+    def handle_db_timeout(e):
+        if hasattr(e, 'orig') and 'canceling statement due to statement timeout' in str(e.orig):
+            app.logger.warning('Statement timeout on %s', request.path)
+            return jsonify({'message': 'Query timed out', 'status': 504}), 504
+        return handle_exception(e)
 
     @app.errorhandler(Exception)
     def handle_exception(exception):

--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -119,7 +119,7 @@ def create_app(test_config=None):
     app.config['PROPAGATE_EXCEPTIONS'] = True
     query_cache_size = int(env.get_credential('QUERY_CACHE_SIZE', '100'))
     pool_pre_ping = bool(env.get_credential('POOL_PRE_PING_BOOL', 'False'))
-    statement_timeout = int(env.get_credential('SQLA_STATEMENT_TIMEOUT', 1000))
+    statement_timeout = int(env.get_credential('SQLA_STATEMENT_TIMEOUT', 55000))
     app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
             'query_cache_size': query_cache_size,
             'max_overflow': 50,


### PR DESCRIPTION
Adds back statement timeouts now that we have the slack alert turned off. 




## How to test

- pull this PR
- `pytest`
- Make sure you have SQLA_FOLLOWERS set to dev, stage, or your local db.
- set an artificially low statement timeout locally
`export SQLA_STATEMENT_TIMEOUT=1`

- `flask run`
- Run any query and you should see a 504 error, you can try a 404 and 422 as well:
504: http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&filing_frequency=M&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
404: http://127.0.0.1:5000/v1/committes/?page=1&per_page=20&filing_frequency=M&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
422: http://127.0.0.1:5000/v1/committees/?page=1&per_page=20&filing_frequency=ZZ&sort=name&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false