### PR TITLE
Override transitive dependency

### DIFF
--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -29,10 +29,10 @@ dependencies {
     implementation "io.netty:netty-codec-http2:4.1.136.Final"
     implementation "io.netty:netty-resolver-dns:4.1.136.Final"
     implementation "io.projectreactor.netty:reactor-netty-http:1.2.18"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.21.4"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
     implementation "com.nimbusds:nimbus-jose-jwt:10.0.2"
     implementation (group: "org.flywaydb", name: "flyway-commandline", version: "13.0.0") {
+        exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
         exclude group: "com.microsoft.sqlserver", module: "msql-jdbc"
         exclude group: "com.microsoft.azure", module: "msal4j"
         exclude group: "com.google.cloud", module: "google-cloud-storage"
@@ -53,6 +53,7 @@ dependencies {
         exclude group: "com.google.guava", module: "guava"
         constraints {
 	       implementation("org.postgresql:postgresql:42.6.0.jar")
+           implementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
         }
     }
 }


### PR DESCRIPTION
## Summary (required)

Override jackson-databind transitive dependencies and enforce strict version

I have noticed that this transitive dependencies problem only appears on the Snyk UI, but it doesn’t show up when running scans through the CLI. In our CircleCI pipeline, both jackson-databind versions 2.22.1 and 3.1.5 are being downloaded. To be on safe side, I have pinned version 2.22.1 as a constraint in the build.gradle file, and I have also excluded the group "com.fasterxml.jackson.core" just in case.

FYI,  the CLI does not flag jackson-databind as a transitive vulnerable package.

```
Some discrepancy between SCM imports and CLI scan is expected due to the environments. 
Stated in documentation here:

https://docs.snyk.io/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/differences-in-open-source-vulnerability-counts-across-environments
```

- Resolves #6675 

### Required reviewers

1-2 reviewers

## Impacted areas of the application

- database flyway migration


## How to test
- run: `git checkout feature/exclude-flyway-transitive-dependencies`
- run: `dropdb cfdm_test`
- run: `createdb cfdm_test`
- run: `invoke create-sample-db`
- run: `snyk test --file=data/flyway/build.gradle` (No transitive dependency issues flagged here)
- run `pytest` 
- run `flask run` (optional, test endpoints)

