### PR TITLE
Add derived_committee_type to /efile/test-form1/

### DIFF
--- a/webservices/common/models/filings.py
+++ b/webservices/common/models/filings.py
@@ -329,7 +329,7 @@ class TestForm1(db.Model):
     candidate_party = db.Column('party', db.String, index=True, doc=docs.PARTY)
     candidate_district = db.Column('district', db.String, index=True, doc=docs.ELECTION_DISTRICT)
 
-    committee_type = db.Column('cmte_type', db.String, index=True, doc=docs.COMMITTEE_TYPE)
+    committee_type = db.Column('cmte_type', db.String, index=True, doc=docs.COMMITTEE_TYPE_EFILE)
     committee_city = db.Column('com_city', db.String, doc=docs.COMMITTEE_CITY)
     committee_name = db.Column('com_name', db.String, doc=docs.COMMITTEE_NAME)
     committee_state = db.Column('com_state', db.String, doc=docs.COMMITTEE_STATE)
@@ -337,6 +337,7 @@ class TestForm1(db.Model):
     committee_str2 = db.Column('com_str2', db.String, doc=docs.COMMITTEE_STREET_2)
     committee_zip = db.Column('com_zip', db.String, doc=docs.COMMITTEE_ZIP)
     committee_id = db.Column('comid', db.String, index=True, doc=docs.COMMITTEE_ID)
+    derived_committee_type = db.Column('derived_cmte_type', db.String, doc=docs.DERIVED_COMMITTEE_TYPE)
     email = db.Column(db.String, doc=docs.COMMITTEE_EMAIL)
 
     election_state = db.Column('el_state', db.String, index=True, doc=docs.ELECTION_STATE)


### PR DESCRIPTION
## Summary (required)

- Resolves #6692  
Add derived committee type to endpoint: /efile/test-form1/
### Required reviewers

1-2 devs

## How to test
- Checkout branch
- `pytest`
- `export FEC_SHOW_TEST_F1=true` on local
-  test url: http://127.0.0.1:5000/v1/efile/form1/?page=1&per_page=20&sort=-load_timestamp&sort_hide_null=false&sort_null_only=false&sort_nulls_last=false
check **derived_committee_type** new field.
<img width="350" height="327" alt="Screenshot 2026-08-18 at 5 02 37 PM" src="https://github.com/user-attachments/assets/b6a37093-c1ac-41ea-b23a-2b8d052e543f" />

