### PR TITLE
Flyway gradle - exclude unnecessary jar files to fix translative issues

### DIFF
--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -34,6 +34,12 @@ dependencies {
     implementation "com.nimbusds:nimbus-jose-jwt:10.0.2"
     implementation (group: "org.flywaydb", name: "flyway-commandline", version: "13.0.0") {
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
+        exclude group: "com.microsoft.azure", module: "msal4j"
+        exclude group: "com.google.cloud", module: "google-cloud-storage"
+        exclude group: "com.azure", module: "azure-identity"
+        exclude group: "com.ing.data", module: "cassandra-jdbc-wrapper"
+        exclude group: "org.flywaydb", module: "flyway-database-nc-cassandra"
+        exclude group: "org.apache.commons", module: "commons-text"
         exclude group: "com.h2database", module: "h2"
         exclude group: "com.pivotal.jdbc", module: "greenplumdriver"
         exclude group: "net.sourceforge.jtds", module: "jtds"

--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -21,7 +21,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: ""
+    implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.6.1"
     implementation "io.netty:netty-handler:4.1.136.Final"
     implementation "io.netty:netty-handler-proxy:4.1.136.Final"
     implementation "io.netty:netty-codec-dns:4.1.136.Final"


### PR DESCRIPTION
## Summary (required)

This PR fixes the **critical** transitive dependency issues by excluding unused Flyway JARs in build.gradle. These JARs are not needed for running migrations locally or in Docker

Gradle version pinned per ticket findings [here ](https://github.com/fecgov/openFEC/issues/6638#issuecomment-5064076381)

- Resolves #6675

### Required reviewers

1-2 developers

## How to test

- verify on **Dev**: https://app.snyk.io/org/fecgov/project/0f486fbe-4285-4c66-bf9e-195ea4a91d1c (7 transitive issues appear)
- run: git checkout feature/fix-flyway-dependencies
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db` 
-  verify on **My branch**: https://app.snyk.io/org/pkfec/project/107d8275-6b1e-4ce2-8503-71bb8b4a8cd8/history/515d26b9-a87a-4b6c-84ad-4c292ba750c2
- run `pytest` 
- run `flask run` (optional, test endpoints)
