### PR TITLE
Fix flyway gradle compatibility issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ static/swagger-ui/js
 
 # token file
 token.txt
+
+# hide flyway gradle
+data/flyway/.gradle/

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: "java"
-apply plugin: "application"
+plugins {
+    id 'java'
+    id 'application'
+}
 
 repositories {
     mavenCentral()
@@ -49,7 +51,9 @@ dependencies {
     }
 }
 
-mainClassName = "org.flywaydb.commandline.Main"
+application {
+    mainClass = 'org.flywaydb.commandline.Main'
+}
 
 task createJarsDir {
     def jars = file("$buildDir/jars")


### PR DESCRIPTION
## Summary (required)
This PR fixes the Flyway Gradle compatibility issue introduced with the newer Flyway version.

### Required reviewers

1 dev

## Impacted areas of the application

flyway
-

## error message:
Before this PR, when running `snyk test --file=data/flyway/build.gradle`
get error:
<img width="700" height="350" alt="Screenshot 2026-07-23 at 4 17 55 PM" src="https://github.com/user-attachments/assets/e3c6eb89-c0fb-4d81-9142-1a7266d78ba8" />


## How to test
- activate your virtualenv 
- checkout this branch
- run: `brew upgrade flyway`
- upgrade flyway
- run: `flyway -v` (confirm flyway version 12.9.0)
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run: `pytest`
- run: `snyk test --file=data/flyway/build.gradle` check **unknown property 'mainClassName'** error message gone.