### PR TITLE
fix committee_type for efile arg

### DIFF
--- a/webservices/args.py
+++ b/webservices/args.py
@@ -638,7 +638,7 @@ form1efilings = {
     'image_number': fields.List(ImageNumber, metadata={'description': docs.IMAGE_NUMBER}),
     'min_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
     'max_load_timestamp': Date(metadata={'description': docs.LOAD_DATE}),
-    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE}),
+    'committee_type': fields.List(fields.Str, metadata={'description': docs.COMMITTEE_TYPE_EFILE}),
     'organization_type': fields.List(
         IStr(validate=validate.OneOf(['', 'C', 'L', 'M', 'T', 'V', 'W', 'H', 'I'])),
         metadata={'description': docs.ORGANIZATION_TYPE},


### PR DESCRIPTION
## Summary (required)

Fixes efile commitee_type

### Required reviewers
1 dev


### Test
'gh pr checkout 6699'
http://127.0.0.1:5000/

Should use the new committee_type
<img width="1223" height="443" alt="Screenshot 2026-08-20 at 10 38 49 AM" src="https://github.com/user-attachments/assets/185fac89-39a1-440e-97de-19f08f2d45aa" />


