### PR TITLE
Upgrade jar files to resolve snyk critical vulnerabilities

### DIFF
--- a/data/flyway/build.gradle
+++ b/data/flyway/build.gradle
@@ -8,13 +8,13 @@ repositories {
 }
 
 configurations.all {
-    resolutionStrategy.force "io.netty:netty-handler:4.1.136.Final"
-    resolutionStrategy.force "io.netty:netty-handler-proxy:4.1.136.Final"
-    resolutionStrategy.force "io.netty:netty-codec-dns:4.1.136.Final"
-    resolutionStrategy.force "io.netty:netty-codec-http:4.1.136.Final"
-    resolutionStrategy.force "io.netty:netty-codec-http2:4.1.136.Final"
-    resolutionStrategy.force "io.netty:netty-resolver-dns:4.1.136.Final"
-    resolutionStrategy.force "io.projectreactor.netty:reactor-netty-http:1.2.18"
+    resolutionStrategy.force "io.netty:netty-handler:4.1.137.Final"
+    resolutionStrategy.force "io.netty:netty-handler-proxy:4.1.137.Final"
+    resolutionStrategy.force "io.netty:netty-codec-dns:4.1.137.Final"
+    resolutionStrategy.force "io.netty:netty-codec-http:4.1.137.Final"
+    resolutionStrategy.force "io.netty:netty-codec-http2:4.1.137.Final"
+    resolutionStrategy.force "io.netty:netty-resolver-dns:4.1.137.Final"
+    resolutionStrategy.force "io.projectreactor.netty:reactor-netty-http:3.7.19"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:2.21.4"
     resolutionStrategy.force "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
     resolutionStrategy.force "com.nimbusds:nimbus-jose-jwt:10.0.2"
@@ -22,12 +22,12 @@ configurations.all {
 
 dependencies {
     implementation group: "org.flywaydb", name: "flyway-gradle-plugin", version: "9.6.1"
-    implementation "io.netty:netty-handler:4.1.136.Final"
-    implementation "io.netty:netty-handler-proxy:4.1.136.Final"
-    implementation "io.netty:netty-codec-dns:4.1.136.Final"
-    implementation "io.netty:netty-codec-http:4.1.136.Final"
-    implementation "io.netty:netty-codec-http2:4.1.136.Final"
-    implementation "io.netty:netty-resolver-dns:4.1.136.Final"
+    implementation "io.netty:netty-handler:4.1.137.Final"
+    implementation "io.netty:netty-handler-proxy:4.1.137.Final"
+    implementation "io.netty:netty-codec-dns:4.1.137.Final"
+    implementation "io.netty:netty-codec-http:4.1.137.Final"
+    implementation "io.netty:netty-codec-http2:4.1.137.Final"
+    implementation "io.netty:netty-resolver-dns:4.1.137.Final"
     implementation "io.projectreactor.netty:reactor-netty-http:1.2.18"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
     implementation "com.nimbusds:nimbus-jose-jwt:10.0.2"
@@ -51,6 +51,7 @@ dependencies {
         exclude group: "org.xerial", module: "sqlite-jdbc"
         exclude group: "com.google.protobuf", module: "protobuf-java"
         exclude group: "com.google.guava", module: "guava"
+        exclude group: "com.couchbase.client", module: "core-io"
         constraints {
 	       implementation("org.postgresql:postgresql:42.6.0.jar")
            implementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")


### PR DESCRIPTION
This PR fixes the **critical** issues by updating the JARs in build.gradle. 


- Resolves # https://github.com/fecgov/openFEC/issues/6705


### Screenshots

**Before**

```
  Upgrade io.netty:netty-codec-http@4.1.136.Final to io.netty:netty-codec-http@4.1.137.Final to fix
  ✗ Use of Cache Containing Sensitive Information (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131] in io.netty:netty-codec-http@4.1.136.Final
    introduced by io.netty:netty-codec-http@4.1.136.Final and 4 other path(s)
  ✗ Improper Validation of Certificate with Host Mismatch (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233599] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
  ✗ Improper Check for Unusual or Exceptional Conditions (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)

  Upgrade io.netty:netty-codec-http2@4.1.136.Final to io.netty:netty-codec-http2@4.1.137.Final to fix
  ✗ Use of Cache Containing Sensitive Information (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131] in io.netty:netty-codec-http@4.1.136.Final
    introduced by io.netty:netty-codec-http@4.1.136.Final and 4 other path(s)
  ✗ Improper Validation of Certificate with Host Mismatch (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233599] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
  ✗ Improper Check for Unusual or Exceptional Conditions (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)

  Upgrade io.netty:netty-handler@4.1.136.Final to io.netty:netty-handler@4.1.137.Final to fix
  ✗ Improper Validation of Certificate with Host Mismatch (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233599] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
  ✗ Improper Check for Unusual or Exceptional Conditions (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)

  Upgrade io.netty:netty-handler-proxy@4.1.136.Final to io.netty:netty-handler-proxy@4.1.137.Final to fix
  ✗ Null Byte Interaction Error (Poison Null Byte) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233598] in io.netty:netty-codec-socks@4.1.136.Final
    introduced by io.netty:netty-handler-proxy@4.1.136.Final > io.netty:netty-codec-socks@4.1.136.Final
  ✗ Use of Cache Containing Sensitive Information (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131] in io.netty:netty-codec-http@4.1.136.Final
    introduced by io.netty:netty-codec-http@4.1.136.Final and 4 other path(s)

  Upgrade io.netty:netty-resolver-dns@4.1.136.Final to io.netty:netty-resolver-dns@4.1.137.Final to fix
  ✗ Improper Validation of Certificate with Host Mismatch (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233599] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
  ✗ Improper Check for Unusual or Exceptional Conditions (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)

  Upgrade io.projectreactor.netty:reactor-netty-http@1.2.18 to io.projectreactor.netty:reactor-netty-http@1.3.7 to fix
  ✗ Open Redirect (new) [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTORNETTY-19267392] in io.projectreactor.netty:reactor-netty-http@1.2.18
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18
  ✗ User Impersonation (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTORNETTY-19267393] in io.projectreactor.netty:reactor-netty-http@1.2.18
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18
  ✗ Use of Incorrectly-Resolved Name or Reference (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTORNETTY-19267432] in io.projectreactor.netty:reactor-netty-core@1.2.18
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18 > io.projectreactor.netty:reactor-netty-core@1.2.18
  ✗ Use of Cache Containing Sensitive Information (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131] in io.netty:netty-codec-http@4.1.136.Final
    introduced by io.netty:netty-codec-http@4.1.136.Final and 4 other path(s)
  ✗ Improper Validation of Certificate with Host Mismatch (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19233599] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
  ✗ Allocation of Resources Without Limits or Throttling (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTOR-19267101] in io.projectreactor:reactor-core@3.7.19
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18 > io.projectreactor:reactor-core@3.7.19 and 2 other path(s)
  ✗ Race Condition (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTOR-19267102] in io.projectreactor:reactor-core@3.7.19
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18 > io.projectreactor:reactor-core@3.7.19 and 2 other path(s)
  ✗ Allocation of Resources Without Limits or Throttling (new) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTORNETTY-19267394] in io.projectreactor.netty:reactor-netty-http@1.2.18
    introduced by io.projectreactor.netty:reactor-netty-http@1.2.18
  ✗ Improper Check for Unusual or Exceptional Conditions (new) [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879] in io.netty:netty-handler@4.1.136.Final
    introduced by io.netty:netty-handler@4.1.136.Final and 5 other path(s)
```

### Required reviewers

1-2 developers

## How to test

- run: `git checkout master`
- run:  `pyenv activate <your api virtualenv>`
- run: `snyk test --file=data/flyway/build.gradle` (snyk lists all the vulnerable jars, see the screenshot above)
- run: `git checkout feature/6705-upgrade-flyway-dependency-packages`
- run: `snyk test --file=data/flyway/build.gradle` (no vulnerabilities )
- run: `dropdb cfdm_test` (optional)
- run: `createdb cfdm_test` (optional)
- run: `invoke create-sample-db` (optional)
- run `pytest` (optional)
- run `flask run` (optional, test endpoints)
