### PR TITLE
[MERGE WITH GITFLOW] upgrade flyway v12.11.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
           command: |
             sudo apt-get --allow-releaseinfo-change-suite update && sudo apt-get install -y default-jdk
             mkdir flyway
-            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.9.0/flyway-commandline-12.9.0-linux-x64.tar.gz | tar zxv -C flyway
-            echo 'export PATH=./flyway/flyway-12.9.0:$PATH' >> $BASH_ENV
+            curl -sL https://github.com/flyway/flyway/releases/download/flyway-12.11.0/flyway-commandline-12.11.0-linux-x64.tar.gz | tar zxv -C flyway
+            echo 'export PATH=./flyway/flyway-12.11.0:$PATH' >> $BASH_ENV
 
       - restore_cache:
           keys:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ We are always trying to improve our documentation. If you have suggestions or ru
      - Read a [Windows tutorial](https://www.postgresqltutorial.com/install-postgresql/)
      - Read a [Linux tutorial](https://www.postgresql.org/docs/13/installation.html) (or follow your OS package manager)
    - Opensearch 2.11 (instructions [here](https://docs.opensearch.org/2.11/install-and-configure/install-opensearch/index/))
-   - Flyway 12.9.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
+   - Flyway 12.11.0 ([homebrew instructions](https://formulae.brew.sh/formula/flyway))
 
-     - After downloading, create a .toml file in the following location: `flyway-12.9.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
+     - After downloading, create a .toml file in the following location: `flyway-12.11.0/conf/flyway.toml` and set the flyway environment variables `environment`, `url`, `user`, `password` and`locations` as
 
        ```
        [environments.local]

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -13,7 +13,7 @@ configurations.all {
     resolutionStrategy.force "io.netty:netty-codec-http2:4.1.135.Final"
     resolutionStrategy.force "io.netty:netty-resolver-dns:4.1.135.Final"
     resolutionStrategy.force "io.projectreactor.netty:reactor-netty-http:1.2.18"
-    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:2.21.2"
+    resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:2.21.4"
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:5.3.5"
     resolutionStrategy.force "com.nimbusds:nimbus-jose-jwt:10.0.2"
 }
@@ -27,10 +27,10 @@ dependencies {
     implementation "io.netty:netty-codec-http2:4.1.135.Final"
     implementation "io.netty:netty-resolver-dns:4.1.135.Final"
     implementation "io.projectreactor.netty:reactor-netty-http:1.2.18"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.21.2"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.21.4"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.3.5"
     implementation "com.nimbusds:nimbus-jose-jwt:10.0.2"
-    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.9.0") {
+    implementation (group: "org.flywaydb", name: "flyway-commandline", version: "12.11.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"

--- a/data/flyway/manifest_headless_flyway.yml
+++ b/data/flyway/manifest_headless_flyway.yml
@@ -7,7 +7,7 @@ applications:
     command: /home/vcap/app/flyway/bin/run.sh && echo SUCCESS && sleep infinity
     path: build/distributions/flyway.zip
     env:
-      CLASSPATH: app/gradle/lib/flyway-commandline-12.9.0.jar:app/gradle/lib/flyway-core-12.9.0.jar
+      CLASSPATH: app/gradle/lib/flyway-commandline-12.11.0.jar:app/gradle/lib/flyway-core-12.11.0.jar
       JAVA_HOME: /home/vcap/app/.java-buildpack/open_jdk_jre
     services:
       - fec-flyway-creds


### PR DESCRIPTION
## Summary (required)

- Resolves #6651

This hotfix upgrades flyway to remediate a critical security vulnerability.

### Required reviewers 2 devs 


## Impacted areas of the application

General components of the application that this PR will affect:

- flyway 

## How to test


- activate your virtualenv 
- checkout this branch
- run: `brew upgrade flyway`
- run: `flyway -v` (confirm flyway version 12.11.0)
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run:` pytest`
- run: `snyk test --file=data/flyway/build.gradle`

Also here is a link to the snyk report for this branch: https://app.snyk.io/org/tmpayton/project/066f28e7-c438-4353-b7f8-e7a6524b273a

Note: The two other high severity vulnerabilities have only a beta version patch. Since these are not due we can wait until there is a full release.


