### PR TITLE
Switch requirements to marshmallow master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ yappi==1.7.3
 
 # Marshalling
 flask-apispec==0.11.4
-git+https://github.com/fecgov/marshmallow-pagination@check_result_exist
+git+https://github.com/fecgov/marshmallow-pagination@master
 marshmallow==3.26.2
 marshmallow-sqlalchemy==1.4.2
 


### PR DESCRIPTION
## Summary (required)

This PR switched the marshmallow pagination branch back to master.
After **Check result exist** PR merge into marshmallow-pagination/master branch.
[https://github.com/fecgov/marshmallow-pagination/pull/22](https://github.com/fecgov/marshmallow-pagination/pull/22)

### Required reviewers 1

## Impacted areas of the application

General components of the application that this PR will affect:
- requirements.txt 


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- checkout this branch 
- start up virtualenv 
- `pytest`
