### PR TITLE
add derived_cmte_type to test_efile.test_f1

### DIFF
--- a/data/migrations/V0324__Add_Column_derived_cmte_type_to_test_efile_test_f1.sql
+++ b/data/migrations/V0324__Add_Column_derived_cmte_type_to_test_efile_test_f1.sql
@@ -1,0 +1,15 @@
+/*
+This migration file is for ticket #6660
+-- add column derived_cmte_type character varying(1) to table test_efile.test_f1;
+*/
+
+DO $$
+BEGIN
+    EXECUTE format('alter table test_efile.test_f1 
+	ADD COLUMN derived_cmte_type varchar(1)');
+EXCEPTION
+             WHEN duplicate_column THEN
+                null;
+             WHEN others THEN
+                RAISE NOTICE 'some other error: %, %',  sqlstate, sqlerrm;
+END$$;


### PR DESCRIPTION
## Summary (required)
Column derived_cmte_type is added to test_efile.test_f1 in PG databases for future API work.

- Resolves #6660

### Required reviewers
1 dev

## How to test
1. Checkout branch
2. Run `pytest`
3. Run `flyway migrate` and check for the new column in test_efile.test_f1 on local database
