### PR TITLE
Ensure celery monitoring endpoint does not return cached data

### DIFF
--- a/webservices/rest.py
+++ b/webservices/rest.py
@@ -420,6 +420,8 @@ def create_app(test_config=None):
             return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, CALENDAR_CACHE)
         if '/legal/' in url:
             return DEFAULT_HEADER_TYPE, '{}{}'.format(DEFAULT_HEADER_PREFIX, LEGAL_CACHE)
+        if '/monitoring/celery_check' in url:
+            return DEFAULT_HEADER_TYPE, 'no-store, no-cache, must-revalidate, max-age=0'
 
         # This will work differently in local environment - will use local timezone
         for endpoint in LONG_CACHE_ENDPOINTS:


### PR DESCRIPTION
## Summary (required)

This PR adds cache headers to ensure the endpoint is not returning cached data. 

### Required reviewers 1 dev


## Impacted areas of the application

General components of the application that this PR will affect:

- celery monitoring endpoint


## How to test

- deploy this test branch to dev: https://app.circleci.com/pipelines/github/fecgov/openFEC?branch=test-celery-cache
- navigate to the celery monitoring endpoint and view the response headers: https://fec-dev-api.app.cloud.gov/v1/monitoring/celery_check//
   -  The cache control headers should state: `no-store, no-cache, must-revalidate, max-age=0`