### PR TITLE
6011 sort citations in asc order

### DIFF
--- a/tests/test_legal/test_legal_data.py
+++ b/tests/test_legal/test_legal_data.py
@@ -2139,7 +2139,9 @@ first_citation = {
       "citation_text": "2 U.S.C. §31021",
       "citation_type": "statute",
       "doc_type": "murs",
-      "type": "citations"
+      "type": "citations",
+      "sort3": 2,
+      "sort4": 31021
     }
 
 
@@ -2147,21 +2149,27 @@ second_citation = {
       "citation_text": "18 U.S.C. 603",
       "citation_type": "statute",
       "doc_type": "advisory_opinions",
-      "type": "citations"
+      "type": "citations",
+      "sort3": 18,
+      "sort4": 603
     }
 
 third_citation = {
       "citation_text": "11 CFR §104.12",
       "citation_type": "regulation",
       "doc_type": "murs",
-      "type": "citations"
+      "type": "citations",
+      "sort3": 11,
+      "sort4": 104012
     }
 
 fourth_citation = {
       "citation_text": "11 CFR §116.12",
       "citation_type": "regulation",
       "doc_type": "advisory_opinions",
-      "type": "citations"
+      "type": "citations",
+      "sort3": 11,
+      "sort4": 116012
     }
 
 

--- a/webservices/legal/legal_docs/advisory_opinions.py
+++ b/webservices/legal/legal_docs/advisory_opinions.py
@@ -454,15 +454,18 @@ def get_citations(ao_names):
             "citation_text": "%d CFR §%d.%d" % (citation[0], citation[1], citation[2]),
             "citation_type": "regulation",
             "doc_type": "advisory_opinions",
+            "sort3": citation[0],
+            "sort4": (citation[1] * 1000 + citation[2]),
         }
         opensearch_client.index(index=AO_ALIAS, body=entry, id=entry["citation_text"])
-
     for citation in all_statutory_citations:
         entry = {
             "type": "citations",
             "citation_text": "%d U.S.C. §%s" % (citation[0], citation[1]),
             "citation_type": "statute",
             "doc_type": "advisory_opinions",
+            "sort3": citation[0],
+            "sort4": re.sub(r'\D', '', citation[1])
         }
         opensearch_client.index(index=AO_ALIAS, body=entry, id=entry["citation_text"])
     logger.info(" AO Citations loaded.")

--- a/webservices/legal/mappings/ao_mapping.py
+++ b/webservices/legal/mappings/ao_mapping.py
@@ -63,6 +63,8 @@ AO_MAPPING = {
         "representative_names": {"type": "text"},
         "citation_type": {"type": "keyword"},
         "citation_text": {"type": "keyword"},
+        "sort3": {"type": "integer"},
+        "sort4": {"type": "integer"},
         "doc_type": {"type": "keyword"},
         "entities": {
             "properties": {

--- a/webservices/resources/legal.py
+++ b/webservices/resources/legal.py
@@ -975,8 +975,10 @@ class GetLegalCitation(Resource):
                 ],
                 minimum_should_match=1,
             )
+            .source(excludes=["sort3", "sort4"])
             .extra(size=10)
             .index(SEARCH_ALIAS)
+            .sort({"sort3": {"order": "asc"}, "sort4": {"order": "asc"}})
         )
 
         # logger.debug("Citation final query =" + json.dumps(query.to_dict(), indent=3, cls=DateTimeEncoder))


### PR DESCRIPTION
## Summary (required)

- Resolves #6011

Sort citations in legal citation endpoint in ascending order

### Required reviewers

1-2 devs

## Impacted areas of the application

- legal/citation endpoint

## How to test

- checkout this branch 
- start your virtualenv 
- start elasticsearch in new terminal 
-  `pytest`
- `python cli.py slow_reload_zero_downtime ao_index` or ` python cli.py initialize_legal_data ao_index`
- `flask run`
- Test endpoint

Sample URLs: 

http://127.0.0.1:5000/v1/legal/citation/regulation/100.13
http://127.0.0.1:5000/v1/legal/citation/statute/150
http://127.0.0.1:5000/v1/legal/citation/statute/10/?doc_type=advisory_opinions
http://127.0.0.1:5000/v1/legal/citation/regulation/100.13/?doc_type=advisory_opinions
