### PR TITLE
upgrade gitpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.1.1
 gevent==25.5.1
 gunicorn==23.0.0
-GitPython==3.1.50
+GitPython==3.1.57
 icalendar==4.0.2
 invoke==2.2.0
 kombu==5.5.3 # Starting from celery 5.x release, the minimum required version is Kombu 5.x


### PR DESCRIPTION
## Summary (required)

- Resolves #6668

This ticket upgrades gitpython to remove a security vulnerability.

## Impacted areas of the application

General components of the application that this PR will affect:

-  automated release process/interaction with git libraries


## How to test

- `git checkout develop`
- `snyk test --file=requirements.txt --package-manager=pip` (Terminal output shows gitpython as vulnerable package)
- `gh pr checkout 6679`
- `pyenv activate your_env`
- `pip install -r requirements.txt` 
- `snyk test --file=requirements.txt --package-manager=pip` (Terminal output **no longer shows** gitpython as vulnerable package)
- `pytest`
